### PR TITLE
V2 minor fixes

### DIFF
--- a/flecs.c
+++ b/flecs.c
@@ -80,7 +80,7 @@ ecs_table_t* ecs_table_find_or_create(
 ecs_table_t* ecs_table_from_type(
     ecs_world_t *world,
     ecs_stage_t *stage,
-    ecs_type_t type);    
+    ecs_type_t type);
 
 /* Get table data from main stage */
 ecs_data_t *ecs_table_get_data(
@@ -97,11 +97,11 @@ ecs_data_t *ecs_table_get_staged_data(
 ecs_data_t *ecs_table_get_or_create_data(
     ecs_world_t *world,
     ecs_stage_t *stage,
-    ecs_table_t *table); 
+    ecs_table_t *table);
 
 /* Activates / deactivates table for systems. A deactivated table will not be
  * evaluated when the system is invoked. Tables automatically get activated /
- * deactivated when they become non-empty / empty. 
+ * deactivated when they become non-empty / empty.
  *
  * If a query is provided, the table will only be activated / deactivated for
  * that query. */
@@ -129,7 +129,7 @@ void ecs_table_clear_silent(
 /* Clear table data. Don't call OnRemove handlers. */
 void ecs_table_clear_data(
     ecs_table_t *table,
-    ecs_data_t *data);    
+    ecs_data_t *data);
 
 /* Return number of entities in table in main stage. */
 int32_t ecs_table_count(
@@ -185,14 +185,14 @@ void ecs_table_set_size(
     ecs_world_t *world,
     ecs_table_t *table,
     ecs_data_t *data,
-    int32_t count); 
+    int32_t count);
 
 /* Set table to a fixed count. Useful for copying data in bulk. */
 void ecs_table_set_count(
     ecs_world_t *world,
     ecs_table_t *table,
     ecs_data_t *data,
-    int32_t count); 
+    int32_t count);
 
 /* Match table with filter */
 bool ecs_table_match_filter(
@@ -227,7 +227,7 @@ int32_t* ecs_table_get_monitor(
 #define ECS_WORLD_MAGIC (0x65637377)
 #define ECS_THREAD_MAGIC (0x65637374)
 
-/* Maximum number of entities that can be added in a single operation. 
+/* Maximum number of entities that can be added in a single operation.
  * Increasing this value will increase consumption of stack space. */
 #define ECS_MAX_ADD_REMOVE (32)
 
@@ -244,7 +244,7 @@ typedef struct ecs_comp_set_t {
 
 /** Callback used by the system signature expression parser. */
 typedef int (*ecs_parse_action_t)(
-    ecs_world_t *world,                 
+    ecs_world_t *world,
     const char *id,
     const char *expr,
     int64_t column,
@@ -286,7 +286,7 @@ typedef struct ecs_table_event_t {
     /* If the nubmer of fields gets out of hand, this can be turned into a union
      * but since events are very temporary objects, this works for now and makes
      * initializing an event a bit simpler. */
-} ecs_table_event_t;    
+} ecs_table_event_t;
 
 /** A component column. */
 struct ecs_column_t {
@@ -307,7 +307,7 @@ struct ecs_data_t {
     ecs_vector_t *record_ptrs;   /**< Ptrs to records in main entity index */
     ecs_column_t *columns;       /**< Component columns */
     ecs_sw_column_t *sw_columns; /**< Switch columns */
-    bool marked_dirty;           /**< Was table marked dirty by stage? */  
+    bool marked_dirty;           /**< Was table marked dirty by stage? */
 };
 
 /** Small footprint data structure for storing data associated with a table. */
@@ -392,7 +392,7 @@ struct ecs_table_t {
 /* Sparse query column */
 typedef struct ecs_sparse_column_t {
     ecs_sw_column_t *sw_column;
-    ecs_entity_t sw_case; 
+    ecs_entity_t sw_case;
     int32_t signature_column_index;
 } ecs_sparse_column_t;
 
@@ -418,7 +418,7 @@ typedef struct ecs_table_slice_t {
     int32_t count;                  /**< Number of entities in range */
 } ecs_table_slice_t;
 
-#define EcsQueryNeedsTables (1)      /* Query needs matching with tables */ 
+#define EcsQueryNeedsTables (1)      /* Query needs matching with tables */
 #define EcsQueryMonitor (2)          /* Query needs to be registered as a monitor */
 #define EcsQueryOnSet (4)            /* Query needs to be registered as on_set system */
 #define EcsQueryUnSet (8)            /* Query needs to be registered as un_set system */
@@ -459,12 +459,12 @@ struct ecs_query_t {
     ecs_vector_t *empty_tables;
 
     /* Handle to system (optional) */
-    ecs_entity_t system;   
+    ecs_entity_t system;
 
     /* Used for sorting */
     ecs_entity_t sort_on_component;
-    ecs_compare_action_t compare;   
-    ecs_vector_t *table_slices;     
+    ecs_compare_action_t compare;
+    ecs_vector_t *table_slices;
 
     /* Used for table sorting */
     ecs_entity_t rank_on_component;
@@ -498,7 +498,7 @@ typedef struct ecs_on_demand_in_t {
 typedef enum ecs_op_kind_t {
     EcsOpNone,
     EcsOpAdd,
-    EcsOpRemove,   
+    EcsOpRemove,
     EcsOpSet,
 } ecs_op_kind_t;
 
@@ -527,8 +527,8 @@ struct ecs_stage_t {
      * world pointers (or constantly obtaining the real world when needed). */
     ecs_world_t *world;
 
-    /* If this is not main stage, 
-     * changes to the entity index 
+    /* If this is not main stage,
+     * changes to the entity index
      * are buffered here */
     ecs_sparse_t *entity_index; /* Entity lookup table for (table, row) */
 
@@ -566,7 +566,7 @@ typedef struct ecs_entity_info_t {
 } ecs_entity_info_t;
 
 /** A type desribing a worker thread. When a system is invoked by a worker
- * thread, it receives a pointer to an ecs_thread_t instead of a pointer to an 
+ * thread, it receives a pointer to an ecs_thread_t instead of a pointer to an
  * ecs_world_t (provided by the ecs_iter_t type). When this ecs_thread_t is passed down
  * into the flecs API, the API functions are able to tell whether this is an
  * ecs_thread_t or an ecs_world_t by looking at the 'magic' number. This allows the
@@ -620,10 +620,10 @@ struct ecs_world_t {
     /* Keep track of components that were added/removed to/from monitored
      * entities. Monitored entities are entities that a query has matched with
      * specifically, as is the case with PARENT / CASCADE columns, FromEntity
-     * columns and columns matched from prefabs. 
+     * columns and columns matched from prefabs.
      * When these entities change type, queries may have to be rematched.
      * Queries register themselves as component monitors for specific components
-     * and when these components change they are rematched. The component 
+     * and when these components change they are rematched. The component
      * monitors are evaluated during a merge. */
     ecs_component_monitor_t component_monitors;
 
@@ -633,11 +633,11 @@ struct ecs_world_t {
      * adds or removes a CHILDOF flag. In that case, every component of that
      * parent will be marked dirty. This allows column modifiers like CASCADE
      * to correctly determine when the depth ranking of a table has changed. */
-    ecs_component_monitor_t parent_monitors; 
+    ecs_component_monitor_t parent_monitors;
 
 
     /* -- Systems -- */
-    
+
     ecs_entity_t pipeline;             /* Current pipeline */
     ecs_map_t *on_activate_components; /* Trigger on activate of [in] column */
     ecs_map_t *on_enable_components;   /* Trigger on enable of [in] column */
@@ -666,7 +666,7 @@ struct ecs_world_t {
     /* -- Multithreading -- */
 
     ecs_vector_t *workers;           /* Worker threads */
-    
+
     ecs_os_cond_t worker_cond;       /* Signal that worker threads can start */
     ecs_os_cond_t sync_cond;         /* Signal that worker thread job is done */
     ecs_os_mutex_t sync_mutex;       /* Mutex for job_cond */
@@ -709,7 +709,7 @@ struct ecs_world_t {
     bool measure_frame_time;      /* Time spent on each frame */
     bool measure_system_time;     /* Time spent by each system */
     bool should_quit;             /* Did a system signal that app should quit */
-    bool locking_enabled;         /* Lock world when in progress */    
+    bool locking_enabled;         /* Lock world when in progress */
 };
 
 #endif
@@ -767,12 +767,12 @@ bool ecs_get_info(
     ecs_entity_info_t *info);
 
 void ecs_run_monitors(
-    ecs_world_t *world, 
-    ecs_stage_t *stage, 
+    ecs_world_t *world,
+    ecs_stage_t *stage,
     ecs_table_t *dst_table,
-    ecs_vector_t *v_dst_monitors, 
-    int32_t dst_row, 
-    int32_t count, 
+    ecs_vector_t *v_dst_monitors,
+    int32_t dst_row,
+    int32_t count,
     ecs_vector_t *v_src_monitors);
 
 
@@ -839,7 +839,7 @@ void ecs_notify_tables(
 void ecs_notify_queries(
     ecs_world_t *world,
     ecs_query_event_t *event);
-    
+
 
 ////////////////////////////////////////////////////////////////////////////////
 //// Stage API
@@ -919,7 +919,7 @@ void ecs_run_add_actions(
     ecs_entities_t *added,
     ecs_comp_set_t *set_mask,
     bool get_all,
-    bool run_on_set);   
+    bool run_on_set);
 
 void ecs_run_remove_actions(
     ecs_world_t *world,
@@ -958,23 +958,23 @@ void ecs_table_unset(
 
 /* Destruct columns */
 void ecs_table_destruct(
-    ecs_world_t *world, 
-    ecs_table_t *table, 
-    ecs_data_t *data, 
-    int32_t row, 
+    ecs_world_t *world,
+    ecs_table_t *table,
+    ecs_data_t *data,
+    int32_t row,
     int32_t count);
 
 /* Free table */
 void ecs_table_free(
     ecs_world_t *world,
-    ecs_table_t *table); 
+    ecs_table_t *table);
 
 /* Merge table data */
 void ecs_table_merge_data(
     ecs_world_t *world,
     ecs_table_t *table,
     ecs_data_t *data);
-    
+
 /* Replace data */
 void ecs_table_replace_data(
     ecs_world_t *world,
@@ -1009,7 +1009,7 @@ ecs_table_t *ecs_table_traverse_remove(
     ecs_stage_t *stage,
     ecs_table_t *table,
     ecs_entities_t *to_remove,
-    ecs_entities_t *removed);    
+    ecs_entities_t *removed);
 
 void ecs_table_mark_dirty_w_index(
     ecs_table_t *table,
@@ -1030,7 +1030,7 @@ const EcsComponent* ecs_component_from_id(
 int32_t ecs_table_switch_from_case(
     ecs_world_t *world,
     ecs_table_t *table,
-    ecs_entity_t add);    
+    ecs_entity_t add);
 
 void ecs_table_notify(
     ecs_world_t *world,
@@ -1043,7 +1043,7 @@ void ecs_table_notify(
 
 ecs_query_t* ecs_query_new_w_sig(
     ecs_world_t *world,
-    ecs_entity_t system, 
+    ecs_entity_t system,
     ecs_sig_t *sig);
 
 void ecs_query_set_iter(
@@ -1098,7 +1098,7 @@ void ecs_os_time_setup(void);
 uint64_t ecs_os_time_now(void);
 
 void ecs_os_time_sleep(
-    int32_t sec, 
+    int32_t sec,
     int32_t nanosec);
 
 /* Increase or reset timer resolution (Windows only) */
@@ -1120,11 +1120,11 @@ int16_t ecs_to_i16(
 
 /* Convert 64 bit signed integer to 32 bit */
 int32_t ecs_to_i32(
-    int64_t v);  
+    int64_t v);
 
 /* Convert 64 bit unsigned integer to 32 bit */
 uint32_t ecs_to_u32(
-    uint64_t v);        
+    uint64_t v);
 
 /* Convert signed integer to size_t */
 size_t ecs_to_size_t(
@@ -1132,7 +1132,7 @@ size_t ecs_to_size_t(
 
 /* Convert size_t to ecs_size_t */
 ecs_size_t ecs_from_size_t(
-    size_t size);    
+    size_t size);
 
 /* Convert int64_t to entity */
 ecs_entity_t ecs_to_entity(
@@ -1140,10 +1140,10 @@ ecs_entity_t ecs_to_entity(
 
 /* Convert int64_t from entity */
 int64_t ecs_from_entity(
-    ecs_entity_t v);   
+    ecs_entity_t v);
 
 int32_t ecs_from_entity_to_i32(
-    ecs_entity_t v);        
+    ecs_entity_t v);
 
 /* Convert 64bit value to ecs_record_t type. ecs_record_t is stored as 64bit int in the
  * entity index */
@@ -1156,22 +1156,22 @@ uint64_t ecs_from_row(
 
 /* Get actual row from record row */
 int32_t ecs_record_to_row(
-    int32_t row, 
+    int32_t row,
     bool *is_watched_out);
 
 /* Convert actual row to record row */
 int32_t ecs_row_to_record(
-    int32_t row, 
+    int32_t row,
     bool is_watched);
 
 /* Convert type to entity array */
 ecs_entities_t ecs_type_to_entities(
-    ecs_type_t type); 
+    ecs_type_t type);
 
 /* Convert a symbol name to an entity name by removing the prefix */
 const char* ecs_name_from_symbol(
     ecs_world_t *world,
-    const char *type_name); 
+    const char *type_name);
 
 /* Lookup an entity by name with a specific id */
 ecs_entity_t ecs_lookup_w_id(
@@ -1222,14 +1222,14 @@ char *ecs_vasprintf(
 
     va_end(tmpa);
 
-    if ((int32_t)size < 0) { 
-        return NULL; 
+    if ((int32_t)size < 0) {
+        return NULL;
     }
 
     result = (char *) ecs_os_malloc(size + 1);
 
-    if (!result) { 
-        return NULL; 
+    if (!result) {
+        return NULL;
     }
 
     ecs_os_vsprintf(result, fmt, args);
@@ -1474,7 +1474,7 @@ void ecs_tracing_enable(
 
 void _ecs_parser_error(
     const char *name,
-    const char *expr, 
+    const char *expr,
     int64_t column,
     const char *fmt,
     ...)
@@ -1487,8 +1487,8 @@ void _ecs_parser_error(
         ecs_os_err("%s:%d: error: %s", name, column + 1, msg);
         ecs_os_err("    %s", expr);
         ecs_os_err("    %*s^", column, "");
-        
-        ecs_os_free(msg);        
+
+        ecs_os_free(msg);
     }
 
     ecs_os_abort();
@@ -1582,7 +1582,7 @@ const char* ecs_strerror(
     case ECS_INVALID_WHILE_MERGING:
         return "operation is invalid while merging";
     case ECS_INVALID_WHILE_ITERATING:
-        return "operation is invalid while iterating";    
+        return "operation is invalid while iterating";
     case ECS_INVALID_FROM_WORKER:
         return "operation is invalid from worker thread";
     case ECS_UNRESOLVED_IDENTIFIER:
@@ -1610,7 +1610,7 @@ const char* ecs_strerror(
     case ECS_DESERIALIZE_COMPONENT_ID_CONFLICT:
         return "serialized data contains conflicting component id";
     case ECS_DESERIALIZE_COMPONENT_SIZE_CONFLICT:
-        return "serialized data contains conflicting component size";   
+        return "serialized data contains conflicting component size";
     case ECS_DESERIALIZE_FORMAT_ERROR:
         return "serialized data has invalid format";
     case ECS_INVALID_REACTIVE_SIGNATURE:
@@ -1640,9 +1640,9 @@ ecs_data_t* init_data(
     ecs_table_t *table,
     ecs_data_t *result)
 {
-    ecs_type_t type = table->type; 
+    ecs_type_t type = table->type;
     int32_t i, count = table->column_count, sw_count = table->sw_column_count;
-    
+
     result->entities = NULL;
     result->record_ptrs = NULL;
 
@@ -1655,7 +1655,7 @@ ecs_data_t* init_data(
     ecs_entity_t *entities = ecs_vector_first(type, ecs_entity_t);
 
     if (count && !sw_count) {
-        result->columns = ecs_os_calloc(ECS_SIZEOF(ecs_column_t) * count);    
+        result->columns = ecs_os_calloc(ECS_SIZEOF(ecs_column_t) * count);
     } else if (count || sw_count) {
         /* If a table has switch columns, store vector with the case values
             * as a regular column, so it's easier to access for systems. To
@@ -1701,8 +1701,8 @@ ecs_data_t* init_data(
             int32_t sw_array_count = ecs_vector_count(sw_type);
 
             ecs_switch_t *sw = ecs_switch_new(
-                sw_array[0], 
-                sw_array[sw_array_count - 1], 
+                sw_array[0],
+                sw_array[sw_array_count - 1],
                 0);
             result->sw_columns[i].data = sw;
             result->sw_columns[i].type = sw_type;
@@ -1757,19 +1757,19 @@ void deinit_all_data(
 {
     ecs_data_t *data = ecs_vector_first(table->data, ecs_data_t);
     int32_t i, count = ecs_vector_count(table->data);
-    
+
     for (i = 0; i < count; i ++) {
         deinit_data(table, &data[i]);
     }
 
     ecs_vector_free(table->data);
 
-    table->data = NULL; 
+    table->data = NULL;
 }
 
 static
 ecs_flags32_t get_component_action_flags(
-    ecs_c_info_t *c_info) 
+    ecs_c_info_t *c_info)
 {
     ecs_flags32_t flags = 0;
 
@@ -1790,9 +1790,9 @@ ecs_flags32_t get_component_action_flags(
     }
     if (c_info->on_remove) {
         flags |= EcsTableHasOnRemove;
-    }    
+    }
 
-    return flags;  
+    return flags;
 }
 
 /* Check if table has instance of component, including traits */
@@ -1810,7 +1810,7 @@ bool has_component(
             return true;
         }
     }
-    
+
     return false;
 }
 
@@ -1828,7 +1828,7 @@ void notify_component_info(
         if (!column_count) {
             return;
         }
-        
+
         if (!table->c_info) {
             table->c_info = ecs_os_calloc(
                 ECS_SIZEOF(ecs_c_info_t*) * column_count);
@@ -1845,7 +1845,7 @@ void notify_component_info(
             if (!c) {
                 continue;
             }
-            
+
             ecs_c_info_t *c_info = ecs_get_c_info(world, c);
             if (c_info) {
                 ecs_flags32_t flags = get_component_action_flags(c_info);
@@ -1854,7 +1854,7 @@ void notify_component_info(
 
             /* Store pointer to c_info for fast access */
             table->c_info[i] = c_info;
-        }        
+        }
     }
 }
 
@@ -1867,7 +1867,7 @@ void run_un_set_handlers(
     int32_t count = ecs_vector_count(data->entities);
 
     if (count) {
-        ecs_run_monitors(world, &world->stage, table, table->un_set_all, 
+        ecs_run_monitors(world, &world->stage, table, table->un_set_all,
             0, count, NULL);
     }
 }
@@ -1910,9 +1910,9 @@ void add_monitor(
     /* Sort the system list so that it is easy to get the difference OnSet
      * OnSet systems between two tables. */
     qsort(
-        ecs_vector_first(*array, ecs_matched_query_t), 
+        ecs_vector_first(*array, ecs_matched_query_t),
         ecs_to_size_t(ecs_vector_count(*array)),
-        ECS_SIZEOF(ecs_matched_query_t), 
+        ECS_SIZEOF(ecs_matched_query_t),
         compare_matched_query);
 }
 
@@ -1989,7 +1989,7 @@ void register_on_set(
 
     if (table->column_count) {
         if (!table->on_set) {
-            table->on_set = 
+            table->on_set =
                 ecs_os_calloc(ECS_SIZEOF(ecs_vector_t) * table->column_count);
         }
 
@@ -2003,7 +2003,7 @@ void register_on_set(
          * component that was overridden. */
         bool match_override = false;
 
-        /* Add system to each matched column. This makes it easy to get the list 
+        /* Add system to each matched column. This makes it easy to get the list
          * of systems when setting a single component. */
         ecs_sig_column_t *columns = ecs_vector_first(query->sig.columns,
             ecs_sig_column_t);
@@ -2014,7 +2014,7 @@ void register_on_set(
             ecs_sig_from_kind_t from_kind = column->from_kind;
 
             if ((from_kind != EcsFromAny && from_kind != EcsFromOwned) ||
-                (oper_kind != EcsOperAnd && oper_kind != EcsOperOptional)) 
+                (oper_kind != EcsOperAnd && oper_kind != EcsOperOptional))
             {
                 continue;
             }
@@ -2028,22 +2028,22 @@ void register_on_set(
             if (index >= table->column_count) {
                 continue;
             }
-            
+
             ecs_vector_t *set_c = table->on_set[index];
             ecs_matched_query_t *m = ecs_vector_add(&set_c, ecs_matched_query_t);
             m->query = query;
             m->matched_table_index = matched_table_index;
             table->on_set[index] = set_c;
-            
+
             match_override |= is_override(world, table, comp);
-        } 
+        }
 
         if (match_override) {
             add_monitor(&table->on_set_override, query, matched_table_index);
         }
     }
 
-    add_monitor(&table->on_set_all, query, matched_table_index);   
+    add_monitor(&table->on_set_all, query, matched_table_index);
 }
 
 static
@@ -2081,9 +2081,9 @@ void ecs_table_activate(
             ecs_query_notify(world, buffer[i], &(ecs_query_event_t) {
                 .kind = activate ? EcsQueryTableNonEmpty : EcsQueryTableEmpty,
                 .table = table
-            });                
+            });
         }
-    }     
+    }
 }
 
 /* This function is called when a query is matched with a table. A table keeps
@@ -2152,14 +2152,14 @@ ecs_data_t* get_data_intern(
 
     /* Make sure the array is large enough for the number of active stages. This
      * guarantees that any pointers returned by this function are stable, unless
-     * the number of stages changes (can happen when the number of worker 
+     * the number of stages changes (can happen when the number of worker
      * threads changes) */
     if (count != stage_count) {
         if (stage_count > count) {
             /* Grow array, initialize table data to 0 */
             ecs_vector_set_count(&table->data, ecs_data_t, stage_count);
             data_array = ecs_vector_first(table->data, ecs_data_t);
-            ecs_os_memset(&data_array[count], 
+            ecs_os_memset(&data_array[count],
                 0, ECS_SIZEOF(ecs_data_t) * (stage_count - count));
         } else {
             /* If the number of stages is reduced, deinit redudant stages */
@@ -2169,10 +2169,10 @@ ecs_data_t* get_data_intern(
             }
 
             ecs_vector_set_count(&table->data, ecs_data_t, stage_count);
-            data_array = ecs_vector_first(table->data, ecs_data_t);           
+            data_array = ecs_vector_first(table->data, ecs_data_t);
         }
     }
-    
+
     return &data_array[id];
 }
 
@@ -2198,7 +2198,7 @@ ecs_data_t* ecs_table_get_or_create_data(
 {
     ecs_data_t *result = get_data_intern(world, stage, table, true);
 
-    /* If write access is requested from table and stage is not the main 
+    /* If write access is requested from table and stage is not the main
      * stage mark this table as dirty as it will contain staged data. */
     if (world->in_progress && !result->marked_dirty) {
         ecs_table_t** table_ptr = ecs_vector_add(
@@ -2209,7 +2209,7 @@ ecs_data_t* ecs_table_get_or_create_data(
         result->marked_dirty = true;
     }
 
-    return result;   
+    return result;
 }
 
 static
@@ -2230,7 +2230,7 @@ void ctor_component(
 
         void *ptr = ecs_vector_get_t(column->data, size, alignment, row);
 
-        ctor(world, cdata->component, entities, ptr, 
+        ctor(world, cdata->component, entities, ptr,
             ecs_to_size_t(size), count, ctx);
     }
 }
@@ -2249,7 +2249,7 @@ void dtor_component(
     if (cdata && (dtor = cdata->lifecycle.dtor)) {
         void *ctx = cdata->lifecycle.ctx;
         int16_t size = column->size;
-        int16_t alignment = column->alignment;    
+        int16_t alignment = column->alignment;
 
         void *ptr = ecs_vector_get_t(column->data, size, alignment, row);
 
@@ -2272,7 +2272,7 @@ void dtor_all_components(
     for (i = 0; i < column_count; i ++) {
         ecs_column_t *column = &data->columns[i];
         dtor_component(
-            world, table->c_info[i], column, entities, row, 
+            world, table->c_info[i], column, entities, row,
             count);
     }
 }
@@ -2288,7 +2288,7 @@ void run_remove_actions(
 {
     if (count) {
         if (!dtor_only) {
-            ecs_run_monitors(world, &world->stage, table, NULL, 
+            ecs_run_monitors(world, &world->stage, table, NULL,
                     row, count, table->un_set_all);
         }
 
@@ -2297,10 +2297,10 @@ void run_remove_actions(
 }
 
 void ecs_table_destruct(
-    ecs_world_t *world, 
-    ecs_table_t *table, 
-    ecs_data_t *data, 
-    int32_t row, 
+    ecs_world_t *world,
+    ecs_table_t *table,
+    ecs_data_t *data,
+    int32_t row,
     int32_t count)
 {
     if (table->flags & EcsTableHasDtors) {
@@ -2328,7 +2328,7 @@ void ecs_table_clear_silent(
     }
 
     int32_t count = ecs_vector_count(data->entities);
-    
+
     deinit_all_data(table);
 
     if (count) {
@@ -2337,7 +2337,7 @@ void ecs_table_clear_silent(
 }
 
 /* Delete all entities in table, invoke OnRemove handlers. This function is used
- * when an application invokes delete_w_filter. Use ecs_table_clear_silent, as 
+ * when an application invokes delete_w_filter. Use ecs_table_clear_silent, as
  * the table may have to be deactivated with systems. */
 void ecs_table_clear(
     ecs_world_t *world,
@@ -2358,7 +2358,7 @@ void ecs_table_clear(
     ecs_table_clear_silent(world, table);
 }
 
-/* Unset all components in table. This function is called before a table is 
+/* Unset all components in table. This function is called before a table is
  * deleted, and invokes all UnSet handlers, if any */
 void ecs_table_unset(
     ecs_world_t *world,
@@ -2368,7 +2368,7 @@ void ecs_table_unset(
     ecs_data_t *data = ecs_table_get_data(world, table);
     if (data) {
         run_un_set_handlers(world, table, data);
-    }   
+    }
 }
 
 /* Free table resources. Do not invoke handlers and do not activate/deactivate
@@ -2398,7 +2398,7 @@ void ecs_table_free(
     if (table->c_info) {
         ecs_os_free(table->c_info);
     }
-    
+
     if (table->on_set) {
         int32_t i;
         for (i = 0; i < table->column_count; i ++) {
@@ -2454,11 +2454,11 @@ void ecs_table_mark_dirty(
 
 static
 void move_switch_columns(
-    ecs_table_t *new_table, 
-    ecs_data_t *new_data, 
+    ecs_table_t *new_table,
+    ecs_data_t *new_data,
     int32_t new_index,
-    ecs_table_t *old_table, 
-    ecs_data_t *old_data, 
+    ecs_table_t *old_table,
+    ecs_data_t *old_data,
     int32_t old_index,
     int32_t count)
 {
@@ -2518,8 +2518,8 @@ void ensure_data(
     ecs_column_t *columns = NULL;
     ecs_sw_column_t *sw_columns = NULL;
 
-    /* It is possible that the table data was created without content. 
-     * Now that data is going to be written to the table, initialize */ 
+    /* It is possible that the table data was created without content.
+     * Now that data is going to be written to the table, initialize */
     if (column_count | sw_column_count) {
         columns = data->columns;
         sw_columns = data->sw_columns;
@@ -2558,7 +2558,7 @@ void grow_column(
 
     ecs_assert(new_size >= new_count, ECS_INTERNAL_ERROR, NULL);
 
-    /* If the array could possibly realloc and the component has a move action 
+    /* If the array could possibly realloc and the component has a move action
      * defined, move old elements manually */
     ecs_move_t move;
     if (c_info && count && can_realloc && (move = c_info->lifecycle.move)) {
@@ -2576,13 +2576,13 @@ void grow_column(
             new_vec, size, alignment);
 
         /* First construct elements (old and new) in new buffer */
-        ctor(world, c_info->component, entities, new_buffer, 
-            ecs_to_size_t(size), construct ? new_count : count, 
+        ctor(world, c_info->component, entities, new_buffer,
+            ecs_to_size_t(size), construct ? new_count : count,
             c_info->lifecycle.ctx);
-        
+
         /* Move old elements */
-        move(world, c_info->component, entities, entities, 
-            new_buffer, old_buffer, ecs_to_size_t(size), count, 
+        move(world, c_info->component, entities, entities,
+            new_buffer, old_buffer, ecs_to_size_t(size), count,
             c_info->lifecycle.ctx);
 
         /* Free old vector */
@@ -2600,14 +2600,14 @@ void grow_column(
         if (construct && c_info && (ctor = c_info->lifecycle.ctor)) {
             /* If new elements need to be constructed and component has a
              * constructor, construct */
-            ctor(world, c_info->component, &entities[count], elem, 
+            ctor(world, c_info->component, &entities[count], elem,
                 ecs_to_size_t(size), to_add, c_info->lifecycle.ctx);
         }
 
         column->data = vec;
     }
 
-    ecs_assert(ecs_vector_size(column->data) == new_size, 
+    ecs_assert(ecs_vector_size(column->data) == new_size,
         ECS_INTERNAL_ERROR, NULL);
 }
 
@@ -2628,8 +2628,8 @@ int32_t grow_data(
     int32_t sw_column_count = table->sw_column_count;
     ecs_column_t *columns;
     ecs_sw_column_t *sw_columns;
-    ensure_data(world, table, data, &column_count, &sw_column_count, 
-        &columns, &sw_columns);    
+    ensure_data(world, table, data, &column_count, &sw_column_count,
+        &columns, &sw_columns);
 
     /* Add record to record ptr array */
     ecs_vector_set_size(&data->record_ptrs, ecs_record_t*, size);
@@ -2671,7 +2671,7 @@ int32_t grow_data(
         }
 
         grow_column(world, entities, column, c_info, to_add, size, true);
-        ecs_assert(ecs_vector_size(columns[i].data) == size, 
+        ecs_assert(ecs_vector_size(columns[i].data) == size,
             ECS_INTERNAL_ERROR, NULL);
     }
 
@@ -2731,23 +2731,23 @@ int32_t ecs_table_append(
     int32_t sw_column_count = table->sw_column_count;
     ecs_column_t *columns;
     ecs_sw_column_t *sw_columns;
-    ensure_data(world, table, data, &column_count, &sw_column_count, 
+    ensure_data(world, table, data, &column_count, &sw_column_count,
         &columns, &sw_columns);
 
     /* Grow buffer with entity ids, set new element to new entity */
     ecs_entity_t *e = ecs_vector_add(&data->entities, ecs_entity_t);
     ecs_assert(e != NULL, ECS_INTERNAL_ERROR, NULL);
-    *e = entity;    
+    *e = entity;
 
     /* Keep track of alloc count. This allows references to check if cached
-     * pointers need to be updated. */  
+     * pointers need to be updated. */
     table->alloc_count += (count == size);
 
     /* Add record ptr to array with record ptrs */
     ecs_record_t **r = ecs_vector_add(&data->record_ptrs, ecs_record_t*);
     ecs_assert(r != NULL, ECS_INTERNAL_ERROR, NULL);
     *r = record;
- 
+
     /* If the table is monitored indicate that there has been a change */
     mark_table_dirty(table, 0);
 
@@ -2769,7 +2769,7 @@ int32_t ecs_table_append(
     ecs_entity_t *entities = ecs_vector_first(
         data->entities, ecs_entity_t);
 
-    /* Reobtain size to ensure that the columns have the same size as the 
+    /* Reobtain size to ensure that the columns have the same size as the
      * entities and record vectors. This keeps reasoning about when allocations
      * occur easier. */
     size = ecs_vector_size(data->entities);
@@ -2788,14 +2788,14 @@ int32_t ecs_table_append(
         }
 
         grow_column(world, entities, column, c_info, 1, size, construct);
-        
+
         ecs_assert(
-            ecs_vector_size(columns[i].data) == ecs_vector_size(data->entities), 
-            ECS_INTERNAL_ERROR, NULL); 
-            
+            ecs_vector_size(columns[i].data) == ecs_vector_size(data->entities),
+            ECS_INTERNAL_ERROR, NULL);
+
         ecs_assert(
-            ecs_vector_count(columns[i].data) == ecs_vector_count(data->entities), 
-            ECS_INTERNAL_ERROR, NULL);                        
+            ecs_vector_count(columns[i].data) == ecs_vector_count(data->entities),
+            ECS_INTERNAL_ERROR, NULL);
     }
 
     /* Add element to each switch column */
@@ -2811,7 +2811,7 @@ int32_t ecs_table_append(
 static
 void fast_delete_last(
     ecs_column_t *columns,
-    int32_t column_count) 
+    int32_t column_count)
 {
     int i;
     for (i = 0; i < column_count; i ++) {
@@ -2824,7 +2824,7 @@ static
 void fast_delete(
     ecs_column_t *columns,
     int32_t column_count,
-    int32_t index) 
+    int32_t index)
 {
     int i;
     for (i = 0; i < column_count; i ++) {
@@ -2833,7 +2833,7 @@ void fast_delete(
         if (size) {
             int16_t alignment = column->alignment;
             ecs_vector_remove_index_t(column->data, size, alignment, index);
-        } 
+        }
     }
 }
 
@@ -2855,7 +2855,7 @@ void ecs_table_delete(
 
     ecs_assert(count > 0, ECS_INTERNAL_ERROR, NULL);
     count --;
-    
+
     ecs_assert(index <= count, ECS_INTERNAL_ERROR, NULL);
 
     ecs_c_info_t **c_info_array = table->c_info;
@@ -2870,14 +2870,14 @@ void ecs_table_delete(
     ecs_vector_remove_last(entity_column);
 
     /* Move last record ptr to index */
-    ecs_vector_t *record_column = data->record_ptrs;     
+    ecs_vector_t *record_column = data->record_ptrs;
     ecs_record_t **records = ecs_vector_first(record_column, ecs_record_t*);
 
     ecs_assert(count < ecs_vector_count(record_column), ECS_INTERNAL_ERROR, NULL);
     ecs_record_t *record_to_move = records[count];
 
     records[index] = record_to_move;
-    ecs_vector_remove_last(record_column);    
+    ecs_vector_remove_last(record_column);
 
     /* Update record of moved entity in entity index */
     if (index != count) {
@@ -2892,10 +2892,10 @@ void ecs_table_delete(
             row.row = index + 1;
             ecs_eis_set(stage, entity_to_move, &row);
         }
-    } 
+    }
 
     /* If the table is monitored indicate that there has been a change */
-    mark_table_dirty(table, 0);    
+    mark_table_dirty(table, 0);
 
     if (!world->in_progress && !count) {
         ecs_table_activate(world, table, NULL, false);
@@ -2938,7 +2938,7 @@ void ecs_table_delete(
                     ecs_xtor_t ctor = c_info->lifecycle.ctor;
                     ecs_assert(ctor != NULL, ECS_INTERNAL_ERROR, NULL);
                     ctor(world, c_info->component, &entity_to_move, dst,
-                        ecs_to_size_t(size), 1, c_info->lifecycle.ctx);   
+                        ecs_to_size_t(size), 1, c_info->lifecycle.ctx);
                 }
 
                 /* Move last element into deleted element */
@@ -2946,10 +2946,10 @@ void ecs_table_delete(
                     ecs_to_size_t(size), 1, ctx);
 
                 /* Memory has been copied, we can now simply remove last */
-                ecs_vector_remove_last(column->data);                              
+                ecs_vector_remove_last(column->data);
             } else {
                 if (destruct && c_info && (dtor = c_info->lifecycle.dtor)) {
-                    dtor(world, c_info->component, &entities[index], dst, 
+                    dtor(world, c_info->component, &entities[index], dst,
                         ecs_to_size_t(size), 1, c_info->lifecycle.ctx);
                 }
 
@@ -3002,7 +3002,7 @@ void fast_move(
 
                 ecs_assert(dst != NULL, ECS_INTERNAL_ERROR, NULL);
                 ecs_assert(src != NULL, ECS_INTERNAL_ERROR, NULL);
-                ecs_os_memcpy(dst, src, size); 
+                ecs_os_memcpy(dst, src, size);
             }
         }
 
@@ -3085,10 +3085,10 @@ void ecs_table_move(
                         ecs_assert(ctor != NULL, ECS_INTERNAL_ERROR, NULL);
 
                         /* Construct a new value, move the value to it */
-                        ctor(world, new_component, &dst_entity, dst, 
+                        ctor(world, new_component, &dst_entity, dst,
                                 ecs_to_size_t(size), 1, ctx);
 
-                        move(world, new_component, &dst_entity, &src_entity, 
+                        move(world, new_component, &dst_entity, &src_entity,
                             dst, src, ecs_to_size_t(size), 1, ctx);
                     } else {
                         ecs_os_memcpy(dst, src, size);
@@ -3099,10 +3099,10 @@ void ecs_table_move(
                         ecs_move_t move;
                         if (cdata && (move = cdata->lifecycle.move)) {
                             void *ctx = cdata->lifecycle.ctx;
-                            move(world, new_component, &dst_entity, &src_entity, 
+                            move(world, new_component, &dst_entity, &src_entity,
                                 dst, src, ecs_to_size_t(size), 1, ctx);
                         } else {
-                            ecs_os_memcpy(dst, src, size); 
+                            ecs_os_memcpy(dst, src, size);
                         }
                     } else {
                         /* When copying from main stage to stage or from one
@@ -3117,15 +3117,15 @@ void ecs_table_move(
 
                             /* Construct a new value in the stage, copy the
                              * value to it */
-                            ctor(world, new_component, &dst_entity, dst, 
+                            ctor(world, new_component, &dst_entity, dst,
                                 ecs_to_size_t(size), 1, ctx);
-                            copy(world, new_component, &dst_entity, &src_entity, 
+                            copy(world, new_component, &dst_entity, &src_entity,
                                 dst, src, ecs_to_size_t(size), 1, ctx);
                         } else {
                             ecs_move_t move;
                             if (cdata && (move = cdata->lifecycle.move)) {
                                 void *ctx = cdata->lifecycle.ctx;
-                                move(world, new_component, &dst_entity, &src_entity, 
+                                move(world, new_component, &dst_entity, &src_entity,
                                     dst, src, ecs_to_size_t(size), 1, ctx);
                             } else {
                                 ecs_os_memcpy(dst, src, size);
@@ -3142,7 +3142,7 @@ void ecs_table_move(
                 /* An old component is destroyed. Never destroy components when
                  * moving from main stage to stage, as we don't want to destroy
                  * a component that has not been copied.
-                 * Note that a component is never copied between different 
+                 * Note that a component is never copied between different
                  * tables when copying from stage to main stage. */
                 dtor_component(world, old_table->c_info[i_new],
                     &old_columns[i_old], &src_entity, old_index, 1);
@@ -3194,7 +3194,7 @@ void ecs_table_set_size(
         int32_t sw_column_count = table->sw_column_count;
         ecs_column_t *columns;
         ecs_sw_column_t *sw_columns;
-        ensure_data(world, table, data, &column_count, &sw_column_count, 
+        ensure_data(world, table, data, &column_count, &sw_column_count,
             &columns, &sw_columns);
     }
 }
@@ -3236,7 +3236,7 @@ void ecs_table_swap(
     ecs_data_t *data,
     int32_t row_1,
     int32_t row_2)
-{    
+{
     (void)world;
 
     ecs_assert(data != NULL, ECS_INTERNAL_ERROR, NULL);
@@ -3245,7 +3245,7 @@ void ecs_table_swap(
 
     ecs_assert(row_1 >= 0, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(row_2 >= 0, ECS_INTERNAL_ERROR, NULL);
-    
+
     if (row_1 == row_2) {
         return;
     }
@@ -3257,7 +3257,7 @@ void ecs_table_swap(
     ecs_record_t **record_ptrs = ecs_vector_first(data->record_ptrs, ecs_record_t*);
     ecs_record_t *record_ptr_1 = record_ptrs[row_1];
     ecs_record_t *record_ptr_2 = record_ptrs[row_2];
-    
+
     /* Get pointers to records in entity index */
     if (!record_ptr_1) {
         record_ptr_1 = ecs_eis_get(stage, e1);
@@ -3277,7 +3277,7 @@ void ecs_table_swap(
 
     /* Swap columns */
     int32_t i, column_count = table->column_count;
-    
+
     for (i = 0; i < column_count; i ++) {
         int16_t size = columns[i].size;
         int16_t alignment = columns[i].alignment;
@@ -3296,7 +3296,7 @@ void ecs_table_swap(
     }
 
     /* If the table is monitored indicate that there has been a change */
-    mark_table_dirty(table, 0);    
+    mark_table_dirty(table, 0);
 }
 
 static
@@ -3315,18 +3315,18 @@ void merge_vector(
         }
 
         *dst_out = src;
-    
+
     /* If the new table is not empty, copy the contents from the
      * src into the dst. */
     } else {
         int32_t src_count = ecs_vector_count(src);
         ecs_vector_set_count_t(&dst, size, alignment, dst_count + src_count);
-        
+
         void *dst_ptr = ecs_vector_first_t(dst, size, alignment);
         void *src_ptr = ecs_vector_first_t(src, size, alignment);
 
         dst_ptr = ECS_OFFSET(dst_ptr, size * dst_count);
-        
+
         ecs_os_memcpy(dst_ptr, src_ptr, size * src_count);
 
         ecs_vector_free(src);
@@ -3362,18 +3362,18 @@ void merge_table_data(
     }
 
     /* Merge entities */
-    merge_vector(&new_data->entities, old_data->entities, ECS_SIZEOF(ecs_entity_t), 
+    merge_vector(&new_data->entities, old_data->entities, ECS_SIZEOF(ecs_entity_t),
         ECS_ALIGNOF(ecs_entity_t));
     old_data->entities = NULL;
     ecs_entity_t *entities = ecs_vector_first(new_data->entities, ecs_entity_t);
 
-    ecs_assert(ecs_vector_count(new_data->entities) == old_count + new_count, 
+    ecs_assert(ecs_vector_count(new_data->entities) == old_count + new_count,
         ECS_INTERNAL_ERROR, NULL);
 
     /* Merge entity index record pointers */
-    merge_vector(&new_data->record_ptrs, old_data->record_ptrs, 
+    merge_vector(&new_data->record_ptrs, old_data->record_ptrs,
         ECS_SIZEOF(ecs_record_t*), ECS_ALIGNOF(ecs_record_t*));
-    old_data->record_ptrs = NULL;        
+    old_data->record_ptrs = NULL;
 
     for (i_new = 0; (i_new < new_component_count) && (i_old < old_component_count); ) {
         ecs_entity_t new_component = new_components[i_new];
@@ -3381,22 +3381,22 @@ void merge_table_data(
         int16_t size = new_columns[i_new].size;
         int16_t alignment = new_columns[i_new].alignment;
 
-        if ((new_component & ECS_ROLE_MASK) || 
-            (old_component & ECS_ROLE_MASK)) 
+        if ((new_component & ECS_ROLE_MASK) ||
+            (old_component & ECS_ROLE_MASK))
         {
             break;
         }
 
         if (new_component == old_component) {
             merge_vector(
-                &new_columns[i_new].data, old_columns[i_old].data, size, 
+                &new_columns[i_new].data, old_columns[i_old].data, size,
                 alignment);
 
             old_columns[i_old].data = NULL;
 
             /* Mark component column as dirty */
             mark_table_dirty(new_table, i_new + 1);
-            
+
             i_new ++;
             i_old ++;
         } else if (new_component < old_component) {
@@ -3410,26 +3410,26 @@ void merge_table_data(
                 /* Construct new values */
                 ecs_c_info_t *c_info;
                 ecs_xtor_t ctor;
-                if ((c_info = new_table->c_info[i_new]) && 
-                    (ctor = c_info->lifecycle.ctor)) 
+                if ((c_info = new_table->c_info[i_new]) &&
+                    (ctor = c_info->lifecycle.ctor))
                 {
-                    ctor_component(world, c_info, column, 
+                    ctor_component(world, c_info, column,
                         entities, 0, old_count + new_count);
                 }
             }
-            
+
             i_new ++;
         } else if (new_component > old_component) {
             if (size) {
                 ecs_column_t *column = &old_columns[i_old];
-                
+
                 /* Destruct old values */
                 ecs_c_info_t *c_info;
                 ecs_xtor_t dtor;
-                if ((c_info = old_table->c_info[i_old]) && 
-                    (dtor = c_info->lifecycle.dtor)) 
+                if ((c_info = old_table->c_info[i_old]) &&
+                    (dtor = c_info->lifecycle.dtor))
                 {
-                    dtor_component(world, c_info, column, 
+                    dtor_component(world, c_info, column,
                         entities, 0, old_count);
                 }
 
@@ -3458,10 +3458,10 @@ void merge_table_data(
             /* Construct new values */
             ecs_c_info_t *c_info;
             ecs_xtor_t ctor;
-            if ((c_info = new_table->c_info[i_new]) && 
-                (ctor = c_info->lifecycle.ctor)) 
+            if ((c_info = new_table->c_info[i_new]) &&
+                (ctor = c_info->lifecycle.ctor))
             {
-                ctor_component(world, c_info, column, 
+                ctor_component(world, c_info, column,
                     entities, 0, old_count + new_count);
             }
         }
@@ -3470,24 +3470,24 @@ void merge_table_data(
     /* Destroy remaining columns */
     for (; i_old < old_component_count; i_old ++) {
         ecs_column_t *column = &old_columns[i_old];
-                
+
         /* Destruct old values */
         ecs_c_info_t *c_info;
         ecs_xtor_t dtor;
-        if ((c_info = old_table->c_info[i_old]) && 
-            (dtor = c_info->lifecycle.dtor)) 
+        if ((c_info = old_table->c_info[i_old]) &&
+            (dtor = c_info->lifecycle.dtor))
         {
-            dtor_component(world, c_info, column, entities, 
+            dtor_component(world, c_info, column, entities,
                 0, old_count);
         }
 
         /* Old column does not occur in new table, remove */
         ecs_vector_free(column->data);
         column->data = NULL;
-    }    
+    }
 
     /* Mark entity column as dirty */
-    mark_table_dirty(new_table, 0); 
+    mark_table_dirty(new_table, 0);
 }
 
 ecs_data_t* ecs_table_merge(
@@ -3499,7 +3499,7 @@ ecs_data_t* ecs_table_merge(
 {
     ecs_assert(old_table != NULL, ECS_INTERNAL_ERROR, NULL);
     bool move_data = false;
-    
+
     /* If there is nothing to merge to, just clear the old table */
     if (!new_table) {
         ecs_table_clear_data(old_table, old_data);
@@ -3514,7 +3514,7 @@ ecs_data_t* ecs_table_merge(
     if (!new_data) {
         new_data = ecs_table_get_or_create_data(
             world, &world->stage, new_table);
-        
+
         if (new_table == old_table) {
             move_data = true;
         }
@@ -3550,7 +3550,7 @@ ecs_data_t* ecs_table_merge(
     if (move_data) {
         *new_data = *old_data;
     } else {
-        merge_table_data(world, new_table, old_table, old_count, new_count, 
+        merge_table_data(world, new_table, old_table, old_count, new_count,
             old_data, new_data);
     }
 
@@ -3605,7 +3605,7 @@ bool ecs_table_match_filter(
     }
 
     ecs_type_t type = table->type;
-    
+
     if (filter->include) {
         /* If filter kind is exact, types must be the same */
         if (filter->include_kind == EcsMatchExact) {
@@ -3614,8 +3614,8 @@ bool ecs_table_match_filter(
             }
 
         /* Default for include_kind is MatchAll */
-        } else if (!ecs_type_contains(world, type, filter->include, 
-            filter->include_kind != EcsMatchAny, true)) 
+        } else if (!ecs_type_contains(world, type, filter->include,
+            filter->include_kind != EcsMatchAny, true))
         {
             return false;
         }
@@ -3627,9 +3627,9 @@ bool ecs_table_match_filter(
             if (type == filter->exclude) {
                 return false;
             }
-        
-        /* Default for exclude_kind is MatchAny */                
-        } else if (ecs_type_contains(world, type, filter->exclude, 
+
+        /* Default for exclude_kind is MatchAny */
+        } else if (ecs_type_contains(world, type, filter->exclude,
             filter->exclude_kind == EcsMatchAll, true))
         {
             return false;
@@ -3730,7 +3730,7 @@ bool comp_mask_is_set(
     return false;
 }
 
-static 
+static
 void* get_component_w_index(
     ecs_entity_info_t *info,
     int32_t index)
@@ -3745,7 +3745,7 @@ void* get_component_w_index(
 
     ecs_column_t *column = &columns[index];
     ecs_vector_t *data_vec = column->data;
-    int16_t size = column->size; 
+    int16_t size = column->size;
 
     ecs_assert(!size || data_vec != NULL, ECS_INTERNAL_ERROR, NULL);
 
@@ -3778,7 +3778,7 @@ void* get_component(
             return get_component_w_index(info, c_ptr_i);
         }
     });
-    
+
     return NULL;
 }
 
@@ -3800,7 +3800,7 @@ void set_info_from_record(
     ecs_record_t *record)
 {
     (void)e;
-    
+
     ecs_assert(record != NULL, ECS_INTERNAL_ERROR, NULL);
 
     info->record = record;
@@ -3819,7 +3819,7 @@ void set_info_from_record(
 
     info->data = data;
 
-    ecs_assert(ecs_vector_count(data->entities) > info->row, 
+    ecs_assert(ecs_vector_count(data->entities) > info->row,
         ECS_INTERNAL_ERROR, NULL);
 }
 
@@ -3862,7 +3862,7 @@ bool get_staged_info(
         return false;
     }
 
-    int32_t row = set_row_info(info, record->row);    
+    int32_t row = set_row_info(info, record->row);
 
     ecs_table_t *table = record->table;
 
@@ -3900,7 +3900,7 @@ bool ecs_get_info(
         }
 
         return true;
-    }    
+    }
 }
 
 static
@@ -3932,7 +3932,7 @@ void ecs_get_column_info(
             ecs_entity_t id = type_array[i];
             cinfo[i].id = id;
             cinfo[i].ci = get_c_info(world, id);
-            cinfo[i].column = i;            
+            cinfo[i].column = i;
         }
     } else {
         ecs_entity_t *array = components->array;
@@ -3964,7 +3964,7 @@ void run_component_trigger_for_entities(
     int32_t row,
     int32_t count,
     ecs_entity_t *entities)
-{    
+{
     (void)world;
     int32_t i, trigger_count = ecs_vector_count(trigger_vec);
     if (trigger_count) {
@@ -4012,7 +4012,7 @@ void ecs_run_component_trigger(
         return;
     }
 
-    ecs_entity_t *entities = ecs_vector_first(data->entities, ecs_entity_t);        
+    ecs_entity_t *entities = ecs_vector_first(data->entities, ecs_entity_t);
     ecs_assert(entities != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(row < ecs_vector_count(data->entities), ECS_INTERNAL_ERROR, NULL);
     ecs_assert((row + count) <= ecs_vector_count(data->entities), ECS_INTERNAL_ERROR, NULL);
@@ -4023,7 +4023,7 @@ void ecs_run_component_trigger(
         world, stage, trigger_vec, component, table, data, row, count, entities);
 }
 
-#ifdef FLECS_SYSTEM 
+#ifdef FLECS_SYSTEM
 static
 void run_set_systems_for_entities(
     ecs_world_t *world,
@@ -4034,7 +4034,7 @@ void run_set_systems_for_entities(
     int32_t count,
     ecs_entity_t *entities,
     bool set_all)
-{   
+{
     /* Run OnSet systems */
     if (set_all) {
         ecs_vector_t *queries = table->on_set_all;
@@ -4064,33 +4064,33 @@ void ecs_run_set_systems(
     int32_t count,
     bool set_all)
 {
-#ifdef FLECS_SYSTEM    
+#ifdef FLECS_SYSTEM
     if (!count || !data) {
         return;
     }
-    
-    ecs_entity_t *entities = ecs_vector_first(data->entities, ecs_entity_t);        
+
+    ecs_entity_t *entities = ecs_vector_first(data->entities, ecs_entity_t);
     ecs_assert(entities != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(row < ecs_vector_count(data->entities), ECS_INTERNAL_ERROR, NULL);
     ecs_assert((row + count) <= ecs_vector_count(data->entities), ECS_INTERNAL_ERROR, NULL);
 
     entities = ECS_OFFSET(entities, ECS_SIZEOF(ecs_entity_t) * row);
 
-    run_set_systems_for_entities(world, stage, components, table, row, 
+    run_set_systems_for_entities(world, stage, components, table, row,
         count, entities, set_all);
 #endif
 }
 
 void ecs_run_monitors(
-    ecs_world_t *world, 
-    ecs_stage_t *stage, 
+    ecs_world_t *world,
+    ecs_stage_t *stage,
     ecs_table_t *dst_table,
-    ecs_vector_t *v_dst_monitors, 
-    int32_t dst_row, 
-    int32_t count, 
+    ecs_vector_t *v_dst_monitors,
+    int32_t dst_row,
+    int32_t count,
     ecs_vector_t *v_src_monitors)
 {
-#ifdef FLECS_SYSTEM    
+#ifdef FLECS_SYSTEM
     if (v_dst_monitors == v_src_monitors) {
         return;
     }
@@ -4205,7 +4205,7 @@ void instantiate_children(
 
     for (i = 0; i < type_count; i ++) {
         ecs_entity_t c = type_array[i];
-        
+
         /* Make sure instances don't have EcsPrefab */
         if (c == EcsPrefab) {
             continue;
@@ -4213,10 +4213,10 @@ void instantiate_children(
 
         /* Keep track of the element that creates the CHILDOF relationship with
         * the prefab parent. We need to replace this element to make sure the
-        * created children point to the instance and not the prefab */ 
+        * created children point to the instance and not the prefab */
         if (ECS_HAS_ROLE(c, CHILDOF) && (c & ECS_ENTITY_MASK) == base) {
             base_index = pos;
-        }        
+        }
 
         /* Store pointer to component array. We'll use this component array to
         * create our new entities in bulk with new_w_data */
@@ -4249,7 +4249,7 @@ void instantiate_children(
         ecs_assert(table != NULL, ECS_INTERNAL_ERROR, NULL);
 
         /* Create children */
-        int32_t child_row; 
+        int32_t child_row;
         new_w_data(world, stage, table, NULL, child_count, c_info, &child_row);
 
         /* If prefab child table has children itself, recursively instantiate */
@@ -4261,7 +4261,7 @@ void instantiate_children(
             ecs_entity_t child = children[j];
             instantiate(world, stage, child, i_data, child_row + j, 1);
         }
-    }    
+    }
 }
 
 static
@@ -4272,7 +4272,7 @@ void instantiate(
     ecs_data_t *data,
     int32_t row,
     int32_t count)
-{    
+{
     /* If base is a parent, instantiate children of base for instances */
     ecs_vector_t *child_tables = ecs_map_get_ptr(
         world->child_tables, ecs_vector_t*, base);
@@ -4340,14 +4340,14 @@ bool override_from_base(
             for (index = 0; index < count; index ++) {
                 ecs_os_memcpy(data_ptr, base_ptr, data_size);
                 data_ptr = ECS_OFFSET(data_ptr, data_size);
-            }                    
+            }
         }
 
         return true;
     } else {
         /* If component not found on base, check if base itself inherits */
         ecs_type_t base_type = base_info.table->type;
-        return override_component(world, component, base_type, data, column, row, 
+        return override_component(world, component, base_type, data, column, row,
             count);
     }
 }
@@ -4375,7 +4375,7 @@ bool override_component(
         }
 
         if (ECS_HAS_ROLE(e, INSTANCEOF)) {
-            return override_from_base(world, e & ECS_ENTITY_MASK, component, 
+            return override_from_base(world, e & ECS_ENTITY_MASK, component,
                 data, column, row, count);
         }
     } while (--i >= 0);
@@ -4424,7 +4424,7 @@ void ecs_components_override(
                     .array = &component,
                     .count = 1
                 };
-                table_without_base = ecs_table_traverse_remove(world, stage, 
+                table_without_base = ecs_table_traverse_remove(world, stage,
                     table_without_base, &to_remove, NULL);
             }
         }
@@ -4436,23 +4436,23 @@ void ecs_components_override(
 
         if (!comp_mask_is_set(set_mask, component)) {
             ecs_column_t *column = &columns[column_index];
-            if (override_component(world, component, type, data, column, 
-                row, count)) 
+            if (override_component(world, component, type, data, column,
+                row, count))
             {
                 ecs_entities_t to_remove = {
                     .array = &component,
                     .count = 1
                 };
-                table_without_base = ecs_table_traverse_remove(world, 
+                table_without_base = ecs_table_traverse_remove(world,
                     stage, table_without_base, &to_remove, NULL);
             }
         }
     }
 
-    /* Run OnSet actions when a base entity is added to the entity for 
+    /* Run OnSet actions when a base entity is added to the entity for
      * components not overridden by the entity. */
     if (run_on_set && table_without_base != table) {
-        ecs_run_monitors(world, stage, table, table->on_set_all, row, count, 
+        ecs_run_monitors(world, stage, table, table->on_set_all, row, count,
             table_without_base->on_set_all);
     }
 }
@@ -4560,7 +4560,7 @@ void ecs_run_add_actions(
 
     if (table->flags & EcsTableHasBase) {
         ecs_components_override(
-            world, stage, table, data, row, count, cinfo, 
+            world, stage, table, data, row, count, cinfo,
             added_count, set_mask, run_on_set);
     }
 
@@ -4570,7 +4570,7 @@ void ecs_run_add_actions(
     }
 
     if (table->flags & EcsTableHasOnAdd) {
-        ecs_components_on_add(world, stage, table, data, row, count, 
+        ecs_components_on_add(world, stage, table, data, row, count,
             cinfo, added_count);
     }
 }
@@ -4593,9 +4593,9 @@ void ecs_run_remove_actions(
     int removed_count = removed->count;
 
     if (table->flags & EcsTableHasOnRemove) {
-        ecs_components_on_remove(world, stage, table, data, 
+        ecs_components_on_remove(world, stage, table, data,
             row, count, cinfo, removed_count);
-    }   
+    }
 }
 
 static
@@ -4634,24 +4634,24 @@ int32_t new_entity(
     }
 
     ecs_assert(
-        ecs_vector_count(new_data[0].entities) > new_row, 
-        ECS_INTERNAL_ERROR, NULL);    
+        ecs_vector_count(new_data[0].entities) > new_row,
+        ECS_INTERNAL_ERROR, NULL);
 
     if (new_table->flags & EcsTableHasAddActions) {
         ecs_comp_set_t set_mask = {0};
-        
+
         ecs_run_add_actions(
-            world, stage, new_table, new_data, new_row, 1, added, &set_mask, 
+            world, stage, new_table, new_data, new_row, 1, added, &set_mask,
             true, true);
 
         if (new_table->flags & EcsTableHasMonitors) {
             ecs_run_monitors(
-                world, stage, new_table, new_table->monitors, new_row, 1, NULL);              
-        }        
-    }   
+                world, stage, new_table, new_table->monitors, new_row, 1, NULL);
+        }
+    }
 
     info->data = new_data;
-    
+
     return new_row;
 }
 
@@ -4680,7 +4680,7 @@ int32_t move_entity(
     ecs_table_t *dst_table,
     ecs_entities_t *added,
     ecs_entities_t *removed)
-{    
+{
     ecs_data_t *dst_data = ecs_table_get_or_create_data(world, stage, dst_table);
     if (src_data == dst_data) {
         return src_row;
@@ -4708,27 +4708,27 @@ int32_t move_entity(
         });
     }
 
-    ecs_assert(ecs_vector_count(src_data->entities) > src_row, 
+    ecs_assert(ecs_vector_count(src_data->entities) > src_row,
         ECS_INTERNAL_ERROR, NULL);
 
     /* Copy entity & components from src_table to dst_table */
     if (src_table->type) {
         ecs_table_move(
-            world, stage, entity, entity, dst_table, dst_data, dst_row, src_table, 
+            world, stage, entity, entity, dst_table, dst_data, dst_row, src_table,
             src_data, src_row, same_stage);
 
         /* If components were removed, invoke remove actions before deleting */
         if (removed && (src_table->flags & EcsTableHasRemoveActions)) {
             /* If entity was moved, invoke UnSet monitors for each component that
             * the entity no longer has */
-            ecs_run_monitors(world, stage, dst_table, src_table->un_set_all, 
+            ecs_run_monitors(world, stage, dst_table, src_table->un_set_all,
                 dst_row, 1, dst_table->un_set_all);
 
             ecs_run_remove_actions(
                 world, stage, src_table, src_data, src_row, 1, removed, false);
-        }            
+        }
     }
-    
+
     /* Only delete from source table if moving to the same stage */
     if (same_stage) {
         ecs_table_delete(world, stage, src_table, src_data, src_row, false);
@@ -4739,22 +4739,22 @@ int32_t move_entity(
         if (added && (dst_table->flags & EcsTableHasAddActions)) {
             ecs_comp_set_t set_mask = {0};
             ecs_run_add_actions(
-                world, stage, dst_table, dst_data, dst_row, 1, added, &set_mask, 
+                world, stage, dst_table, dst_data, dst_row, 1, added, &set_mask,
                 false, true);
         }
 
         /* Run monitors */
         if (dst_table->flags & EcsTableHasMonitors) {
-            ecs_run_monitors(world, stage, dst_table, dst_table->monitors, dst_row, 
+            ecs_run_monitors(world, stage, dst_table, dst_table->monitors, dst_row,
                 1, src_table->monitors);
         }
 
-        /* If removed components were overrides, run OnSet systems for those, as 
-         * the value of those components changed from the removed component to 
+        /* If removed components were overrides, run OnSet systems for those, as
+         * the value of those components changed from the removed component to
          * the value of component on the base entity */
         if (removed && dst_table->flags & EcsTableHasBase) {
-            ecs_run_monitors(world, stage, dst_table, src_table->on_set_override, 
-                dst_row, 1, dst_table->on_set_override);          
+            ecs_run_monitors(world, stage, dst_table, src_table->on_set_override,
+                dst_row, 1, dst_table->on_set_override);
         }
     }
 
@@ -4773,14 +4773,14 @@ void delete_entity(
     ecs_entities_t *removed)
 {
     if (removed) {
-        ecs_run_monitors(world, stage, src_table, src_table->un_set_all, 
+        ecs_run_monitors(world, stage, src_table, src_table->un_set_all,
             src_row, 1, NULL);
 
         /* Invoke remove actions before deleting */
-        if (src_table->flags & EcsTableHasRemoveActions) {   
+        if (src_table->flags & EcsTableHasRemoveActions) {
             ecs_run_remove_actions(
                 world, stage, src_table, src_data, src_row, 1, removed, true);
-        } 
+        }
     }
 
     bool same_stage = compare_stage_w_data(stage, src_table, src_data);
@@ -4834,8 +4834,8 @@ void update_component_monitors(
     /* If this entity is a parent, check if anything changed that could impact
      * its place in the hierarchy. If so, we need to mark all of the parent's
      * entities as dirty. */
-    if (childof_changed && 
-        ecs_map_get(world->child_tables, ecs_vector_t*, entity)) 
+    if (childof_changed &&
+        ecs_map_get(world->child_tables, ecs_vector_t*, entity))
     {
         ecs_type_t type = ecs_get_type(world, entity);
         ecs_entities_t entities = ecs_type_to_entities(type);
@@ -4849,7 +4849,7 @@ void commit(
     ecs_stage_t *stage,
     ecs_entity_t entity,
     ecs_entity_info_t *info,
-    ecs_table_t *dst_table,   
+    ecs_table_t *dst_table,
     ecs_entities_t *added,
     ecs_entities_t *removed)
 {
@@ -4864,8 +4864,8 @@ void commit(
 
         /* However, if a component was added in the process of traversing a
          * table, this suggests that a case switch could have occured. */
-        if (added && added->count && src_table && 
-            src_table->flags & EcsTableHasSwitch) 
+        if (added && added->count && src_table &&
+            src_table->flags & EcsTableHasSwitch)
         {
             ecs_components_switch(
                 world, info->data, info->row, 1, added);
@@ -4881,30 +4881,30 @@ void commit(
         /* Only move entity when it is not moved to the root table, unless we're
          * iterating. In this case the entities need to be kept around so that
          * the merge knows to remove them from their previous tables. */
-        if (dst_table->type || in_progress) { 
-            info->row = move_entity(world, stage, entity, info, src_table, 
+        if (dst_table->type || in_progress) {
+            info->row = move_entity(world, stage, entity, info, src_table,
                 src_data, info->row, dst_table, added, removed);
             info->table = dst_table;
         } else {
             delete_entity(
-                world, stage, src_table, src_data, info->row, 
+                world, stage, src_table, src_data, info->row,
                 removed);
 
             ecs_eis_set(stage, entity, &(ecs_record_t){
                 NULL, -info->is_watched
             });
-        }      
-    } else {        
+        }
+    } else {
         if (dst_table->type) {
             info->row = new_entity(world, stage, entity, info, dst_table, added);
             info->table = dst_table;
-        }        
+        }
     }
 
     /* If the entity is being watched, it is being monitored for changes and
     * requires rematching systems when components are added or removed. This
     * ensures that systems that rely on components from containers or prefabs
-    * update the matched tables when the application adds or removes a 
+    * update the matched tables when the application adds or removes a
     * component from, for example, a container. */
     if (info->is_watched) {
         update_component_monitors(world, entity, added, removed);
@@ -4978,7 +4978,7 @@ const ecs_entity_t* new_w_data(
     ecs_assert(stage != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(table != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(count != 0, ECS_INTERNAL_ERROR, NULL);
-    
+
     int32_t sparse_count = ecs_eis_count(stage);
     const ecs_entity_t *ids = ecs_sparse_new_ids(stage->entity_index, count);
     ecs_assert(ids != NULL, ECS_INTERNAL_ERROR, NULL);
@@ -4998,14 +4998,14 @@ const ecs_entity_t* new_w_data(
     ecs_data_t *data = ecs_table_get_or_create_data(world, stage, table);
     int32_t row = ecs_table_appendn(world, table, data, count, ids);
     ecs_entities_t added = ecs_type_to_entities(type);
-    
+
     /* Update entity index. If entities are being created in the main stage,
      * set the record pointers in the table. */
     int i;
     if (stage == &world->stage) {
         ecs_record_t **record_ptrs = ecs_vector_first(data->record_ptrs, ecs_record_t*);
-        for (i = 0; i < count; i ++) { 
-            record_ptrs[row + i] = ecs_eis_set(stage, ids[i], 
+        for (i = 0; i < count; i ++) {
+            record_ptrs[row + i] = ecs_eis_set(stage, ids[i],
             &(ecs_record_t){
                 .table = table,
                 .row = row + i + 1
@@ -5019,11 +5019,11 @@ const ecs_entity_t* new_w_data(
             });
         }
     }
-    
+
     ecs_defer_begin(world, stage, EcsOpNone, 0, 0, NULL, 0);
 
     ecs_comp_set_t set_mask = { 0 };
-    ecs_run_add_actions(world, stage, table, data, row, count, &added, &set_mask, 
+    ecs_run_add_actions(world, stage, table, data, row, count, &added, &set_mask,
         true, component_data == NULL);
 
     if (component_data) {
@@ -5036,7 +5036,7 @@ const ecs_entity_t* new_w_data(
             if (c >= ECS_HI_COMPONENT_ID) {
                 break;
             }
-            
+
             comp_mask_set(&set_mask, c);
 
             /* Copy component data */
@@ -5057,15 +5057,15 @@ const ecs_entity_t* new_w_data(
             ecs_copy_t copy = cdata->lifecycle.copy;
             if (copy) {
                 ecs_entity_t *entities = ecs_vector_first(data->entities, ecs_entity_t);
-                copy(world, c, entities, entities, ptr, src_ptr, 
+                copy(world, c, entities, entities, ptr, src_ptr,
                     ecs_to_size_t(size), count, cdata->lifecycle.ctx);
             } else {
                 ecs_os_memcpy(ptr, src_ptr, size * count);
             }
         };
 
-        ecs_run_set_systems(world, stage, &added, 
-            table, data, row, count, true);        
+        ecs_run_set_systems(world, stage, &added,
+            table, data, row, count, true);
     }
 
     ecs_run_monitors(world, stage, table, table->monitors, row, count, NULL);
@@ -5087,7 +5087,7 @@ bool has_type(
     ecs_entity_t entity,
     ecs_type_t type,
     bool match_any,
-    bool match_prefabs)    
+    bool match_prefabs)
 {
     ecs_assert(world != NULL, ECS_INVALID_PARAMETER, NULL);
 
@@ -5132,7 +5132,7 @@ void add_remove(
         world, stage, src_table, to_remove, &removed);
 
     dst_table = ecs_table_traverse_add(
-        world, stage, dst_table, to_add, &added);    
+        world, stage, dst_table, to_add, &added);
 
     commit(world, stage, entity, &info, dst_table, &added, &removed);
 }
@@ -5211,7 +5211,7 @@ void remove_entities(
     ecs_entities_t *components)
 {
     ecs_assert(world != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(components->count < ECS_MAX_ADD_REMOVE, ECS_INVALID_PARAMETER, NULL);    
+    ecs_assert(components->count < ECS_MAX_ADD_REMOVE, ECS_INVALID_PARAMETER, NULL);
     ecs_stage_t *stage = ecs_get_stage(&world);
 
     if (ecs_defer_begin(world, stage, EcsOpRemove, entity, components, NULL, 0)) {
@@ -5293,8 +5293,8 @@ void *get_mutable(
 /* -- Private functions -- */
 
 int32_t ecs_record_to_row(
-    int32_t row, 
-    bool *is_watched_out) 
+    int32_t row,
+    bool *is_watched_out)
 {
     bool is_watched = row < 0;
     row = row * -(is_watched * 2 - 1) - 1 * (row != 0);
@@ -5303,8 +5303,8 @@ int32_t ecs_record_to_row(
 }
 
 int32_t ecs_row_to_record(
-    int32_t row, 
-    bool is_watched) 
+    int32_t row,
+    bool is_watched)
 {
     return (row + 1) * -(is_watched * 2 - 1);
 }
@@ -5322,7 +5322,7 @@ void ecs_set_watch(
     ecs_world_t *world,
     ecs_stage_t *stage,
     ecs_entity_t entity)
-{    
+{
     (void)world;
 
     ecs_record_t *record = ecs_eis_get(stage, entity);
@@ -5384,7 +5384,7 @@ ecs_entity_t ecs_new_id(
         entity = ecs_eis_recycle(&world->stage);
     } else {
         int32_t thread_count = ecs_vector_count(world->workers);
-        if (thread_count >= 1) { 
+        if (thread_count >= 1) {
             /* Can't atomically increase number above max int */
             ecs_assert(
                 world->stats.last_id < UINT_MAX, ECS_INTERNAL_ERROR, NULL);
@@ -5392,10 +5392,10 @@ ecs_entity_t ecs_new_id(
             entity = (ecs_entity_t)ecs_os_ainc((int32_t*)&world->stats.last_id);
         } else {
             entity = ++ world->stats.last_id;
-        } 
+        }
     }
 
-    ecs_assert(!world->stats.max_id || entity <= world->stats.max_id, 
+    ecs_assert(!world->stats.max_id || entity <= world->stats.max_id,
         ECS_OUT_OF_RANGE, NULL);
 
     return entity;
@@ -5420,7 +5420,7 @@ ecs_entity_t ecs_new_w_type(
     ecs_type_t type)
 {
     ecs_assert(world != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_stage_t *stage = ecs_get_stage(&world);    
+    ecs_stage_t *stage = ecs_get_stage(&world);
     ecs_entity_t entity = ecs_new_id(world);
 
     if (type || stage->scope) {
@@ -5438,7 +5438,7 @@ ecs_entity_t ecs_new_w_entity(
     ecs_entity_t component)
 {
     ecs_assert(world != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_stage_t *stage = ecs_get_stage(&world);    
+    ecs_stage_t *stage = ecs_get_stage(&world);
     ecs_entity_t entity = ecs_new_id(world);
 
     if (component || stage->scope) {
@@ -5471,9 +5471,9 @@ const ecs_entity_t* ecs_bulk_new_w_data(
     void *data)
 {
     ecs_stage_t *stage = ecs_get_stage(&world);
-    ecs_type_t type = ecs_type_find(world, 
+    ecs_type_t type = ecs_type_find(world,
         component_ids->array, component_ids->count);
-    ecs_table_t *table = ecs_table_from_type(world, stage, type);    
+    ecs_table_t *table = ecs_table_from_type(world, stage, type);
     return new_w_data(world, stage, table, NULL, count, data, NULL);
 }
 
@@ -5527,7 +5527,7 @@ void ecs_clear(
         /* Remove all components */
         ecs_entities_t to_remove = ecs_type_to_entities(type);
         remove_entities_w_info(world, stage, entity, &info, &to_remove);
-    }    
+    }
 }
 
 void ecs_delete_children(
@@ -5653,8 +5653,8 @@ void ecs_add_remove_entity(
     ecs_entity_t to_add,
     ecs_entity_t to_remove)
 {
-    ecs_entities_t components_add = { .array = &to_add, .count = 1 };      
-    ecs_entities_t components_remove = { .array = &to_remove, .count = 1 };      
+    ecs_entities_t components_add = { .array = &to_add, .count = 1 };
+    ecs_entities_t components_remove = { .array = &to_remove, .count = 1 };
     add_remove(world, entity, &components_add, &components_remove);
 }
 
@@ -5678,7 +5678,7 @@ ecs_entity_t ecs_clone(
     ecs_assert(world != NULL, ECS_INVALID_PARAMETER, NULL);
     ecs_stage_t *stage = ecs_get_stage(&world);
     ecs_assert(!world->is_merging, ECS_INVALID_WHILE_MERGING, NULL);
-    
+
     if (!dst) {
         dst = ecs_new_id(world);
     }
@@ -5699,12 +5699,12 @@ ecs_entity_t ecs_clone(
         world, stage, dst, &dst_info, src_table, &to_add);
 
     if (copy_value) {
-        ecs_table_move(world, stage, dst, src, src_table, dst_info.data, 
+        ecs_table_move(world, stage, dst, src, src_table, dst_info.data,
             dst_info.row, src_table, src_info.data, src_info.row, true);
 
         int i;
         for (i = 0; i < to_add.count; i ++) {
-            ecs_run_set_systems(world, stage, &to_add, 
+            ecs_run_set_systems(world, stage, &to_add,
                 src_table, src_info.data, dst_info.row, 1, true);
         }
     }
@@ -5736,7 +5736,7 @@ const void* ecs_get_w_entity(
                 ptr = get_base_component(
                     world, stage, entity, &info, 0, component);
             }
-        }        
+        }
     }
 
     return ptr;
@@ -5839,7 +5839,7 @@ void ecs_modified_w_entity(
             .array = &component,
             .count = 1
         };
-        ecs_run_set_systems(world, stage, &added, 
+        ecs_run_set_systems(world, stage, &added,
             info.table, info.data, info.row, 1, false);
     }
 }
@@ -5850,7 +5850,7 @@ ecs_entity_t ecs_set_ptr_w_entity(
     ecs_entity_t component,
     size_t size,
     const void *ptr)
-{    
+{
     ecs_stage_t *stage = ecs_get_stage(&world);
 
     ecs_entities_t added = {
@@ -5866,8 +5866,8 @@ ecs_entity_t ecs_set_ptr_w_entity(
         }
     }
 
-    if (ecs_defer_begin(world, stage, EcsOpSet, entity, &added, ptr, 
-        ecs_from_size_t(size))) 
+    if (ecs_defer_begin(world, stage, EcsOpSet, entity, &added, ptr,
+        ecs_from_size_t(size)))
     {
         return entity;
     }
@@ -5884,7 +5884,7 @@ ecs_entity_t ecs_set_ptr_w_entity(
         ecs_copy_t copy;
 
         if (cdata && (copy = cdata->lifecycle.copy)) {
-            copy(world, real_id, &entity, &entity, dst, ptr, size, 1, 
+            copy(world, real_id, &entity, &entity, dst, ptr, size, 1,
                 cdata->lifecycle.ctx);
         } else {
             ecs_os_memcpy(dst, ptr, ecs_from_size_t(size));
@@ -5895,7 +5895,7 @@ ecs_entity_t ecs_set_ptr_w_entity(
 
     ecs_table_mark_dirty(info.table, component);
 
-    ecs_run_set_systems(world, stage, &added, 
+    ecs_run_set_systems(world, stage, &added,
         info.table, info.data, info.row, 1, false);
 
     ecs_defer_end(world, stage);
@@ -5931,8 +5931,8 @@ ecs_entity_t ecs_get_case(
     index -= table->sw_column_offset;
     ecs_assert(index >= 0, ECS_INTERNAL_ERROR, NULL);
 
-    ecs_switch_t *sw = data->sw_columns[index].data;  
-    return ecs_switch_get(sw, info.row);  
+    ecs_switch_t *sw = data->sw_columns[index].data;
+    return ecs_switch_get(sw, info.row);
 }
 
 bool ecs_has_entity(
@@ -5950,7 +5950,7 @@ bool ecs_has_entity(
         ecs_table_t *table = info.table;
         int32_t index = ecs_table_switch_from_case(world, table, component);
         ecs_assert(index < table->sw_column_count, ECS_INTERNAL_ERROR, NULL);
-        
+
         ecs_data_t *data = info.data;
         ecs_switch_t *sw = data->sw_columns[index].data;
         ecs_entity_t value = ecs_switch_get(sw, info.row);
@@ -5975,7 +5975,7 @@ ecs_entity_t ecs_get_parent_w_entity(
     ecs_entity_t entity,
     ecs_entity_t component)
 {
-    ecs_type_t type = ecs_get_type(world, entity);    
+    ecs_type_t type = ecs_get_type(world, entity);
     ecs_entity_t parent = ecs_find_in_type(world, type, component, ECS_CHILDOF);
     return parent;
 }
@@ -6016,7 +6016,7 @@ ecs_type_t ecs_type_from_entity(
 }
 
 ecs_entity_t ecs_type_to_entity(
-    ecs_world_t *world, 
+    ecs_world_t *world,
     ecs_type_t type)
 {
     (void)world;
@@ -6024,7 +6024,7 @@ ecs_entity_t ecs_type_to_entity(
     if (!type) {
         return 0;
     }
-    
+
     /* If array contains n entities, it cannot be reduced to a single entity */
     if (ecs_vector_count(type) != 1) {
         ecs_abort(ECS_TYPE_NOT_AN_ENTITY, NULL);
@@ -6053,14 +6053,14 @@ ecs_type_t ecs_get_type(
     if (record && (table = record->table)) {
         return table->type;
     }
-    
+
     return NULL;
 }
 
 int32_t ecs_count_type(
     ecs_world_t *world,
     ecs_type_t type)
-{    
+{
     if (!type) {
         return 0;
     }
@@ -6073,7 +6073,7 @@ int32_t ecs_count_type(
 int32_t ecs_count_entity(
     ecs_world_t *world,
     ecs_entity_t entity)
-{    
+{
     if (!entity) {
         return 0;
     }
@@ -6101,7 +6101,7 @@ int32_t ecs_count_w_filter(
             result += ecs_table_count(table);
         }
     }
-    
+
     return result;
 }
 
@@ -6117,7 +6117,7 @@ bool ecs_defer_begin(
     ecs_size_t size)
 {
     (void)world;
-    
+
     if (stage->defer && op_kind != EcsOpNone) {
         if (!components->count) {
             return true;
@@ -6151,7 +6151,7 @@ bool ecs_defer_begin(
     } else {
         stage->defer ++;
     }
-    
+
     return false;
 }
 
@@ -6179,8 +6179,8 @@ void ecs_defer_end(
                     remove_entities(world, op->entity, &op->components);
                     break;
                 case EcsOpSet:
-                    ecs_set_ptr_w_entity(world, op->entity, 
-                        op->components.array[0], ecs_to_size_t(op->size), 
+                    ecs_set_ptr_w_entity(world, op->entity,
+                        op->components.array[0], ecs_to_size_t(op->size),
                         op->value);
                     break;
                 }
@@ -6217,7 +6217,7 @@ size_t append_to_str(
         to_write = len;
         bytes_left -= len;
     }
-    
+
     if (to_write) {
         ecs_os_strncpy(ptr, str, to_write);
     }
@@ -6295,7 +6295,7 @@ size_t ecs_entity_str(
             ecs_os_free(hi_path);
 
             bytes_left = append_to_str(&ptr, ">", bytes_left, &required);
-        }            
+        }
 
         char *lo_path = ecs_get_fullpath(world, lo);
         bytes_left = append_to_str(&ptr, lo_path, bytes_left, &required);
@@ -6317,7 +6317,7 @@ size_t ecs_entity_str(
 static
 void clear_columns(
     ecs_world_t *world,
-    ecs_stage_t *stage, 
+    ecs_stage_t *stage,
     ecs_data_t *data)
 {
     int32_t i, entity_count = ecs_vector_count(data->entities);
@@ -6327,7 +6327,7 @@ void clear_columns(
     for (i = 0; i < entity_count; i ++) {
         ecs_entity_t e = entities[i];
         ecs_record_t *record = record_ptrs[i];
-        
+
         if (!record && e > ECS_HI_ENTITY_ID) {
             record = ecs_eis_get(stage, e);
         }
@@ -6385,7 +6385,7 @@ void merge_commits(
         ecs_entity_t *entities = ecs_vector_first(data->entities, ecs_entity_t);
         ecs_record_t **record_ptrs = ecs_vector_first(data->record_ptrs, ecs_record_t*);
         int32_t component_count = ecs_vector_count(table->type);
-        
+
         ecs_assert(main_data != data, ECS_INTERNAL_ERROR, NULL);
         data->marked_dirty = false;
 
@@ -6413,7 +6413,7 @@ void merge_commits(
         }
 
         for (e = 0; e < entity_count; e ++) {
-            ecs_record_t *record = record_ptrs[e];            
+            ecs_record_t *record = record_ptrs[e];
             ecs_entity_t entity = entities[e];
 
             /* If the entity did not yet exist in the main stage, register it */
@@ -6423,7 +6423,7 @@ void merge_commits(
             }
 
             bool is_watched;
-            int32_t row = ecs_record_to_row(record->row, &is_watched);            
+            int32_t row = ecs_record_to_row(record->row, &is_watched);
             ecs_table_t *src_table = record->table;
 
             /* If one or more of the components in the table have a move action
@@ -6440,7 +6440,7 @@ void merge_commits(
 
                     /* Move entity from src table to destination table */
                     if (src_table->flags & EcsTableHasMove) {
-                        ecs_table_move(world, &world->stage, entity, entity, table, 
+                        ecs_table_move(world, &world->stage, entity, entity, table,
                             main_data, dst_row, src_table, src_data, row, true);
                     }
 
@@ -6450,14 +6450,14 @@ void merge_commits(
                 }
 
                 /* Now move data from stage into the main stage */
-                ecs_table_move(world, &world->stage, entity, entity, table, 
+                ecs_table_move(world, &world->stage, entity, entity, table,
                     main_data, dst_row, table, data, e, false);
 
                 record->table = table;
                 record->row = ecs_row_to_record(dst_row, is_watched);
             } else {
                 /* If entity is already in this table, simply move */
-                ecs_table_move(world, &world->stage, entity, entity, table, 
+                ecs_table_move(world, &world->stage, entity, entity, table,
                     main_data, row, table, data, e, false);
             }
         }
@@ -6503,7 +6503,7 @@ void merge_on_set(
     ecs_entity_t *entities = ecs_vector_first(data->entities, ecs_entity_t);
     ecs_record_t **r_ptrs = ecs_vector_first(data->record_ptrs, ecs_record_t*);
     int32_t i, count = ecs_table_data_count(data);
-    
+
     world->in_progress = true;
 
     for (i = 0; i < count; i ++) {
@@ -6533,17 +6533,17 @@ void merge_on_set(
             src_set = src_table->on_set_all;
             src_mon = src_table->monitors;
 
-            /* We don't know if components were added or removed, so we have to 
+            /* We don't know if components were added or removed, so we have to
              * run UnSet systems too */
-            ecs_run_monitors(world, stage, table, src_table->un_set_all, 
-                i, 1, table->un_set_all);  
+            ecs_run_monitors(world, stage, table, src_table->un_set_all,
+                i, 1, table->un_set_all);
 
             /* It is possible that removing a component caused a base component
              * to get exposed, which should trigger an OnSet system. */
             if (table->flags & EcsTableHasBase) {
-                ecs_run_monitors(world, stage, table, 
+                ecs_run_monitors(world, stage, table,
                     src_table->on_set_override, i, 1, table->on_set_override);
-            }                
+            }
         }
 
         /* Run OnSet systems */
@@ -6557,7 +6557,7 @@ void merge_on_set(
         }
 
     }
-    
+
     world->in_progress = false;
 }
 
@@ -6600,13 +6600,13 @@ void merge_tables(
         ecs_data_t *staged_data = ecs_table_get_staged_data(
             world, stage, main_table);
 
-        ecs_assert(!staged_data || !staged_data->columns, 
+        ecs_assert(!staged_data || !staged_data->columns,
             ECS_INTERNAL_ERROR, NULL);
 #endif
 
         ecs_data_t *main_staged_data = ecs_table_get_or_create_data(
             world, stage, main_table);
-        
+
         ecs_assert(main_staged_data != NULL, ECS_INTERNAL_ERROR, NULL);
 
         /* Move the staged data from the staged table to the stage-specific
@@ -6620,8 +6620,8 @@ void merge_tables(
         /* If the main_table has been matched with OnSet systems, these
          * systems have not yet been invoked for the entities in this table
          * as systems aren't matched while in progress. Invoke them now. */
-        if (main_table->on_set_all || main_table->un_set_all || 
-            main_table->monitors || main_table->on_set_override) 
+        if (main_table->on_set_all || main_table->un_set_all ||
+            main_table->monitors || main_table->on_set_override)
         {
             /* TODO: if an entity is moved by an OnSet handler to a new
              * table that is also created in the stage, it is possible that
@@ -6640,7 +6640,7 @@ void merge_tables(
 
         /* Add main stage table to dirty_tables. This will cause both the
          * staged table as well as the main stage table to be added to
-         * the array. This is ok, as the staged table is now empty, so 
+         * the array. This is ok, as the staged table is now empty, so
          * entities won't be added twice. */
         ecs_table_t **el = ecs_vector_add(&stage->dirty_tables, ecs_table_t*);
         *el = main_table;
@@ -6657,7 +6657,7 @@ void merge_tables(
         if (data) {
             *data = (ecs_data_t){ 0 };
         }
-    }    
+    }
 }
 
 /* -- Private functions -- */
@@ -6769,7 +6769,7 @@ ecs_vector_t* _ecs_vector_new(
     int32_t elem_count)
 {
     ecs_assert(elem_size != 0, ECS_INTERNAL_ERROR, NULL);
-    
+
     ecs_vector_t *result =
         ecs_os_malloc(offset + elem_size * elem_count);
     ecs_assert(result != NULL, ECS_OUT_OF_MEMORY, NULL);
@@ -6789,7 +6789,7 @@ ecs_vector_t* _ecs_vector_from_array(
     void *array)
 {
     ecs_assert(elem_size != 0, ECS_INTERNAL_ERROR, NULL);
-    
+
     ecs_vector_t *result =
         ecs_os_malloc(offset + elem_size * elem_count);
     ecs_assert(result != NULL, ECS_OUT_OF_MEMORY, NULL);
@@ -6801,7 +6801,7 @@ ecs_vector_t* _ecs_vector_from_array(
 #ifndef NDEBUG
     result->elem_size = elem_size;
 #endif
-    return result;   
+    return result;
 }
 
 void ecs_vector_free(
@@ -6827,7 +6827,7 @@ void* _ecs_vector_addn(
     if (elem_count == 1) {
         return _ecs_vector_add(array_inout, elem_size, offset);
     }
-    
+
     ecs_vector_t *vector = *array_inout;
     if (!vector) {
         vector = _ecs_vector_new(elem_size, offset, 1);
@@ -6917,7 +6917,7 @@ int32_t _ecs_vector_remove(
     void *elem)
 {
     ecs_assert(vector->elem_size == elem_size, ECS_INTERNAL_ERROR, NULL);
-    
+
     if (!elem) {
         return 0;
     }
@@ -6984,7 +6984,7 @@ int32_t _ecs_vector_remove_index(
     int32_t index)
 {
     ecs_assert(vector->elem_size == elem_size, ECS_INTERNAL_ERROR, NULL);
-    
+
     int32_t count = vector->count;
     void *buffer = ECS_OFFSET(vector, offset);
     void *elem = ECS_OFFSET(buffer, index * elem_size);
@@ -7010,7 +7010,7 @@ void _ecs_vector_reclaim(
     ecs_vector_t *vector = *array_inout;
 
     ecs_assert(vector->elem_size == elem_size, ECS_INTERNAL_ERROR, NULL);
-    
+
     int32_t size = vector->size;
     int32_t count = vector->count;
 
@@ -7151,8 +7151,8 @@ void* _ecs_vector_get(
     if (!vector) {
         return NULL;
     }
-    
-    ecs_assert(vector->elem_size == elem_size, ECS_INTERNAL_ERROR, NULL);    
+
+    ecs_assert(vector->elem_size == elem_size, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(index >= 0, ECS_INTERNAL_ERROR, NULL);
 
     int32_t count = vector->count;
@@ -7192,7 +7192,7 @@ void _ecs_vector_sort(
         return;
     }
 
-    ecs_assert(vector->elem_size == elem_size, ECS_INTERNAL_ERROR, NULL);    
+    ecs_assert(vector->elem_size == elem_size, ECS_INTERNAL_ERROR, NULL);
 
     int32_t count = vector->count;
     void *buffer = ECS_OFFSET(vector, offset);
@@ -7244,7 +7244,7 @@ ecs_vector_t* _ecs_vector_copy(
 
 typedef struct chunk_t {
     int32_t *sparse;            /* Sparse array with indices to dense array */
-    void *data;                 /* Store data in sparse array to reduce  
+    void *data;                 /* Store data in sparse array to reduce
                                  * indirection and provide stable pointers. */
 } chunk_t;
 
@@ -7285,11 +7285,11 @@ chunk_t* chunk_new(
 
     /* Initialize sparse array with zero's, as zero is used to indicate that the
      * sparse element has not been paired with a dense element. Use zero
-     * as this means we can take advantage of calloc having a possibly better 
+     * as this means we can take advantage of calloc having a possibly better
      * performance than malloc + memset. */
     result->sparse = ecs_os_calloc(ECS_SIZEOF(int32_t) * CHUNK_COUNT);
 
-    /* Initialize the data array with zero's to guarantee that data is 
+    /* Initialize the data array with zero's to guarantee that data is
      * always initialized. When an entry is removed, data is reset back to
      * zero. Initialize now, as this can take advantage of calloc. */
     result->data = ecs_os_calloc(sparse->size * CHUNK_COUNT);
@@ -7343,9 +7343,9 @@ void grow_dense(
 
 static
 void assign_index(
-    chunk_t *chunk, 
-    uint64_t *dense_array, 
-    uint64_t index, 
+    chunk_t *chunk,
+    uint64_t *dense_array,
+    uint64_t index,
     int32_t dense)
 {
     chunk->sparse[OFFSET(index)] = dense;
@@ -7384,10 +7384,10 @@ uint64_t create_id(
 
     chunk_t *chunk = get_or_create_chunk(sparse, CHUNK(index));
     ecs_assert(chunk->sparse[OFFSET(index)] == 0, ECS_INTERNAL_ERROR, NULL);
-    
+
     uint64_t *dense_array = ecs_vector_first(sparse->dense, uint64_t);
     assign_index(chunk, dense_array, index, dense);
-    
+
     return index;
 }
 
@@ -7407,14 +7407,14 @@ uint64_t new_index(
         return dense_array[count];
     } else {
         return create_id(sparse, count);
-    }    
+    }
 }
 
 static
 void* try_sparse(
     const ecs_sparse_t *sparse,
     uint64_t index)
-{    
+{
     chunk_t *chunk = get_chunk(sparse, CHUNK(index));
     if (!chunk) {
         return NULL;
@@ -7440,7 +7440,7 @@ void* get_sparse(
 {
     chunk_t *chunk = get_chunk(sparse, CHUNK(index));
     int32_t offset = OFFSET(index);
-    
+
     ecs_assert(chunk != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(dense == chunk->sparse[offset], ECS_INTERNAL_ERROR, NULL);
 
@@ -7501,7 +7501,7 @@ void ecs_sparse_clear(
     ecs_vector_free(sparse->chunks);
     ecs_vector_set_count(&sparse->dense, uint64_t, 1);
 
-    sparse->chunks = NULL;   
+    sparse->chunks = NULL;
     sparse->count = 1;
     sparse->max_id_local = 0;
 }
@@ -7583,7 +7583,7 @@ void* _ecs_sparse_get_or_create(
 
     if (dense) {
         /* Element is already paired, check consistency */
-        ecs_assert(index == *ecs_vector_get(sparse->dense, uint64_t, dense), 
+        ecs_assert(index == *ecs_vector_get(sparse->dense, uint64_t, dense),
             ECS_INTERNAL_ERROR, NULL);
 
         /* Check if element is alive. If element is not alive, update indices so
@@ -7665,7 +7665,7 @@ void _ecs_sparse_remove(
     } else {
         /* Element is not paired and thus not alive, nothing to be done */
     }
-    
+
     /* Reset memory to zero on remove */
     ecs_size_t size = sparse->size;
     void *ptr = DATA(chunk->data, size, offset);
@@ -7714,7 +7714,7 @@ int32_t ecs_sparse_size(
     if (!sparse) {
         return 0;
     }
-        
+
     return ecs_vector_count(sparse->dense) - 1;
 }
 
@@ -7748,7 +7748,7 @@ void sparse_copy(
 {
     ecs_sparse_set_size(dst, ecs_sparse_size(src));
     const uint64_t *indices = ecs_sparse_ids(src);
-    
+
     ecs_size_t size = src->size;
     int32_t i, count = src->count;
 
@@ -7867,7 +7867,7 @@ void ecs_table_writer_register_table(
         ecs_vector_each(data->entities, ecs_entity_t, e_ptr, {
             ecs_eis_delete(&world->stage, *e_ptr);
         });
-      
+
         return;
     } else {
         /* Set size of table to 0. This will initialize columns */
@@ -7895,12 +7895,12 @@ void ecs_table_writer_finalize_table(
 
         if (record_ptr) {
             if (record_ptr->table != writer->table) {
-                ecs_table_t *table = record_ptr->table;                
+                ecs_table_t *table = record_ptr->table;
                 ecs_data_t *table_data = ecs_table_get_data(world, table);
 
                 ecs_assert(table != NULL, ECS_INTERNAL_ERROR, NULL);
 
-                ecs_table_delete(world, &world->stage, 
+                ecs_table_delete(world, &world->stage,
                     table, table_data, record_ptr->row - 1, false);
             }
         } else {
@@ -7925,7 +7925,7 @@ void ecs_table_writer_prepare_column(
     ecs_world_t *world = stream->world;
     ecs_data_t *data = ecs_table_get_or_create_data(
         world, &world->stage, writer->table);
-        
+
     ecs_assert(data != NULL, ECS_INTERNAL_ERROR, NULL);
 
     if (writer->column_index) {
@@ -7937,7 +7937,7 @@ void ecs_table_writer_prepare_column(
 
             /* Initialize new elements to 0 */
             void *buffer = ecs_vector_first_t(column->data, size, 0);
-            ecs_os_memset(ECS_OFFSET(buffer, old_count * size), 0, 
+            ecs_os_memset(ECS_OFFSET(buffer, old_count * size), 0,
                 (writer->row_count - old_count) * size);
         }
 
@@ -7948,16 +7948,16 @@ void ecs_table_writer_prepare_column(
             &data->entities, ecs_entity_t, writer->row_count);
 
         ecs_vector_set_count(
-            &data->record_ptrs, ecs_record_t*, writer->row_count);            
+            &data->record_ptrs, ecs_record_t*, writer->row_count);
 
         writer->column_vector = data->entities;
-        writer->column_size = ECS_SIZEOF(ecs_entity_t);      
+        writer->column_size = ECS_SIZEOF(ecs_entity_t);
     }
 
     writer->column_data = ecs_vector_first_t(writer->column_vector,
-        writer->column_size, 
+        writer->column_size,
         writer->column_alignment);
-        
+
     writer->column_written = 0;
 }
 
@@ -8134,7 +8134,7 @@ ecs_size_t ecs_table_writer(
             name_ptr->alloc_value = writer->name.name;
 
             /* Don't overwrite entity name */
-            ecs_name_writer_reset(&writer->name);   
+            ecs_name_writer_reset(&writer->name);
 
             ecs_table_writer_next(stream);
         }
@@ -8169,7 +8169,7 @@ int ecs_writer_write(
 
     while (total_written < size) {
         if (writer->state == EcsStreamHeader) {
-            writer->state = *(ecs_blob_header_kind_t*)ECS_OFFSET(buffer, 
+            writer->state = *(ecs_blob_header_kind_t*)ECS_OFFSET(buffer,
                 total_written);
 
             if (writer->state != EcsTableHeader) {
@@ -8180,7 +8180,7 @@ int ecs_writer_write(
             written = ECS_SIZEOF(ecs_blob_header_kind_t);
         } else
         if (writer->state == EcsTableHeader) {
-            written = ecs_table_writer(ECS_OFFSET(buffer, total_written), 
+            written = ecs_table_writer(ECS_OFFSET(buffer, total_written),
                 remaining, writer);
         }
 
@@ -8193,7 +8193,7 @@ int ecs_writer_write(
         }
 
         remaining -= written;
-        total_written += written;    
+        total_written += written;
     }
 
     ecs_assert(total_written <= size, ECS_INTERNAL_ERROR, NULL);
@@ -8268,7 +8268,7 @@ ecs_entity_t ecs_import(
     /* Copy value of module component in handles_out parameter */
     if (handles_size && handles_out) {
         void *handles_ptr = ecs_get_mut_w_entity(world, e, e, NULL);
-        ecs_os_memcpy(handles_out, handles_ptr, ecs_from_size_t(handles_size));   
+        ecs_os_memcpy(handles_out, handles_ptr, ecs_from_size_t(handles_size));
     }
 
     /* Restore to previous state */
@@ -8300,7 +8300,7 @@ ecs_entity_t ecs_import_from_library(
     if (!import_func) {
         import_func = ecs_os_malloc(ecs_os_strlen(library_name) + ECS_SIZEOF("Import"));
         ecs_assert(import_func != NULL, ECS_OUT_OF_MEMORY, NULL);
-        
+
         const char *ptr;
         char ch, *bptr = import_func;
         bool capitalize = true;
@@ -8335,24 +8335,24 @@ ecs_entity_t ecs_import_from_library(
         }
         return 0;
     } else {
-        ecs_trace_1("found file '%s' for library '%s'", 
+        ecs_trace_1("found file '%s' for library '%s'",
             library_filename, library_name);
     }
 
     ecs_os_dl_t dl = ecs_os_dlopen(library_filename);
     if (!dl) {
-        ecs_os_err("failed to load library '%s' ('%s')", 
+        ecs_os_err("failed to load library '%s' ('%s')",
             library_name, library_filename);
-        
+
         ecs_os_free(library_filename);
 
         if (module != module_name) {
             ecs_os_free(module);
-        }    
+        }
 
         return 0;
     } else {
-        ecs_trace_1("library '%s' ('%s') loaded", 
+        ecs_trace_1("library '%s' ('%s') loaded",
             library_name, library_filename);
     }
 
@@ -8362,7 +8362,7 @@ ecs_entity_t ecs_import_from_library(
         ecs_os_err("failed to load import function %s from library %s",
             import_func, library_name);
         ecs_os_free(library_filename);
-        ecs_os_dlclose(dl);            
+        ecs_os_dlclose(dl);
         return 0;
     } else {
         ecs_trace_1("found import function '%s' in library '%s' for module '%s'",
@@ -8454,7 +8454,7 @@ ecs_queue_t* _ecs_queue_from_array(
 
     result->data = _ecs_vector_from_array(elem_size, offset, elem_count, array);
     result->index = 0;
-    return result;    
+    return result;
 }
 
 void* _ecs_queue_push(
@@ -8577,15 +8577,15 @@ ecs_data_t* duplicate_data(
             ecs_vector_set_count_t(&dst_vec, size, alignment, count);
             void *dst_ptr = ecs_vector_first_t(dst_vec, size, alignment);
             void *ctx = cdata->lifecycle.ctx;
-            
+
             ecs_xtor_t ctor = cdata->lifecycle.ctor;
             if (ctor) {
-                ctor(world, component, entities, dst_ptr, ecs_to_size_t(size), 
+                ctor(world, component, entities, dst_ptr, ecs_to_size_t(size),
                     count, ctx);
             }
 
             void *src_ptr = ecs_vector_first_t(column->data, size, alignment);
-            copy(world, component, entities, entities, dst_ptr, src_ptr, 
+            copy(world, component, entities, entities, dst_ptr, src_ptr,
                 ecs_to_size_t(size), count, ctx);
 
             column->data = dst_vec;
@@ -8730,17 +8730,17 @@ void ecs_snapshot_restore(
                     ecs_record_t *r = ecs_eis_get(&world->stage, *e_ptr);
                     if (r && r->table) {
                         ecs_data_t *data = ecs_table_get_data(world, r->table);
-                        
+
                         /* Data must be not NULL, otherwise entity index could
                          * not point to it */
                         ecs_assert(data != NULL, ECS_INTERNAL_ERROR, NULL);
 
                         bool is_monitored;
                         int32_t row = ecs_record_to_row(r->row, &is_monitored);
-                        
+
                         /* Always delete entity, so that even if the entity is
                         * in the current table, there won't be duplicates */
-                        ecs_table_delete(world, &world->stage, r->table, 
+                        ecs_table_delete(world, &world->stage, r->table,
                             data, row, false);
                     }
                 });
@@ -8760,7 +8760,7 @@ void ecs_snapshot_restore(
             } else {
                 ecs_table_replace_data(world, table, leaf->data);
             }
-            
+
             ecs_os_free(leaf->data);
             l ++;
         } else {
@@ -8794,12 +8794,12 @@ void ecs_snapshot_restore(
             ecs_data_t *table_data = ecs_table_get_data(world, table);
             int32_t entity_count = ecs_table_data_count(table_data);
 
-            ecs_run_set_systems(world, &world->stage, &components, table, 
-                table_data, 0, entity_count, true);            
+            ecs_run_set_systems(world, &world->stage, &components, table,
+                table_data, 0, entity_count, true);
         }
     }
 
-    ecs_vector_free(snapshot->tables);   
+    ecs_vector_free(snapshot->tables);
 
     ecs_os_free(snapshot);
 }
@@ -8851,7 +8851,7 @@ bool ecs_snapshot_next(
         return true;
     }
 
-    return false;    
+    return false;
 }
 
 /** Cleanup snapshot */
@@ -8866,7 +8866,7 @@ void ecs_snapshot_free(
         ecs_table_leaf_t *leaf = &tables[i];
         ecs_table_clear_data(leaf->table, leaf->data);
         ecs_os_free(leaf->data);
-    }    
+    }
 
     ecs_vector_free(snapshot->tables);
     ecs_os_free(snapshot);
@@ -8883,15 +8883,15 @@ ecs_table_t *ecs_dbg_find_table(
 {
     ecs_table_t *table = ecs_table_from_type(
         world, &world->stage, type);
-        
+
     ecs_assert(table != NULL, ECS_INTERNAL_ERROR, NULL);
 
     return table;
 }
 
 void ecs_dbg_table(
-    ecs_world_t *world, 
-    ecs_table_t *table, 
+    ecs_world_t *world,
+    ecs_table_t *table,
     ecs_dbg_table_t *dbg_out)
 {
     ecs_assert(dbg_out != NULL, ECS_INVALID_PARAMETER, NULL);
@@ -8932,7 +8932,7 @@ void ecs_dbg_table(
             ecs_dbg_entity(world, e & ECS_ENTITY_MASK, &base_dbg);
 
             ecs_dbg_table_t base_table_dbg;
-            ecs_dbg_table(world, base_dbg.table, &base_table_dbg);            
+            ecs_dbg_table(world, base_dbg.table, &base_table_dbg);
 
             /* Owned and shared components are available from base */
             dbg_out->shared = ecs_type_merge(
@@ -8956,7 +8956,7 @@ void ecs_dbg_table(
 
             /* Add base entities of entity to list of base entities */
             dbg_out->base_entities = ecs_type_add(
-                world, base_table_dbg.base_entities, e & ECS_ENTITY_MASK);                                                       
+                world, base_table_dbg.base_entities, e & ECS_ENTITY_MASK);
         }
     }
 
@@ -8994,12 +8994,12 @@ ecs_type_t ecs_dbg_table_get_type(
 }
 
 void ecs_dbg_entity(
-    ecs_world_t *world, 
-    ecs_entity_t entity, 
+    ecs_world_t *world,
+    ecs_entity_t entity,
     ecs_dbg_entity_t *dbg_out)
 {
     *dbg_out = (ecs_dbg_entity_t){.entity = entity};
-    
+
     ecs_entity_info_t info = { 0 };
     if (ecs_get_info(world, &world->stage, entity, &info)) {
         dbg_out->table = info.table;
@@ -9020,7 +9020,7 @@ bool iter_table(
     ecs_table_reader_t *reader,
     ecs_iter_t *it,
     ecs_iter_next_action_t next,
-    bool skip_builtin)    
+    bool skip_builtin)
 {
     bool table_found = false;
 
@@ -9054,13 +9054,13 @@ void next_table(
     ecs_world_t *world,
     ecs_reader_t *stream,
     ecs_table_reader_t *reader)
-{    
+{
     int32_t count;
 
     /* First iterate all component tables, as component data must always be
      * stored in a blob before anything else */
     bool table_found = iter_table(
-        world, reader, &stream->component_iter, stream->component_next, 
+        world, reader, &stream->component_iter, stream->component_next,
         false);
 
     /* If all components have been added, add the regular data tables. Make sure
@@ -9115,7 +9115,7 @@ void ecs_table_reader_next(
             reader->column_vector = reader->data->entities;
             reader->column_size = ECS_SIZEOF(ecs_entity_t);
         } else {
-            ecs_column_t *column = 
+            ecs_column_t *column =
                 &reader->data->columns[reader->column_index - 1];
             reader->column_vector = column->data;
             reader->column_size = column->size;
@@ -9125,16 +9125,16 @@ void ecs_table_reader_next(
 
     case EcsTableColumnSize:
         reader->state = EcsTableColumnData;
-        reader->column_data = ecs_vector_first_t(reader->column_vector, 
+        reader->column_data = ecs_vector_first_t(reader->column_vector,
             reader->column_size, reader->column_alignment);
         reader->column_written = 0;
         break;
 
     case EcsTableColumnNameHeader: {
         reader->state = EcsTableColumnNameLength;
-        ecs_column_t *column = 
+        ecs_column_t *column =
                 &reader->data->columns[reader->column_index - 1];
-        reader->column_vector = column->data;                
+        reader->column_vector = column->data;
         reader->column_data = ecs_vector_first(reader->column_vector, EcsName);
         reader->row_index = 0;
         break;
@@ -9161,7 +9161,7 @@ void ecs_table_reader_next(
             ecs_entity_t *type_buffer = ecs_vector_first(reader->type, ecs_entity_t);
             if (reader->column_index >= 1) {
                 ecs_entity_t e = type_buffer[reader->column_index - 1];
-                
+
                 if (e != ecs_entity(EcsName)) {
                     reader->state = EcsTableColumnHeader;
                 } else {
@@ -9169,7 +9169,7 @@ void ecs_table_reader_next(
                 }
             } else {
                 reader->state = EcsTableColumnHeader;
-            }            
+            }
         }
         break;
 
@@ -9203,7 +9203,7 @@ ecs_size_t ecs_table_reader(
     }
 
     switch(reader->state) {
-    case EcsTableHeader:  
+    case EcsTableHeader:
         *(ecs_blob_header_kind_t*)buffer = EcsTableHeader;
         read = ECS_SIZEOF(ecs_blob_header_kind_t);
         ecs_table_reader_next(stream);
@@ -9213,7 +9213,7 @@ ecs_size_t ecs_table_reader(
         *(int32_t*)buffer = ecs_vector_count(reader->type);
         read = ECS_SIZEOF(int32_t);
         ecs_table_reader_next(stream);
-        break;  
+        break;
 
     case EcsTableType: {
         ecs_entity_t *type_array = ecs_vector_first(reader->type, ecs_entity_t);
@@ -9224,7 +9224,7 @@ ecs_size_t ecs_table_reader(
         if (reader->type_written == ecs_vector_count(reader->type) * ECS_SIZEOF(ecs_entity_t)) {
             ecs_table_reader_next(stream);
         }
-        break;                
+        break;
     }
 
     case EcsTableSize:
@@ -9237,7 +9237,7 @@ ecs_size_t ecs_table_reader(
         *(ecs_blob_header_kind_t*)buffer = EcsTableColumnHeader;
         read = ECS_SIZEOF(ecs_blob_header_kind_t);
         ecs_table_reader_next(stream);
-        break; 
+        break;
 
     case EcsTableColumnSize:
         *(int32_t*)buffer = reader->column_size;
@@ -9247,7 +9247,7 @@ ecs_size_t ecs_table_reader(
         if (!reader->column_size) {
             ecs_table_reader_next(stream);
         }
-        break; 
+        break;
 
     case EcsTableColumnData: {
         ecs_size_t column_bytes = reader->column_size * reader->row_count;
@@ -9292,16 +9292,16 @@ ecs_size_t ecs_table_reader(
         reader->name_written = 0;
         *(int32_t*)buffer = reader->name_len;
         read = ECS_SIZEOF(int32_t);
-        ecs_table_reader_next(stream);    
+        ecs_table_reader_next(stream);
         break;
 
-    case EcsTableColumnName:   
+    case EcsTableColumnName:
         read = reader->name_len - reader->name_written;
         if (read >= ECS_SIZEOF(int32_t)) {
 
             int32_t i;
             for (i = 0; i < 4; i ++) {
-                *(char*)ECS_OFFSET(buffer, i) = 
+                *(char*)ECS_OFFSET(buffer, i) =
                     *(char*)ECS_OFFSET(reader->name, reader->name_written + i);
             }
 
@@ -9353,10 +9353,10 @@ ecs_size_t ecs_reader_read(
                 break;
             }
 
-            ecs_assert(remaining % 4 == 0, ECS_INTERNAL_ERROR, NULL);        
+            ecs_assert(remaining % 4 == 0, ECS_INTERNAL_ERROR, NULL);
         }
-    }  
-    
+    }
+
     return total_read;
 }
 
@@ -9411,7 +9411,7 @@ void bulk_delete(
     ecs_assert(world != NULL, ECS_INVALID_PARAMETER, NULL);
     ecs_stage_t *stage = ecs_get_stage(&world);
 
-    ecs_assert(stage == &world->stage, ECS_UNSUPPORTED, 
+    ecs_assert(stage == &world->stage, ECS_UNSUPPORTED,
         "delete_w_filter currently only supported on main stage");
 
     int32_t i, count = ecs_sparse_count(stage->tables);
@@ -9459,7 +9459,7 @@ void merge_table(
     ecs_table_t *src_table,
     ecs_entities_t *to_add,
     ecs_entities_t *to_remove)
-{    
+{
     if (!dst_table->type) {
         /* If this removes all components, clear table */
         ecs_table_clear(world, src_table);
@@ -9471,7 +9471,7 @@ void merge_table(
             int32_t src_count = ecs_table_count(src_table);
 
             if (to_remove && to_remove->count && src_data) {
-                ecs_run_remove_actions(world, &world->stage, src_table, 
+                ecs_run_remove_actions(world, &world->stage, src_table,
                     src_data, 0, src_count, to_remove, false);
             }
 
@@ -9481,7 +9481,7 @@ void merge_table(
 
             if (to_add && to_add->count && dst_data) {
                 ecs_comp_set_t set_mask = {0};
-                ecs_run_add_actions(world, &world->stage, dst_table, dst_data, 
+                ecs_run_add_actions(world, &world->stage, dst_table, dst_data,
                     dst_count, src_count, to_add, &set_mask, false, true);
             }
         }
@@ -9514,7 +9514,7 @@ void ecs_bulk_add_remove_type(
     ecs_entities_t added = {
         .array = ecs_os_alloca(ECS_SIZEOF(ecs_entity_t) * to_add_array.count),
         .count = 0
-    }; 
+    };
 
     ecs_entities_t removed = {
         .array = ecs_os_alloca(ECS_SIZEOF(ecs_entity_t) * to_remove_array.count),
@@ -9535,7 +9535,7 @@ void ecs_bulk_add_remove_type(
 
         ecs_table_t *dst_table = ecs_table_traverse_remove(
             world, stage, table, &to_remove_array, &removed);
-        
+
         dst_table = ecs_table_traverse_add(
             world, stage, dst_table, &to_add_array, &added);
 
@@ -9546,12 +9546,12 @@ void ecs_bulk_add_remove_type(
             continue;
         }
 
-        ecs_assert(dst_table != NULL, ECS_INTERNAL_ERROR, NULL);   
+        ecs_assert(dst_table != NULL, ECS_INTERNAL_ERROR, NULL);
 
         merge_table(world, dst_table, table, &added, &removed);
         added.count = 0;
         removed.count = 0;
-    }    
+    }
 }
 
 void ecs_bulk_add_type(
@@ -9561,7 +9561,7 @@ void ecs_bulk_add_type(
 {
     ecs_assert(world != NULL, ECS_INVALID_PARAMETER, NULL);
     ecs_assert(to_add != NULL, ECS_INVALID_PARAMETER, NULL);
-    
+
     ecs_stage_t *stage = ecs_get_stage(&world);
     ecs_assert(stage == &world->stage, ECS_UNSUPPORTED, NULL);
 
@@ -9582,10 +9582,10 @@ void ecs_bulk_add_type(
         if (!ecs_table_match_filter(world, table, filter)) {
             continue;
         }
-        
+
         ecs_table_t *dst_table = ecs_table_traverse_add(
             world, stage, table, &to_add_array, &added);
-        
+
         ecs_assert(added.count <= to_add_array.count, ECS_INTERNAL_ERROR, NULL);
 
         if (!added.count) {
@@ -9595,7 +9595,7 @@ void ecs_bulk_add_type(
         ecs_assert(dst_table != NULL, ECS_INTERNAL_ERROR, NULL);
         merge_table(world, dst_table, table, &added, NULL);
         added.count = 0;
-    }    
+    }
 }
 
 void ecs_bulk_add_entity(
@@ -9628,20 +9628,20 @@ void ecs_bulk_add_entity(
         if (!ecs_table_match_filter(world, table, filter)) {
             continue;
         }
-        
+
         ecs_table_t *dst_table = ecs_table_traverse_add(
             world, stage, table, &to_add_array, &added);
 
         ecs_assert(added.count <= to_add_array.count, ECS_INTERNAL_ERROR, NULL);
-        
+
         if (!added.count) {
             continue;
-        }         
+        }
 
-        ecs_assert(dst_table != NULL, ECS_INTERNAL_ERROR, NULL);   
+        ecs_assert(dst_table != NULL, ECS_INTERNAL_ERROR, NULL);
         merge_table(world, dst_table, table, &added, NULL);
         added.count = 0;
-    }    
+    }
 }
 
 void ecs_bulk_remove_type(
@@ -9672,7 +9672,7 @@ void ecs_bulk_remove_type(
         if (!ecs_table_match_filter(world, table, filter)) {
             continue;
         }
-        
+
         ecs_table_t *dst_table = ecs_table_traverse_remove(
             world, stage, table, &to_remove_array, &removed);
 
@@ -9684,8 +9684,8 @@ void ecs_bulk_remove_type(
 
         ecs_assert(dst_table != NULL, ECS_INTERNAL_ERROR, NULL);
         merge_table(world, dst_table, table, NULL, &removed);
-        removed.count = 0;        
-    }    
+        removed.count = 0;
+    }
 }
 
 void ecs_bulk_remove_entity(
@@ -9717,7 +9717,7 @@ void ecs_bulk_remove_entity(
 
         if (!ecs_table_match_filter(world, table, filter)) {
             continue;
-        }            
+        }
 
         ecs_table_t *dst_table = ecs_table_traverse_remove(
             world, stage, table, &to_remove_array, &removed);
@@ -9728,10 +9728,10 @@ void ecs_bulk_remove_entity(
             continue;
         }
 
-        ecs_assert(dst_table != NULL, ECS_INTERNAL_ERROR, NULL);   
+        ecs_assert(dst_table != NULL, ECS_INTERNAL_ERROR, NULL);
         merge_table(world, dst_table, table, NULL, &removed);
-        removed.count = 0;        
-    }    
+        removed.count = 0;
+    }
 }
 
 #endif
@@ -9759,12 +9759,12 @@ ecs_stage_t *ecs_get_stage(
         *world_ptr = thread->world;
         return thread->stage;
     }
-    
+
     return NULL;
 }
 
 /* Evaluate component monitor. If a monitored entity changed it will have set a
- * flag in one of the world's component monitors. Queries can register 
+ * flag in one of the world's component monitors. Queries can register
  * themselves with component monitors to determine whether they need to rematch
  * with tables. */
 static
@@ -9794,7 +9794,7 @@ void eval_component_monitor(
             });
         });
     }
-    
+
     mon->rematch = false;
 }
 
@@ -9821,7 +9821,7 @@ void ecs_component_monitor_register(
     /* Ignore component ids > ECS_HI_COMPONENT_ID */
     if(component >= ECS_HI_COMPONENT_ID) {
         return;
-    }    
+    }
 
     ecs_query_t **q = ecs_vector_add(&mon->monitors[component], ecs_query_t*);
     *q = query;
@@ -9885,9 +9885,9 @@ ecs_world_t *ecs_mini(void) {
     ecs_assert(world != NULL, ECS_OUT_OF_MEMORY, NULL);
 
     world->magic = ECS_WORLD_MAGIC;
-    memset(&world->c_info, 0, sizeof(ecs_c_info_t) * ECS_HI_COMPONENT_ID); 
-    world->t_info = ecs_map_new(ecs_c_info_t, 0);  
-    world->fini_actions = NULL; 
+    memset(&world->c_info, 0, sizeof(ecs_c_info_t) * ECS_HI_COMPONENT_ID);
+    world->t_info = ecs_map_new(ecs_c_info_t, 0);
+    world->fini_actions = NULL;
 
     world->queries = ecs_vector_new(ecs_query_t*, 0);
     world->fini_tasks = ecs_vector_new(ecs_entity_t, 0);
@@ -10070,10 +10070,10 @@ void ecs_set_component_actions_w_entity(
 
     /* If no constructor is set, invoking any of the other lifecycle actions is
      * not safe as they will potentially access uninitialized memory. For ease
-     * of use, if no constructor is specified, set a default one that 
+     * of use, if no constructor is specified, set a default one that
      * initializes the component to 0. */
     if (!lifecycle->ctor) {
-        c_info->lifecycle.ctor = ctor_init_zero;   
+        c_info->lifecycle.ctor = ctor_init_zero;
     }
 
     ecs_notify_tables(world, &(ecs_table_event_t) {
@@ -10089,7 +10089,7 @@ void ecs_atfini(
 {
     ecs_assert(action != NULL, ECS_INTERNAL_ERROR, NULL);
 
-    ecs_action_elem_t *elem = ecs_vector_add(&world->fini_actions, 
+    ecs_action_elem_t *elem = ecs_vector_add(&world->fini_actions,
         ecs_action_elem_t);
     ecs_assert(elem != NULL, ECS_INTERNAL_ERROR, NULL);
 
@@ -10105,12 +10105,12 @@ void ecs_run_post_frame(
     ecs_assert(action != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_stage_t *stage = ecs_get_stage(&world);
 
-    ecs_action_elem_t *elem = ecs_vector_add(&stage->post_frame_actions, 
+    ecs_action_elem_t *elem = ecs_vector_add(&stage->post_frame_actions,
         ecs_action_elem_t);
     ecs_assert(elem != NULL, ECS_INTERNAL_ERROR, NULL);
 
     elem->action = action;
-    elem->ctx = ctx;    
+    elem->ctx = ctx;
 }
 
 /* Unset data in tables */
@@ -10151,7 +10151,7 @@ void fini_component_lifecycle(
     while ((c_info = ecs_map_next(&it, ecs_c_info_t, NULL))) {
         ecs_vector_free(c_info->on_add);
         ecs_vector_free(c_info->on_remove);
-    }    
+    }
 
     ecs_map_free(world->t_info);
 }
@@ -10221,7 +10221,7 @@ int ecs_fini(
 
     fini_unset_tables(world);
 
-    fini_actions(world);    
+    fini_actions(world);
 
     if (world->locking_enabled) {
         ecs_os_mutex_free(world->mutex);
@@ -10246,7 +10246,7 @@ int ecs_fini(
     /* End of the world */
     ecs_os_free(world);
 
-    ecs_os_fini(); 
+    ecs_os_fini();
 
     return 0;
 }
@@ -10269,7 +10269,7 @@ void ecs_dim_type(
         ecs_table_t *table = ecs_table_from_type(
             world, &world->stage, type);
         ecs_assert(table != NULL, ECS_INTERNAL_ERROR, NULL);
-        
+
         ecs_data_t *data = ecs_table_get_or_create_data(world, &world->stage, table);
         ecs_table_set_size(world, table, data, entity_count);
     }
@@ -10287,6 +10287,7 @@ void ecs_merge(
 {
     ecs_assert(world->magic == ECS_WORLD_MAGIC, ECS_INVALID_FROM_WORKER, NULL);
     assert(world->is_merging == false);
+    assert(world->in_progress == false);
 
     bool measure_frame_time = world->measure_frame_time;
 
@@ -10333,7 +10334,7 @@ void ecs_merge(
         });
         ecs_vector_free(stage->post_frame_actions);
         stage->post_frame_actions = NULL;
-    });    
+    });
 }
 
 void ecs_set_automerge(
@@ -10516,14 +10517,14 @@ ecs_c_info_t * ecs_get_c_info(
 ecs_c_info_t * ecs_get_or_create_c_info(
     ecs_world_t *world,
     ecs_entity_t component)
-{    
+{
     ecs_c_info_t *c_info = ecs_get_c_info(world, component);
     if (!c_info) {
         ecs_assert(component >= ECS_HI_COMPONENT_ID, ECS_INTERNAL_ERROR, NULL);
         ecs_c_info_t t_info = { 0 };
         ecs_map_set(world->t_info, component, &t_info);
         c_info = ecs_map_get(world->t_info, ecs_c_info_t, component);
-        ecs_assert(c_info != NULL, ECS_INTERNAL_ERROR, NULL);      
+        ecs_assert(c_info != NULL, ECS_INTERNAL_ERROR, NULL);
     }
 
     return c_info;
@@ -10568,7 +10569,7 @@ void ecs_notify_queries(
 
     for (i = 0; i < count; i ++) {
         ecs_query_notify(world, queries[i], event);
-    }    
+    }
 }
 
 static
@@ -10594,7 +10595,7 @@ void remove_node(
     ecs_switch_node_t *nodes,
     ecs_switch_node_t *node,
     int32_t element)
-{    
+{
     /* The node is currently assigned to a value */
     if (hdr->element == element) {
         ecs_assert(node->prev == -1, ECS_INVALID_PARAMETER, NULL);
@@ -10621,7 +10622,7 @@ void remove_node(
 }
 
 ecs_switch_t* ecs_switch_new(
-    uint64_t min, 
+    uint64_t min,
     uint64_t max,
     int32_t elements)
 {
@@ -10649,7 +10650,7 @@ ecs_switch_t* ecs_switch_new(
     ecs_switch_node_t *nodes = ecs_vector_first(
         result->nodes, ecs_switch_node_t);
     uint64_t *values = ecs_vector_first(
-        result->values, uint64_t);        
+        result->values, uint64_t);
 
     for (i = 0; i < elements; i ++) {
         nodes[i].prev = -1;
@@ -10800,10 +10801,10 @@ void ecs_switch_remove(
         } else {
             ecs_switch_header_t *hdr = get_header(sw, values[element]);
             if (hdr && hdr->element != -1) {
-                ecs_assert(hdr->element == ecs_vector_count(sw->nodes), 
+                ecs_assert(hdr->element == ecs_vector_count(sw->nodes),
                     ECS_INTERNAL_ERROR, NULL);
                 hdr->element = element;
-            }             
+            }
         }
     }
 }
@@ -10895,7 +10896,7 @@ bool ecs_filter_next(
     for (i = iter->index; i < count; i ++) {
         ecs_table_t *table = ecs_sparse_get(tables, ecs_table_t, i);
         ecs_assert(table != NULL, ECS_INTERNAL_ERROR, NULL);
-        
+
         ecs_data_t *data = ecs_vector_first(table->data, ecs_data_t);
 
         if (!data) {
@@ -11340,7 +11341,7 @@ void ecs_strbuf_list_pop(
     const char *list_close)
 {
     buffer->list_sp --;
-    
+
     if (list_close) {
         ecs_strbuf_appendstr(buffer, list_close);
     }
@@ -11458,8 +11459,8 @@ static
 bool valid_identifier_char(
     char ch)
 {
-    if (ch && (isalpha(ch) || isdigit(ch) || ch == '_' || ch == '.' || 
-        ch == '$' || ch == '*')) 
+    if (ch && (isalpha(ch) || isdigit(ch) || ch == '_' || ch == '.' ||
+        ch == '$' || ch == '*'))
     {
         return true;
     }
@@ -11521,7 +11522,7 @@ ecs_entity_t parse_role(
     } else if (!ecs_os_strcmp(token, TOK_ROLE_INSTANCEOF)) {
         return ECS_INSTANCEOF;
     } else if (!ecs_os_strcmp(token, TOK_ROLE_TRAIT)) {
-        return ECS_TRAIT;            
+        return ECS_TRAIT;
     } else if (!ecs_os_strcmp(token, TOK_ROLE_AND)) {
         return ECS_AND;
     } else if (!ecs_os_strcmp(token, TOK_ROLE_OR)) {
@@ -11557,11 +11558,11 @@ ecs_sig_from_kind_t parse_source(
     } else if (!ecs_os_strcmp(token, TOK_SHARED)) {
         return EcsFromShared;
     } else if (!ecs_os_strcmp(token, TOK_CASCADE)) {
-        return EcsCascade;  
+        return EcsCascade;
     } else {
         return EcsFromEntity;
     }
-} 
+}
 
 static
 ecs_sig_oper_kind_t parse_operator(
@@ -11581,7 +11582,7 @@ const char* parse_annotation(
     const char *name,
     const char *sig,
     int64_t column,
-    const char *ptr, 
+    const char *ptr,
     ecs_sig_inout_kind_t *inout_kind_out)
 {
     char token[ECS_MAX_TOKEN_SIZE];
@@ -11658,7 +11659,7 @@ const char* parse_element(
         if (!ptr) {
             return NULL;
         }
-        
+
         /* Is token a source identifier? */
         if (ptr[0] == TOK_SOURCE) {
             ptr ++;
@@ -11680,7 +11681,7 @@ const char* parse_element(
 
     /* Nothing else expected here */
     } else {
-        ecs_parser_error(name, sig, (ptr - sig), 
+        ecs_parser_error(name, sig, (ptr - sig),
             "unexpected character '%c'", ptr[0]);
         return NULL;
     }
@@ -11696,7 +11697,7 @@ empty_source:
 
         goto parse_component;
     } else {
-        ecs_parser_error(name, sig, (ptr - sig), 
+        ecs_parser_error(name, sig, (ptr - sig),
             "expected identifier after source operator");
         return NULL;
     }
@@ -11722,7 +11723,7 @@ parse_source:
         /* If not, it's a component */
         goto parse_component;
     } else {
-        ecs_parser_error(name, sig, (ptr - sig), 
+        ecs_parser_error(name, sig, (ptr - sig),
             "expected identifier after source");
         return NULL;
     }
@@ -11751,7 +11752,7 @@ parse_role:
         /* If not, it's a component */
         goto parse_component;
     } else {
-        ecs_parser_error(name, sig, (ptr - sig), 
+        ecs_parser_error(name, sig, (ptr - sig),
             "expected identifier after role");
         return NULL;
     }
@@ -11769,7 +11770,7 @@ parse_trait:
         /* Can only be a component */
         goto parse_component;
     } else {
-        ecs_parser_error(name, sig, (ptr - sig), 
+        ecs_parser_error(name, sig, (ptr - sig),
             "expected identifier after trait");
         return NULL;
     }
@@ -11797,21 +11798,21 @@ parse_name:
 
 parse_done:
     if (ptr[0] != TOK_AND && ecs_os_strncmp(ptr, TOK_OR, 2) && ptr[0]) {
-        ecs_parser_error(name, sig, (ptr - sig), 
+        ecs_parser_error(name, sig, (ptr - sig),
             "expected end of expression or next element");
         return NULL;
     }
 
     if (!ecs_os_strcmp(elem.component, "0")) {
         if (ptr[0]) {
-            ecs_parser_error(name, sig, (ptr - sig), 
-                "unexpected element after 0"); 
+            ecs_parser_error(name, sig, (ptr - sig),
+                "unexpected element after 0");
             return NULL;
         }
 
         if (elem.from_kind != EcsFromOwned) {
-            ecs_parser_error(name, sig, (ptr - sig), 
-                "invalid source modifier for 0"); 
+            ecs_parser_error(name, sig, (ptr - sig),
+                "invalid source modifier for 0");
             return NULL;
         }
     }
@@ -11838,7 +11839,7 @@ int ecs_parse_expr(
             elem.oper_kind = EcsOperOr;
         }
 
-        if (action(world, name, sig, ptr - sig, 
+        if (action(world, name, sig, ptr - sig,
             elem.from_kind, elem.oper_kind, elem.inout_kind, elem.role,
             elem.component, elem.source, elem.trait, elem.name, ctx))
         {
@@ -11858,13 +11859,13 @@ int ecs_parse_expr(
         if (!strncmp(ptr, TOK_OR, 2)) {
             is_or = true;
             if (elem.from_kind == EcsFromEmpty) {
-                ecs_parser_error(name, sig, ptr - sig, 
+                ecs_parser_error(name, sig, ptr - sig,
                     "invalid empty source in or expression");
                 return -1;
             }
 
             if (elem.from_kind == EcsFromSystem) {
-                ecs_parser_error(name, sig, ptr - sig, 
+                ecs_parser_error(name, sig, ptr - sig,
                     "invalid system source in or expression");
                 return -1;
             }
@@ -11876,7 +11877,7 @@ int ecs_parse_expr(
                 ptr ++;
             }
         }
-        
+
         ptr = skip_space(ptr);
 
         if (!ptr[0]) {
@@ -11888,7 +11889,7 @@ int ecs_parse_expr(
         if (!name) {
             return -1;
         }
-        
+
         ecs_abort(ECS_INVALID_SIGNATURE, sig);
     }
 
@@ -11924,7 +11925,7 @@ int ecs_parse_signature_action(
             /* No need to add 0 component to signature */
             return 0;
         } else {
-            ecs_parser_error(name, expr, column, 
+            ecs_parser_error(name, expr, column,
                 "unresolved component identifier '%s'", entity_id);
         }
     }
@@ -11933,7 +11934,7 @@ int ecs_parse_signature_action(
     if (trait_id) {
         ecs_entity_t trait = ecs_lookup_fullpath(world, trait_id);
         if (!trait) {
-            ecs_parser_error(name, expr, column, 
+            ecs_parser_error(name, expr, column,
                 "unresolved trait identifier '%s'", trait_id);
         } else {
             component = ecs_entity_t_comb(component, trait);
@@ -11947,14 +11948,14 @@ int ecs_parse_signature_action(
         if (from_kind == EcsFromEntity) {
             source = ecs_lookup_fullpath(world, source_id);
             if (!source) {
-                ecs_parser_error(name, expr, column, 
+                ecs_parser_error(name, expr, column,
                     "unresolved source identifier '%s'", source_id);
             }
         }
     }
 
     return ecs_sig_add(
-        world, sig, from_kind, oper_kind, inout_kind, component, source, 
+        world, sig, from_kind, oper_kind, inout_kind, component, source,
         arg_name);
 }
 
@@ -11975,7 +11976,7 @@ void ecs_sig_init(
 
 void ecs_sig_deinit(
     ecs_sig_t *sig)
-{   
+{
     ecs_vector_each(sig->columns, ecs_sig_column_t, column, {
         if (column->oper_kind == EcsOperOr) {
             ecs_vector_free(column->is.type);
@@ -12004,7 +12005,7 @@ int ecs_sig_add(
         elem = ecs_vector_add(&sig->columns, ecs_sig_column_t);
         const EcsType *type = ecs_get(world, component, EcsType);
         if (!type) {
-            ecs_parser_error(sig->name, sig->expr, 0, 
+            ecs_parser_error(sig->name, sig->expr, 0,
                 "AND flag can only be applied to types");
         }
 
@@ -12014,14 +12015,14 @@ int ecs_sig_add(
         elem->inout_kind = inout_kind;
         elem->source = source;
 
-    } else 
+    } else
 
     /* If component has OR role, add type as OR column */
     if (ECS_HAS_ROLE(component, OR)) {
         elem = ecs_vector_add(&sig->columns, ecs_sig_column_t);
         const EcsType *type = ecs_get(world, component, EcsType);
         if (!type) {
-            ecs_parser_error(sig->name, sig->expr, 0, 
+            ecs_parser_error(sig->name, sig->expr, 0,
                 "OR flag can only be applied to types");
         }
 
@@ -12054,14 +12055,14 @@ int ecs_sig_add(
         } else {
             if (elem->from_kind != from_kind) {
                 /* Cannot mix FromEntity and FromComponent in OR */
-                ecs_parser_error(sig->name, sig->expr, 0, 
+                ecs_parser_error(sig->name, sig->expr, 0,
                     "cannot mix source kinds in || expression");
                 goto error;
             }
 
             if (elem->oper_kind != EcsOperAnd && elem->oper_kind != EcsOperOr) {
-                ecs_parser_error(sig->name, sig->expr, 0, 
-                    "cannot mix operators in || expression");                
+                ecs_parser_error(sig->name, sig->expr, 0,
+                    "cannot mix operators in || expression");
             }
 
             vec_add_entity(&elem->is.type, component);
@@ -12132,7 +12133,7 @@ ecs_entity_t ecs_find_entity_in_prefabs(
             }
 
             if (ecs_type_owns_entity(
-                world, prefab_type, component, true)) 
+                world, prefab_type, component, true))
             {
                 return prefab;
             } else {
@@ -12182,7 +12183,7 @@ ecs_type_t ecs_type_add_intern(
 {
     ecs_assert(world != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(stage != NULL, ECS_INTERNAL_ERROR, NULL);
-    
+
     ecs_table_t *table = ecs_table_from_type(world, stage, type);
 
     ecs_entities_t entities = {
@@ -12266,10 +12267,10 @@ ecs_entity_t ecs_type_contains(
         }
 
         if (e1 != e2) {
-            if (match_prefab && e2 != 
-                ecs_entity(EcsName) && e2 != 
-                EcsPrefab && e2 != 
-                EcsDisabled) 
+            if (match_prefab && e2 !=
+                ecs_entity(EcsName) && e2 !=
+                EcsPrefab && e2 !=
+                EcsDisabled)
             {
                 if (ecs_find_entity_in_prefabs(world, 0, type_1, e2, 0)) {
                     e1 = e2;
@@ -12305,7 +12306,7 @@ int32_t ecs_type_index_of(
 {
     ecs_vector_each(type, ecs_entity_t, c_ptr, {
         if (*c_ptr == entity) {
-            return c_ptr_i; 
+            return c_ptr_i;
         }
     });
 
@@ -12322,12 +12323,12 @@ ecs_type_t ecs_type_merge_intern(
     ecs_table_t *table = ecs_table_from_type(world, stage, type);
     ecs_entities_t add_array = ecs_type_to_entities(to_add);
     ecs_entities_t remove_array = ecs_type_to_entities(to_remove);
-    
+
     table = ecs_table_traverse_remove(
-        world, stage, table, &remove_array, NULL); 
+        world, stage, table, &remove_array, NULL);
 
     table = ecs_table_traverse_add(
-        world, stage, table, &add_array, NULL); 
+        world, stage, table, &add_array, NULL);
 
     if (!table) {
         return NULL;
@@ -12387,7 +12388,7 @@ int match_entity(
 
         if (lo == EcsWildcard) {
             ecs_assert(hi != 0, ECS_INTERNAL_ERROR, NULL);
-            
+
             if (!ECS_HAS_ROLE(e, TRAIT) || !has_trait(hi, e)) {
                 return 0;
             }
@@ -12408,7 +12409,7 @@ int match_entity(
                 return 1;
             }
         }
-    } else 
+    } else
     if (ECS_HAS_ROLE(match_with, CASE)) {
         ecs_entity_t sw_case = match_with & ECS_ENTITY_MASK;
         if (ECS_HAS_ROLE(e, SWITCH) && has_case(world, sw_case, e)) {
@@ -12594,8 +12595,8 @@ ecs_entity_t ecs_type_get_entity_for_xor(
 }
 
 int32_t ecs_type_trait_index_of(
-    ecs_type_t type, 
-    int32_t start_index, 
+    ecs_type_t type,
+    int32_t start_index,
     ecs_entity_t trait)
 {
     int32_t i, count = ecs_vector_count(type);
@@ -12640,7 +12641,7 @@ void ecs_os_init(void)
     if (!ecs_os_api_initialized) {
         ecs_os_set_api_defaults();
     }
-    
+
     if (!(ecs_os_api_init_count ++)) {
         if (ecs_os_api.init_) {
             ecs_os_api.init_();
@@ -12758,9 +12759,9 @@ void* ecs_os_api_realloc(void *ptr, ecs_size_t size) {
         ecs_os_api_realloc_count ++;
     } else {
         /* If not actually reallocing, treat as malloc */
-        ecs_os_api_malloc_count ++; 
+        ecs_os_api_malloc_count ++;
     }
-    
+
     return realloc(ptr, (size_t)size);
 }
 
@@ -12843,7 +12844,7 @@ void ecs_os_set_api_defaults(void)
     }
 
     ecs_os_time_setup();
-    
+
     /* Memory management */
     ecs_os_api.malloc_ = ecs_os_api_malloc;
     ecs_os_api.free_ = ecs_os_api_free;
@@ -12876,7 +12877,7 @@ void ecs_os_set_api_defaults(void)
 }
 
 bool ecs_os_has_heap(void) {
-    return 
+    return
         (ecs_os_api.malloc_ != NULL) &&
         (ecs_os_api.calloc_ != NULL) &&
         (ecs_os_api.realloc_ != NULL) &&
@@ -12895,17 +12896,17 @@ bool ecs_os_has_threading(void) {
         (ecs_os_api.cond_signal_ != NULL) &&
         (ecs_os_api.cond_broadcast_ != NULL) &&
         (ecs_os_api.thread_new_ != NULL) &&
-        (ecs_os_api.thread_join_ != NULL);   
+        (ecs_os_api.thread_join_ != NULL);
 }
 
 bool ecs_os_has_time(void) {
-    return 
+    return
         (ecs_os_api.get_time_ != NULL) &&
         (ecs_os_api.sleep_ != NULL);
 }
 
 bool ecs_os_has_logging(void) {
-    return 
+    return
         (ecs_os_api.log_ != NULL) &&
         (ecs_os_api.log_error_ != NULL) &&
         (ecs_os_api.log_debug_ != NULL) &&
@@ -12913,14 +12914,14 @@ bool ecs_os_has_logging(void) {
 }
 
 bool ecs_os_has_dl(void) {
-    return 
+    return
         (ecs_os_api.dlopen_ != NULL) &&
         (ecs_os_api.dlproc_ != NULL) &&
-        (ecs_os_api.dlclose_ != NULL);  
+        (ecs_os_api.dlclose_ != NULL);
 }
 
 bool ecs_os_has_modules(void) {
-    return 
+    return
         (ecs_os_api.module_to_dl_ != NULL) &&
         (ecs_os_api.module_to_etc_ != NULL);
 }
@@ -12938,9 +12939,9 @@ typedef struct EcsSystem {
     ecs_query_t *query;                   /* System query */
     ecs_on_demand_out_t *on_demand;       /* Keep track of [out] column refs */
     ecs_system_status_action_t status_action; /* Status action */
-    void *status_ctx;                     /* User data for status action */    
+    void *status_ctx;                     /* User data for status action */
     ecs_entity_t tick_source;             /* Tick source associated with system */
-    
+
     int32_t invoke_count;                 /* Number of times system is invoked */
     float time_spent;                     /* Time spent on running system */
     float time_passed;                    /* Time passed since last invocation */
@@ -13090,7 +13091,7 @@ void order_ranked_tables(
     ecs_query_t *query)
 {
     if (query->group_table) {
-        ecs_vector_sort(query->tables, ecs_matched_table_t, table_compare);       
+        ecs_vector_sort(query->tables, ecs_matched_table_t, table_compare);
     }
 
     /* Re-register monitors after tables have been reordered. This will update
@@ -13106,7 +13107,7 @@ void order_ranked_tables(
         });
     }
 
-    query->match_count ++; 
+    query->match_count ++;
 }
 
 static
@@ -13137,7 +13138,7 @@ void group_tables(
 
         ecs_vector_each(query->empty_tables, ecs_matched_table_t, table, {
             group_table(world, query, table);
-        });              
+        });
     }
 }
 
@@ -13183,8 +13184,8 @@ void get_comp_and_src(
     }
 
     /* Column that retrieves data from self or a fixed entity */
-    if (from == EcsFromAny || from == EcsFromEntity || 
-        from == EcsFromOwned || from == EcsFromShared) 
+    if (from == EcsFromAny || from == EcsFromEntity ||
+        from == EcsFromOwned || from == EcsFromShared)
     {
         if (op == EcsOperAnd || op == EcsOperNot || op == EcsOperOptional) {
             component = column->is.component;
@@ -13192,7 +13193,7 @@ void get_comp_and_src(
             component = column->is.component & ECS_ENTITY_MASK;
         } else if (op == EcsOperOr) {
             component = ecs_type_contains(
-                world, table_type, column->is.type, 
+                world, table_type, column->is.type,
                 false, true);
         }
 
@@ -13263,12 +13264,12 @@ int32_t get_trait_index(
     } else {
         /* First time for this iteration that the trait index is resolved, look
          * it up in the type. */
-        result = ecs_type_trait_index_of(table_type, 
+        result = ecs_type_trait_index_of(table_type,
             trait_offsets[column_index].index, component);
         trait_offsets[column_index].index = result + 1;
         trait_offsets[column_index].count = count;
     }
-    
+
     return result;
 }
 
@@ -13296,12 +13297,12 @@ int32_t get_component_index(
 
             result += table->sw_column_offset;
         } else
-        if (ECS_HAS_ROLE(component, TRAIT)) { 
+        if (ECS_HAS_ROLE(component, TRAIT)) {
             /* If only the lo part of the trait identifier is set, interpret it
              * as the trait to match. This will match any instance of the trait
              * on the entity and in a signature looks like "TRAIT | MyTrait". */
             if (!ecs_entity_t_hi(component & ECS_ENTITY_MASK)) {
-                ecs_assert(trait_offsets != NULL, 
+                ecs_assert(trait_offsets != NULL,
                     ECS_INTERNAL_ERROR, NULL);
 
                 /* Strip the TRAIT role */
@@ -13311,11 +13312,11 @@ int32_t get_component_index(
                  * as this may not be the first instance of the trait. */
                 result = get_trait_index(
                     table_type, component, column_index, trait_offsets, count);
-                
+
                 if (result != -1) {
-                    /* If component of current column is a trait, get the actual 
-                     * trait type for the table, so the system can see which 
-                     * component the trait was applied to */   
+                    /* If component of current column is a trait, get the actual
+                     * trait type for the table, so the system can see which
+                     * component the trait was applied to */
                     ecs_entity_t *trait = ecs_vector_get(
                         table_type, ecs_entity_t, result);
                     *component_out = *trait;
@@ -13333,7 +13334,7 @@ int32_t get_component_index(
                  * like "TRAIT | MyTrait > Comp". */
                 ecs_entity_t lo = ecs_entity_t_lo(component);
                 if (lo == EcsWildcard) {
-                    ecs_assert(trait_offsets != NULL, 
+                    ecs_assert(trait_offsets != NULL,
                         ECS_INTERNAL_ERROR, NULL);
 
                     /* Get id for the trait to lookup by taking the trait from
@@ -13342,9 +13343,9 @@ int32_t get_component_index(
                     component = ecs_entity_t_hi(component & ECS_ENTITY_MASK);
 
                     /* If the low part of the identifier is the wildcard entity,
-                     * this column is requesting the component to which the 
+                     * this column is requesting the component to which the
                      * trait is applied. First, find the component identifier */
-                    result = get_trait_index(table_type, component, 
+                    result = get_trait_index(table_type, component,
                         column_index, trait_offsets, count);
 
                     /* Type must have the trait, otherwise table would not have
@@ -13366,7 +13367,7 @@ int32_t get_component_index(
 
                 /* If the low part is a regular entity (component), then
                  * this query exactly matches a single trait instance. In
-                 * this case we can simply do a lookup of the trait 
+                 * this case we can simply do a lookup of the trait
                  * identifier in the table type. */
                 result = ecs_type_index_of(table_type, component);
             }
@@ -13382,8 +13383,8 @@ int32_t get_component_index(
 
             /* Check if component is a tag. If it is, set table_data to
             * zero, so that a system won't try to access the data */
-            if (!ECS_HAS_ROLE(component, CASE) && 
-                !ECS_HAS_ROLE(component, SWITCH)) 
+            if (!ECS_HAS_ROLE(component, CASE) &&
+                !ECS_HAS_ROLE(component, SWITCH))
             {
                 const EcsComponent *data = ecs_get(
                     world, component, EcsComponent);
@@ -13393,10 +13394,10 @@ int32_t get_component_index(
                 }
             }
         }
-        
+
         /* ecs_table_column_offset may return -1 if the component comes
          * from a prefab. If so, the component will be resolved as a
-         * reference (see below) */           
+         * reference (see below) */
     }
 
     if (op == EcsOperAll) {
@@ -13425,11 +13426,11 @@ void add_ref(
     ecs_sig_from_kind_t from)
 {
     const EcsComponent *c_info = ecs_get(world, component, EcsComponent);
-    
+
     ecs_entity_t e;
     ecs_ref_t *ref = ecs_vector_add(
             &table_data->references, ecs_ref_t);
-    
+
     table_data->columns[column_index] = -ecs_vector_count(table_data->references);
 
     /* Find the entity for the component */
@@ -13447,7 +13448,7 @@ void add_ref(
     if (from != EcsCascade) {
         ecs_assert(e != 0, ECS_INTERNAL_ERROR, NULL);
     }
-    
+
     *ref = (ecs_ref_t){0};
     ref->entity = e;
     ref->component = component;
@@ -13457,7 +13458,7 @@ void add_ref(
             if (e) {
                 ecs_get_ref_w_entity(
                     world, ref, e, component);
-                ecs_set_watch(world, &world->stage, e);                     
+                ecs_set_watch(world, &world->stage, e);
             }
 
             query->flags |= EcsQueryHasRefs;
@@ -13561,12 +13562,12 @@ void add_table(
     }
 
     int32_t trait_cur = 0, trait_count = count_traits(query, table_type);
-    
+
     /* If the query has traits, we need to account for the fact that a table may
      * have multiple components to which the trait is applied, which means the
      * table has to be registered with the query multiple times, with different
      * table columns. If so, allocate a small array for each trait in which the
-     * last added table index of the trait is stored, so that in the next 
+     * last added table index of the trait is stored, so that in the next
      * iteration we can start the search from the correct offset type. */
     trait_offset_t *trait_offsets = NULL;
     if (trait_count) {
@@ -13638,15 +13639,15 @@ add_trait:
         table_data->columns[c] = 0;
 
         /* Get actual component and component source for current column */
-        get_comp_and_src(world, query, table_type, column, op, from, &component, 
+        get_comp_and_src(world, query, table_type, column, op, from, &component,
             &entity);
 
         /* This column does not retrieve data from a static entity (either
          * EcsFromSystem or EcsFromParent) and is not just a handle */
         if (!entity && from != EcsFromEmpty) {
-            int32_t index = get_component_index(world, table, table_type, 
+            int32_t index = get_component_index(world, table, table_type,
                 &component, c, op, trait_offsets, trait_cur + 1);
-            
+
             table_data->columns[c] = index;
 
             /* If the column is a case, we should only iterate the entities in
@@ -13663,12 +13664,12 @@ add_trait:
 
         /* Check if a the component is a reference. If 'entity' is set, the
          * component must be resolved from another entity, which is the case
-         * for FromEntity and FromContainer. 
-         * 
+         * for FromEntity and FromContainer.
+         *
          * If no entity is set but the component is not found in the table, it
          * must come from a prefab. This is guaranteed, as at this point it is
          * already validated that the table matches with the system.
-         * 
+         *
          * If the column from is Cascade, there may not be an entity in case the
          * current table contains root entities. In that case, still add a
          * reference field. The application can, after the table has matched,
@@ -13677,7 +13678,7 @@ add_trait:
          * makes changing this administation easier when the change happens.
          */
         if ((entity || table_data->columns[c] == -1 || from == EcsCascade)) {
-            add_ref(world, query, table_type, c, table_data, component, entity, 
+            add_ref(world, query, table_type, c, table_data, component, entity,
                 from);
         }
 
@@ -13724,7 +13725,7 @@ bool match_column(
     if (from_kind == EcsFromAny) {
         failure_info->reason = EcsMatchFromSelf;
         return ecs_type_has_entity(world, type, component);
-        
+
     } else if (from_kind == EcsFromOwned) {
         failure_info->reason = EcsMatchFromOwned;
         return ecs_type_owns_entity(world, type, component, true);
@@ -13803,19 +13804,19 @@ bool ecs_query_match(
 
         if (oper_kind == EcsOperAnd) {
             if (!match_column(
-                world, table_type, from_kind, elem->is.component, 
-                elem->source, failure_info)) 
+                world, table_type, from_kind, elem->is.component,
+                elem->source, failure_info))
             {
                 return false;
             }
 
         } else if (oper_kind == EcsOperNot) {
             if (match_column(
-                world, table_type, from_kind, elem->is.component, 
-                elem->source, failure_info)) 
+                world, table_type, from_kind, elem->is.component,
+                elem->source, failure_info))
             {
                 return false;
-            }           
+            }
 
         } else if (oper_kind == EcsOperOr || oper_kind == EcsOperAll) {
             bool match_all = oper_kind == EcsOperAll;
@@ -13848,7 +13849,7 @@ bool ecs_query_match(
                 {
                     failure_info->reason = EcsMatchOrFromShared;
                     return false;
-                }                                
+                }
             } else if (from_kind == EcsFromParent) {
                 if (!(table->flags & EcsTableHasParent)) {
                     failure_info->reason = EcsMatchOrFromContainer;
@@ -13933,7 +13934,7 @@ void resolve_cascade_container(
 {
     ecs_matched_table_t *table_data = ecs_vector_get(
         query->tables, ecs_matched_table_t, table_data_index);
-    
+
     ecs_assert(table_data->references != 0, ECS_INTERNAL_ERROR, NULL);
 
     /* Obtain reference index */
@@ -13943,22 +13944,22 @@ void resolve_cascade_container(
 
     /* Obtain pointer to the reference data */
     ecs_ref_t *references = ecs_vector_first(table_data->references, ecs_ref_t);
-    ecs_assert(ref_index < ecs_vector_count(table_data->references), 
+    ecs_assert(ref_index < ecs_vector_count(table_data->references),
         ECS_INTERNAL_ERROR, NULL);
 
     ecs_ref_t *ref = &references[ref_index];
-    ecs_assert(ref->component == get_cascade_component(query), 
+    ecs_assert(ref->component == get_cascade_component(query),
         ECS_INTERNAL_ERROR, NULL);
 
     /* Resolve container entity */
     ecs_entity_t container = ecs_find_in_type(
-        world, table_type, ref->component, ECS_CHILDOF);    
+        world, table_type, ref->component, ECS_CHILDOF);
 
     /* If container was found, update the reference */
     if (container) {
         references[ref_index].entity = container;
         ecs_get_ref_w_entity(
-            world, &references[ref_index], container, 
+            world, &references[ref_index], container,
             ref->component);
     } else {
         references[ref_index].entity = 0;
@@ -13973,7 +13974,7 @@ int32_t qsort_partition(
     ecs_table_t *table,
     ecs_data_t *data,
     ecs_entity_t *entities,
-    void *ptr,    
+    void *ptr,
     int32_t elem_size,
     int32_t lo,
     int32_t hi,
@@ -13983,7 +13984,7 @@ int32_t qsort_partition(
     void *pivot = ELEM(ptr, elem_size, p);
     ecs_entity_t pivot_e = entities[p];
     int32_t i = lo - 1, j = hi + 1;
-    void *el;    
+    void *el;
 
 repeat:
     {
@@ -14026,17 +14027,17 @@ void qsort_array(
     int32_t lo,
     int32_t hi,
     ecs_compare_action_t compare)
-{   
+{
     if ((hi - lo) < 1)  {
         return;
-    }   
+    }
 
     int32_t p = qsort_partition(
         world, table, data, entities, ptr, size, lo, hi, compare);
 
     qsort_array(world, table, data, entities, ptr, size, lo, p, compare);
 
-    qsort_array(world, table, data, entities, ptr, size, p + 1, hi, compare); 
+    qsort_array(world, table, data, entities, ptr, size, p + 1, hi, compare);
 }
 
 static
@@ -14138,8 +14139,8 @@ void build_sorted_table_range(
         helper[to_sort].table = table;
         helper[to_sort].entities = ecs_vector_first(data->entities, ecs_entity_t);
         helper[to_sort].row = 0;
-        helper[to_sort].count = ecs_table_count(table->table);  
-        to_sort ++;      
+        helper[to_sort].count = ecs_table_count(table->table);
+        to_sort ++;
     }
 
     ecs_table_slice_t *cur = NULL;
@@ -14289,7 +14290,7 @@ void sort_tables(
     if (!compare) {
         return;
     }
-    
+
     ecs_entity_t sort_on_component = query->sort_on_component;
 
     /* Iterate over active tables. Don't bother with inactive tables, since
@@ -14321,10 +14322,10 @@ void sort_tables(
             * sorting on has changed or if entities have been added / re(moved) */
             index = ecs_type_index_of(table->type, sort_on_component);
             ecs_assert(index != -1, ECS_INVALID_PARAMETER, NULL);
-            ecs_assert(index < ecs_vector_count(table->type), ECS_INTERNAL_ERROR, NULL); 
+            ecs_assert(index < ecs_vector_count(table->type), ECS_INTERNAL_ERROR, NULL);
             is_dirty = is_dirty || (dirty_state[index + 1] != m_table->monitor[index + 1]);
-        }      
-        
+        }
+
         /* Check both if entities have moved (element 0) or if the component
          * we're sorting on has changed (index + 1) */
         if (is_dirty) {
@@ -14379,7 +14380,7 @@ bool has_traits(
         }
     }
 
-    return false;    
+    return false;
 }
 
 static
@@ -14391,7 +14392,7 @@ void register_monitors(
         /* If component is requested with CASCADE source register component as a
          * parent monitor. Parent monitors keep track of whether an entity moved
          * in the hierarchy, which potentially requires the query to reorder its
-         * tables. 
+         * tables.
          * Also register a regular component monitor for EcsCascade columns.
          * This ensures that when the component used in the CASCADE column
          * is added or removed tables are updated accordingly*/
@@ -14415,7 +14416,7 @@ void register_monitors(
         /* FromSelf also requires registering a monitor, as FromSelf columns can
          * be matched with prefabs. The only column kinds that do not require
          * registering a monitor are FromOwned and FromNothing. */
-        } else if (column->from_kind == EcsFromAny || 
+        } else if (column->from_kind == EcsFromAny ||
             column->from_kind == EcsFromShared ||
             column->from_kind == EcsFromEntity ||
             column->from_kind == EcsFromParent)
@@ -14443,8 +14444,8 @@ void process_signature(
 
     for (i = 0; i < count; i ++) {
         ecs_sig_column_t *column = &columns[i];
-        ecs_sig_oper_kind_t op = column->oper_kind; 
-        ecs_sig_from_kind_t from = column->from_kind; 
+        ecs_sig_oper_kind_t op = column->oper_kind;
+        ecs_sig_from_kind_t from = column->from_kind;
         ecs_sig_inout_kind_t inout = column->inout_kind;
 
         if (inout != EcsIn) {
@@ -14460,7 +14461,7 @@ void process_signature(
                     world, column->is.type, EcsDisabled, true))
                 {
                     query->flags |= EcsQueryMatchDisabled;
-                }         
+                }
             } else if (op == EcsOperAnd || op == EcsOperOptional) {
                 if (column->is.component == EcsDisabled) {
                     query->flags |= EcsQueryMatchDisabled;
@@ -14477,7 +14478,7 @@ void process_signature(
                     world, column->is.type, EcsPrefab, true))
                 {
                     query->flags |= EcsQueryMatchPrefab;
-                }            
+                }
             } else if (op == EcsOperAnd || op == EcsOperOptional) {
                 if (column->is.component == EcsPrefab) {
                     query->flags |= EcsQueryMatchPrefab;
@@ -14485,10 +14486,10 @@ void process_signature(
             }
         }
 
-        if (from == EcsFromAny || 
+        if (from == EcsFromAny ||
             from == EcsFromOwned ||
             from == EcsFromShared ||
-            from == EcsFromParent) 
+            from == EcsFromParent)
         {
             query->flags |= EcsQueryNeedsTables;
         }
@@ -14542,7 +14543,7 @@ void activate_table(
     if (i == -1) {
         /* Received an activate event for a table we're not matched with. This
          * can only happen if this is a subquery */
-        ecs_assert((query->flags & EcsQueryIsSubquery) != 0, 
+        ecs_assert((query->flags & EcsQueryIsSubquery) != 0,
             ECS_INTERNAL_ERROR, NULL);
         return;
     }
@@ -14577,9 +14578,9 @@ void activate_table(
 
 static
 void add_subquery(
-    ecs_world_t *world, 
-    ecs_query_t *parent, 
-    ecs_query_t *subquery) 
+    ecs_world_t *world,
+    ecs_query_t *parent,
+    ecs_query_t *subquery)
 {
     ecs_query_t **elem = ecs_vector_add(&parent->subqueries, ecs_query_t*);
     *elem = subquery;
@@ -14601,7 +14602,7 @@ void add_subquery(
     for (i = 0; i < count; i ++) {
         ecs_matched_table_t *table = &tables[i];
         match_table(world, subquery, table->table);
-    }    
+    }
 }
 
 static
@@ -14672,7 +14673,7 @@ void unmatch_table_w_index(
                 .table = table
             });
         }
-    }  
+    }
 }
 
 static
@@ -14701,8 +14702,8 @@ void rematch_table(
             }
 
         /* If table still matches and has cascade column, reevaluate the
-         * sources of references. This may have changed in case 
-         * components were added/removed to container entities */ 
+         * sources of references. This may have changed in case
+         * components were added/removed to container entities */
         } else if (query->cascade_by) {
             resolve_cascade_container(
                 world, query, match, table->type);
@@ -14735,7 +14736,7 @@ void rematch_tables(
         for (i = 0; i < count; i ++) {
             ecs_table_t *table = tables[i].table;
             rematch_table(world, query, table);
-        }        
+        }
     } else {
         ecs_sparse_t *tables = world->stage.tables;
         int32_t i, count = ecs_sparse_count(tables);
@@ -14777,7 +14778,7 @@ void ecs_query_notify(
         break;
     case EcsQueryTableRematch:
         rematch_tables(world, query, event->parent_query);
-        break;        
+        break;
     case EcsQueryTableEmpty:
         activate_table(world, query, event->table, false);
         break;
@@ -14807,7 +14808,7 @@ ecs_query_t* ecs_query_new_w_sig_intern(
 
     process_signature(world, result);
 
-    ecs_trace_2("query #[green]%s#[reset] created with expression #[red]%s", 
+    ecs_trace_2("query #[green]%s#[reset] created with expression #[red]%s",
         query_name(world, result), result->sig.expr);
 
     ecs_log_push();
@@ -14817,14 +14818,14 @@ ecs_query_t* ecs_query_new_w_sig_intern(
             if (ecs_has_entity(world, system, EcsMonitor)) {
                 result->flags |= EcsQueryMonitor;
             }
-            
+
             if (ecs_has_entity(world, system, EcsOnSet)) {
                 result->flags |= EcsQueryOnSet;
             }
 
             if (ecs_has_entity(world, system, EcsUnSet)) {
                 result->flags |= EcsQueryUnSet;
-            }        
+            }
 
             match_tables(world, result);
         } else {
@@ -14977,8 +14978,8 @@ void ecs_query_set_iter(
     ecs_table_t *world_table = table->table;
     ecs_data_t *table_data = ecs_table_get_staged_data(world, stage, world_table);
     ecs_assert(table_data != NULL, ECS_INTERNAL_ERROR, NULL);
-    
-    ecs_entity_t *entity_buffer = ecs_vector_first(table_data->entities, ecs_entity_t);  
+
+    ecs_entity_t *entity_buffer = ecs_vector_first(table_data->entities, ecs_entity_t);
     it->entities = &entity_buffer[row];
 
     it->world = world;
@@ -15043,7 +15044,7 @@ int find_smallest_column(
     ecs_matched_table_t *matched_table,
     ecs_vector_t *sparse_columns)
 {
-    ecs_sparse_column_t *sparse_column_array = 
+    ecs_sparse_column_t *sparse_column_array =
         ecs_vector_first(sparse_columns, ecs_sparse_column_t);
     int32_t i, count = ecs_vector_count(sparse_columns);
     int32_t min = INT_MAX, index = 0;
@@ -15067,7 +15068,7 @@ int find_smallest_column(
 
             /* Get the sparse column */
             ecs_data_t *data = ecs_table_get_data(world, table);
-            sc = sparse_column->sw_column = 
+            sc = sparse_column->sw_column =
                 &data->sw_columns[table_column_index - 1];
         }
 
@@ -15119,7 +15120,7 @@ int sparse_column_next(
 
     if (first == -1) {
         goto done;
-    }    
+    }
 
     /* Check if entity matches with other sparse columns, if any */
     int32_t i, count = ecs_vector_count(sparse_columns);
@@ -15195,7 +15196,7 @@ bool ecs_query_next(
         query->tables, ecs_matched_table_t);
 
     ecs_assert(!slice || query->compare, ECS_INTERNAL_ERROR, NULL);
-    
+
     ecs_page_cursor_t cur;
     int32_t table_count = it->table_count;
     int32_t prev_count = it->total_count;
@@ -15207,13 +15208,13 @@ bool ecs_query_next(
         ecs_data_t *table_data = NULL;
 
         iter->index = i + 1;
-        
+
         if (world_table) {
             ecs_vector_t *sparse_columns = table->sparse_columns;
             table_data = ecs_table_get_data(world, world_table);
             ecs_assert(table_data != NULL, ECS_INTERNAL_ERROR, NULL);
             it->table_columns = table_data->columns;
-            
+
             if (slice) {
                 cur.first = slice[i].start_row;
                 cur.count = slice[i].count;
@@ -15224,11 +15225,11 @@ bool ecs_query_next(
 
             if (cur.count) {
                 if (sparse_columns) {
-                    if (sparse_column_next(world, world_table, table, 
+                    if (sparse_column_next(world, world_table, table,
                         sparse_columns, iter, &cur) == -1)
                     {
                         /* No more elements in sparse column */
-                        continue;    
+                        continue;
                     } else {
                         iter->index = i;
                     }
@@ -15245,7 +15246,7 @@ bool ecs_query_next(
             }
 
             ecs_entity_t *entity_buffer = ecs_vector_first(
-                table_data->entities, ecs_entity_t); 
+                table_data->entities, ecs_entity_t);
             it->entities = &entity_buffer[cur.first];
             it->offset = cur.first;
             it->count = cur.count;
@@ -15282,7 +15283,7 @@ bool ecs_query_next_w_filter(
         }
         table = iter->table;
     } while (filter && !ecs_table_match_filter(iter->world, table, filter));
-    
+
     return true;
 }
 
@@ -15345,7 +15346,7 @@ void ecs_query_order_by(
     ecs_vector_free(query->table_slices);
     query->table_slices = NULL;
 
-    sort_tables(world, query);    
+    sort_tables(world, query);
 
     if (!query->table_slices) {
         build_sorted_tables(world, query);
@@ -15415,7 +15416,7 @@ const EcsComponent* ecs_component_from_id(
             * the component type of the component the trait is applied to. */
         e = ecs_entity_t_lo(trait);
         component = ecs_get(world, e, EcsComponent);
-    }    
+    }
 
     return component;
 }
@@ -15432,12 +15433,12 @@ int32_t data_column_count(
 
         /* Typically all components will be clustered together at the start of
          * the type as components are created from a separate id pool, and type
-         * vectors are sorted. 
+         * vectors are sorted.
          * Explicitly check for EcsComponent and EcsName since the ecs_has check
          * doesn't work during bootstrap. */
-        if ((component == ecs_entity(EcsComponent)) || 
-            (component == ecs_entity(EcsName)) || 
-            ecs_component_from_id(world, component) != NULL) 
+        if ((component == ecs_entity(EcsComponent)) ||
+            (component == ecs_entity(EcsName)) ||
+            ecs_component_from_id(world, component) != NULL)
         {
             count = c_ptr_i + 1;
         }
@@ -15495,7 +15496,7 @@ void register_child_table(
         if (!child_tables) {
             child_tables = ecs_vector_new(ecs_table_t*, 1);
         }
-        
+
         ecs_table_t **el = ecs_vector_add(&child_tables, ecs_table_t*);
         *el = table;
 
@@ -15520,7 +15521,7 @@ void init_edges(
     table->hi_edges = ecs_map_new(ecs_edge_t, 0);
 
     table->lo_edges[0].add = table;
-    
+
     /* Make add edges to own components point to self */
     int32_t i;
     for (i = 0; i < count; i ++) {
@@ -15546,7 +15547,7 @@ void init_edges(
 
         /* As we're iterating over the table components, also set the table
          * flags. These allow us to quickly determine if the table contains
-         * data that needs to be handled in a special way, like prefabs or 
+         * data that needs to be handled in a special way, like prefabs or
          * containers */
         if (e <= EcsLastInternalComponentId) {
             table->flags |= EcsTableHasBuiltins;
@@ -15595,7 +15596,7 @@ void init_edges(
     ecs_table_notify(world, table, &(ecs_table_event_t){
         .kind = EcsTableComponentInfo
     });
-    
+
     /* Register as root table */
     if (!(table->flags & EcsTableHasParent)) {
         register_child_table(world, stage, table, 0);
@@ -15670,7 +15671,7 @@ void add_entity_to_type(
     ecs_entities_t *out)
 {
     int32_t count = ecs_vector_count(type);
-    ecs_entity_t *array = ecs_vector_first(type, ecs_entity_t);    
+    ecs_entity_t *array = ecs_vector_first(type, ecs_entity_t);
     bool added = false;
 
     int32_t i, el = 0;
@@ -15684,7 +15685,7 @@ void add_entity_to_type(
             out->array[el ++] = add;
             added = true;
         }
-        
+
         out->array[el ++] = e;
 
         ecs_assert(el <= out->count, ECS_INTERNAL_ERROR, NULL);
@@ -15730,11 +15731,11 @@ ecs_edge_t* get_edge(
     if (e < ECS_HI_COMPONENT_ID) {
         edge = &node->lo_edges[e];
     } else {
-        edge = ecs_map_get(node->hi_edges, ecs_edge_t, e);        
+        edge = ecs_map_get(node->hi_edges, ecs_edge_t, e);
         if (!edge) {
             ecs_edge_t new_edge = {0};
             ecs_map_set(node->hi_edges, e, &new_edge);
-            edge = ecs_map_get(node->hi_edges, ecs_edge_t, e);    
+            edge = ecs_map_get(node->hi_edges, ecs_edge_t, e);
             ecs_assert(edge != NULL, ECS_INTERNAL_ERROR, NULL);
         }
     }
@@ -15786,7 +15787,7 @@ ecs_entity_t find_xor_replace(
                 ecs_assert(type_ptr != NULL, ECS_INTERNAL_ERROR, NULL);
 
                 if (ecs_type_owns_entity(
-                    world, type_ptr->normalized, add, true)) 
+                    world, type_ptr->normalized, add, true))
                 {
                     xor_type = type_ptr->normalized;
                 }
@@ -15837,7 +15838,7 @@ int32_t ecs_table_switch_from_case(
             ecs_assert(type_ptr != NULL, ECS_INTERNAL_ERROR, NULL);
 
             if (ecs_type_owns_entity(
-                world, type_ptr->normalized, add, true)) 
+                world, type_ptr->normalized, add, true))
             {
                 return i;
             }
@@ -15859,7 +15860,7 @@ ecs_table_t *find_or_create_table_include(
 {
     /* If table has one or more switches and this is a case, return self */
     if (ECS_HAS_ROLE(add, CASE)) {
-        ecs_assert((node->flags & EcsTableHasSwitch) != 0, 
+        ecs_assert((node->flags & EcsTableHasSwitch) != 0,
             ECS_INVALID_CASE, NULL);
         return node;
     } else {
@@ -15872,16 +15873,16 @@ ecs_table_t *find_or_create_table_include(
         };
 
         /* If table has a XOR column, check if the entity that is being added to
-         * the table is part of the XOR type, and if it is, find the current 
-         * entity in the table type matching the XOR type. This entity must be 
-         * replaced in the new table, to ensure the XOR constraint isn't 
+         * the table is part of the XOR type, and if it is, find the current
+         * entity in the table type matching the XOR type. This entity must be
+         * replaced in the new table, to ensure the XOR constraint isn't
          * violated. */
         ecs_entity_t replace = find_xor_replace(world, node, type, add);
 
         add_entity_to_type(type, add, replace, &entities);
 
         ecs_table_t *result = ecs_table_find_or_create(world, stage, &entities);
-        
+
         if (result != node && stage == &world->stage) {
             create_backlink_after_add(result, node, add);
         }
@@ -15916,7 +15917,7 @@ ecs_table_t *find_or_create_table_exclude(
         create_backlink_after_remove(result, node, remove);
     }
 
-    return result;    
+    return result;
 }
 
 static
@@ -15957,7 +15958,7 @@ ecs_table_t* traverse_remove_hi_edges(
 
         if (removed && node != next) removed->array[removed->count ++] = e;
 
-        node = next;        
+        node = next;
     }
 
     return node;
@@ -15980,7 +15981,7 @@ ecs_table_t* ecs_table_traverse_remove(
         /* If the array is not a simple component array, use a function that
          * handles all cases, but is slower */
         if (e >= ECS_HI_COMPONENT_ID) {
-            return traverse_remove_hi_edges(world, stage, node, i, to_remove, 
+            return traverse_remove_hi_edges(world, stage, node, i, to_remove,
                 removed);
         }
 
@@ -16010,7 +16011,7 @@ ecs_table_t* ecs_table_traverse_remove(
         if (removed) removed->array[removed->count ++] = e;
 
         node = next;
-    }    
+    }
 
     return node;
 }
@@ -16070,8 +16071,8 @@ ecs_table_t* traverse_add_hi_edges(
         if (!next) {
             next = find_or_create_table_include(
                 world, stage, node, next_e);
-            
-            ecs_assert(next != NULL, ECS_INTERNAL_ERROR, NULL);                    
+
+            ecs_assert(next != NULL, ECS_INTERNAL_ERROR, NULL);
 
             /* Only make links when not staged, to prevent tables from the main
              * stage pointing to staged tables. */
@@ -16089,12 +16090,12 @@ ecs_table_t* traverse_add_hi_edges(
                 e = ECS_CASE | ecs_entity_t_comb(e, s_case);
             }
 
-            added->array[added->count ++] = e; 
+            added->array[added->count ++] = e;
         }
 
         if ((node != next) && ECS_HAS_ROLE(e, INSTANCEOF)) {
             find_owned_components(world, next, ECS_ENTITY_MASK & e, &owned);
-        } 
+        }
 
         node = next;
     }
@@ -16112,7 +16113,7 @@ ecs_table_t* ecs_table_traverse_add(
     ecs_stage_t *stage,
     ecs_table_t *node,
     ecs_entities_t *to_add,
-    ecs_entities_t *added)    
+    ecs_entities_t *added)
 {
     int32_t i, count = to_add->count;
     ecs_entity_t *entities = to_add->array;
@@ -16185,7 +16186,7 @@ bool ecs_entity_array_is_ordered(
             return false;
         }
         prev = array[i];
-    }    
+    }
 
     return true;
 }
@@ -16218,15 +16219,15 @@ int32_t count_occurrences(
     ecs_world_t *world,
     ecs_entities_t *entities,
     ecs_entity_t entity,
-    int32_t constraint_index)    
+    int32_t constraint_index)
 {
     const EcsType *type_ptr = ecs_get(world, entity, EcsType);
-    ecs_assert(type_ptr != NULL, 
+    ecs_assert(type_ptr != NULL,
         ECS_INVALID_PARAMETER, "flag must be applied to type");
 
     ecs_type_t type = type_ptr->normalized;
     int32_t count = 0;
-    
+
     int i;
     for (i = 0; i < constraint_index; i ++) {
         ecs_entity_t e = entities->array[i];
@@ -16251,7 +16252,7 @@ void verify_constraints(
     for (i = count - 1; i >= 0; i --) {
         ecs_entity_t e = entities->array[i];
         ecs_entity_t mask = e & ECS_ROLE_MASK;
-        if (!mask || 
+        if (!mask ||
             ((mask != ECS_OR) &&
              (mask != ECS_XOR) &&
              (mask != ECS_NOT)))
@@ -16269,7 +16270,7 @@ void verify_constraints(
             ecs_assert(matches == 1, ECS_TYPE_CONSTRAINT_VIOLATION, NULL);
             break;
         case ECS_NOT:
-            ecs_assert(matches == 0, ECS_TYPE_CONSTRAINT_VIOLATION, NULL);    
+            ecs_assert(matches == 0, ECS_TYPE_CONSTRAINT_VIOLATION, NULL);
             break;
         }
     }
@@ -16283,9 +16284,9 @@ ecs_table_t *find_or_create(
     ecs_stage_t *stage,
     ecs_stage_t *search_stage,
     ecs_entities_t *entities)
-{    
+{
     ecs_assert(world != NULL, ECS_INTERNAL_ERROR, NULL);
-    ecs_assert(stage != NULL, ECS_INTERNAL_ERROR, NULL);    
+    ecs_assert(stage != NULL, ECS_INTERNAL_ERROR, NULL);
 
     /* Make sure array is ordered and does not contain duplicates */
     int32_t type_count = entities->count;
@@ -16303,7 +16304,7 @@ ecs_table_t *find_or_create(
         type_count = ecs_entity_array_dedup(ordered, type_count);
     } else {
         ordered = entities->array;
-    }    
+    }
 
     /* Iterate tables, look if a table matches the type */
     ecs_sparse_t *tables = search_stage->tables;
@@ -16324,7 +16325,7 @@ ecs_table_t *find_or_create(
             /* Table found */
             return table;
         }
-    }  
+    }
 
     ecs_entities_t ordered_entities = {
         .array = ordered,
@@ -16349,10 +16350,10 @@ ecs_table_t *find_or_create(
 
     /* If we get here, the table has not been found in any stages. It has to be
      * created. */
-    
+
     ecs_table_t *result = create_table(world, stage, &ordered_entities);
 
-    ecs_assert(ordered_entities.count == ecs_vector_count(result->type), 
+    ecs_assert(ordered_entities.count == ecs_vector_count(result->type),
         ECS_INTERNAL_ERROR, NULL);
 
     return result;
@@ -16450,7 +16451,7 @@ int32_t get_bucket_count(
 static
 uint64_t get_bucket_id(
     int32_t bucket_count,
-    ecs_map_key_t key) 
+    ecs_map_key_t key)
 {
     ecs_assert(bucket_count > 0, ECS_INTERNAL_ERROR, NULL);
     uint64_t result = key & ((uint64_t)bucket_count - 1);
@@ -16488,7 +16489,7 @@ ecs_bucket_t* find_or_create_bucket(
     }
 
     uint64_t bucket_id = get_bucket_id(bucket_count, key);
-    return _ecs_sparse_get_or_create(buckets, 0, bucket_id);    
+    return _ecs_sparse_get_or_create(buckets, 0, bucket_id);
 }
 
 static
@@ -16588,8 +16589,8 @@ void rehash(
 
                     indices = ecs_sparse_ids(buckets);
 
-                    if (add_to_bucket(new_bucket, elem_size, offset, 
-                        key, PAYLOAD(elem)) == BUCKET_COUNT) 
+                    if (add_to_bucket(new_bucket, elem_size, offset,
+                        key, PAYLOAD(elem)) == BUCKET_COUNT)
                     {
                         rehash_again = true;
                     }
@@ -16602,13 +16603,13 @@ void rehash(
             }
         }
 
-        bucket_count *= 2;        
+        bucket_count *= 2;
     } while (rehash_again);
 }
 
 ecs_map_t* _ecs_map_new(
     ecs_size_t elem_size,
-    ecs_size_t alignment, 
+    ecs_size_t alignment,
     int32_t element_count)
 {
     ecs_map_t *result = ecs_os_calloc(ECS_SIZEOF(ecs_map_t) * 1);
@@ -16624,7 +16625,7 @@ ecs_map_t* _ecs_map_new(
     } else {
         result->elem_size = elem_size;
     }
-    
+
     if (alignment < ECS_SIZEOF(ecs_map_key_t)) {
         result->offset = ECS_SIZEOF(ecs_map_key_t);
     } else {
@@ -16718,7 +16719,7 @@ void _ecs_map_set(
 
     ecs_bucket_t * bucket = find_or_create_bucket(map, key);
     ecs_assert(bucket != NULL, ECS_INTERNAL_ERROR, NULL);
-    
+
     int32_t bucket_count = bucket->count;
     void *array = PAYLOAD_ARRAY(bucket, map->offset);
     ecs_map_key_t *elem = array, *found = NULL;
@@ -16743,7 +16744,7 @@ void _ecs_map_set(
 
             bucket_count = ++bucket->count;
             int32_t map_count = ++map->count;
-            
+
             *elem = key;
             ecs_os_memcpy(PAYLOAD(elem), payload, elem_size);
 
@@ -16756,7 +16757,7 @@ void _ecs_map_set(
                 if (target_bucket_count > map_bucket_count) {
                     rehash(map, target_bucket_count);
                 }
-            }            
+            }
         }
     } else {
         *found = key;
@@ -16776,7 +16777,7 @@ void ecs_map_remove(
     if (!bucket) {
         return;
     }
-   
+
     ecs_size_t elem_size = map->elem_size;
     void *array = PAYLOAD_ARRAY(bucket, map->offset);
     ecs_map_key_t *elem = array;
@@ -16801,7 +16802,7 @@ void ecs_map_remove(
         }
 
         elem = NEXT_ELEM(elem, elem_size);
-    } while (++i < bucket_count);   
+    } while (++i < bucket_count);
 }
 
 int32_t ecs_map_count(
@@ -16843,10 +16844,10 @@ void* _ecs_map_next(
     ecs_map_key_t *key_out)
 {
     const ecs_map_t *map = iter->map;
-    
+
     ecs_assert(map != NULL, ECS_INVALID_PARAMETER, NULL);
     ecs_assert(!elem_size || elem_size == map->type_elem_size, ECS_INVALID_PARAMETER, NULL);
- 
+
     ecs_bucket_t *bucket = iter->bucket;
     int32_t element_index = iter->element_index;
     elem_size = map->elem_size;
@@ -16877,7 +16878,7 @@ void* _ecs_map_next(
 
     void *array = PAYLOAD_ARRAY(bucket, map->offset);
     ecs_map_key_t *elem = GET_ELEM(array, elem_size, element_index);
-    
+
     if (key_out) {
         *key_out = *elem;
     }
@@ -16898,7 +16899,7 @@ void* _ecs_map_next_ptr(
 }
 
 void ecs_map_grow(
-    ecs_map_t *map, 
+    ecs_map_t *map,
     int32_t element_count)
 {
     ecs_assert(map != NULL, ECS_INVALID_PARAMETER, NULL);
@@ -16911,9 +16912,9 @@ void ecs_map_grow(
 }
 
 void ecs_map_set_size(
-    ecs_map_t *map, 
+    ecs_map_t *map,
     int32_t element_count)
-{    
+{
     ecs_assert(map != NULL, ECS_INVALID_PARAMETER, NULL);
     int32_t bucket_count = get_bucket_count(element_count);
 
@@ -16923,7 +16924,7 @@ void ecs_map_set_size(
 }
 
 void ecs_map_memory(
-    ecs_map_t *map, 
+    ecs_map_t *map,
     int32_t *allocd,
     int32_t *used)
 {
@@ -16941,9 +16942,9 @@ ecs_map_t* ecs_map_copy(
     if (!src) {
         return NULL;
     }
-    
+
     ecs_map_t *dst = ecs_os_memdup(src, ECS_SIZEOF(ecs_map_t));
-    
+
     dst->buckets = ecs_sparse_copy(src->buckets);
 
     return dst;
@@ -16978,11 +16979,11 @@ const void* get_shared_column(
 #ifndef NDEBUG
     if (size) {
         const EcsComponent *cdata = ecs_get(
-            it->world, it->references[-table_column - 1].component, 
+            it->world, it->references[-table_column - 1].component,
             EcsComponent);
 
         ecs_assert(cdata != NULL, ECS_INTERNAL_ERROR, NULL);
-        ecs_assert(cdata->size == size, ECS_COLUMN_TYPE_MISMATCH, 
+        ecs_assert(cdata->size == size, ECS_COLUMN_TYPE_MISMATCH,
             ecs_get_name(it->world, it->system));
     }
 #endif
@@ -17054,7 +17055,7 @@ void* ecs_column_w_size(
 }
 
 void* ecs_element_w_size(
-    const ecs_iter_t *it, 
+    const ecs_iter_t *it,
     size_t size,
     int32_t column,
     int32_t row)
@@ -17083,9 +17084,9 @@ bool ecs_is_readonly(
     if (query) {
         ecs_sig_column_t *column_data = ecs_vector_get(
             it->query->sig.columns, ecs_sig_column_t, column - 1);
-                    
-        if (!ecs_is_owned(it, column) && 
-            column_data->from_kind != EcsFromEntity) 
+
+        if (!ecs_is_owned(it, column) &&
+            column_data->from_kind != EcsFromEntity)
         {
             return true;
         }
@@ -17207,7 +17208,7 @@ void* ecs_table_column(
 {
     ecs_table_t *table = it->table;
 
-    ecs_assert(column_index < ecs_vector_count(table->type), 
+    ecs_assert(column_index < ecs_vector_count(table->type),
         ECS_INVALID_PARAMETER, NULL);
 
     if (table->column_count < column_index) {
@@ -17225,7 +17226,7 @@ size_t ecs_table_column_size(
 {
     ecs_table_t *table = it->table;
 
-    ecs_assert(column_index < ecs_vector_count(table->type), 
+    ecs_assert(column_index < ecs_vector_count(table->type),
         ECS_INVALID_PARAMETER, NULL);
 
     if (table->column_count < column_index) {
@@ -17234,7 +17235,7 @@ size_t ecs_table_column_size(
 
     ecs_column_t *columns = it->table_columns;
     ecs_column_t *column = &columns[column_index];
-    
+
     return ecs_to_size_t(column->size);
 }
 
@@ -17263,7 +17264,7 @@ uint32_t ecs_to_u32(
     uint64_t v)
 {
     ecs_assert(v < UINT32_MAX, ECS_INTERNAL_ERROR, NULL);
-    return (uint32_t)v;    
+    return (uint32_t)v;
 }
 
 size_t ecs_to_size_t(
@@ -17276,7 +17277,7 @@ size_t ecs_to_size_t(
 ecs_size_t ecs_from_size_t(
     size_t size)
 {
-   ecs_assert(size < INT64_MAX, ECS_INTERNAL_ERROR, NULL); 
+   ecs_assert(size < INT64_MAX, ECS_INTERNAL_ERROR, NULL);
    return (ecs_size_t)size;
 }
 
@@ -17349,22 +17350,22 @@ double ecs_time_measure(
 }
 
 void* ecs_os_memdup(
-    const void *src, 
-    ecs_size_t size) 
+    const void *src,
+    ecs_size_t size)
 {
     if (!src) {
         return NULL;
     }
-    
+
     void *dst = ecs_os_malloc(size);
     ecs_assert(dst != NULL, ECS_OUT_OF_MEMORY, NULL);
-    ecs_os_memcpy(dst, src, size);  
-    return dst;  
+    ecs_os_memcpy(dst, src, size);
+    return dst;
 }
 
 /*
-    This code was taken from sokol_time.h 
-    
+    This code was taken from sokol_time.h
+
     zlib/libpng license
     Copyright (c) 2018 Andre Weissflog
     This software is provided 'as-is', without any express or implied warranty.
@@ -17417,7 +17418,7 @@ void ecs_os_time_setup(void) {
     if ( ecs_os_time_initialized) {
         return;
     }
-    
+
     ecs_os_time_initialized = 1;
     #if defined(_WIN32)
         LARGE_INTEGER freq;
@@ -17430,7 +17431,7 @@ void ecs_os_time_setup(void) {
     #else
         struct timespec ts;
         clock_gettime(CLOCK_MONOTONIC, &ts);
-        _ecs_os_time_posix_start = (uint64_t)ts.tv_sec*1000000000 + (uint64_t)ts.tv_nsec; 
+        _ecs_os_time_posix_start = (uint64_t)ts.tv_sec*1000000000 + (uint64_t)ts.tv_nsec;
     #endif
 }
 
@@ -17455,8 +17456,8 @@ uint64_t ecs_os_time_now(void) {
 }
 
 void ecs_os_time_sleep(
-    int32_t sec, 
-    int32_t nanosec) 
+    int32_t sec,
+    int32_t nanosec)
 {
 #ifndef _WIN32
     struct timespec sleepTime;
@@ -17610,8 +17611,8 @@ void* worker(void *arg) {
     while (!world->quit_workers) {
         ecs_entity_t old_scope = ecs_set_scope((ecs_world_t*)thread, 0);
         ecs_pipeline_progress(
-            (ecs_world_t*)thread, 
-            world->pipeline, 
+            (ecs_world_t*)thread,
+            world->pipeline,
             world->stats.delta_time);
         ecs_set_scope((ecs_world_t*)thread, old_scope);
     }
@@ -17701,9 +17702,9 @@ void wait_for_sync(
     if (world->workers_waiting != thread_count) {
         ecs_os_cond_wait(world->sync_cond, world->sync_mutex);
     }
-    
+
     /* We should have been signalled unless all workers are waiting on sync */
-    ecs_assert(world->workers_waiting == thread_count, 
+    ecs_assert(world->workers_waiting == thread_count,
         ECS_INTERNAL_ERROR, NULL);
 
     ecs_os_mutex_unlock(world->sync_mutex);
@@ -17737,7 +17738,7 @@ void ecs_stop_threads(
     world->worker_stages = NULL;
     world->workers = NULL;
     world->quit_workers = false;
-    
+
     ecs_assert(world->workers_running == 0, ECS_INTERNAL_ERROR, NULL);
 }
 
@@ -17834,7 +17835,7 @@ void ecs_workers_progress(
 
     if (world->measure_frame_time) {
         world->stats.system_time_total += (float)ecs_time_measure(&start);
-    }    
+    }
 }
 
 
@@ -17897,10 +17898,10 @@ ECS_DTOR(EcsPipelineQuery, ptr, {
 
 static
 int compare_entity(
-    ecs_entity_t e1, 
-    void *ptr1, 
-    ecs_entity_t e2, 
-    void *ptr2) 
+    ecs_entity_t e1,
+    void *ptr1,
+    ecs_entity_t e2,
+    void *ptr2)
 {
     (void)ptr1;
     (void)ptr2;
@@ -17911,7 +17912,7 @@ static
 int rank_phase(
     ecs_world_t *world,
     ecs_entity_t rank_component,
-    ecs_type_t type) 
+    ecs_type_t type)
 {
     const EcsType *pipeline_type = ecs_get(world, rank_component, EcsType);
     ecs_assert(pipeline_type != NULL, ECS_INTERNAL_ERROR, NULL);
@@ -17984,7 +17985,7 @@ bool check_column_component(
     ecs_sig_column_t *column,
     bool is_active,
     ecs_entity_t component,
-    ecs_map_t *write_state)    
+    ecs_map_t *write_state)
 {
     int32_t state = get_write_state(write_state, component);
 
@@ -18026,7 +18027,7 @@ bool check_column(
     if (column->oper_kind != EcsOperOr) {
         return check_column_component(
             column, is_active,column->is.component, write_state);
-    }  
+    }
 
     return false;
 }
@@ -18046,7 +18047,7 @@ bool build_pipeline(
         return false;
     }
 
-    ecs_trace_1("rebuilding pipeline #[green]%s", 
+    ecs_trace_1("rebuilding pipeline #[green]%s",
         ecs_get_name(world, pipeline));
 
     world->stats.pipeline_build_count_total ++;
@@ -18063,10 +18064,10 @@ bool build_pipeline(
     /* Iterate systems in pipeline, add ops for running / merging */
     ecs_iter_t it = ecs_query_iter(query);
     while (ecs_query_next(&it)) {
-        EcsSystem *sys = ecs_column(&it, EcsSystem, 1);        
+        EcsSystem *sys = ecs_column(&it, EcsSystem, 1);
 
         int i;
-        for (i = 0; i < it.count; i ++) {            
+        for (i = 0; i < it.count; i ++) {
             ecs_query_t *q = sys[i].query;
             if (!q) {
                 continue;
@@ -18097,7 +18098,7 @@ bool build_pipeline(
 
                 /* The component states were just reset, so if we conclude that
                  * another merge is needed something is wrong. */
-                ecs_assert(needs_merge == false, ECS_INTERNAL_ERROR, NULL);        
+                ecs_assert(needs_merge == false, ECS_INTERNAL_ERROR, NULL);
             }
 
             if (!op) {
@@ -18212,7 +18213,7 @@ void ecs_pipeline_progress(
     int32_t ran_since_merge = 0;
 
     ecs_worker_begin(world);
-    
+
     ecs_iter_t it = ecs_query_iter(pq->query);
     while (ecs_query_next(&it)) {
         EcsSystem *sys = ecs_column(&it, EcsSystem, 1);
@@ -18220,8 +18221,8 @@ void ecs_pipeline_progress(
         int32_t i;
         for(i = 0; i < it.count; i ++) {
             ecs_entity_t e = it.entities[i];
-            
-            ecs_run_intern(world, stage, e, &sys[i], delta_time, 0, 0, 
+
+            ecs_run_intern(world, stage, e, &sys[i], delta_time, 0, 0,
                 NULL, NULL, false);
 
             ran_since_merge ++;
@@ -18255,22 +18256,22 @@ void add_pipeline_tags_to_sig(
     ecs_type_t type)
 {
     (void)world;
-    
+
     int32_t i, count = ecs_vector_count(type);
     ecs_entity_t *entities = ecs_vector_first(type, ecs_entity_t);
 
     for (i = 0; i < count; i ++) {
         if (!i) {
-            ecs_sig_add(world, sig, EcsFromAny, EcsOperAnd, EcsIn, entities[i], 
+            ecs_sig_add(world, sig, EcsFromAny, EcsOperAnd, EcsIn, entities[i],
                 0, NULL);
         } else {
-            ecs_sig_add(world, sig, EcsFromAny, EcsOperOr, EcsIn, entities[i], 
+            ecs_sig_add(world, sig, EcsFromAny, EcsOperOr, EcsIn, entities[i],
                 0, NULL);
         }
     }
 }
 
-static 
+static
 void EcsOnAddPipeline(
     ecs_iter_t *it)
 {
@@ -18284,7 +18285,7 @@ void EcsOnAddPipeline(
 
         const EcsType *type_ptr = ecs_get(world, pipeline, EcsType);
         ecs_assert(type_ptr != NULL, ECS_INTERNAL_ERROR, NULL);
-        
+
 #ifndef NDEBUG
         char *str = ecs_type_str(world, type_ptr->normalized);
         ecs_trace_1("pipeline #[green]%s#[normal] created with #[red][%s]",
@@ -18297,10 +18298,10 @@ void EcsOnAddPipeline(
          * pipeline as a XOR column, and ignores systems with EcsInactive and
          * EcsDisabledIntern. Note that EcsDisabled is automatically ignored by
          * the regular query matching */
-        ecs_sig_add(world, &sig, EcsFromAny, EcsOperAnd, EcsIn, 
+        ecs_sig_add(world, &sig, EcsFromAny, EcsOperAnd, EcsIn,
             ecs_entity(EcsSystem), 0, NULL);
         ecs_sig_add(world, &sig, EcsFromAny, EcsOperNot, EcsIn, EcsInactive, 0, NULL);
-        ecs_sig_add(world, &sig, EcsFromAny, EcsOperNot, EcsIn, 
+        ecs_sig_add(world, &sig, EcsFromAny, EcsOperNot, EcsIn,
             EcsDisabledIntern, 0, NULL);
         add_pipeline_tags_to_sig(world, &sig, type_ptr->normalized);
 
@@ -18311,18 +18312,18 @@ void EcsOnAddPipeline(
 
         /* Build signature for pipeline build query. The build query includes
          * systems that are inactive, as an inactive system may become active as
-         * a result of another system, and as a result the correct merge 
+         * a result of another system, and as a result the correct merge
          * operations need to be put in place. */
-        ecs_sig_add(world, &sig, EcsFromAny, EcsOperAnd, EcsIn, 
+        ecs_sig_add(world, &sig, EcsFromAny, EcsOperAnd, EcsIn,
             ecs_entity(EcsSystem), 0, NULL);
-        ecs_sig_add(world, &sig, EcsFromAny, EcsOperNot, EcsIn, 
+        ecs_sig_add(world, &sig, EcsFromAny, EcsOperNot, EcsIn,
             EcsDisabledIntern, 0, NULL);
         add_pipeline_tags_to_sig(world, &sig, type_ptr->normalized);
 
         /* Use the same sorting functions for the build query */
         ecs_query_t *build_query = ecs_query_new_w_sig(world, 0, &sig);
         ecs_query_order_by(world, build_query, 0, compare_entity);
-        ecs_query_group_by(world, build_query, pipeline, rank_phase);       
+        ecs_query_group_by(world, build_query, pipeline, rank_phase);
 
         EcsPipelineQuery *pq = ecs_get_mut(
             world, pipeline, EcsPipelineQuery, NULL);
@@ -18350,7 +18351,7 @@ double insert_sleep(
     }
 
     double target_delta_time = (1.0 / world->stats.target_fps);
-    double world_sleep_err = 
+    double world_sleep_err =
         world->stats.sleep_err / (double)world->stats.frame_count_total;
 
     /* Calculate the time we need to sleep by taking the measured delta from the
@@ -18368,7 +18369,7 @@ double insert_sleep(
          * just do a busy loop */
         if (world_sleep_err / sleep_time > 0.1) {
             sleep_time = 0;
-        } 
+        }
     }
 
     /* If the time we need to sleep is large enough to warrant a sleep, sleep */
@@ -18392,9 +18393,9 @@ double insert_sleep(
             double prev_delta_time = delta_time;
             delta_time = ecs_time_measure(&now);
 
-            /* Measure the error of the sleep by taking the difference between 
-             * the time we expected to sleep, and the measured time. This 
-             * assumes that a sleep is less accurate than a high resolution 
+            /* Measure the error of the sleep by taking the difference between
+             * the time we expected to sleep, and the measured time. This
+             * assumes that a sleep is less accurate than a high resolution
              * timer which should be true in most cases. */
             sleep_err = delta_time - prev_delta_time - sleep_time;
             iterations ++;
@@ -18403,7 +18404,7 @@ double insert_sleep(
         /* Add sleep error measurement to sleep error, with a bias towards the
          * latest measured values. */
         world->stats.sleep_err = (float)
-            (world_sleep_err * 0.9 + sleep_err * 0.1) * 
+            (world_sleep_err * 0.9 + sleep_err * 0.1) *
                 (float)world->stats.frame_count_total;
     }
 
@@ -18440,11 +18441,11 @@ float start_measure_frame(
                     delta_time = 1.0 / 60.0; /* Best guess */
                 }
             }
-        
+
         /* Keep trying while delta_time is zero */
         } while (delta_time == 0);
 
-        world->frame_start_time = t;  
+        world->frame_start_time = t;
 
         /* Keep track of total time passed in world */
         world->stats.world_time_total_raw += (float)delta_time;
@@ -18487,7 +18488,7 @@ float ecs_frame_begin(
 
     /* Keep track of total scaled time passed in world */
     world->stats.world_time_total += world->stats.delta_time;
-    
+
     return user_delta_time;
 }
 
@@ -18579,7 +18580,7 @@ void ecs_set_pipeline(
     ecs_world_t *world,
     ecs_entity_t pipeline)
 {
-    ecs_assert( ecs_get(world, pipeline, EcsPipelineQuery) != NULL, 
+    ecs_assert( ecs_get(world, pipeline, EcsPipelineQuery) != NULL,
         ECS_INVALID_PARAMETER, NULL);
 
     world->pipeline = pipeline;
@@ -18600,7 +18601,7 @@ ecs_entity_t ecs_new_pipeline(
     assert(world->magic == ECS_WORLD_MAGIC);
 
     ecs_entity_t result = ecs_new_type(world, e, name, expr);
-    ecs_assert(ecs_get(world, result, EcsType) != NULL, 
+    ecs_assert(ecs_get(world, result, EcsType) != NULL,
         ECS_INTERNAL_ERROR, NULL);
 
     ecs_add_entity(world, result, EcsPipeline);
@@ -18699,14 +18700,14 @@ void ProgressTimers(ecs_iter_t *it) {
 
         float time_elapsed = timer[i].time + it->world->stats.delta_time_raw;
         float timeout = timer[i].timeout;
-        
+
         if (time_elapsed >= timeout) {
             float t = time_elapsed - timeout;
             if (t > timeout) {
                 t = 0;
             }
 
-            timer[i].time = t; /* Initialize with remainder */            
+            timer[i].time = t; /* Initialize with remainder */
             tick_source[i].tick = true;
             tick_source[i].time_elapsed = time_elapsed;
 
@@ -18715,7 +18716,7 @@ void ProgressTimers(ecs_iter_t *it) {
             }
         } else {
             timer[i].time = time_elapsed;
-        }  
+        }
     }
 }
 
@@ -18748,7 +18749,7 @@ void ProgressRateFilters(ecs_iter_t *it) {
 
             if (triggered) {
                 filter[i].time_elapsed = 0;
-            }            
+            }
         } else {
             tick_dst[i].tick = false;
         }
@@ -18806,9 +18807,9 @@ ecs_entity_t ecs_set_interval(
     EcsSystem *system_data = ecs_get_mut(world, timer, EcsSystem, NULL);
     if (system_data) {
         system_data->tick_source = timer;
-    }  
+    }
 
-    return timer;  
+    return timer;
 }
 
 float ecs_get_interval(
@@ -18866,9 +18867,9 @@ ecs_entity_t ecs_set_rate_filter(
     EcsSystem *system_data = ecs_get_mut(world, filter, EcsSystem, NULL);
     if (system_data) {
         system_data->tick_source = filter;
-    }  
+    }
 
-    return filter;     
+    return filter;
 }
 
 void ecs_set_tick_source(
@@ -18888,7 +18889,7 @@ void ecs_set_tick_source(
 
 void FlecsTimerImport(
     ecs_world_t *world)
-{    
+{
     ECS_MODULE(world, FlecsTimer);
 
     ECS_IMPORT(world, FlecsPipeline);
@@ -18943,7 +18944,7 @@ void StatsAddMemoryStats(ecs_iter_t *it) {
 static
 void StatsAddSystemStats(ecs_iter_t *it) {
     ECS_COLUMN_COMPONENT(it, EcsSystemStats, 2);
-    
+
     int32_t i;
     for (i = 0; i < it->count; i ++) {
         ecs_set(it->world, it->entities[i], EcsSystemStats, {0});
@@ -18953,7 +18954,7 @@ void StatsAddSystemStats(ecs_iter_t *it) {
 static
 void StatsAddColSystemMemoryStats(ecs_iter_t *it) {
     ECS_COLUMN_COMPONENT(it, EcsSystemMemoryStats, 2);
-    
+
     int32_t i;
     for (i = 0; i < it->count; i ++) {
         ecs_set(it->world, it->entities[i], EcsSystemMemoryStats, {0});
@@ -18963,7 +18964,7 @@ void StatsAddColSystemMemoryStats(ecs_iter_t *it) {
 static
 void StatsAddComponentStats(ecs_iter_t *it) {
     ECS_COLUMN_COMPONENT(it, EcsComponentStats, 2);
-    
+
     int32_t i;
     for (i = 0; i < it->count; i ++) {
         ecs_set(it->world, it->entities[i], EcsComponentStats, {0});
@@ -18973,7 +18974,7 @@ void StatsAddComponentStats(ecs_iter_t *it) {
 static
 void StatsAddTableStats(ecs_iter_t *it) {
     ECS_COLUMN_COMPONENT(it, EcsTableStats, 2);
-    
+
     int32_t i;
     for (i = 0; i < it->count; i ++) {
         ecs_set(it->world, it->entities[i], EcsTableStats, {0});
@@ -18983,7 +18984,7 @@ void StatsAddTableStats(ecs_iter_t *it) {
 static
 void StatsAddTypeStats(ecs_iter_t *it) {
     ECS_COLUMN_COMPONENT(it, EcsTypeStats, 2);
-    
+
     int32_t i;
     for (i = 0; i < it->count; i ++) {
         ecs_set(it->world, it->entities[i], EcsTypeStats, {0});
@@ -18994,9 +18995,9 @@ void StatsAddTypeStats(ecs_iter_t *it) {
 
 static
 void StatsCollectWorldStats_StatusAction(
-    ecs_world_t *world, 
+    ecs_world_t *world,
     ecs_entity_t system,
-    ecs_system_status_t status, 
+    ecs_system_status_t status,
     void *ctx)
 {
     (void)system;
@@ -19020,7 +19021,7 @@ void StatsCollectWorldStats(ecs_iter_t *it) {
     stats->col_systems_count = ecs_count(world, EcsSystem);
     stats->tables_count = ecs_sparse_count(world->stage.tables);
     stats->threads_count = ecs_vector_count(world->workers);
-    
+
     stats->frame_seconds_total = world->stats.frame_time_total;
     stats->system_seconds_total = world->stats.system_time_total;
     stats->merge_seconds_total = world->stats.merge_time_total;
@@ -19047,7 +19048,7 @@ void StatsCollectColSystemMemoryTotals(ecs_iter_t *it) {
 
     int32_t i;
     for (i = 0; i < it->count; i ++) {
-        stat->allocd_bytes += 
+        stat->allocd_bytes +=
             stats[i].base_memory_bytes +
             stats[i].columns_memory.allocd_bytes +
             stats[i].active_tables_memory.allocd_bytes +
@@ -19055,13 +19056,13 @@ void StatsCollectColSystemMemoryTotals(ecs_iter_t *it) {
             stats[i].jobs_memory.allocd_bytes +
             stats[i].other_memory_bytes;
 
-        stat->used_bytes += 
+        stat->used_bytes +=
             stats[i].base_memory_bytes +
             stats[i].columns_memory.used_bytes +
             stats[i].active_tables_memory.used_bytes +
             stats[i].inactive_tables_memory.used_bytes +
             stats[i].jobs_memory.used_bytes +
-            stats[i].other_memory_bytes;            
+            stats[i].other_memory_bytes;
     }
 }
 
@@ -19080,21 +19081,21 @@ void StatsCollectTableMemoryTotals(ecs_iter_t *it) {
         world_stats->entities_memory.allocd_bytes += stats[i].entity_memory.allocd_bytes;
 
         world_stats->tables_memory.used_bytes += stats[i].other_memory_bytes;
-        world_stats->tables_memory.allocd_bytes += stats[i].other_memory_bytes; 
+        world_stats->tables_memory.allocd_bytes += stats[i].other_memory_bytes;
     }
 }
 
 static
 void compute_stage_memory(
-    ecs_stage_t *stage, 
+    ecs_stage_t *stage,
     EcsMemoryStats *stats)
 {
-    ecs_eis_memory(stage, 
-        &stats->entities_memory.allocd_bytes, 
+    ecs_eis_memory(stage,
+        &stats->entities_memory.allocd_bytes,
         &stats->entities_memory.used_bytes);
 
     ecs_sparse_memory(stage->tables,
-        &stats->stages_memory.allocd_bytes, &stats->stages_memory.used_bytes);    
+        &stats->stages_memory.allocd_bytes, &stats->stages_memory.used_bytes);
 }
 
 static
@@ -19102,7 +19103,7 @@ void compute_world_memory(
     ecs_world_t *world,
     EcsMemoryStats *stats)
 {
-    stats->world_memory.used_bytes = 
+    stats->world_memory.used_bytes =
     stats->world_memory.allocd_bytes = ECS_SIZEOF(ecs_world_t);
 
     /* Add memory spent on worker threads to world memory */
@@ -19110,10 +19111,10 @@ void compute_world_memory(
         &stats->world_memory.allocd_bytes, &stats->world_memory.used_bytes);
 
     /* Add memory spent on on demand lookup structures to system memory */
-    ecs_map_memory(world->on_enable_components, 
-        &stats->systems_memory.allocd_bytes, &stats->systems_memory.used_bytes);        
+    ecs_map_memory(world->on_enable_components,
+        &stats->systems_memory.allocd_bytes, &stats->systems_memory.used_bytes);
     ecs_map_memory(world->on_activate_components,
-        &stats->systems_memory.allocd_bytes, &stats->systems_memory.used_bytes);     
+        &stats->systems_memory.allocd_bytes, &stats->systems_memory.used_bytes);
 
     ecs_vector_memory(world->fini_tasks, ecs_entity_t,
         &stats->systems_memory.allocd_bytes, &stats->systems_memory.used_bytes);
@@ -19123,15 +19124,15 @@ void compute_world_memory(
         &stats->tables_memory.allocd_bytes, &stats->tables_memory.used_bytes);
 
     /* Add misc lookup indices to world memory */
-    ecs_map_memory(world->type_handles, 
-        &stats->world_memory.allocd_bytes, &stats->world_memory.used_bytes);   
+    ecs_map_memory(world->type_handles,
+        &stats->world_memory.allocd_bytes, &stats->world_memory.used_bytes);
 
     stats->stages_memory = (ecs_memory_stat_t){0};
-    
+
     /* Compute memory used in temporary stage */
     compute_stage_memory(&world->temp_stage, stats);
     stats->stages_memory.used_bytes += ECS_SIZEOF(ecs_stage_t);
-    stats->stages_memory.allocd_bytes += ECS_SIZEOF(ecs_stage_t);    
+    stats->stages_memory.allocd_bytes += ECS_SIZEOF(ecs_stage_t);
 
     /* Compute memory used in thread stages */
     int32_t i, count = ecs_vector_count(world->worker_stages);
@@ -19156,11 +19157,11 @@ void StatsCollectMemoryStats(ecs_iter_t *it) {
 
     /* Compute entity memory (entity index) */
     stats->entities_memory = (ecs_memory_stat_t){0};
-    
-    ecs_eis_memory(&world->stage, 
-        &stats->entities_memory.allocd_bytes, 
+
+    ecs_eis_memory(&world->stage,
+        &stats->entities_memory.allocd_bytes,
         &stats->entities_memory.used_bytes);
-    
+
     /* Compute entity (entity columns), component and table memory */
     stats->components_memory = (ecs_memory_stat_t){0};
     stats->tables_memory = (ecs_memory_stat_t){0};
@@ -19188,14 +19189,14 @@ void StatsCollectMemoryStats(ecs_iter_t *it) {
         stats->tables_memory.allocd_bytes +
         stats->types_memory.allocd_bytes +
         stats->stages_memory.allocd_bytes +
-        stats->systems_memory.allocd_bytes;        
+        stats->systems_memory.allocd_bytes;
 }
 
 static
 void StatsCollectSystemStats_StatusAction(
-    ecs_world_t *world, 
+    ecs_world_t *world,
     ecs_entity_t system,
-    ecs_system_status_t status, 
+    ecs_system_status_t status,
     void *ctx)
 {
     (void)system;
@@ -19260,7 +19261,7 @@ void collect_system_table_metrics(
 {
     int32_t column_count = ecs_vector_count(system->query->sig.columns);
 
-    ecs_vector_memory(tables, ecs_matched_table_t, 
+    ecs_vector_memory(tables, ecs_matched_table_t,
         &stat->allocd_bytes, &stat->used_bytes);
 
     ecs_matched_table_t *tables_buffer = ecs_vector_first(tables, ecs_matched_table_t);
@@ -19274,10 +19275,10 @@ void collect_system_table_metrics(
     stat->allocd_bytes += (ECS_SIZEOF(ecs_entity_t) * column_count) * count;
     stat->used_bytes += (ECS_SIZEOF(ecs_entity_t) * column_count) * count;
 
-    /* Refs are different for each table, so we'll have to loop to get accurate 
+    /* Refs are different for each table, so we'll have to loop to get accurate
      * numbers */
     for (i = 0; i < count; i ++) {
-        ecs_vector_memory(tables_buffer[i].references, ecs_ref_t, 
+        ecs_vector_memory(tables_buffer[i].references, ecs_ref_t,
             &stat->allocd_bytes, &stat->used_bytes);
     }
 }
@@ -19295,16 +19296,16 @@ void StatsCollectColSystemMemoryStats(ecs_iter_t *it) {
         stats[i].inactive_tables_memory = (ecs_memory_stat_t){0};
         stats[i].jobs_memory = (ecs_memory_stat_t){0};
         stats[i].other_memory_bytes = 0;
-        
-        ecs_vector_memory(system->query->sig.columns, ecs_sig_column_t, 
-            &stats[i].columns_memory.allocd_bytes, 
+
+        ecs_vector_memory(system->query->sig.columns, ecs_sig_column_t,
+            &stats[i].columns_memory.allocd_bytes,
             &stats[i].columns_memory.used_bytes);
 
-        collect_system_table_metrics(system, system->query->tables, 
+        collect_system_table_metrics(system, system->query->tables,
             &stats[i].active_tables_memory);
 
-        collect_system_table_metrics(system, system->query->empty_tables, 
-            &stats[i].inactive_tables_memory);            
+        collect_system_table_metrics(system, system->query->empty_tables,
+            &stats[i].inactive_tables_memory);
 
         if (system->on_demand) {
             stats[i].other_memory_bytes += ECS_SIZEOF(ecs_on_demand_out_t);
@@ -19324,7 +19325,7 @@ void StatsCollectComponentStats(ecs_iter_t *it) {
         stats[i].entity = entity;
         stats[i].name = ecs_get_name(it->world, entity);
         stats[i].size_bytes = component[i].size;
-        
+
         /* Reset values */
         stats[i].tables_count = 0;
         stats[i].entities_count = 0;
@@ -19350,8 +19351,8 @@ void StatsCollectComponentStats(ecs_iter_t *it) {
                     ecs_vector_t *column = columns[c].data;
                     stats[i].tables_count ++;
                     stats[i].entities_count += ecs_vector_count(column);
-                    ecs_vector_memory_t(column, columns[c].size, columns[c].alignment, 
-                        &stats[i].memory.allocd_bytes, 
+                    ecs_vector_memory_t(column, columns[c].size, columns[c].alignment,
+                        &stats[i].memory.allocd_bytes,
                         &stats[i].memory.used_bytes);
                     break;
                 }
@@ -19405,8 +19406,8 @@ void collect_table_data_memory(
 
     stats->entity_memory = (ecs_memory_stat_t){0};
 
-    ecs_vector_memory(data->entities, ecs_entity_t, 
-        &stats->entity_memory.allocd_bytes, 
+    ecs_vector_memory(data->entities, ecs_entity_t,
+        &stats->entity_memory.allocd_bytes,
         &stats->entity_memory.used_bytes);
 
     stats->component_memory = (ecs_memory_stat_t){0};
@@ -19414,7 +19415,7 @@ void collect_table_data_memory(
     for (c = 0; c < count; c ++) {
         ecs_column_t *column = &columns[c];
         ecs_vector_memory_t(column->data, columns->size, columns->alignment,
-            &stats->component_memory.allocd_bytes, 
+            &stats->component_memory.allocd_bytes,
             &stats->component_memory.used_bytes);
     }
 }
@@ -19438,7 +19439,7 @@ void StatsCollectTableStats(ecs_iter_t *it) {
         stats[i].columns_count = ecs_vector_count(type);
         stats[i].rows_count = ecs_vector_count(columns[0].data);
         stats[i].systems_matched_count = ecs_vector_count(table->queries);
-        stats[i].other_memory_bytes = 
+        stats[i].other_memory_bytes =
             ECS_SIZEOF(ecs_column_t) + ecs_vector_count(type) +
             ECS_SIZEOF(ecs_entity_t) * ecs_vector_count(table->queries);
 
@@ -19475,7 +19476,7 @@ void StatsCollectTypeStats(ecs_iter_t *it) {
         for (j = 0; j < count; j ++) {
             ecs_entity_t e = entities[j];
             bool has_flags = false;
-            
+
             if (ECS_HAS_ROLE(e, CHILDOF)) {
                 stats[i].entities_childof_count ++;
                 has_flags = true;
@@ -19510,7 +19511,7 @@ void StatsCollectTypeStats(ecs_iter_t *it) {
 
 void FlecsStatsImport(
     ecs_world_t *world)
-{    
+{
     ECS_MODULE(world, FlecsStats);
 
     ECS_IMPORT(world, FlecsPipeline);
@@ -19527,40 +19528,40 @@ void FlecsStatsImport(
     ECS_COMPONENT(world, EcsTableStats);
     ECS_COMPONENT(world, EcsTablePtr);
     ECS_COMPONENT(world, EcsTypeStats);
-    
+
     ECS_ENTITY(world, EcsStatsSkipCollect, 0);
 
     /* -- Helper systems -- */
 
-    ECS_SYSTEM(world, StatsCollectColSystemMemoryTotals, 0, 
+    ECS_SYSTEM(world, StatsCollectColSystemMemoryTotals, 0,
         [in] EcsSystemMemoryStats,
         [out] World:EcsMemoryStats,
         SYSTEM:EcsOnDemand, SYSTEM:Hidden);
 
-    ECS_SYSTEM(world, StatsCollectTableMemoryTotals, 0, 
+    ECS_SYSTEM(world, StatsCollectTableMemoryTotals, 0,
         [in] EcsTableStats,
         [out] World:EcsMemoryStats,
         SYSTEM:EcsOnDemand, SYSTEM:Hidden);
 
     /* -- Component creation systems -- */
 
-    ECS_SYSTEM(world, StatsAddWorldStats, EcsOnStore, [out] !World:EcsWorldStats, 
+    ECS_SYSTEM(world, StatsAddWorldStats, EcsOnStore, [out] !World:EcsWorldStats,
         SYSTEM:EcsOnDemand, SYSTEM:Hidden);
 
-    ECS_SYSTEM(world, StatsAddAllocStats, EcsOnStore, [out] !World:EcsAllocStats, 
+    ECS_SYSTEM(world, StatsAddAllocStats, EcsOnStore, [out] !World:EcsAllocStats,
         SYSTEM:EcsOnDemand, SYSTEM:Hidden);
 
-    ECS_SYSTEM(world, StatsAddMemoryStats, EcsPostLoad, [out] !World:EcsMemoryStats, 
+    ECS_SYSTEM(world, StatsAddMemoryStats, EcsPostLoad, [out] !World:EcsMemoryStats,
         SYSTEM:EcsOnDemand, SYSTEM:Hidden);
 
     ECS_SYSTEM(world, StatsAddSystemStats, EcsOnStore,
         flecs.system.EcsSystem, [out] !EcsSystemStats,
-        SYSTEM:EcsOnDemand, SYSTEM:Hidden, 
+        SYSTEM:EcsOnDemand, SYSTEM:Hidden,
         SYSTEM:EcsStatsSkipCollect, !EcsStatsSkipCollect);
 
     ECS_SYSTEM(world, StatsAddColSystemMemoryStats, EcsOnStore,
         flecs.system.EcsSystem, [out] !EcsSystemMemoryStats,
-        SYSTEM:EcsOnDemand, SYSTEM:Hidden, 
+        SYSTEM:EcsOnDemand, SYSTEM:Hidden,
         SYSTEM:EcsStatsSkipCollect, !EcsStatsSkipCollect);
 
     ECS_SYSTEM(world, StatsAddComponentStats, EcsOnStore,
@@ -19586,14 +19587,14 @@ void FlecsStatsImport(
         world, StatsCollectWorldStats, StatsCollectWorldStats_StatusAction, NULL);
 
     ECS_SYSTEM(world, StatsCollectAllocStats, EcsPostLoad,
-        [out] EcsAllocStats, 
+        [out] EcsAllocStats,
         SYSTEM:EcsOnDemand, SYSTEM:Hidden);
 
     ECS_SYSTEM(world, StatsCollectMemoryStats, EcsPostLoad,
         [out] EcsMemoryStats,
         :StatsCollectColSystemMemoryTotals,
         :StatsCollectTableMemoryTotals,
-        SYSTEM:EcsOnDemand, SYSTEM:Hidden);      
+        SYSTEM:EcsOnDemand, SYSTEM:Hidden);
 
     ECS_SYSTEM(world, StatsCollectSystemStats, EcsPostLoad,
         flecs.system.EcsSystem, [out] EcsSystemStats,
@@ -19617,7 +19618,7 @@ void FlecsStatsImport(
 
     /* This handler creates entities for tables when system is enabled */
     ecs_set_system_status_action(
-        world, StatsCollectTableStats, StatsCollectTableStats_StatusAction, 
+        world, StatsCollectTableStats, StatsCollectTableStats_StatusAction,
         ecs_type(EcsTablePtr));
 
     ECS_SYSTEM(world, StatsCollectTypeStats, EcsPostLoad,
@@ -19692,9 +19693,9 @@ void activate_in_columns(
 
             /* If this is the first system that registers the in component, walk
              * over all already registered systems to enable them */
-            if (in->systems && 
-               ((activate && in->count == 1) || 
-                (!activate && !in->count))) 
+            if (in->systems &&
+               ((activate && in->count == 1) ||
+                (!activate && !in->count)))
             {
                 ecs_on_demand_out_t **out = ecs_vector_first(in->systems, ecs_on_demand_out_t*);
                 int32_t s, in_count = ecs_vector_count(in->systems);
@@ -19702,18 +19703,18 @@ void activate_in_columns(
                 for (s = 0; s < in_count; s ++) {
                     /* Increase the count of the system with the out params */
                     out[s]->count += activate ? 1 : -1;
-                    
+
                     /* If this is the first out column that is requested from
                      * the OnDemand system, enable it */
                     if (activate && out[s]->count == 1) {
                         ecs_remove_entity(world, out[s]->system, EcsDisabledIntern);
                     } else if (!activate && !out[s]->count) {
-                        ecs_add_entity(world, out[s]->system, EcsDisabledIntern);             
+                        ecs_add_entity(world, out[s]->system, EcsDisabledIntern);
                     }
                 }
             }
         }
-    }    
+    }
 }
 
 static
@@ -19765,7 +19766,7 @@ void register_out_columns(
             }
 
             register_out_column(
-                component_map, columns[i].is.component, 
+                component_map, columns[i].is.component,
                 system_data->on_demand);
 
             out_count ++;
@@ -19812,11 +19813,11 @@ void ecs_system_activate(
         world, system_data->query, world->on_activate_components, activate);
 
     /* Invoke system status action */
-    invoke_status_action(world, system, system_data, 
+    invoke_status_action(world, system, system_data,
         activate ? EcsSystemActivated : EcsSystemDeactivated);
 
-    ecs_trace_2("system #[green]%s#[reset] %s", 
-        ecs_get_name(world, system), 
+    ecs_trace_2("system #[green]%s#[reset] %s",
+        ecs_get_name(world, system),
         activate ? "activated" : "deactivated");
 }
 
@@ -19842,11 +19843,11 @@ void ecs_enable_system(
 
     /* Enable/disable systems that trigger on [in] enablement */
     activate_in_columns(
-        world, 
-        query, 
-        world->on_enable_components, 
+        world,
+        query,
+        world->on_enable_components,
         enabled);
-    
+
     /* Invoke action for enable/disable status */
     invoke_status_action(
         world, system, system_data,
@@ -19916,14 +19917,14 @@ void ecs_init_system(
             * columns of the on demand system, disable it */
             if (!sptr->on_demand->count) {
                 ecs_add_entity(world, system, EcsDisabledIntern);
-            }        
+            }
         }
 
         /* Check if system has out columns */
         int32_t i, count = ecs_vector_count(query->sig.columns);
         ecs_sig_column_t *columns = ecs_vector_first(
                 query->sig.columns, ecs_sig_column_t);
-        
+
         for (i = 0; i < count; i ++) {
             if (columns[i].inout_kind != EcsIn) {
                 break;
@@ -19931,7 +19932,7 @@ void ecs_init_system(
         }
     }
 
-    ecs_trace_1("system #[green]%s#[reset] created with #[red]%s", 
+    ecs_trace_1("system #[green]%s#[reset] created with #[red]%s",
         ecs_get_name(world, system), query->sig.expr);
 }
 
@@ -19979,8 +19980,8 @@ void ecs_set_system_status_action(
     system_data->status_ctx = (void*)ctx;
 
     if (!ecs_has_entity(world, system, EcsDisabled)) {
-        /* If system is already enabled, generate enable status. The API 
-         * should guarantee that it exactly matches enable-disable 
+        /* If system is already enabled, generate enable status. The API
+         * should guarantee that it exactly matches enable-disable
          * notifications and activate-deactivate notifications. */
         invoke_status_action(world, system, system_data, EcsSystemEnabled);
 
@@ -20003,7 +20004,7 @@ ecs_entity_t ecs_run_intern(
     int32_t limit,
     const ecs_filter_t *filter,
     void *param,
-    bool ran_by_app) 
+    bool ran_by_app)
 {
     if (!param) {
         param = system_data->ctx;
@@ -20047,7 +20048,7 @@ ecs_entity_t ecs_run_intern(
     it.delta_system_time = time_elapsed;
     it.world_time = world->stats.world_time_total;
     it.frame_offset = offset;
-    
+
     /* Set param if provided, otherwise use system context */
     if (param) {
         it.param = param;
@@ -20068,14 +20069,14 @@ ecs_entity_t ecs_run_intern(
         int32_t current = thread->index;
 
         while (ecs_query_next_worker(&it, current, total)) {
-            action(&it);               
+            action(&it);
         }
     }
 
     if (measure_time) {
         system_data->time_spent += (float)ecs_time_measure(&time_start);
     }
-    
+
     system_data->invoke_count ++;
 
     return it.interrupted_by;
@@ -20100,7 +20101,7 @@ ecs_entity_t ecs_run_w_filter(
     assert(system_data != NULL);
 
     ecs_entity_t interrupted_by = ecs_run_intern(
-        world, stage, system, system_data, delta_time, offset, limit, 
+        world, stage, system, system_data, delta_time, offset, limit,
         filter, param, true);
 
     /* If world wasn't in progress when we entered this function, we need to
@@ -20140,7 +20141,7 @@ void ecs_run_monitor(
     }
 
     ecs_iter_t it = {0};
-    ecs_query_set_iter( world, stage, query, &it, 
+    ecs_query_set_iter( world, stage, query, &it,
         monitor->matched_table_index, row, count);
 
     it.world = stage->world;
@@ -20201,11 +20202,11 @@ void ecs_colsystem_dtor(
         }
 
         /* Invoke Disabled action for enabled systems */
-        if (!ecs_has_entity(world, e, EcsDisabled) && 
-            !ecs_has_entity(world, e, EcsDisabledIntern)) 
+        if (!ecs_has_entity(world, e, EcsDisabled) &&
+            !ecs_has_entity(world, e, EcsDisabledIntern))
         {
             invoke_status_action(world, e, ptr, EcsSystemDisabled);
-        }           
+        }
 
         ecs_os_free(cur->on_demand);
     }
@@ -20252,7 +20253,7 @@ void trigger_set(
             ecs_abort(ECS_INVALID_PARAMETER, NULL);
             break;
         }
-        
+
         ecs_assert(el != NULL, ECS_INTERNAL_ERROR, NULL);
 
         *el = ct[i];
@@ -20261,7 +20262,7 @@ void trigger_set(
         ecs_notify_tables(world, &(ecs_table_event_t) {
             .kind = EcsTableComponentInfo,
             .component = c
-        });        
+        });
 
         ecs_trace_1("trigger #[green]%s#[normal] created for component #[red]%s",
             ct[i].kind == EcsOnAdd
@@ -20275,7 +20276,7 @@ void OnSetTrigger(
     ecs_iter_t *it)
 {
     EcsTrigger *ct = ecs_column(it, EcsTrigger, 1);
-    
+
     trigger_set(it->world, it->entities, ct, it->count);
 }
 
@@ -20291,7 +20292,7 @@ void OnSetTriggerCtx(
         ct[i].ctx = (void*)ctx[i].ctx;
     }
 
-    trigger_set(it->world, it->entities, ct, it->count);    
+    trigger_set(it->world, it->entities, ct, it->count);
 }
 
 /* System that registers component lifecycle callbacks */
@@ -20305,12 +20306,12 @@ void OnSetComponentLifecycle(
     int i;
     for (i = 0; i < it->count; i ++) {
         ecs_entity_t e = it->entities[i];
-        ecs_set_component_actions_w_entity(world, e, &cl[i]);   
+        ecs_set_component_actions_w_entity(world, e, &cl[i]);
     }
 }
 
 /* Disable system when EcsDisabled is added */
-static 
+static
 void DisableSystem(
     ecs_iter_t *it)
 {
@@ -20340,13 +20341,13 @@ void EnableSystem(
 /* Parse a signature expression into the ecs_sig_t data structure */
 static
 void CreateSignature(
-    ecs_iter_t *it) 
+    ecs_iter_t *it)
 {
     ecs_world_t *world = it->world;
     ecs_entity_t *entities = it->entities;
 
     EcsSignatureExpr *signature = ecs_column(it, EcsSignatureExpr, 1);
-    
+
     int32_t i;
     for (i = 0; i < it->count; i ++) {
         ecs_entity_t e = entities[i];
@@ -20362,20 +20363,20 @@ void CreateSignature(
             if (column->from_kind == EcsFromSystem) {
                 ecs_add_entity(world, e, column->is.component);
             }
-        });    
+        });
     }
 }
 
 /* Create a query from a signature */
 static
 void CreateQuery(
-    ecs_iter_t *it) 
+    ecs_iter_t *it)
 {
     ecs_world_t *world = it->world;
     ecs_entity_t *entities = it->entities;
 
     EcsSignature *signature = ecs_column(it, EcsSignature, 1);
-    
+
     int32_t i;
     for (i = 0; i < it->count; i ++) {
         ecs_entity_t e = entities[i];
@@ -20399,7 +20400,7 @@ void CreateSystem(
     EcsQuery *query = ecs_column(it, EcsQuery, 1);
     EcsIterAction *action = ecs_column(it, EcsIterAction, 2);
     EcsContext *ctx = ecs_column(it, EcsContext, 3);
-    
+
     int32_t i;
     for (i = 0; i < it->count; i ++) {
         ecs_entity_t e = entities[i];
@@ -20514,7 +20515,7 @@ ecs_entity_t ecs_new_trigger(
             trigger->action = action;
         }
     }
-    
+
     ecs_modified(world, result, EcsTrigger);
 
     return result;
@@ -20615,10 +20616,10 @@ int ecs_dbg_system(
         ecs_table_t *table = mt->table;
         if (table) {
             dbg_out->entities_matched_count += ecs_table_count(table);
-        }        
+        }
     });
 
-    /* Inactive tables are inactive because they are empty, so no need to 
+    /* Inactive tables are inactive because they are empty, so no need to
      * iterate them */
 
     return 0;
@@ -20658,7 +20659,7 @@ ecs_table_t* ecs_dbg_active_table(
     if (!table) {
         return NULL;
     }
-    
+
     return table->table;
 }
 
@@ -20675,8 +20676,8 @@ ecs_table_t* ecs_dbg_inactive_table(
     if (!table) {
         return NULL;
     }
-    
-    return table->table;    
+
+    return table->table;
 }
 
 ecs_type_t ecs_dbg_get_column_type(
@@ -20688,7 +20689,7 @@ ecs_type_t ecs_dbg_get_column_type(
     if (!system_data) {
         return NULL;
     }
-    
+
     ecs_sig_column_t *columns = ecs_vector_first(
         system_data->query->sig.columns, ecs_sig_column_t);
     int32_t count = ecs_vector_count(system_data->query->sig.columns);
@@ -20709,7 +20710,7 @@ ecs_type_t ecs_dbg_get_column_type(
         result = ecs_type_from_entity(world, column->is.component);
         break;
     }
-    
+
     return result;
 }
 
@@ -20736,9 +20737,9 @@ int parse_type_action(
     ecs_vector_t **array = data;
     (void)source_id;
     (void)inout_kind;
-    
+
     if (arg_name) {
-        ecs_parser_error(name, sig, column, 
+        ecs_parser_error(name, sig, column,
             "column names not supported in type expression");
         return -1;
     }
@@ -20751,7 +20752,7 @@ int parse_type_action(
                 return -1;
             }
 
-            ecs_parser_error(name, sig, column, 
+            ecs_parser_error(name, sig, column,
                 "source modifiers not supported for type expressions");
             return -1;
         }
@@ -20762,7 +20763,7 @@ int parse_type_action(
                 return -1;
             }
 
-            ecs_parser_error(name, sig, column, 
+            ecs_parser_error(name, sig, column,
                 "unresolved identifier '%s'", entity_id);
             return -1;
         }
@@ -20770,13 +20771,13 @@ int parse_type_action(
         if (trait_id) {
             ecs_entity_t trait = ecs_lookup_fullpath(world, trait_id);
             if (!trait) {
-                ecs_parser_error(name, sig, column, 
+                ecs_parser_error(name, sig, column,
                     "unresolved trait identifier '%s'", trait_id);
                 return -1;
             }
 
             entity = ecs_entity_t_comb(entity, trait);
-        }        
+        }
 
         if (oper_kind == EcsOperAnd) {
             ecs_entity_t* e_ptr = ecs_vector_add(array, ecs_entity_t);
@@ -20787,7 +20788,7 @@ int parse_type_action(
             }
 
             /* Only AND and OR operators are supported for type expressions */
-            ecs_parser_error(name, sig, column, 
+            ecs_parser_error(name, sig, column,
                 "invalid operator for type expression");
             return -1;
         }
@@ -20814,7 +20815,7 @@ EcsType type_from_vec(
         world, &world->stage, &entities);
     if (!table) {
         return (EcsType){ 0 };
-    }    
+    }
 
     result.type = table->type;
 
@@ -20828,14 +20829,14 @@ EcsType type_from_vec(
         if (ECS_HAS_ROLE(e, AND)) {
             ecs_entity_t entity = e & ECS_ENTITY_MASK;
             const EcsType *type_ptr = ecs_get(world, entity, EcsType);
-            ecs_assert(type_ptr != NULL, ECS_INVALID_PARAMETER, 
+            ecs_assert(type_ptr != NULL, ECS_INVALID_PARAMETER,
                 "flag must be applied to type");
 
             ecs_vector_each(type_ptr->normalized, ecs_entity_t, c_ptr, {
                 ecs_entity_t *el = ecs_vector_add(&normalized, ecs_entity_t);
                 *el = *c_ptr;
             })
-        }       
+        }
     }
 
     /* Only get normalized type if it's different from the type */
@@ -20873,7 +20874,7 @@ EcsType type_from_expr(
 
 /* If a name prefix is set with ecs_set_name_prefix, check if the entity name
  * has the prefix, and if so remove it. This enables using prefixed names in C
- * for components / systems while storing a canonical / language independent 
+ * for components / systems while storing a canonical / language independent
  * identifier. */
 const char* ecs_name_from_symbol(
     ecs_world_t *world,
@@ -20882,8 +20883,8 @@ const char* ecs_name_from_symbol(
     const char *prefix = world->name_prefix;
     if (type_name && prefix) {
         ecs_size_t len = ecs_os_strlen(prefix);
-        if (!ecs_os_strncmp(type_name, prefix, len) && 
-           (isupper(type_name[len]) || type_name[len] == '_')) 
+        if (!ecs_os_strncmp(type_name, prefix, len) &&
+           (isupper(type_name[len]) || type_name[len] == '_'))
         {
             if (type_name[len] == '_') {
                 return type_name + len + 1;
@@ -20903,9 +20904,9 @@ void ecs_set_symbol(
 {
     const char *e_name = ecs_name_from_symbol(world, name);
 
-    ecs_set(world, e, EcsName, { 
-        .value = e_name, 
-        .symbol = name 
+    ecs_set(world, e, EcsName, {
+        .value = e_name,
+        .symbol = name
     });
 }
 
@@ -20926,7 +20927,7 @@ ecs_entity_t ecs_lookup_w_id(
             }
         }
     }
-    
+
     ecs_entity_t result = e;
     if (!result) {
         if (!name) {
@@ -20936,7 +20937,7 @@ ecs_entity_t ecs_lookup_w_id(
 
         result = ecs_lookup(world, name);
     }
-    
+
     return result;
 }
 
@@ -20961,7 +20962,7 @@ ecs_entity_t ecs_new_entity(
         result = ecs_new(world, 0);
         ecs_set_symbol(world, result, name);
     }
-    
+
     EcsType type = type_from_expr(world, name, expr);
     ecs_add_type(world, result, type.normalized);
 
@@ -21045,7 +21046,7 @@ ecs_entity_t ecs_new_type(
     if (!result) {
         result = ecs_new_entity(world, 0, name, NULL);
     }
-    
+
     EcsType type_parsed = type_from_expr(world, name, expr);
 
     bool added = false;
@@ -21061,7 +21062,7 @@ ecs_entity_t ecs_new_type(
         if (type->normalized != type_parsed.normalized) {
             ecs_abort(ECS_ALREADY_DEFINED, name);
         }
-    }     
+    }
 
     /* This will allow the type to show up in debug tools */
     ecs_map_set(world->type_handles, (uintptr_t)type_parsed.type, &result);
@@ -21094,7 +21095,7 @@ ECS_COPY(EcsName, dst, src, {
         ecs_os_free(dst->alloc_value);
         dst->alloc_value = NULL;
     }
-    
+
     if (src->alloc_value) {
         dst->alloc_value = ecs_os_strdup(src->alloc_value);
         dst->value = dst->alloc_value;
@@ -21149,7 +21150,7 @@ void _bootstrap_component(
     /* Set size and id */
     EcsComponent *c_info = ecs_vector_first(columns[0].data, EcsComponent);
     EcsName *id_data = ecs_vector_first(columns[1].data, EcsName);
-    
+
     c_info[index].size = size;
     c_info[index].alignment = alignment;
     id_data[index].value = &id[ecs_os_strlen("Ecs")]; /* Skip prefix */
@@ -21162,7 +21163,7 @@ ecs_type_t ecs_bootstrap_type(
     ecs_world_t *world,
     ecs_entity_t entity)
 {
-    ecs_table_t *table = ecs_table_find_or_create(world, &world->stage, 
+    ecs_table_t *table = ecs_table_find_or_create(world, &world->stage,
         &(ecs_entities_t){
             .array = (ecs_entity_t[]){entity},
             .count = 1
@@ -21187,9 +21188,9 @@ void bootstrap_types(
 
 /** Initialize component table. This table is manually constructed to bootstrap
  * flecs. After this function has been called, the builtin components can be
- * created. 
+ * created.
  * The reason this table is constructed manually is because it requires the size
- * and alignment of the EcsComponent and EcsName components, which haven't been 
+ * and alignment of the EcsComponent and EcsName components, which haven't been
  * created yet */
 static
 ecs_table_t* bootstrap_component_table(
@@ -21221,7 +21222,7 @@ ecs_table_t* bootstrap_component_table(
     data->columns[1].alignment = ECS_ALIGNOF(EcsName);
 
     result->column_count = 2;
-    
+
     return result;
 }
 
@@ -21285,7 +21286,7 @@ void ecs_bootstrap(
     ecs_set(world, EcsWildcard, EcsName, {.value = "*"});
     ecs_assert(ecs_get_name(world, EcsWildcard) != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(ecs_lookup(world, "*") == EcsWildcard, ECS_INTERNAL_ERROR, NULL);
-    ecs_add_entity(world, EcsWildcard, ECS_CHILDOF | EcsFlecsCore);    
+    ecs_add_entity(world, EcsWildcard, ECS_CHILDOF | EcsFlecsCore);
 
     ecs_set_scope(world, 0);
 
@@ -21295,9 +21296,9 @@ void ecs_bootstrap(
 
 static
 bool path_append(
-    ecs_world_t *world, 
-    ecs_entity_t parent, 
-    ecs_entity_t child, 
+    ecs_world_t *world,
+    ecs_entity_t parent,
+    ecs_entity_t child,
     ecs_entity_t component,
     const char *sep,
     const char *prefix,
@@ -21305,7 +21306,7 @@ bool path_append(
 {
     ecs_type_t type = ecs_get_type(world, child);
     ecs_entity_t cur = ecs_find_in_type(world, type, component, ECS_CHILDOF);
-    
+
     if (cur) {
         if (cur != parent && cur != EcsFlecsCore) {
             path_append(world, parent, cur, component, sep, prefix, buf);
@@ -21346,7 +21347,7 @@ char* ecs_get_path_w_sep(
     return ecs_strbuf_get(&buf);
 }
 
-static 
+static
 ecs_entity_t name_to_id(
     const char *name)
 {
@@ -21405,13 +21406,13 @@ ecs_entity_t find_child_in_stage(
     const char *name)
 {
     (void)parent;
-    
+
     ecs_sparse_each(stage->tables, ecs_table_t, table, {
         ecs_entity_t result = find_child_in_table(world, stage, table, name);
         if (result) {
             return result;
         }
-    });    
+    });
 
     return 0;
 }
@@ -21426,7 +21427,7 @@ ecs_entity_t ecs_lookup_child(
 
     ecs_vector_t *child_tables = ecs_map_get_ptr(
         world->child_tables, ecs_vector_t*, parent);
-    
+
     if (child_tables) {
         ecs_vector_each(child_tables, ecs_table_t*, table_ptr, {
             ecs_table_t *table = *table_ptr;
@@ -21434,7 +21435,7 @@ ecs_entity_t ecs_lookup_child(
             result = find_child_in_table(world, stage, table, name);
             if (!result) {
                 if (stage != &world->stage) {
-                    result = find_child_in_table(world, &world->stage, table, 
+                    result = find_child_in_table(world, &world->stage, table,
                         name);
                 }
             }
@@ -21451,7 +21452,7 @@ ecs_entity_t ecs_lookup_child(
      * have to look for the entity in the staged tables.
      * This edge case should rarely result in a lot of overhead,
      * since the number of tables should stabilize over time, which
-     * means table creation while staged should be infrequent. */    
+     * means table creation while staged should be infrequent. */
     if (!result && stage != &world->stage) {
         result = find_child_in_stage(world, stage, parent, name);
     }
@@ -21462,7 +21463,7 @@ ecs_entity_t ecs_lookup_child(
 ecs_entity_t ecs_lookup(
     ecs_world_t *world,
     const char *name)
-{   
+{
     if (!name) {
         return 0;
     }
@@ -21470,14 +21471,14 @@ ecs_entity_t ecs_lookup(
     if (isdigit(name[0])) {
         return name_to_id(name);
     }
-    
+
     return ecs_lookup_child(world, 0, name);
 }
 
 ecs_entity_t ecs_lookup_symbol(
     ecs_world_t *world,
     const char *name)
-{   
+{
     if (!name) {
         return 0;
     }
@@ -21485,7 +21486,7 @@ ecs_entity_t ecs_lookup_symbol(
     if (isdigit(name[0])) {
         return name_to_id(name);
     }
-    
+
     return find_child_in_stage(world, &world->stage, 0, name);
 }
 
@@ -21514,9 +21515,9 @@ const char *path_elem(
     char *bptr, ch;
 
     for (bptr = buff, ptr = path; (ch = *ptr); ptr ++) {
-        ecs_assert(bptr - buff < ECS_MAX_NAME_LENGTH, ECS_INVALID_PARAMETER, 
+        ecs_assert(bptr - buff < ECS_MAX_NAME_LENGTH, ECS_INVALID_PARAMETER,
             NULL);
-            
+
         if (is_sep(&ptr, sep)) {
             *bptr = '\0';
             return ptr + 1;
@@ -21573,7 +21574,7 @@ ecs_entity_t ecs_lookup_path_w_sep(
     if (!path) {
         return 0;
     }
-    
+
     char buff[ECS_MAX_NAME_LENGTH];
     const char *ptr;
     ecs_entity_t cur;
@@ -21709,7 +21710,7 @@ bool ecs_scope_next(
     for (i = iter->index; i < count; i ++) {
         ecs_table_t *table = *ecs_vector_get(tables, ecs_table_t*, i);
         ecs_assert(table != NULL, ECS_INTERNAL_ERROR, NULL);
-        
+
         ecs_data_t *data = ecs_vector_first(table->data, ecs_data_t);
         if (!data) {
             continue;
@@ -21735,7 +21736,7 @@ bool ecs_scope_next(
         return true;
     }
 
-    return false;    
+    return false;
 }
 
 const char* ecs_set_name_prefix(
@@ -21783,7 +21784,7 @@ ecs_entity_t ecs_add_path_w_sep(
             if (entity && !path_elem(ptr, buff, sep)) {
                 e = entity;
             }
-            
+
             e = ecs_set(world, e, EcsName, {
                 .value = name,
                 .alloc_value = name

--- a/include/flecs/flecs.hpp
+++ b/include/flecs/flecs.hpp
@@ -1516,7 +1516,7 @@ public:
      * @param value The value to assign to the component.
      */
     template <typename T>
-    const base_type& set(const T&& value) const {
+    const base_type& set(T&& value) const {
         static_cast<base_type*>(this)->invoke(
         [&value](world_t *world, entity_t id) {
             ecs_set_ptr_w_entity(

--- a/include/flecs/flecs.hpp
+++ b/include/flecs/flecs.hpp
@@ -2863,7 +2863,7 @@ public:
         s_name = ecs_get_fullpath(world, entity);
     }
 
-    static entity_t id_no_lifecycle(world_t *world = nullptr, const char *name = nullptr) {
+    static entity_t id_no_lifecycle(world_t *world, const char *name = nullptr) {
         if (!s_id) {
             if (!name) {
                 name = _::name_helper<T>::name();

--- a/include/flecs/flecs.hpp
+++ b/include/flecs/flecs.hpp
@@ -2863,7 +2863,7 @@ public:
         s_name = ecs_get_fullpath(world, entity);
     }
 
-    static entity_t id_no_lifecycle(world_t *world, const char *name = nullptr) {
+    static entity_t id_no_lifecycle(world_t *world = nullptr, const char *name = nullptr) {
         if (!s_id) {
             if (!name) {
                 name = _::name_helper<T>::name();

--- a/include/flecs/flecs.hpp
+++ b/include/flecs/flecs.hpp
@@ -1790,7 +1790,7 @@ public:
         return this->id() != e.id();
     }            
 
-    operator bool() {
+    explicit operator bool() {
         return m_id != 0;
     }
 
@@ -2433,7 +2433,7 @@ protected:
 /** Prefab class */
 class prefab final : public entity {
 public:
-    prefab(const flecs::world& world, const char *name = nullptr) 
+    explicit prefab(const flecs::world& world, const char *name = nullptr) 
         : entity(world, name)
     {
         this->add(flecs::Prefab);
@@ -2447,7 +2447,7 @@ public:
 
 class type final : entity {
 public:
-    type(const flecs::world& world, const char *name = nullptr, const char *expr = nullptr)
+    explicit type(const flecs::world& world, const char *name = nullptr, const char *expr = nullptr)
         : entity(world, ecs_new_type(world.c_ptr(), 0, name, expr))
     { 
         sync_from_flecs();
@@ -3554,7 +3554,7 @@ private:
 template<typename ... Components>
 class system final : public entity {
 public:
-    system(const flecs::world& world, const char *name = nullptr, const char *signature = nullptr) 
+    explicit system(const flecs::world& world, const char *name = nullptr, const char *signature = nullptr) 
         : entity(world, name)
         , m_kind(static_cast<ecs_entity_t>(OnUpdate)) 
         , m_signature(signature)
@@ -3955,7 +3955,7 @@ private:
 
 class reader final {
 public:
-    reader(world& world) {
+    explicit reader(world& world) {
         m_reader = ecs_reader_init(world.c_ptr());
     }
 
@@ -3980,7 +3980,7 @@ private:
 
 class writer final {
 public:
-    writer(world& world) {
+    explicit writer(world& world) {
         m_writer = ecs_writer_init(world.c_ptr());
     }
 

--- a/include/flecs/flecs.hpp
+++ b/include/flecs/flecs.hpp
@@ -680,6 +680,9 @@ public:
 
     world(world&& obj) {
         m_world = obj.m_world;
+        m_owned = obj.m_owned;
+        obj.m_world = nullptr;
+        obj.m_owned = false;
     }
 
     /** Not allowed to copy a world. May only take a reference.
@@ -687,12 +690,17 @@ public:
     world& operator=(const world& obj) = delete;
 
     world& operator=(world&& obj) {
+        this->~world();
+
         m_world = obj.m_world;
+        m_owned = obj.m_owned;
+        obj.m_world = nullptr;
+        obj.m_owned = false;
         return *this;
     }
     
     ~world() { 
-        if (m_owned) {
+        if (m_owned && m_world) {
             ecs_fini(m_world); 
         }
     }


### PR DESCRIPTION
Porting several minor fixes from bleeding edge and combined them in a single PR:

- _*(needs checking)*_ ecs_merge: should assert if world->in_progress == false
- bug: flecs::world move constructor doesn't "steal" from passed in world causing double destruction
- fix: mark single parameter constructors as explicit to prevent incorrect automatic type conversion
- ~~lint: id_no_lifecycle() - default nullptr value for world. Function asserts if its nullptr ergo that's can never be a valid value~~
- fix: entity::set() should not take a const rvalue parameter as that prevents moves