### PR TITLE
Fix missing alloca() on FreeBSD

### DIFF
--- a/flecs.h
+++ b/flecs.h
@@ -1384,6 +1384,8 @@ bool ecs_strbuf_list_appendstr(
 
 #if defined(_MSC_VER) || defined(__MINGW32__)
 #include <malloc.h>
+#elif defined(__FreeBSD__)
+#include <stdlib>
 #else
 #include <alloca.h>
 #endif

--- a/include/flecs/os_api.h
+++ b/include/flecs/os_api.h
@@ -5,6 +5,8 @@
 
 #if defined(_MSC_VER) || defined(__MINGW32__)
 #include <malloc.h>
+#elif defined(__FreeBSD__)
+#include <stdlib.h>
 #else
 #include <alloca.h>
 #endif


### PR DESCRIPTION
Unbreak build/usage on FreeBSD systems which don't have alloca.h (but have this function in stdlib.h)