### PR TITLE
Update meson build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,44 +1,48 @@
 project('flecs', 'c')
 
+if get_option('default_library') == 'shared'
+    add_project_arguments('-Dflecs_EXPORTS', language : 'c')
+endif
+
 flecs_inc = include_directories('include')
 
 flecs_deps = dependency('threads')
 
-flecs_src = files([
-    'src/addon/dbg.c',
-    'src/addon/reader.c',
-    'src/addon/ringbuf.c',
-    'src/addon/snapshot.c',
-    'src/addon/writer.c',
-    'src/api_support.c',
-    'src/bootstrap.c',
-    'src/bulk.c',
+flecs_src = files(
+    'src/vector.c',
+    'src/log.c',
+    'src/misc.c',
+    'src/os_api.c',
+    'src/type.c',
+    'src/sparse.c',
     'src/entity.c',
     'src/entity_index.c',
-    'src/err.c',
-    'src/filter.c',
+    'src/strbuf.c',
     'src/iter.c',
-    'src/map.c',
-    'src/misc.c',
+    'src/addon/writer.c',
+    'src/addon/ringbuf.c',
+    'src/addon/reader.c',
+    'src/addon/dbg.c',
+    'src/addon/snapshot.c',
+    'src/table.c',
+    'src/signature.c',
+    'src/world.c',
+    'src/stage.c',
+    'src/bootstrap.c',
+    'src/scope.c',
     'src/module.c',
+    'src/map.c',
+    'src/filter.c',
+    'src/query.c',
+    'src/api_support.c',
+    'src/modules/stats.c',
     'src/modules/pipeline/pipeline.c',
     'src/modules/pipeline/worker.c',
-    'src/modules/stats.c',
     'src/modules/system.c',
     'src/modules/timer.c',
-    'src/os_api.c',
-    'src/query.c',
-    'src/scope.c',
-    'src/signature.c',
-    'src/sparse.c',
-    'src/stage.c',
-    'src/strbuf.c',
-    'src/table.c',
     'src/table_graph.c',
-    'src/type.c',
-    'src/vector.c',
-    'src/world.c'
-])
+    'src/bulk.c'
+)
 
 install_headers('include/flecs.h')
 install_subdir('include/flecs', install_dir : get_option('includedir'))
@@ -55,6 +59,10 @@ flecs_dep = declare_dependency(
     dependencies : flecs_deps,
     include_directories : flecs_inc
 )
+
+if meson.version().version_compare('>= 0.54.0')
+    meson.override_dependency('flecs', flecs_dep)
+endif
 
 pkg = import('pkgconfig')
 pkg.generate(flecs_lib)

--- a/meson.build
+++ b/meson.build
@@ -60,6 +60,14 @@ flecs_dep = declare_dependency(
     include_directories : flecs_inc
 )
 
+helloword_inc = include_directories('examples/c/01_helloworld/include')
+
+helloworld_exe = executable('helloword',
+    'examples/c/01_helloworld/src/main.c',
+    include_directories : helloword_inc,
+    dependencies : flecs_dep
+)
+
 if meson.version().version_compare('>= 0.54.0')
     meson.override_dependency('flecs', flecs_dep)
 endif

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('flecs', 'c')
+project('flecs', 'c', license : 'mit', default_options : ['c_std=c99'])
 
 if get_option('default_library') == 'shared'
     add_project_arguments('-Dflecs_EXPORTS', language : 'c')

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('flecs', 'c', license : 'mit', default_options : ['c_std=c99'])
 
-if get_option('default_library') == 'shared'
-    add_project_arguments('-Dflecs_EXPORTS', language : 'c')
+if get_option('default_library') == 'static'
+    add_project_arguments('-DFLECS_STATIC', language : 'c')
 endif
 
 flecs_inc = include_directories('include')
@@ -50,6 +50,7 @@ install_subdir('include/flecs', install_dir : get_option('includedir'))
 flecs_lib = library('flecs',
     flecs_src,
     install : true,
+    c_args : '-Dflecs_EXPORTS',
     dependencies : flecs_deps,
     include_directories : flecs_inc
 )


### PR DESCRIPTION
Updated sources, added helloworld executable and `-Dflecs_EXPORTS` when building the library.

Specifies `FLECS_STATIC` for static builds, assuming the `#if` guard is added back into `bake_config.h`, this is needed because static builds should not tag functions with `dllimport/dllexport` in any case.

Adding `target_compile_options(flecs_static PUBLIC "-DFLECS_STATIC")` in the CMakefile would also get rid of link warnings on msvc.

`meson.override_dependency()` allows for `dependency(flecs)` in a superproject without having to specify dependency variable.