### PR TITLE
Cascade systems

### DIFF
--- a/include/flecs.h
+++ b/include/flecs.h
@@ -145,6 +145,9 @@ extern ecs_type_t
 /* This allows passing 0 as type to functions that accept types */
 #define T0 (0)
 
+/* This id can be used to indicate an entity handle is not set */
+#define ECS_INVALID_ENTITY ((ecs_entity_t)-1)
+
 FLECS_EXPORT
 extern const char 
     *ECS_COMPONENT_ID,

--- a/include/private/flecs.h
+++ b/include/private/flecs.h
@@ -151,6 +151,12 @@ int16_t ecs_type_index_of(
     ecs_array_t *type,
     ecs_entity_t component);
 
+/* Get number of containers (parents) for a type */
+int32_t ecs_type_container_depth(
+   ecs_world_t *world,
+   ecs_type_t type,
+   ecs_entity_t component);
+
 /* -- Table API -- */
 
 /* Initialize table */

--- a/include/private/types.h
+++ b/include/private/types.h
@@ -91,9 +91,9 @@ typedef struct EcsSystem {
     ecs_array_t *columns;          /* Column components */
     ecs_type_t not_from_entity;    /* Exclude components from entity */
     ecs_type_t not_from_component; /* Exclude components from components */
-    ecs_type_t and_from_entity;   /* Which components are required from entity */
+    ecs_type_t and_from_entity;  /* Which components are required from entity */
     ecs_type_t and_from_system;    /* Used to auto-add components to system */
-    ecs_entity_t cascade_by;       /* Component used for ordering system tables */
+    int32_t cascade_by;            /* CASCADE column index */
     EcsSystemKind kind;            /* Kind of system */
     float time_spent;              /* Time spent on running system */
     bool enabled;                  /* Is system enabled or not */

--- a/include/private/types.h
+++ b/include/private/types.h
@@ -93,6 +93,7 @@ typedef struct EcsSystem {
     ecs_type_t not_from_component; /* Exclude components from components */
     ecs_type_t and_from_entity;   /* Which components are required from entity */
     ecs_type_t and_from_system;    /* Used to auto-add components to system */
+    ecs_entity_t cascade_by;       /* Component used for ordering system tables */
     EcsSystemKind kind;            /* Kind of system */
     float time_spent;              /* Time spent on running system */
     bool enabled;                  /* Is system enabled or not */

--- a/include/private/types.h
+++ b/include/private/types.h
@@ -45,7 +45,8 @@ typedef enum ecs_system_expr_elem_kind_t {
     EcsFromSystem,          /* Get component from system */
     EcsFromId,              /* Get entity handle by id */
     EcsFromSingleton,       /* Get singleton component */
-    EcsFromEntity           /* Get component from other entity */
+    EcsFromEntity,          /* Get component from other entity */
+    EcsCascade              /* Walk component in cascading (hierarchy) order */
 } ecs_system_expr_elem_kind_t;
 
 /** Type describing an operator used in an signature of a system signature */

--- a/src/entity.c
+++ b/src/entity.c
@@ -565,6 +565,8 @@ void ecs_set_watching(
                 world->main_stage.entity_index, entity, ecs_from_row(row));
         }
     }
+
+    world->should_match = true;
 }
 
 /* -- Public functions -- */

--- a/src/parser.c
+++ b/src/parser.c
@@ -53,6 +53,8 @@ char* parse_complex_elem(
             /* default */
         } else if (!strncmp(bptr, "ID", dot - bptr)) {
             *elem_kind = EcsFromId;
+        } else if (!strncmp(bptr, "CASCADE", dot - bptr)) {
+            *elem_kind = EcsCascade;            
         } else {
             *elem_kind = EcsFromEntity;
             *source = bptr;

--- a/src/system.c
+++ b/src/system.c
@@ -92,6 +92,7 @@ ecs_entity_t new_row_system(
     system_data->base.signature = sig;
     system_data->base.enabled = true;
     system_data->base.kind = kind;
+    system_data->base.cascade_by = 0;
     system_data->components = ecs_array_new(&handle_arr_params, count);
 
     if (ecs_parse_component_expr(
@@ -173,7 +174,7 @@ void ecs_system_compute_and_families(
                   world, NULL, system_data->and_from_system, elem->is.component);
             }
         } else if (elem_kind == EcsCascade) {
-            system_data->cascade_by = elem->is.component;
+            system_data->cascade_by = i + 1;
         }
     }
 }
@@ -399,9 +400,11 @@ ecs_entity_t ecs_new_system(
         ecs_abort(ECS_INVALID_PARAMETERS, 0);
     }
 
-    if (needs_tables && (kind == EcsOnUpdate || kind == EcsOnValidate || kind == EcsPreUpdate ||
-                         kind == EcsPostUpdate || kind == EcsManual ||
-                         kind == EcsOnLoad || kind == EcsOnStore))
+    if (needs_tables && (kind == EcsOnLoad ||
+                         kind == EcsPreUpdate || kind == EcsOnUpdate ||
+                         kind == EcsOnValidate || kind == EcsPostUpdate ||
+                         kind == EcsPreStore || kind == EcsOnStore ||
+                         kind == EcsManual))
     {
         result = ecs_new_col_system(world, id, kind, sig, action);
     } else if (!needs_tables ||

--- a/src/system.c
+++ b/src/system.c
@@ -172,6 +172,8 @@ void ecs_system_compute_and_families(
                 system_data->and_from_system = ecs_type_add(
                   world, NULL, system_data->and_from_system, elem->is.component);
             }
+        } else if (elem_kind == EcsCascade) {
+            system_data->cascade_by = elem->is.component;
         }
     }
 }

--- a/src/table_system.c
+++ b/src/table_system.c
@@ -130,10 +130,6 @@ ecs_entity_t get_entity_for_component(
         }
     }
 
-    /* This function must only be called if it has already been validated that
-     * a component is available for a given type or entity */
-    assert(entity != 0);
-
     return entity;
 }
 
@@ -182,38 +178,40 @@ void add_table(
     for (c = 0; c < count; c ++) {
         ecs_system_column_t *column = &columns[c];
         ecs_entity_t entity = 0, component = 0;
+        ecs_system_expr_elem_kind_t kind = column->kind;
+        ecs_system_expr_oper_kind_t oper_kind = column->oper_kind;
 
-        /* Column that retrieves data from an entity */
-        if (column->kind == EcsFromSelf || column->kind == EcsFromEntity) {
-            if (column->oper_kind == EcsOperAnd) {
+        /* Column that retrieves data from self or a fixed entity */
+        if (kind == EcsFromSelf || kind == EcsFromEntity) {
+            if (oper_kind == EcsOperAnd) {
                 component = column->is.component;
-            } else if (column->oper_kind == EcsOperOptional) {
+            } else if (oper_kind == EcsOperOptional) {
                 component = column->is.component;
-            } else if (column->oper_kind == EcsOperOr) {
+            } else if (oper_kind == EcsOperOr) {
                 component = ecs_type_contains(
                     world, &world->main_stage, table_type, column->is.type, 
                     false, true);
             }
 
-            if (column->kind == EcsFromEntity) {
+            if (kind == EcsFromEntity) {
                 entity = column->source;
             }
 
         /* Column that just passes a handle to the system (no data) */
-        } else if (column->kind == EcsFromId) {
+        } else if (kind == EcsFromId) {
             component = column->is.component;
             table_data[i] = 0;
 
-        /* Column that retrieves data from a component */
-        } else if (column->kind == EcsFromContainer || column->kind == EcsCascade) {
-            if (column->oper_kind == EcsOperAnd ||
-                column->oper_kind == EcsOperOptional)
+        /* Column that retrieves data from a dynamic entity */
+        } else if (kind == EcsFromContainer || kind == EcsCascade) {
+            if (oper_kind == EcsOperAnd ||
+                oper_kind == EcsOperOptional)
             {
                 component = column->is.component;
                 components_contains_component(
                     world, table_type, component, &entity);
 
-            } else if (column->oper_kind == EcsOperOr) {
+            } else if (oper_kind == EcsOperOr) {
                 component = components_contains(
                     world,
                     table_type,
@@ -223,22 +221,22 @@ void add_table(
             }
 
         /* Column that retrieves data from a system */
-        } else if (column->kind == EcsFromSystem) {
-            if (column->oper_kind == EcsOperAnd) {
+        } else if (kind == EcsFromSystem) {
+            if (oper_kind == EcsOperAnd) {
                 component = column->is.component;
             }
 
             entity = system;
 
         /* Column that retrieves singleton components */
-        } else if (column->kind == EcsFromSingleton) {
+        } else if (kind == EcsFromSingleton) {
             component = column->is.component;
             entity = 0;
         }
 
         /* This column does not retrieve data from a static entity (either
          * EcsFromSystem or EcsFromContainer) and is not just a handle */
-        if (!entity && column->kind != EcsFromId) {
+        if (!entity && kind != EcsFromId) {
             if (component) {
                 /* Retrieve offset for component */
                 table_data[i] = ecs_type_index_of(table->type, component);
@@ -267,7 +265,7 @@ void add_table(
             }
         }
 
-        if (column->oper_kind == EcsOperOptional) {
+        if (oper_kind == EcsOperOptional) {
             /* If table doesn't have the field, mark it as no data */
             if (!ecs_type_contains_component(
                 world, &world->main_stage, table_type, component, true))
@@ -276,9 +274,25 @@ void add_table(
             }
         }
 
-        /* If entity is set, or component is not found in table, add it as a ref
-         * to data of a specific entity. */
-        if (entity || table_data[i] == -1 || column->kind == EcsFromSingleton) {
+        /* Check if a the component is a reference. If 'entity' is set, the
+         * component must be resolved from another entity, which is the case
+         * for FromEntity and FromContainer. 
+         * 
+         * If no entity is set but the component is not found in the table, it
+         * must come from a prefab. This is guaranteed, as at this point it is
+         * already validated that the table matches with the system.
+         * 
+         * If the column kind is FromSingleton, the entity will be 0, but still
+         * a reference needs to be added to the singleton component.
+         * 
+         * If the column kind is Cascade, there may not be an entity in case the
+         * current table contains root entities. In that case, still add a
+         * reference field. The application can, after the table has matched,
+         * change the set of components, so that this column will turn into a
+         * reference. Having the reference already linked to the system table
+         * makes changing this administation easier when the change happens.
+         * */
+        if (entity || table_data[i] == -1 || kind == EcsFromSingleton || kind == EcsCascade) {
             if (ecs_has(world, component, EcsComponent)) {
                 EcsComponent *component_data = ecs_get_ptr(
                         world, component, EcsComponent);
@@ -292,13 +306,19 @@ void add_table(
                     }
 
                     /* Find the entity for the component */
-                    if (column->kind == EcsFromSingleton) {
+                    if (kind == EcsFromSingleton) {
                         e = 0;
-                    } else if (column->kind == EcsFromEntity) {
+                    } else if (kind == EcsFromEntity) {
                         e = entity;
                     } else {
                         e = get_entity_for_component(
                             world, entity, table_type, component);
+
+                        if (kind != EcsCascade) {
+                            ecs_assert(e != 0, ECS_INTERNAL_ERROR, NULL);
+                        } else if (!e) {
+                            e = ECS_INVALID_ENTITY;
+                        }
                     }
 
                     ref_data[ref].entity = e;
@@ -501,11 +521,21 @@ int table_compare(
     return table_1_data[DEPTH_INDEX] - table_2_data[DEPTH_INDEX];
 }
 
+static
+ecs_entity_t get_cascade_component(
+    EcsColSystem *system_data)
+{
+    ecs_system_column_t *column = ecs_array_buffer(system_data->base.columns);
+    return column[system_data->base.cascade_by - 1].is.component;
+}
+
+static
 void order_cascade_tables(
     ecs_world_t *world,
     EcsColSystem *system_data)
 {
     uint32_t i, count = ecs_array_count(system_data->tables);
+    ecs_entity_t cascade_component = get_cascade_component(system_data);
 
     for (i = 0; i < count; i ++) {
         int32_t *table_data = ecs_array_get(
@@ -513,7 +543,7 @@ void order_cascade_tables(
         ecs_table_t *tables = ecs_array_buffer(world->main_stage.tables);
         ecs_type_t type = tables[table_data[TABLE_INDEX]].type_id;
         table_data[DEPTH_INDEX] = ecs_type_container_depth(
-            world, type, system_data->base.cascade_by);
+            world, type, cascade_component);
     }
 
     ecs_array_sort(system_data->tables, &system_data->table_params, table_compare);
@@ -564,7 +594,131 @@ int32_t table_matched(
     return -1;
 }
 
-/* -- Private functions -- */
+/* Does a system have references to shared components */
+static
+bool has_refs(
+    EcsColSystem *system_data)
+{
+    uint32_t i, count = ecs_array_count(system_data->base.columns);
+    ecs_system_column_t *columns = ecs_array_buffer(system_data->base.columns);
+
+    for (i = 0; i < count; i ++) {
+        ecs_system_expr_elem_kind_t elem_kind = columns[i].kind;
+
+        if (columns[i].oper_kind == EcsOperNot && elem_kind == EcsFromId) {
+            /* Special case: if oper kind is Not and the query contained a
+             * shared expression, the expression is translated to FromId to
+             * prevent resolving the ref */
+            return true;
+        } else if (elem_kind != EcsFromSelf && elem_kind != EcsFromId) {
+            /* If the component is not from the entity being iterated over, and
+             * the column is not just passing an id, it must be a reference to
+             * another entity. */
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static
+void resolve_cascade_container(
+    ecs_world_t *world,
+    EcsColSystem *system_data,
+    int32_t table_data_index,
+    ecs_type_t table_type)
+{
+    int32_t *table_data = ecs_array_get(
+        system_data->tables, &system_data->table_params, table_data_index);
+    
+    ecs_assert(table_data[REFS_INDEX] != 0, ECS_INTERNAL_ERROR, NULL);
+
+    /* Obtain reference index */
+    int32_t *column_indices = &table_data[COLUMNS_INDEX];
+    int32_t column = system_data->base.cascade_by - 1;
+    int32_t ref_index = -column_indices[column] - 1;
+
+    /* Obtain pointer to the reference data */
+    ecs_reference_t *references = ecs_array_get(
+        system_data->refs, &system_data->ref_params, table_data[REFS_INDEX]-1);
+    ecs_reference_t *ref = &references[ref_index];
+    ecs_assert(ref->component == get_cascade_component(system_data), 
+        ECS_INTERNAL_ERROR, NULL);
+
+    /* Resolve container entity */
+    ecs_entity_t container = 0;
+    components_contains_component(
+        world, table_type, ref->component, &container);        
+
+    /* If container was found, update the reference */
+    if (container) {
+        references[ref_index].entity = container;
+    } else {
+        references[ref_index].entity = ECS_INVALID_ENTITY;
+    }
+}
+
+/* -- Private API -- */
+
+/* Rematch system with tables after a change happened to a container or prefab */
+void ecs_rematch_system(
+    ecs_world_t *world,
+    ecs_entity_t system)
+{
+    EcsColSystem *system_data = ecs_get_ptr(world, system, EcsColSystem);
+    ecs_assert(system_data != NULL, ECS_INTERNAL_ERROR, 0);
+
+    /* Only rematch systems that have references */
+    if (has_refs(system_data)) {
+        ecs_array_t *tables = world->main_stage.tables;
+        uint32_t i, count = ecs_array_count(tables);
+        ecs_table_t *buffer = ecs_array_buffer(tables);
+        bool changed = false;
+
+        for (i = 0; i < count; i ++) {
+            /* Is the system currently matched with the table? */
+            int32_t match = table_matched(world, system_data, system_data->tables, i);
+            ecs_table_t *table = &buffer[i];
+
+            if (match_table(world, table, system_data)) {
+                /* If the table matches, and it is not currently matched, add */
+                if (match == -1) {
+                    add_table(world, system, system_data, table);
+                    changed = true;
+
+                /* If table still matches and has cascade column, reevaluate the
+                 * sources of references. This may have changed in case 
+                 * components were added/removed to container entities */ 
+                } else if (system_data->base.cascade_by) {
+                    resolve_cascade_container(
+                        world, system_data, match, table->type_id);
+                }
+            } else {
+                /* If table no longer matches, remove it */
+                if (match != -1) {
+                    remove_table(world, system_data, system_data->tables, match);
+                    changed = true;
+                } else {
+                    /* Make sure the table is removed if it was inactive */
+                    match = table_matched(
+                        world, system_data, system_data->inactive_tables, i);
+                    if (match != -1) {
+                        remove_table(
+                            world, system_data, system_data->inactive_tables, 
+                            match);
+                        changed = true;
+                    }
+                }
+            }
+        }
+
+        /* If the system has a CASCADE column and modifications were made, 
+         * reorder the system tables so that the depth order is preserved */
+        if (changed && system_data->base.cascade_by) {
+            order_cascade_tables(world, system_data);
+        }
+    }
+}
 
 /** Match new table against system (table is created after system) */
 void ecs_col_system_notify_of_table(
@@ -637,8 +791,6 @@ void ecs_system_activate_table(
     }
 }
 
-/* -- Private API -- */
-
 ecs_entity_t ecs_new_col_system(
     ecs_world_t *world,
     const char *id,
@@ -665,6 +817,7 @@ ecs_entity_t ecs_new_col_system(
     system_data->base.time_spent = 0;
     system_data->base.columns = ecs_array_new(&column_arr_params, count);
     system_data->base.kind = kind;
+    system_data->base.cascade_by = 0;
 
     system_data->table_params.element_size = sizeof(int32_t) * (count + COLUMNS_INDEX);
     system_data->ref_params.element_size = sizeof(ecs_system_ref_t) * count;
@@ -720,68 +873,6 @@ ecs_entity_t ecs_new_col_system(
     *elem = result;
 
     return result;
-}
-
-static
-bool has_refs(
-    EcsColSystem *system_data)
-{
-    uint32_t i, count = ecs_array_count(system_data->base.columns);
-    ecs_system_column_t *columns = ecs_array_buffer(system_data->base.columns);
-
-    for (i = 0; i < count; i ++) {
-        ecs_system_expr_elem_kind_t elem_kind = columns[i].kind;
-
-        if (columns[i].oper_kind == EcsOperNot && elem_kind == EcsFromId) {
-            /* Special case: if oper kind is Not and the query contained a
-             * shared expression, the expression is translated to FromId to
-             * prevent resolving the ref */
-            return true;
-        } else if (elem_kind != EcsFromSelf && elem_kind != EcsFromId) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-void ecs_rematch_system(
-    ecs_world_t *world,
-    ecs_entity_t system)
-{
-    EcsColSystem *system_data = ecs_get_ptr(world, system, EcsColSystem);
-    ecs_assert(system_data != NULL, ECS_INTERNAL_ERROR, 0);
-
-    if (has_refs(system_data)) {
-        ecs_array_t *tables = world->main_stage.tables;
-        uint32_t i, count = ecs_array_count(tables);
-        ecs_table_t *buffer = ecs_array_buffer(tables);
-
-        for (i = 0; i < count; i ++) {
-            if (match_table(world, &buffer[i], system_data)) {
-                if (table_matched(world, system_data, system_data->tables, i) == -1) {
-                    add_table(world, system, system_data, &buffer[i]);
-                }
-            } else {
-                int32_t match = table_matched(world, system_data, system_data->tables, i);
-
-                if (match != -1) {
-                    remove_table(world, system_data, system_data->tables, match);
-                } else {
-                    match = table_matched(
-                        world, system_data, system_data->inactive_tables, i);
-                    if (match != -1) {
-                        remove_table(
-                            world, system_data, system_data->inactive_tables, match);
-                    }
-                }
-            }
-        }
-
-        if (system_data->base.cascade_by) {
-            order_cascade_tables(world, system_data);
-        }
-    }
 }
 
 /* -- Public API -- */
@@ -938,10 +1029,18 @@ ecs_entity_t _ecs_run_w_filter(
             for (i = 0; i < ref_count; i ++) {
                 ecs_entity_info_t entity_info = {0};
 
-                info.ref_ptrs[i] = get_ptr(real_world, &real_world->main_stage,
-                    info.references[i].entity, info.references[i].component, false, true, &entity_info);
+                ecs_reference_t ref = info.references[i];
 
-                ecs_assert(info.ref_ptrs[i] != NULL, ECS_UNRESOLVED_REFERENCE, ecs_id(world, system));
+                if (ref.entity != ECS_INVALID_ENTITY) {
+                    info.ref_ptrs[i] = get_ptr(real_world, &real_world->main_stage,
+                        info.references[i].entity, info.references[i].component, 
+                        false, true, &entity_info);
+                        
+                    ecs_assert(info.ref_ptrs[i] != NULL, 
+                        ECS_UNRESOLVED_REFERENCE, ecs_id(world, system));
+                } else {
+                    info.ref_ptrs[i] = NULL;
+                }
             }
         } else {
             info.references = NULL;

--- a/src/world.c
+++ b/src/world.c
@@ -455,7 +455,7 @@ void load_admin(
     ecs_type_t TEcsAdmin = ecs_type_from_entity(world, admin);
     ecs_set(world, 0, EcsAdmin, {port});
 
-    printf("Admin is running in port %d\n", port);
+    printf("Admin is running on port %d\n", port);
 #else
     fprintf(stderr, 
         "sorry, loading the admin is only possible if flecs was built with bake :(");

--- a/src/world.c
+++ b/src/world.c
@@ -866,7 +866,7 @@ void stop_measure_frame(
             }
             world->fps_sleep = sleep;
 
-            if (sleep > 0.008) {
+            if (sleep > 0.005) {
                 ecs_sleepf(sleep);
             }
         }

--- a/test/api/project.json
+++ b/test/api/project.json
@@ -258,6 +258,11 @@
                 "match_2_systems_w_populated_table"
             ]
         }, {
+            "id": "SystemCascade",
+            "testcases": [
+                "cascade_1_component"
+            ]
+        }, {
             "id": "SystemManual",
             "testcases": [
                 "1_type_1_component"

--- a/test/api/project.json
+++ b/test/api/project.json
@@ -261,7 +261,9 @@
             "id": "SystemCascade",
             "testcases": [
                 "cascade_depth_1",
-                "cascade_depth_2"
+                "cascade_depth_2",
+                "add_after_match",
+                "adopt_after_match"
             ]
         }, {
             "id": "SystemManual",
@@ -337,6 +339,7 @@
                 "2_column_1_from_container_w_not_prefab",
                 "3_column_1_from_comtainer_1_from_container_w_not",
                 "2_column_1_from_container_w_or",
+                "select_same_from_container",
                 "add_component_after_match",
                 "add_component_after_match_unmatch",
                 "add_component_after_match_unmatch_match",

--- a/test/api/project.json
+++ b/test/api/project.json
@@ -260,7 +260,8 @@
         }, {
             "id": "SystemCascade",
             "testcases": [
-                "cascade_1_component"
+                "cascade_depth_1",
+                "cascade_depth_2"
             ]
         }, {
             "id": "SystemManual",
@@ -340,7 +341,9 @@
                 "add_component_after_match_unmatch",
                 "add_component_after_match_unmatch_match",
                 "add_component_after_match_2_systems",
-                "add_component_in_progress_after_match"
+                "add_component_in_progress_after_match",
+                "adopt_after_match",
+                "new_child_after_match"
             ]
         }, {
             "id": "System_w_FromId",

--- a/test/api/src/SystemCascade.c
+++ b/test/api/src/SystemCascade.c
@@ -1,0 +1,81 @@
+#include <include/api.h>
+
+static
+void Iter(ecs_rows_t *rows) {
+    ECS_COLUMN(rows, Position, p, 1);
+    ECS_SHARED_TEST(rows, Position, p_parent, 2);
+
+    ProbeSystem(rows);
+
+    int i;
+    for (i = 0; i < rows->count; i ++) {
+        p[i].x ++;
+        p[i].y ++;
+
+        if (p_parent) {
+            p[i].x += p_parent->x;
+            p[i].y += p_parent->y;
+        }
+    }
+}
+
+void SystemCascade_cascade_1_component() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_COMPONENT(world, Position);
+
+    ECS_ENTITY(world, e_1, Position);
+    ECS_ENTITY(world, e_2, Position);
+    ECS_ENTITY(world, e_3, Position);
+    ECS_ENTITY(world, e_4, Position);
+
+    ECS_SYSTEM(world, Iter, EcsOnUpdate, Position, CASCADE.Position);
+
+    ecs_set(world, e_1, Position, {1, 2});
+    ecs_set(world, e_2, Position, {1, 2});
+    ecs_set(world, e_3, Position, {1, 2});
+    ecs_set(world, e_4, Position, {1, 2});
+
+    ecs_adopt(world, e_3, e_1);
+    ecs_adopt(world, e_4, e_2);
+
+    SysTestData ctx = {0};
+    ecs_set_context(world, &ctx);
+
+    ecs_progress(world, 1);
+
+    test_int(ctx.count, 4);
+    test_int(ctx.invoked, 1);
+    test_int(ctx.system, Iter);
+    test_int(ctx.column_count, 2);
+    test_null(ctx.param);
+
+    test_int(ctx.e[0], e_1);
+    test_int(ctx.e[1], e_2);
+    test_int(ctx.e[2], e_3);
+    test_int(ctx.e[3], e_4);
+    test_int(ctx.c[0][0], ecs_to_entity(Position));
+    test_int(ctx.s[0][0], 0);
+
+    Position *p = ecs_get_ptr(world, e_1, Position);
+    test_assert(p != NULL);
+    test_int(p->x, 2);
+    test_int(p->y, 3);
+
+    p = ecs_get_ptr(world, e_2, Position);
+    test_assert(p != NULL);
+    test_int(p->x, 2);
+    test_int(p->y, 3);
+
+    p = ecs_get_ptr(world, e_3, Position);
+    test_assert(p != NULL);
+    test_int(p->x, 4);
+    test_int(p->y, 6);
+
+    p = ecs_get_ptr(world, e_4, Position);
+    test_assert(p != NULL);
+    test_int(p->x, 4);
+    test_int(p->y, 6);
+
+    ecs_fini(world);
+}

--- a/test/api/src/SystemCascade.c
+++ b/test/api/src/SystemCascade.c
@@ -158,3 +158,155 @@ void SystemCascade_cascade_depth_2() {
 
     ecs_fini(world);
 }
+
+static
+void AddParent(ecs_rows_t *rows) {
+    ECS_COLUMN(rows, Position, p, 1);
+    ECS_SHARED_TEST(rows, Position, p_parent, 2);
+
+    ProbeSystem(rows);
+
+    int i;
+    for (i = 0; i < rows->count; i ++) {
+        if (p_parent) {
+            p[i].x += p_parent->x;
+            p[i].y += p_parent->y;
+        }
+    }
+}
+
+void SystemCascade_add_after_match() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_COMPONENT(world, Position);
+
+    ECS_ENTITY(world, e_1, Position);
+    ECS_ENTITY(world, e_2, Position);
+    ECS_ENTITY(world, e_3, Position);
+    ECS_ENTITY(world, e_4, Position);
+
+    ECS_SYSTEM(world, AddParent, EcsOnUpdate, Position, CASCADE.Position);
+
+    ecs_entity_t parent = ecs_new(world, 0);
+    ecs_set(world, e_1, Position, {1, 2});
+    ecs_set(world, e_2, Position, {1, 2});
+    ecs_set(world, e_3, Position, {1, 2});
+    ecs_set(world, e_4, Position, {1, 2});
+
+    ecs_adopt(world, e_3, parent);
+    ecs_adopt(world, e_4, parent);
+
+    SysTestData ctx = {0};
+    ecs_set_context(world, &ctx);
+
+    ecs_progress(world, 1);
+
+    ecs_set(world, parent, Position, {1, 2});
+
+    ctx = (SysTestData){0};
+
+    ecs_progress(world, 1);
+
+    test_int(ctx.count, 5);
+    test_int(ctx.invoked, 3);
+    test_int(ctx.system, AddParent);
+    test_int(ctx.column_count, 2);
+    test_null(ctx.param);
+
+    test_int(ctx.e[0], e_1);
+    test_int(ctx.e[1], e_2);
+    test_int(ctx.e[2], parent);
+    test_int(ctx.e[3], e_3);
+    test_int(ctx.e[4], e_4);
+    test_int(ctx.c[0][0], ecs_to_entity(Position));
+    test_int(ctx.s[0][0], 0);
+
+    Position *p = ecs_get_ptr(world, e_1, Position);
+    test_assert(p != NULL);
+    test_int(p->x, 1);
+    test_int(p->y, 2);
+
+    p = ecs_get_ptr(world, e_2, Position);
+    test_assert(p != NULL);
+    test_int(p->x, 1);
+    test_int(p->y, 2);
+
+    p = ecs_get_ptr(world, e_3, Position);
+    test_assert(p != NULL);
+    test_int(p->x, 2);
+    test_int(p->y, 4);
+
+    p = ecs_get_ptr(world, e_4, Position);
+    test_assert(p != NULL);
+    test_int(p->x, 2);
+    test_int(p->y, 4);
+
+    ecs_fini(world);
+}
+
+void SystemCascade_adopt_after_match() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_COMPONENT(world, Position);
+
+    ECS_ENTITY(world, e_1, Position);
+    ECS_ENTITY(world, e_2, Position);
+    ECS_ENTITY(world, e_3, Position);
+    ECS_ENTITY(world, e_4, Position);
+
+    ECS_SYSTEM(world, AddParent, EcsOnUpdate, Position, CASCADE.Position);
+
+    ecs_entity_t parent = ecs_set(world, 0, Position, {1, 2});
+    ecs_set(world, e_1, Position, {1, 2});
+    ecs_set(world, e_2, Position, {1, 2});
+    ecs_set(world, e_3, Position, {1, 2});
+    ecs_set(world, e_4, Position, {1, 2});
+
+    SysTestData ctx = {0};
+    ecs_set_context(world, &ctx);
+
+    ecs_progress(world, 1);
+
+    ecs_adopt(world, e_3, parent);
+    ecs_adopt(world, e_4, parent);
+
+    ctx = (SysTestData){0};
+
+    ecs_progress(world, 1);
+
+    test_int(ctx.count, 5);
+    test_int(ctx.invoked, 3);
+    test_int(ctx.system, AddParent);
+    test_int(ctx.column_count, 2);
+    test_null(ctx.param);
+
+    test_int(ctx.e[0], e_1);
+    test_int(ctx.e[1], e_2);
+    test_int(ctx.e[2], parent);
+    test_int(ctx.e[3], e_3);
+    test_int(ctx.e[4], e_4);
+    test_int(ctx.c[0][0], ecs_to_entity(Position));
+    test_int(ctx.s[0][0], 0);
+
+    Position *p = ecs_get_ptr(world, e_1, Position);
+    test_assert(p != NULL);
+    test_int(p->x, 1);
+    test_int(p->y, 2);
+
+    p = ecs_get_ptr(world, e_2, Position);
+    test_assert(p != NULL);
+    test_int(p->x, 1);
+    test_int(p->y, 2);
+
+    p = ecs_get_ptr(world, e_3, Position);
+    test_assert(p != NULL);
+    test_int(p->x, 2);
+    test_int(p->y, 4);
+
+    p = ecs_get_ptr(world, e_4, Position);
+    test_assert(p != NULL);
+    test_int(p->x, 2);
+    test_int(p->y, 4);
+
+    ecs_fini(world);
+}

--- a/test/api/src/SystemCascade.c
+++ b/test/api/src/SystemCascade.c
@@ -19,7 +19,7 @@ void Iter(ecs_rows_t *rows) {
     }
 }
 
-void SystemCascade_cascade_1_component() {
+void SystemCascade_cascade_depth_1() {
     ecs_world_t *world = ecs_init();
 
     ECS_COMPONENT(world, Position);
@@ -45,15 +45,15 @@ void SystemCascade_cascade_1_component() {
     ecs_progress(world, 1);
 
     test_int(ctx.count, 4);
-    test_int(ctx.invoked, 1);
+    test_int(ctx.invoked, 3);
     test_int(ctx.system, Iter);
     test_int(ctx.column_count, 2);
     test_null(ctx.param);
 
     test_int(ctx.e[0], e_1);
     test_int(ctx.e[1], e_2);
-    test_int(ctx.e[2], e_3);
-    test_int(ctx.e[3], e_4);
+    test_int(ctx.e[2], e_4);
+    test_int(ctx.e[3], e_3);
     test_int(ctx.c[0][0], ecs_to_entity(Position));
     test_int(ctx.s[0][0], 0);
 
@@ -76,6 +76,85 @@ void SystemCascade_cascade_1_component() {
     test_assert(p != NULL);
     test_int(p->x, 4);
     test_int(p->y, 6);
+
+    ecs_fini(world);
+}
+
+void SystemCascade_cascade_depth_2() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_COMPONENT(world, Position);
+
+    ECS_ENTITY(world, e_1, Position);
+    ECS_ENTITY(world, e_2, Position);
+    ECS_ENTITY(world, e_3, Position);
+    ECS_ENTITY(world, e_4, Position);
+    ECS_ENTITY(world, e_5, Position);
+    ECS_ENTITY(world, e_6, Position);
+
+    ECS_SYSTEM(world, Iter, EcsOnUpdate, Position, CASCADE.Position);
+
+    ecs_set(world, e_1, Position, {1, 2});
+    ecs_set(world, e_2, Position, {1, 2});
+    ecs_set(world, e_3, Position, {1, 2});
+    ecs_set(world, e_4, Position, {1, 2});
+    ecs_set(world, e_5, Position, {1, 2});
+    ecs_set(world, e_6, Position, {1, 2});
+
+    ecs_adopt(world, e_3, e_1);
+    ecs_adopt(world, e_4, e_2);
+    ecs_adopt(world, e_5, e_3);
+    ecs_adopt(world, e_6, e_4);
+
+    SysTestData ctx = {0};
+    ecs_set_context(world, &ctx);
+
+    ecs_progress(world, 1);
+
+    test_int(ctx.count, 6);
+    test_int(ctx.invoked, 5);
+    test_int(ctx.system, Iter);
+    test_int(ctx.column_count, 2);
+    test_null(ctx.param);
+
+    test_int(ctx.e[0], e_1);
+    test_int(ctx.e[1], e_2);
+    test_int(ctx.e[2], e_3);
+    test_int(ctx.e[3], e_4);
+    test_int(ctx.e[4], e_6);
+    test_int(ctx.e[5], e_5);    
+    test_int(ctx.c[0][0], ecs_to_entity(Position));
+    test_int(ctx.s[0][0], 0);
+
+    Position *p = ecs_get_ptr(world, e_1, Position);
+    test_assert(p != NULL);
+    test_int(p->x, 2);
+    test_int(p->y, 3);
+
+    p = ecs_get_ptr(world, e_2, Position);
+    test_assert(p != NULL);
+    test_int(p->x, 2);
+    test_int(p->y, 3);
+
+    p = ecs_get_ptr(world, e_3, Position);
+    test_assert(p != NULL);
+    test_int(p->x, 4);
+    test_int(p->y, 6);
+
+    p = ecs_get_ptr(world, e_4, Position);
+    test_assert(p != NULL);
+    test_int(p->x, 4);
+    test_int(p->y, 6);
+
+    p = ecs_get_ptr(world, e_5, Position);
+    test_assert(p != NULL);
+    test_int(p->x, 6);
+    test_int(p->y, 9);
+
+    p = ecs_get_ptr(world, e_6, Position);
+    test_assert(p != NULL);
+    test_int(p->x, 6);
+    test_int(p->y, 9);
 
     ecs_fini(world);
 }

--- a/test/api/src/System_w_FromContainer.c
+++ b/test/api/src/System_w_FromContainer.c
@@ -865,3 +865,99 @@ void System_w_FromContainer_add_component_in_progress_after_match() {
 
     ecs_fini(world);
 }
+
+void System_w_FromContainer_adopt_after_match() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_COMPONENT(world, Position);
+    ECS_COMPONENT(world, Mass);
+
+    ECS_ENTITY(world, e_1, Position);
+    ECS_ENTITY(world, e_2, Position);
+    ECS_ENTITY(world, e_3, Position);
+
+    ECS_SYSTEM(world, Iter, EcsOnUpdate, CONTAINER.Mass, Position);
+
+    ecs_entity_t parent = ecs_new(world, Mass);
+    ecs_adopt(world, e_1, parent);
+    ecs_adopt(world, e_2, parent);
+
+    ecs_set(world, parent, Mass, {2});
+
+    SysTestData ctx = {0};
+    ecs_set_context(world, &ctx);
+
+    ecs_progress(world, 1);
+
+    test_int(ctx.count, 2);
+    test_int(ctx.invoked, 1);
+    test_int(ctx.system, Iter);
+    test_int(ctx.column_count, 2);
+    test_null(ctx.param);
+
+    test_int(ctx.e[0], e_1);
+    test_int(ctx.e[1], e_2);
+    test_int(ctx.c[0][0], ecs_to_entity(Mass));
+    test_int(ctx.s[0][0], parent);
+    test_int(ctx.c[0][1], ecs_to_entity(Position));
+    test_int(ctx.s[0][1], 0);
+
+    Position *p = ecs_get_ptr(world, e_1, Position);
+    test_assert(p != NULL);
+    test_int(p->x, 20);
+    test_int(p->y, 40);
+
+    p = ecs_get_ptr(world, e_2, Position);
+    test_assert(p != NULL);
+    test_int(p->x, 20);
+    test_int(p->y, 40);
+
+    ecs_fini(world);
+}
+
+void System_w_FromContainer_new_child_after_match() {
+        ecs_world_t *world = ecs_init();
+
+    ECS_COMPONENT(world, Position);
+    ECS_COMPONENT(world, Mass);
+
+    ECS_ENTITY(world, e_3, Position);
+
+    ECS_SYSTEM(world, Iter, EcsOnUpdate, CONTAINER.Mass, Position);
+
+    ecs_entity_t parent = ecs_new(world, Mass);
+    ecs_entity_t e_1 = ecs_new_child(world, parent, Position);
+    ecs_entity_t e_2 = ecs_new_child(world, parent, Position);
+
+    ecs_set(world, parent, Mass, {2});
+
+    SysTestData ctx = {0};
+    ecs_set_context(world, &ctx);
+
+    ecs_progress(world, 1);
+
+    test_int(ctx.count, 2);
+    test_int(ctx.invoked, 1);
+    test_int(ctx.system, Iter);
+    test_int(ctx.column_count, 2);
+    test_null(ctx.param);
+
+    test_int(ctx.e[0], e_1);
+    test_int(ctx.e[1], e_2);
+    test_int(ctx.c[0][0], ecs_to_entity(Mass));
+    test_int(ctx.s[0][0], parent);
+    test_int(ctx.c[0][1], ecs_to_entity(Position));
+    test_int(ctx.s[0][1], 0);
+
+    Position *p = ecs_get_ptr(world, e_1, Position);
+    test_assert(p != NULL);
+    test_int(p->x, 20);
+    test_int(p->y, 40);
+
+    p = ecs_get_ptr(world, e_2, Position);
+    test_assert(p != NULL);
+    test_int(p->x, 20);
+    test_int(p->y, 40);
+
+    ecs_fini(world);
+}

--- a/test/api/src/main.c
+++ b/test/api/src/main.c
@@ -230,6 +230,8 @@ void SystemOnFrame_match_2_systems_w_populated_table(void);
 // Testsuite 'SystemCascade'
 void SystemCascade_cascade_depth_1(void);
 void SystemCascade_cascade_depth_2(void);
+void SystemCascade_add_after_match(void);
+void SystemCascade_adopt_after_match(void);
 
 // Testsuite 'SystemManual'
 void SystemManual_1_type_1_component(void);
@@ -295,6 +297,7 @@ void System_w_FromContainer_2_column_1_from_container_w_not(void);
 void System_w_FromContainer_2_column_1_from_container_w_not_prefab(void);
 void System_w_FromContainer_3_column_1_from_comtainer_1_from_container_w_not(void);
 void System_w_FromContainer_2_column_1_from_container_w_or(void);
+void System_w_FromContainer_select_same_from_container(void);
 void System_w_FromContainer_add_component_after_match(void);
 void System_w_FromContainer_add_component_after_match_unmatch(void);
 void System_w_FromContainer_add_component_after_match_unmatch_match(void);
@@ -1312,7 +1315,7 @@ static bake_test_suite suites[] = {
     },
     {
         .id = "SystemCascade",
-        .testcase_count = 2,
+        .testcase_count = 4,
         .testcases = (bake_test_case[]){
             {
                 .id = "cascade_depth_1",
@@ -1321,6 +1324,14 @@ static bake_test_suite suites[] = {
             {
                 .id = "cascade_depth_2",
                 .function = SystemCascade_cascade_depth_2
+            },
+            {
+                .id = "add_after_match",
+                .function = SystemCascade_add_after_match
+            },
+            {
+                .id = "adopt_after_match",
+                .function = SystemCascade_adopt_after_match
             }
         }
     },
@@ -1538,7 +1549,7 @@ static bake_test_suite suites[] = {
     },
     {
         .id = "System_w_FromContainer",
-        .testcase_count = 15,
+        .testcase_count = 16,
         .testcases = (bake_test_case[]){
             {
                 .id = "1_column_from_container",
@@ -1571,6 +1582,10 @@ static bake_test_suite suites[] = {
             {
                 .id = "2_column_1_from_container_w_or",
                 .function = System_w_FromContainer_2_column_1_from_container_w_or
+            },
+            {
+                .id = "select_same_from_container",
+                .function = System_w_FromContainer_select_same_from_container
             },
             {
                 .id = "add_component_after_match",

--- a/test/api/src/main.c
+++ b/test/api/src/main.c
@@ -228,7 +228,8 @@ void SystemOnFrame_use_fields_1_owned_1_shared(void);
 void SystemOnFrame_match_2_systems_w_populated_table(void);
 
 // Testsuite 'SystemCascade'
-void SystemCascade_cascade_1_component(void);
+void SystemCascade_cascade_depth_1(void);
+void SystemCascade_cascade_depth_2(void);
 
 // Testsuite 'SystemManual'
 void SystemManual_1_type_1_component(void);
@@ -299,6 +300,8 @@ void System_w_FromContainer_add_component_after_match_unmatch(void);
 void System_w_FromContainer_add_component_after_match_unmatch_match(void);
 void System_w_FromContainer_add_component_after_match_2_systems(void);
 void System_w_FromContainer_add_component_in_progress_after_match(void);
+void System_w_FromContainer_adopt_after_match(void);
+void System_w_FromContainer_new_child_after_match(void);
 
 // Testsuite 'System_w_FromId'
 void System_w_FromId_2_column_1_from_id(void);
@@ -1309,11 +1312,15 @@ static bake_test_suite suites[] = {
     },
     {
         .id = "SystemCascade",
-        .testcase_count = 1,
+        .testcase_count = 2,
         .testcases = (bake_test_case[]){
             {
-                .id = "cascade_1_component",
-                .function = SystemCascade_cascade_1_component
+                .id = "cascade_depth_1",
+                .function = SystemCascade_cascade_depth_1
+            },
+            {
+                .id = "cascade_depth_2",
+                .function = SystemCascade_cascade_depth_2
             }
         }
     },
@@ -1531,7 +1538,7 @@ static bake_test_suite suites[] = {
     },
     {
         .id = "System_w_FromContainer",
-        .testcase_count = 13,
+        .testcase_count = 15,
         .testcases = (bake_test_case[]){
             {
                 .id = "1_column_from_container",
@@ -1584,6 +1591,14 @@ static bake_test_suite suites[] = {
             {
                 .id = "add_component_in_progress_after_match",
                 .function = System_w_FromContainer_add_component_in_progress_after_match
+            },
+            {
+                .id = "adopt_after_match",
+                .function = System_w_FromContainer_adopt_after_match
+            },
+            {
+                .id = "new_child_after_match",
+                .function = System_w_FromContainer_new_child_after_match
             }
         }
     },

--- a/test/api/src/main.c
+++ b/test/api/src/main.c
@@ -227,6 +227,9 @@ void SystemOnFrame_use_fields_2_owned(void);
 void SystemOnFrame_use_fields_1_owned_1_shared(void);
 void SystemOnFrame_match_2_systems_w_populated_table(void);
 
+// Testsuite 'SystemCascade'
+void SystemCascade_cascade_1_component(void);
+
 // Testsuite 'SystemManual'
 void SystemManual_1_type_1_component(void);
 
@@ -1305,6 +1308,16 @@ static bake_test_suite suites[] = {
         }
     },
     {
+        .id = "SystemCascade",
+        .testcase_count = 1,
+        .testcases = (bake_test_case[]){
+            {
+                .id = "cascade_1_component",
+                .function = SystemCascade_cascade_1_component
+            }
+        }
+    },
+    {
         .id = "SystemManual",
         .testcase_count = 1,
         .testcases = (bake_test_case[]){
@@ -2190,5 +2203,5 @@ static bake_test_suite suites[] = {
 
 int main(int argc, char *argv[]) {
     ut_init(argv[0]);
-    return bake_test_run("api", argc, argv, suites, 29);
+    return bake_test_run("api", argc, argv, suites, 30);
 }


### PR DESCRIPTION
With `CASCADE` columns, systems can now easily walk entities in the order of the hierarchy (parent -> child -> grand child etc). A cascade query is created like this:

```
ECS_SYSTEM(world, Transform, Position, TransformMatrix, CASCADE.TransformMatrix);
```

This will walk the entities in the hierarchical order of containers that have the `TransformMatrix` component. When iterating, the cascade column will resolve to the container component as if the system had specified `CONTAINER.TransformMatrix`, or will resolve to `NULL` in case the entity is a root.