### PR TITLE
fix: use ecs_os_malloc in C++ api. 

### DIFF
--- a/include/flecs/flecs.hpp
+++ b/include/flecs/flecs.hpp
@@ -26,7 +26,7 @@ namespace flecs {
 namespace _
 {
 struct placement_new_tag_t{};
-inline constexpr placement_new_tag_t placement_new_tag{};
+constexpr placement_new_tag_t placement_new_tag{};
 template<class Ty> inline void destruct_obj(Ty* _ptr) { _ptr->~Ty(); }
 }
 }

--- a/include/flecs/flecs.hpp
+++ b/include/flecs/flecs.hpp
@@ -1969,11 +1969,7 @@ public:
      */
     explicit entity(world_t *world) 
         : m_world( world )
-    {
-        if (m_world) {
-            m_id = ecs_new_w_type(m_world, 0);
-        }
-    }
+        , m_id( world ? ecs_new_w_type(world, 0) : 0 ) { }
 
     /** Create a named entity.
      * Named entities can be looked up with the lookup functions. Entity names

--- a/include/flecs/os_api.h
+++ b/include/flecs/os_api.h
@@ -267,10 +267,18 @@ FLECS_API
 void ecs_os_set_api_defaults(void);
 
 /* Memory management */
-#define ecs_os_malloc(size) ecs_os_api.malloc_(size);
-#define ecs_os_free(ptr) ecs_os_api.free_(ptr);
+#ifndef ecs_os_malloc
+#define ecs_os_malloc(size) ecs_os_api.malloc_(size)
+#endif
+#ifndef ecs_os_free
+#define ecs_os_free(ptr) ecs_os_api.free_(ptr)
+#endif
+#ifndef ecs_os_realloc
 #define ecs_os_realloc(ptr, size) ecs_os_api.realloc_(ptr, size)
+#endif
+#ifndef ecs_os_calloc
 #define ecs_os_calloc(size) ecs_os_api.calloc_(size)
+#endif
 #if defined(_MSC_VER) || defined(__MINGW32__)
 #define ecs_os_alloca(size) _alloca((size_t)(size))
 #else
@@ -278,7 +286,9 @@ void ecs_os_set_api_defaults(void);
 #endif
 
 /* Strings */
+#ifndef ecs_os_strdup
 #define ecs_os_strdup(str) ecs_os_api.strdup_(str)
+#endif
 #define ecs_os_strlen(str) (ecs_size_t)strlen(str)
 #define ecs_os_strcmp(str1, str2) strcmp(str1, str2)
 #define ecs_os_strncmp(str1, str2, num) strncmp(str1, str2, (size_t)(num))

--- a/include/flecs/private/map.h
+++ b/include/flecs/private/map.h
@@ -188,7 +188,7 @@ void ecs_map_memory(
 #ifdef __cplusplus
 #ifndef FLECS_NO_CPP
 
-#include <iostream>
+#include <initializer_list>
 
 namespace flecs {
 

--- a/include/flecs/private/map.h
+++ b/include/flecs/private/map.h
@@ -17,7 +17,7 @@
  *
  * Note that while the implementation is a hashmap, it can only compute hashes
  * for the provided 64 bit keys. This means that the provided keys must always
- * be unique. If the provided keys are hashes themselves, it is the 
+ * be unique. If the provided keys are hashes themselves, it is the
  * responsibility of the user to ensure that collisions are handled.
  *
  * In debug mode the map verifies that the type provided to the map functions
@@ -49,7 +49,7 @@ typedef struct ecs_map_iter_t {
 FLECS_API
 ecs_map_t * _ecs_map_new(
     ecs_size_t elem_size,
-    ecs_size_t alignment, 
+    ecs_size_t alignment,
     int32_t elem_count);
 
 #define ecs_map_new(T, elem_count)\
@@ -151,19 +151,19 @@ void* _ecs_map_next_ptr(
 /** Grow number of buckets in the map for specified number of elements. */
 FLECS_API
 void ecs_map_grow(
-    ecs_map_t *map, 
+    ecs_map_t *map,
     int32_t elem_count);
 
 /** Set number of buckets in the map for specified number of elements. */
 FLECS_API
 void ecs_map_set_size(
-    ecs_map_t *map, 
+    ecs_map_t *map,
     int32_t elem_count);
 
 /** Return memory occupied by map. */
 FLECS_API
 void ecs_map_memory(
-    ecs_map_t *map, 
+    ecs_map_t *map,
     int32_t *allocd,
     int32_t *used);
 
@@ -189,13 +189,14 @@ void ecs_map_memory(
 #ifndef FLECS_NO_CPP
 
 #include <initializer_list>
+#include <utility>
 
 namespace flecs {
 
 template <typename K, typename T>
 class map {
 public:
-    map(int32_t count = 0) { 
+    map(int32_t count = 0) {
         init(count);
     }
 

--- a/include/flecs/private/vector.h
+++ b/include/flecs/private/vector.h
@@ -398,7 +398,6 @@ ecs_vector_t* _ecs_vector_copy(
 #ifdef __cplusplus
 #ifndef FLECS_NO_CPP
 
-#include <iostream>
 #include <initializer_list>
 
 namespace flecs {


### PR DESCRIPTION
## Discussion Points
- FLECS_PLACEMENT_NEW: personal style choice to make it easy to grep code base for no naked news. Can remove
- Opted for FLECS_NEW/FLECS_DELETE macros as it enables tying of source code location in allocation
- Memory leaks(?): Added FLECS_DELETE but I couldn't find the corresponding calls to free memory that were allocated by new
- Allow ecs_os_* allocation defines to be overridable so users can inject debug info (file/src location tracking)

## Opportunistic fixes
- minor fix: entity::m_id not initialized to zero
- minor quality of life: replace iostream include with <initializer_list>