### PR TITLE
docs: fix simple typo, entites -> entities

### DIFF
--- a/examples/c/35_empty_system_signature/src/main.c
+++ b/examples/c/35_empty_system_signature/src/main.c
@@ -11,7 +11,7 @@ int main(int argc, char *argv[]) {
     ecs_world_t *world = ecs_init_w_args(argc, argv);
 
     /* Define a system with an empty signature. Systems that do not match with
-     * any entites are invoked once per frame */
+     * any entities are invoked once per frame */
     ECS_SYSTEM(world, MyTask, EcsOnUpdate, 0);
 
     /* Set target FPS for main loop to 1 frame per second */

--- a/examples/cpp/35_empty_system_signature/src/main.cpp
+++ b/examples/cpp/35_empty_system_signature/src/main.cpp
@@ -5,7 +5,7 @@ int main(int argc, char *argv[]) {
     flecs::world ecs(argc, argv);
 
     /* Define a system with an empty signature. Systems that do not match with
-     * any entites are invoked once per frame */
+     * any entities are invoked once per frame */
     ecs.system<>()
         .iter([](const flecs::iter&) {
             std::cout << "System invoked!" << std::endl;

--- a/flecs.h
+++ b/flecs.h
@@ -3215,7 +3215,7 @@ void ecs_dim(
 
 /** Dimension a type for a specified number of entities.
  * This operation will preallocate memory for a type (table) for the
- * specified number of entites. Specifying a number lower than the current
+ * specified number of entities. Specifying a number lower than the current
  * number of entities in the table will have no effect.
  *
  * @param world The world.

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -685,7 +685,7 @@ void ecs_dim(
 
 /** Dimension a type for a specified number of entities.
  * This operation will preallocate memory for a type (table) for the
- * specified number of entites. Specifying a number lower than the current
+ * specified number of entities. Specifying a number lower than the current
  * number of entities in the table will have no effect.
  *
  * @param world The world.


### PR DESCRIPTION
There is a small typo in examples/c/35_empty_system_signature/src/main.c, examples/cpp/35_empty_system_signature/src/main.cpp, flecs.h, include/flecs.h.

Should read `entities` rather than `entites`.

