### PR TITLE
ecs_os_time_sleep(): use CreateWaitableTimer() on Windows

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -164,6 +164,14 @@ void ecs_os_time_sleep(
         ecs_os_err("nanosleep failed");
     }
 #else
-	Sleep(sec * 1000 + nanosec / 1000000);
+    HANDLE timer;
+	LARGE_INTEGER ft;
+
+	ft.QuadPart = -((int64_t)sec * 10000000 + (int64_t)nanosec / 100);
+
+	timer = CreateWaitableTimer(NULL, TRUE, NULL);
+	SetWaitableTimer(timer, &ft, 0, NULL, NULL, 0);
+	WaitForSingleObject(timer, INFINITE);
+	CloseHandle(timer);
 #endif
 }

--- a/src/misc.c
+++ b/src/misc.c
@@ -165,13 +165,13 @@ void ecs_os_time_sleep(
     }
 #else
     HANDLE timer;
-	LARGE_INTEGER ft;
+    LARGE_INTEGER ft;
 
-	ft.QuadPart = -((int64_t)sec * 10000000 + (int64_t)nanosec / 100);
+    ft.QuadPart = -((int64_t)sec * 10000000 + (int64_t)nanosec / 100);
 
-	timer = CreateWaitableTimer(NULL, TRUE, NULL);
-	SetWaitableTimer(timer, &ft, 0, NULL, NULL, 0);
-	WaitForSingleObject(timer, INFINITE);
-	CloseHandle(timer);
+    timer = CreateWaitableTimer(NULL, TRUE, NULL);
+    SetWaitableTimer(timer, &ft, 0, NULL, NULL, 0);
+    WaitForSingleObject(timer, INFINITE);
+    CloseHandle(timer);
 #endif
 }


### PR DESCRIPTION
Using `Sleep()` 💩 leads to bad 📉📉 frame 🔲🔲  🔲 timing, `CreateWaitableTimer()` is 🈶 much better👌👍🏾.