### PR TITLE
Fix ECS_UNUSED for GCC

### DIFF
--- a/include/flecs/private/api_defines.h
+++ b/include/flecs/private/api_defines.h
@@ -61,7 +61,7 @@ typedef char bool;
 #define ECS_ALIGNOF(T) ((size_t)&((struct { char c; T d; } *)0)->d)
 #endif
 
-#if defined(COMPILER_GCC) || defined(__clang__)
+#if defined(__GNUC__)
 #define ECS_UNUSED __attribute__((unused))
 #else
 #define ECS_UNUSED


### PR DESCRIPTION
`COMPILER_GCC` didn't seem to be defined anywhere, this fixed a lot of `-Wunused-variable` warnings with flecs-meta.

Checking for Clang isn't necessary as it also defines `__GNUC__`.