### PR TITLE
V2 minor fixes II

### DIFF
--- a/include/flecs/flecs.hpp
+++ b/include/flecs/flecs.hpp
@@ -715,7 +715,7 @@ public:
      *
      * @param level The tracing level.
      */
-    void enable_tracing(int level) {
+    static void enable_tracing(int level) {
         ecs_tracing_enable(level);
     }
 

--- a/src/os_api.c
+++ b/src/os_api.c
@@ -161,7 +161,7 @@ void ecs_os_api_free(void *ptr) {
 static
 char* ecs_os_api_strdup(const char *str) {
     int len = ecs_os_strlen(str);
-    char *result = ecs_os_api_malloc(len + 1);
+    char *result = ecs_os_malloc(len + 1);
     ecs_assert(result != NULL, ECS_OUT_OF_MEMORY, NULL);
     ecs_os_strcpy(result, str);
     return result;

--- a/src/world.c
+++ b/src/world.c
@@ -351,7 +351,7 @@ void ecs_set_component_actions_w_entity(
          * is not safe as they will potentially access uninitialized memory. For 
          * ease of use, if no constructor is specified, set a default one that 
          * initializes the component to 0. */
-        if (!lifecycle->ctor) {
+        if (!lifecycle->ctor && (lifecycle->dtor || lifecycle->copy || lifecycle->move)) {
             c_info->lifecycle.ctor = ctor_init_zero;   
         }
 


### PR DESCRIPTION
- ecs_os_api_strdup() default implementation incorrectly using default ecs_os_api_malloc
    should go through override path
- fix: don't add lifecycle->ctor if other lifecycle fn ptrs are null
    registering pod components explicitly should mark lifecycle_set so that in
    translation unit B, component_info::id() doesn't override them with
    register_lifecycle_actions(true,true,true,true)
- minor: mark world::enable_tracing() as static
    it doesn't depend on world and needs to be set to get tracing info from bootstrap init