### PR TITLE
fix dangling reference/ptr to world in entity::type()

### DIFF
--- a/include/flecs/flecs.hpp
+++ b/include/flecs/flecs.hpp
@@ -1527,7 +1527,7 @@ inline filter_iterator snapshot::end() {
 ////////////////////////////////////////////////////////////////////////////////
 
 inline flecs::type entity::type() const {
-    return flecs::type(world(m_world), ecs_get_type(m_world, m_id));
+    return flecs::type(m_world, ecs_get_type(m_world, m_id));
 }
 
 inline flecs::type entity::to_type() const {


### PR DESCRIPTION
In https://github.com/SanderMertens/flecs/blob/master/include/flecs/flecs.hpp#L1530 a temporary flecs::world() is constructed from the `m_world` ptr and passed to the [flecs::type() constructor](https://github.com/SanderMertens/flecs/blob/master/include/flecs/flecs.hpp#L743-L759), which only takes a const reference to the passed world object (`const world& world`).
This leads to a dangling reference/pointer bug and in the below example it hits the assert in https://github.com/SanderMertens/flecs/blob/master/src/world.c#L377-L380 because the magic number comes out as garbage (since the world pointer is invalid)

A minimal example (based on the hello world tutorial to reproduce the issue)

```cpp
#include <helloworld.h>
#include <iostream>

int main(int argc, char *argv[]) {
    /* Create the world, pass arguments for overriding the number of threads,fps
     * or for starting the admin dashboard (see flecs.h for details). */
    flecs::world world(argc, argv);

    struct TagCmp {};
    flecs::component<TagCmp>(world, "TagCmp");

    auto ent = flecs::entity(world)
        .add<TagCmp>();

    auto type = ent.type();
    auto tstr = type.str(); // <--- hits assert while accessing dangling world ptr internally

    world.set_target_fps(60);

    std::cout << "Application helloworld is running, press CTRL-C to exit..." << std::endl;

    /* Run systems */
    while (world.progress()) { }
}
```

I am using VS 2019 16.4.3 on Windows 10 with CMake and a x64 build configuration.