### PR TITLE
Cpp component registration fix

### DIFF
--- a/flecs.c
+++ b/flecs.c
@@ -5532,7 +5532,13 @@ ecs_entity_t ecs_new_component_id(
         /* If the low component ids are depleted, return a regular entity id */
         return ecs_new_id(world);
     } else {
-        return world->stats.last_component_id ++;
+        ecs_entity_t id;
+        
+        do {
+            id = world->stats.last_component_id ++;
+        } while (ecs_exists(world, id));
+
+        return id;
     }
 }
 

--- a/flecs.c
+++ b/flecs.c
@@ -678,7 +678,7 @@ ecs_type_t ecs_bootstrap_type(
     ecs_new_component(world, ecs_typeid(name), #name, sizeof(name), ECS_ALIGNOF(name))
 
 #define ecs_bootstrap_tag(world, name)\
-    ecs_set(world, name, EcsName, {.value = &#name[ecs_os_strlen("Ecs")], .symbol = #name});\
+    ecs_set(world, name, EcsName, {.value = &#name[ecs_os_strlen("Ecs")], .symbol = (char*)#name});\
     ecs_add_entity(world, name, ECS_CHILDOF | ecs_get_scope(world))
 
 
@@ -998,6 +998,7 @@ void ecs_table_clear_silent(
 
 /* Clear table data. Don't call OnRemove handlers. */
 void ecs_table_clear_data(
+    ecs_world_t *world,
     ecs_table_t *table,
     ecs_data_t *data);    
 
@@ -2274,6 +2275,10 @@ void dtor_component(
     int32_t row,
     int32_t count)
 {
+    if (!count) {
+        return;
+    }
+    
     /* An old component is destructed */
     ecs_xtor_t dtor;
     if (cdata && (dtor = cdata->lifecycle.dtor)) {
@@ -2312,27 +2317,25 @@ static
 void run_remove_actions(
     ecs_world_t * world,
     ecs_table_t * table,
-    ecs_data_t * data,
     int32_t row,
-    int32_t count,
-    bool dtor_only)
+    int32_t count)
 {
     if (count) {
-        if (!dtor_only) {
-            ecs_run_monitors(world, table, NULL, row, count, table->un_set_all);
-        }
-
-        dtor_all_components(world, table, data, row, count);
+        ecs_run_monitors(world, table, NULL, row, count, table->un_set_all);        
     }
 }
 
 void ecs_table_clear_data(
-    ecs_table_t * table,
-    ecs_data_t * data)
+    ecs_world_t *world,
+    ecs_table_t *table,
+    ecs_data_t *data)
 {
     if (!data) {
         return;
     }
+
+    int32_t count = ecs_table_data_count(data);
+    dtor_all_components(world, table, data, 0, count);
     
     ecs_column_t *columns = data->columns;
     if (columns) {
@@ -2385,7 +2388,7 @@ void ecs_table_clear_silent(
 
     int32_t count = ecs_vector_count(data->entities);
     
-    ecs_table_clear_data(table, table->data);
+    ecs_table_clear_data(world, table, data);
 
     if (count) {
         ecs_table_activate(world, table, 0, false);
@@ -2400,18 +2403,18 @@ void ecs_table_clear(
     ecs_table_t * table)
 {
     ecs_data_t *data = ecs_table_get_data(table);
+
     if (data) {
-        run_remove_actions(
-            world, table, data, 0, ecs_table_data_count(data), false);
+        run_remove_actions(world, table, 0, ecs_table_data_count(data));
 
         ecs_entity_t *entities = ecs_vector_first(data->entities, ecs_entity_t);
         int32_t i, count = ecs_vector_count(data->entities);
         for(i = 0; i < count; i ++) {
             ecs_eis_delete(world, entities[i]);
         }
-    }
 
-    ecs_table_clear_silent(world, table);
+        ecs_table_clear_silent(world, table);
+    }
 }
 
 /* Unset all components in table. This function is called before a table is 
@@ -2436,11 +2439,10 @@ void ecs_table_free(
     (void)world;
     ecs_data_t *data = ecs_table_get_data(table);
     if (data) {
-        run_remove_actions(
-            world, table, data, 0, ecs_table_data_count(data), false);
+        run_remove_actions(world, table, 0, ecs_table_data_count(data));
+        ecs_table_clear_data(world, table, data);
     }
 
-    ecs_table_clear_data(table, table->data);
     ecs_table_clear_edges(world, table);
 
     ecs_os_free(table->lo_edges);
@@ -3431,8 +3433,8 @@ void ecs_table_swap(
 
 static
 void merge_vector(
-    ecs_vector_t ** dst_out,
-    ecs_vector_t * src,
+    ecs_vector_t **dst_out,
+    ecs_vector_t *src,
     int16_t size,
     int16_t alignment)
 {
@@ -3461,6 +3463,61 @@ void merge_vector(
 
         ecs_vector_free(src);
         *dst_out = dst;
+    }
+}
+
+static
+void merge_column(
+    ecs_world_t *world,
+    ecs_table_t *table,
+    ecs_data_t *data,
+    int32_t column_id,
+    ecs_vector_t *src)
+{
+    ecs_entity_t *entities = ecs_vector_first(data->entities, ecs_entity_t);
+    ecs_c_info_t *c_info = table->c_info[column_id];
+    ecs_column_t *column = &data->columns[column_id];
+    ecs_vector_t *dst = column->data;
+    int16_t size = column->size;
+    int16_t alignment = column->alignment;
+    int32_t dst_count = ecs_vector_count(dst);
+
+    if (!dst_count) {
+        if (dst) {
+            ecs_vector_free(dst);
+        }
+
+        column->data = src;
+    
+    /* If the new table is not empty, copy the contents from the
+     * src into the dst. */
+    } else {
+        int32_t src_count = ecs_vector_count(src);
+        ecs_vector_set_count_t(&dst, size, alignment, dst_count + src_count);
+        column->data = dst;
+
+        /* Construct new values */
+        if (c_info) {
+            ctor_component(
+                world, c_info, column, entities, dst_count, src_count);
+        }
+        
+        void *dst_ptr = ecs_vector_first_t(dst, size, alignment);
+        void *src_ptr = ecs_vector_first_t(src, size, alignment);
+
+        dst_ptr = ECS_OFFSET(dst_ptr, size * dst_count);
+        
+        /* Move values into column */
+        ecs_move_t move;
+        if (c_info && (move = c_info->lifecycle.move)) {
+            move(world, c_info->component, entities, entities, 
+                dst_ptr, src_ptr, ecs_to_size_t(size), src_count, 
+                c_info->lifecycle.ctx);
+        } else {
+            ecs_os_memcpy(dst_ptr, src_ptr, size * src_count);
+        }
+
+        ecs_vector_free(src);
     }
 }
 
@@ -3518,10 +3575,8 @@ void merge_table_data(
         }
 
         if (new_component == old_component) {
-            merge_vector(
-                &new_columns[i_new].data, old_columns[i_old].data, size, 
-                alignment);
-
+            merge_column(world, new_table, new_data, i_new, 
+                old_columns[i_old].data);
             old_columns[i_old].data = NULL;
 
             /* Mark component column as dirty */
@@ -3644,7 +3699,7 @@ ecs_data_t* ecs_table_merge(
     
     /* If there is nothing to merge to, just clear the old table */
     if (!new_table) {
-        ecs_table_clear_data(old_table, old_data);
+        ecs_table_clear_data(world, old_table, old_data);
         return NULL;
     }
 
@@ -3712,9 +3767,8 @@ void ecs_table_replace_data(
 
     if (table_data) {
         prev_count = ecs_vector_count(table_data->entities);
-        run_remove_actions(
-            world, table, table_data, 0, ecs_table_data_count(table_data), false);
-        ecs_table_clear_data(table, table_data);
+        run_remove_actions(world, table, 0, ecs_table_data_count(table_data));
+        ecs_table_clear_data(world, table, table_data);
     }
 
     if (data) {
@@ -9641,6 +9695,7 @@ void ecs_snapshot_restore(
 
     for (t = 0; t < table_count; t ++) {
         ecs_table_t *table = ecs_sparse_get(world->store.tables, ecs_table_t, t);
+
         if (table->flags & EcsTableHasBuiltins) {
             continue;
         }
@@ -9670,7 +9725,7 @@ void ecs_snapshot_restore(
                         
                         /* Always delete entity, so that even if the entity is
                         * in the current table, there won't be duplicates */
-                        ecs_table_delete(world, r->table, data, row, false);
+                        ecs_table_delete(world, r->table, data, row, true);
                     } else {
                         ecs_eis_set_generation(world, *e_ptr);
                     }
@@ -9796,7 +9851,7 @@ void ecs_snapshot_free(
     int32_t i, count = ecs_vector_count(snapshot->tables);
     for (i = 0; i < count; i ++) {
         ecs_table_leaf_t *leaf = &tables[i];
-        ecs_table_clear_data(leaf->table, leaf->data);
+        ecs_table_clear_data(snapshot->world, leaf->table, leaf->data);
         ecs_os_free(leaf->data);
     }    
 
@@ -22421,7 +22476,7 @@ void ecs_set_symbol(
 
     ecs_set(world, e, EcsName, { 
         .value = e_name, 
-        .symbol = ecs_os_strdup(name)
+        .symbol = (char*)name
     });
 }
 
@@ -22664,6 +22719,13 @@ static ECS_COPY(EcsName, dst, src, {
 })
 
 static ECS_MOVE(EcsName, dst, src, {
+    if (dst->alloc_value) {
+        ecs_os_free(dst->alloc_value);
+    }
+    if (dst->symbol) {
+        ecs_os_free(dst->symbol);
+    }
+
     dst->value = src->value;
     dst->alloc_value = src->alloc_value;
     dst->symbol = src->symbol;
@@ -22791,9 +22853,16 @@ void ecs_bootstrap(
     ecs_table_t *table = bootstrap_component_table(world);
     assert(table != NULL);
 
+    bootstrap_component(world, table, EcsName);
     bootstrap_component(world, table, EcsComponent);
     bootstrap_component(world, table, EcsType);
-    bootstrap_component(world, table, EcsName);
+
+    ecs_set_component_actions(world, EcsName, {
+        .ctor = ecs_ctor(EcsName),
+        .dtor = ecs_dtor(EcsName),
+        .copy = ecs_copy(EcsName),
+        .move = ecs_move(EcsName)
+    });    
 
     world->stats.last_component_id = EcsFirstUserComponentId;
     world->stats.last_id = EcsFirstUserEntityId;
@@ -22808,13 +22877,6 @@ void ecs_bootstrap(
     ecs_bootstrap_tag(world, EcsPrefab);
     ecs_bootstrap_tag(world, EcsHidden);
     ecs_bootstrap_tag(world, EcsDisabled);
-
-    ecs_set_component_actions(world, EcsName, {
-        .ctor = ecs_ctor(EcsName),
-        .dtor = ecs_dtor(EcsName),
-        .copy = ecs_copy(EcsName),
-        .move = ecs_move(EcsName)
-    });
 
     /* Initialize scopes */
     ecs_set(world, EcsFlecs, EcsName, {.value = "flecs"});

--- a/flecs.h
+++ b/flecs.h
@@ -11027,6 +11027,33 @@ namespace _
 #error "implicit component registration not supported"
 #endif
 
+// Translate a typename into a langauge-agnostic identifier. This allows for
+// registration of components/modules across language boundaries.
+template <typename T>
+struct symbol_helper
+{
+    static char* symbol(void) {
+        const char *name = name_helper<T>::name();
+
+        // Symbol is same as name, but with '::' replaced with '.'
+        char *ptr, *sym = ecs_os_strdup(name);
+        ecs_size_t i, len = ecs_os_strlen(sym);
+        ptr = sym;
+        for (i = 0, ptr = sym; i < len && *ptr; i ++, ptr ++) {
+            if (*ptr == ':') {
+                sym[i] = '.';
+                ptr ++;
+            } else {
+                sym[i] = *ptr;
+            }
+        }
+
+        sym[i] = '\0';
+
+        return sym;
+    }
+};
+
 // The following functions are lifecycle callbacks that are automatically
 // registered with flecs to ensure component lifecycle is handled correctly. Not
 // all types require this, yet callbacks are registered by default, which
@@ -11255,12 +11282,12 @@ public:
     {
         // If no id has been registered yet, do it now.
         if (!s_id) {
-            const char *symbol = _::name_helper<T>::name();
+            const char *n = _::name_helper<T>::name();
             
             if (!name) {
                 // If no name was provided, retrieve the name implicitly from
                 // the name_helper class.
-                name = symbol;
+                name = n;
             }
 
             s_allow_tag = allow_tag;
@@ -11311,11 +11338,13 @@ public:
             // the same name. Without verifying that the actual C++ type name
             // matches, that scenario would go undetected.
             EcsName *name_comp = ecs_get_mut(world, entity, EcsName, NULL);
+            char *symbol = symbol_helper<T>::symbol();
+
             if (name_comp->symbol) {
                 ecs_assert( !strcmp(name_comp->symbol, symbol), 
                     ECS_COMPONENT_NAME_IN_USE, name);
             } else {
-                name_comp->symbol = ecs_os_strdup(symbol);
+                name_comp->symbol = symbol;
             }
             
             // The identifier returned by the function should be the same as the
@@ -11614,9 +11643,10 @@ ecs_entity_t do_import(world& world) {
     ecs_set_scope(world.c_ptr(), scope);
 
     // It should now be possible to lookup the module
-    const char *symbol = _::name_helper<T>::name();
+    char *symbol = _::symbol_helper<T>::symbol();
     ecs_entity_t m = ecs_lookup_symbol(world.c_ptr(), symbol);
-    ecs_assert(m != 0, ECS_MODULE_UNDEFINED, symbol);  
+    ecs_assert(m != 0, ECS_MODULE_UNDEFINED, symbol);
+    ecs_os_free(symbol);
 
     _::component_info<T>::init(world.c_ptr(), m, false);
 

--- a/flecs.h
+++ b/flecs.h
@@ -11254,8 +11254,6 @@ public:
             // as well.
             ecs_assert(s_name.c_str() != nullptr, ECS_INTERNAL_ERROR, NULL);
 
-            printf("Name = %s, %s\n", ecs_get_name(world, entity), ecs_get_name(world, s_id));
-
             // A component cannot be registered using a different identifier.
             ecs_assert(s_id == entity, ECS_INCONSISTENT_COMPONENT_ID, 
                 _::name_helper<T>::name());
@@ -11283,7 +11281,7 @@ public:
         const char *name = nullptr, bool allow_tag = true) 
     {
         // If no id has been registered yet, do it now.
-        if (!s_id || (world && !ecs_exists(world, s_id))) {
+        if (!s_id) {
             const char *n = _::name_helper<T>::name();
             
             if (!name) {
@@ -11352,6 +11350,26 @@ public:
             // The identifier returned by the function should be the same as the
             // identifier that was passed in.
             ecs_assert(entity == result.id(), ECS_INTERNAL_ERROR, NULL);
+
+        } else if (world && !ecs_exists(world, s_id)) {
+            const char *n = _::name_helper<T>::name();
+            
+            if (!name) {
+                // If no name was provided, retrieve the name implicitly from
+                // the name_helper class.
+                name = n;
+            }
+
+            ecs_entity_t entity = ecs_new_component(
+                world, s_id, name,
+                size(), 
+                alignment());
+                
+            (void)entity;
+
+            ecs_assert(entity == s_id, ECS_INTERNAL_ERROR, NULL);
+
+            init(world, s_id, allow_tag);
         }
 
         // By now we should have a valid identifier
@@ -11571,7 +11589,9 @@ flecs::entity pod_component(const flecs::world& world, const char *name = nullpt
 
             ecs_assert(!strcmp(name_comp->symbol, symbol), 
                 ECS_COMPONENT_NAME_IN_USE, name);
+
             (void)name_comp;
+            (void)symbol;
         }
 
         /* Register id as usual */

--- a/flecs.h
+++ b/flecs.h
@@ -11254,6 +11254,8 @@ public:
             // as well.
             ecs_assert(s_name.c_str() != nullptr, ECS_INTERNAL_ERROR, NULL);
 
+            printf("Name = %s, %s\n", ecs_get_name(world, entity), ecs_get_name(world, s_id));
+
             // A component cannot be registered using a different identifier.
             ecs_assert(s_id == entity, ECS_INCONSISTENT_COMPONENT_ID, 
                 _::name_helper<T>::name());
@@ -11281,7 +11283,7 @@ public:
         const char *name = nullptr, bool allow_tag = true) 
     {
         // If no id has been registered yet, do it now.
-        if (!s_id) {
+        if (!s_id || (world && !ecs_exists(world, s_id))) {
             const char *n = _::name_helper<T>::name();
             
             if (!name) {
@@ -11364,7 +11366,7 @@ public:
         bool allow_tag = true) 
     {
         // If no id has been registered yet, do it now.
-        if (!s_id) {
+        if (!s_id || (world && !ecs_exists(world, s_id))) {
             // This will register a component id, but will not register 
             // lifecycle callbacks.
             id_no_lifecycle(world, name, allow_tag);

--- a/flecs.h
+++ b/flecs.h
@@ -11519,7 +11519,8 @@ flecs::entity pod_component(const flecs::world& world, const char *name = nullpt
         /* If entity is not empty check if the name matches */
         if (ecs_get_type(world_ptr, id) != nullptr) {
             if (id >= EcsFirstUserComponentId) {
-                char *path = ecs_get_fullpath(world_ptr, id);
+                char *path = ecs_get_path_w_sep(
+                    world_ptr, 0, id, 0, "::", nullptr);
                 ecs_assert(!strcmp(path, name), 
                     ECS_INCONSISTENT_COMPONENT_NAME, name);
                 ecs_os_free(path);
@@ -11568,6 +11569,7 @@ flecs::entity pod_component(const flecs::world& world, const char *name = nullpt
 
             ecs_assert(!strcmp(name_comp->symbol, symbol), 
                 ECS_COMPONENT_NAME_IN_USE, name);
+            (void)name_comp;
         }
 
         /* Register id as usual */

--- a/flecs.h
+++ b/flecs.h
@@ -11231,14 +11231,6 @@ public:
             ecs_assert(s_id == entity, ECS_INCONSISTENT_COMPONENT_ID, 
                 _::name_helper<T>::name());
 
-            // Ensure the entity has the same name as what was registered.
-            if (s_id >= EcsFirstUserComponentId) {
-                char *path = ecs_get_fullpath(world, entity);
-                ecs_assert(!strcmp(path, s_name.c_str()), 
-                    ECS_INCONSISTENT_COMPONENT_NAME, path);
-                ecs_os_free(path);
-            }
-
             ecs_assert(allow_tag == s_allow_tag, ECS_INTERNAL_ERROR, NULL);
 
             // Component was already registered and data is consistent with new

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -175,7 +175,7 @@ typedef void (*ecs_fini_action_t)(
 /** Entity name. */
 typedef struct EcsName {
     const char *value;     /**< Entity name */
-    const char *symbol;    /**< Optional symbol name, if it differs from name */
+    char *symbol;          /**< Optional symbol name, if it differs from name */
     char *alloc_value;     /**< If set, value will be freed on destruction */
 } EcsName;
 

--- a/include/flecs/flecs.hpp
+++ b/include/flecs/flecs.hpp
@@ -11,6 +11,7 @@
 #include <sstream>
 #include <array>
 #include <functional>
+#include <iostream>
 
 // Macros so that C++ new calls can allocate using ecs_os_api memory allocation functions
 // Rationale:
@@ -1793,10 +1794,13 @@ public:
     const base_type& set(T&& value) const {
         static_cast<base_type*>(this)->invoke(
         [&value](world_t *world, entity_t id) {
+            auto comp_id = _::component_info<T>::id(world);
+
             ecs_assert(_::component_info<T>::size() != 0, 
                 ECS_INVALID_PARAMETER, NULL);
+
             ecs_set_ptr_w_entity(
-                world, id, _::component_info<T>::id(world), sizeof(T), &value);
+                world, id, comp_id, sizeof(T), &value);
         });
         return *static_cast<base_type*>(this);
     }
@@ -1812,10 +1816,13 @@ public:
     const base_type& set(const T& value) const {
         static_cast<base_type*>(this)->invoke(
         [&value](world_t *world, entity_t id) {
+            auto comp_id = _::component_info<T>::id(world);
+
             ecs_assert(_::component_info<T>::size() != 0, 
                 ECS_INVALID_PARAMETER, NULL);
+
             ecs_set_ptr_w_entity(
-                world, id, _::component_info<T>::id(world), sizeof(T), &value);
+                world, id, comp_id, sizeof(T), &value);
         });
         return *static_cast<base_type*>(this);
     }
@@ -1832,11 +1839,13 @@ public:
     const base_type& set_trait(const T& value) const {
         static_cast<base_type*>(this)->invoke(
         [&value](world_t *world, entity_t id) {
+            auto t_id = _::component_info<T>::id(world);
+
             ecs_assert(_::component_info<T>::size() != 0, 
                 ECS_INVALID_PARAMETER, NULL);
+
             ecs_set_ptr_w_entity(world, id, 
-                ecs_trait(_::component_info<C>::id(world), 
-                    _::component_info<T>::id(world)),
+                ecs_trait(_::component_info<C>::id(world), t_id),
                         sizeof(T), &value);
         });
         return *static_cast<base_type*>(this);
@@ -1879,15 +1888,17 @@ public:
     const base_type& patch(std::function<void(T&, bool)> func) const {
         static_cast<base_type*>(this)->invoke(
         [&func](world_t *world, entity_t id) {
+            auto comp_id = _::component_info<T>::id(world);
+
             ecs_assert(_::component_info<T>::size() != 0, 
                 ECS_INVALID_PARAMETER, NULL);
 
             bool is_added;
             T *ptr = static_cast<T*>(ecs_get_mut_w_entity(
-                world, id, _::component_info<T>::id(world), &is_added));
+                world, id, comp_id, &is_added));
             if (ptr) {
                 func(*ptr, !is_added);
-                ecs_modified_w_entity(world, id, _::component_info<T>::id(world));
+                ecs_modified_w_entity(world, id, comp_id);
             }
         });
         return *static_cast<base_type*>(this);
@@ -1905,15 +1916,17 @@ public:
     const base_type& patch(std::function<void(T&)> func) const {
         static_cast<base_type*>(this)->invoke(
         [&func](world_t *world, entity_t id) {
+            auto comp_id = _::component_info<T>::id(world);
+
             ecs_assert(_::component_info<T>::size() != 0, 
                 ECS_INVALID_PARAMETER, NULL);
 
             bool is_added;
             T *ptr = static_cast<T*>(ecs_get_mut_w_entity(
-                world, id, _::component_info<T>::id(world), &is_added));
+                world, id, comp_id, &is_added));
             if (ptr) {
                 func(*ptr);
-                ecs_modified_w_entity(world, id, _::component_info<T>::id(world));
+                ecs_modified_w_entity(world, id, comp_id);
             }
         });
         return *static_cast<base_type*>(this);
@@ -1939,11 +1952,13 @@ public:
         , m_entity( entity )
         , m_ref() 
     {
+        auto comp_id = _::component_info<T>::id(world);
+
         ecs_assert(_::component_info<T>::size() != 0, 
                 ECS_INVALID_PARAMETER, NULL);
 
         ecs_get_ref_w_entity(
-            m_world, &m_ref, m_entity, _::component_info<T>::id(world));
+            m_world, &m_ref, m_entity, comp_id);
     }
 
     const T* operator->() {
@@ -2231,10 +2246,14 @@ public:
     const T* get() const {
         ecs_assert(m_world != NULL, ECS_INVALID_PARAMETER, NULL);
         ecs_assert(m_id != 0, ECS_INVALID_PARAMETER, NULL);
+
+        auto comp_id = _::component_info<T>::id(m_world);
+
         ecs_assert(_::component_info<T>::size() != 0, 
                 ECS_INVALID_PARAMETER, NULL);
+
         return static_cast<const T*>(
-            ecs_get_w_entity(m_world, m_id, _::component_info<T>::id(m_world)));
+            ecs_get_w_entity(m_world, m_id, comp_id));
     }
 
     /** Get component value (untyped).
@@ -2275,11 +2294,14 @@ public:
     T* get_mut(bool *is_added = nullptr) const {
         ecs_assert(m_world != NULL, ECS_INVALID_PARAMETER, NULL);
         ecs_assert(m_id != 0, ECS_INVALID_PARAMETER, NULL);
+
+        auto comp_id = _::component_info<T>::id(m_world);
+
         ecs_assert(_::component_info<T>::size() != 0, 
                 ECS_INVALID_PARAMETER, NULL);
+
         return static_cast<T*>(
-            ecs_get_mut_w_entity(
-                m_world, m_id, _::component_info<T>::id(m_world), is_added));
+            ecs_get_mut_w_entity(m_world, m_id, comp_id, is_added));
     }
 
     /** Get mutable component value (untyped).
@@ -2325,10 +2347,14 @@ public:
     const T* get_trait() const {
         ecs_assert(m_world != NULL, ECS_INVALID_PARAMETER, NULL);
         ecs_assert(m_id != 0, ECS_INVALID_PARAMETER, NULL);
+        
+        auto t_id = _::component_info<T>::id(m_world);
+
         ecs_assert(_::component_info<T>::size() != 0, 
                 ECS_INVALID_PARAMETER, NULL);
+
         return static_cast<const T*>(ecs_get_w_entity(m_world, m_id, ecs_trait(
-            _::component_info<C>::id(m_world), _::component_info<T>::id(m_world))));
+            _::component_info<C>::id(m_world), t_id)));
     }   
 
     /** Get trait value.
@@ -2342,10 +2368,14 @@ public:
     const T* get_trait(flecs::entity component) const {
         ecs_assert(m_world != NULL, ECS_INVALID_PARAMETER, NULL);
         ecs_assert(m_id != 0, ECS_INVALID_PARAMETER, NULL);
+
+        auto comp_id = _::component_info<T>::id(m_world);
+
         ecs_assert(_::component_info<T>::size() != 0, 
                 ECS_INVALID_PARAMETER, NULL);
+
         return static_cast<const T*>(ecs_get_w_entity(m_world, m_id, ecs_trait(
-            component.id(), _::component_info<T>::id(m_world))));
+            component.id(), comp_id)));
     }
 
     /** Get trait tag value.
@@ -2362,10 +2392,14 @@ public:
     const C* get_trait_tag(flecs::entity trait) const {
         ecs_assert(m_world != NULL, ECS_INVALID_PARAMETER, NULL);
         ecs_assert(m_id != 0, ECS_INVALID_PARAMETER, NULL);
+
+        auto comp_id = _::component_info<C>::id(m_world);
+
         ecs_assert(_::component_info<C>::size() != 0, 
                 ECS_INVALID_PARAMETER, NULL);
+
         return static_cast<const C*>(ecs_get_w_entity(m_world, m_id, ecs_trait(
-            _::component_info<C>::id(m_world), trait.id())));
+            comp_id, trait.id())));
     }
 
     /** Get trait tag value (untyped).
@@ -2399,14 +2433,16 @@ public:
     T* get_trait_mut(bool *is_added = nullptr) const {
         ecs_assert(m_world != NULL, ECS_INVALID_PARAMETER, NULL);
         ecs_assert(m_id != 0, ECS_INVALID_PARAMETER, NULL);
+
+        auto t_id = _::component_info<T>::id(m_world);
+
         ecs_assert(_::component_info<T>::size() != 0, 
                 ECS_INVALID_PARAMETER, NULL);
+
         return static_cast<T*>(
             ecs_get_mut_w_entity(
-                m_world, m_id, ecs_trait(
-                    _::component_info<C>::id(m_world), 
-                    _::component_info<T>::id(m_world)), 
-                    is_added));
+                m_world, m_id, ecs_trait(_::component_info<C>::id(m_world), 
+                    t_id), is_added));
     }    
 
     /** Get mutable trait value.
@@ -2424,14 +2460,15 @@ public:
     T* get_trait_mut(flecs::entity component, bool *is_added = nullptr) const {
         ecs_assert(m_world != NULL, ECS_INVALID_PARAMETER, NULL);
         ecs_assert(m_id != 0, ECS_INVALID_PARAMETER, NULL);
+
+        auto comp_id = _::component_info<T>::id(m_world);
+
         ecs_assert(_::component_info<T>::size() != 0, 
                 ECS_INVALID_PARAMETER, NULL);
+
         return static_cast<T*>(
             ecs_get_mut_w_entity(
-                m_world, m_id, ecs_trait(
-                    _::component_info<T>::id(m_world),
-                    component.id()), 
-                    is_added));
+                m_world, m_id, ecs_trait( comp_id, component.id()), is_added));
     }
 
     /** Get mutable trait tag value.
@@ -2469,9 +2506,13 @@ public:
     void modified() const {
         ecs_assert(m_world != NULL, ECS_INVALID_PARAMETER, NULL);
         ecs_assert(m_id != 0, ECS_INVALID_PARAMETER, NULL);
+
+        auto comp_id = _::component_info<T>::id(m_world);
+
         ecs_assert(_::component_info<T>::size() != 0, 
                 ECS_INVALID_PARAMETER, NULL);
-        ecs_modified_w_entity(m_world, m_id, _::component_info<T>::id(m_world));
+
+        ecs_modified_w_entity(m_world, m_id, comp_id);
     }
 
     /** Signal that component was modified.
@@ -2505,8 +2546,13 @@ public:
     ref<T> get_ref() const {
         ecs_assert(m_world != NULL, ECS_INVALID_PARAMETER, NULL);
         ecs_assert(m_id != 0, ECS_INVALID_PARAMETER, NULL);
+
+        // Ensure component is registered
+        _::component_info<T>::id(m_world);
+
         ecs_assert(_::component_info<T>::size() != 0, 
                 ECS_INVALID_PARAMETER, NULL);
+
         return ref<T>(m_world, m_id);
     }
 
@@ -3383,10 +3429,11 @@ public:
             if (s_id >= EcsFirstUserComponentId) {
                 char *path = ecs_get_fullpath(world, entity);
                 ecs_assert(!strcmp(path, s_name.c_str()), 
-                    ECS_INCONSISTENT_COMPONENT_NAME, 
-                    _::name_helper<T>::name());
+                    ECS_INCONSISTENT_COMPONENT_NAME, path);
                 ecs_os_free(path);
             }
+
+            ecs_assert(allow_tag == s_allow_tag, ECS_INTERNAL_ERROR, NULL);
 
             // Component was already registered and data is consistent with new
             // identifier, so nothing else to be done.
@@ -3410,10 +3457,12 @@ public:
     {
         // If no id has been registered yet, do it now.
         if (!s_id) {
+            const char *symbol = _::name_helper<T>::name();
+            
             if (!name) {
                 // If no name was provided, retrieve the name implicitly from
                 // the name_helper class.
-                name = _::name_helper<T>::name();
+                name = symbol;
             }
 
             s_allow_tag = allow_tag;
@@ -3443,6 +3492,9 @@ public:
             flecs::world w(world);
             flecs::entity result = entity(w, name, true);
             
+            // Init the component_info instance with the identiifer.
+            init(world, result.id(), allow_tag);
+
             // Now use the resulting identifier to register the component. Note
             // that the name is not passed into this function, as the entity was
             // already created with the correct name.
@@ -3450,13 +3502,27 @@ public:
                 world, result.id(), nullptr, 
                 size(), 
                 alignment());
+
+            ecs_assert(entity != 0, ECS_INTERNAL_ERROR, NULL);
+
+            // Set the symbol in the Name component to the actual C++ name.
+            // Comparing symbols allows for verifying whether a different 
+            // component is being registered under the same name. We can't use
+            // the name used for registration, because it is possible that a
+            // user (erroneously) attempts to register the same datatype with
+            // the same name. Without verifying that the actual C++ type name
+            // matches, that scenario would go undetected.
+            EcsName *name_comp = ecs_get_mut(world, entity, EcsName, NULL);
+            if (name_comp->symbol) {
+                ecs_assert( !strcmp(name_comp->symbol, symbol), 
+                    ECS_COMPONENT_NAME_IN_USE, name);
+            } else {
+                name_comp->symbol = ecs_os_strdup(symbol);
+            }
             
             // The identifier returned by the function should be the same as the
             // identifier that was passed in.
             ecs_assert(entity == result.id(), ECS_INTERNAL_ERROR, NULL);
-
-            // Init the component_info instance with the identiifer.
-            init(world, entity);
         }
 
         // By now we should have a valid identifier
@@ -3548,6 +3614,8 @@ public:
 
     // Return the size of a component.
     static size_t size() {
+        ecs_assert(s_id != 0, ECS_INTERNAL_ERROR, NULL);
+        
         // C++ types that have no members still have a size. Use std::is_empty
         // to check if the type is empty. If so, use 0 for the component size.
         //
@@ -3563,6 +3631,8 @@ public:
 
     // Return the alignment of a component.
     static size_t alignment() {
+        ecs_assert(s_id != 0, ECS_INTERNAL_ERROR, NULL);
+
         if (size() == 0) {
             return 0;
         } else {
@@ -3587,6 +3657,7 @@ private:
     static entity_t s_id;
     static type_t s_type;
     static std::string s_name;
+    static std::string s_symbol;
     static bool s_allow_tag;
 };
 
@@ -3614,8 +3685,8 @@ flecs::entity pod_component(const flecs::world& world, const char *name = nullpt
     entity_t id = 0;
 
     if (_::component_info<T>::registered()) {
-        /* To support components across multiple worlds, ensure that the
-         * component ids are the same. */
+        /* Obtain component id. Because the component is already registered,
+         * this operation does nothing besides returning the existing id */
         id = _::component_info<T>::id_no_lifecycle(world_ptr, name, allow_tag);
 
         /* If entity is not empty check if the name matches */
@@ -3659,10 +3730,20 @@ flecs::entity pod_component(const flecs::world& world, const char *name = nullpt
          * or entity has been registered with this name */
         ecs_entity_t entity = ecs_lookup_fullpath(world_ptr, name);
 
-        (void)entity;
+        /* If entity exists, compare symbol name to ensure that the component
+         * we are trying to register under this name is the same */
+        if (entity) {
+            const EcsName *name_comp = ecs_get_mut(world.c_ptr(), entity, EcsName, NULL);
+            ecs_assert(name_comp != NULL, ECS_INTERNAL_ERROR, NULL);
+            ecs_assert(name_comp->symbol != NULL, ECS_INTERNAL_ERROR, NULL);
 
-        ecs_assert(entity == 0, ECS_COMPONENT_NAME_IN_USE, name);
+            const char *symbol = _::name_helper<T>::name();
 
+            ecs_assert(!strcmp(name_comp->symbol, symbol), 
+                ECS_COMPONENT_NAME_IN_USE, name);
+        }
+
+        /* Register id as usual */
         id = _::component_info<T>::id_no_lifecycle(world_ptr, name, allow_tag);
     }
 
@@ -3722,34 +3803,64 @@ flecs::entity module(const flecs::world& world, const char *name = nullptr) {
 ////////////////////////////////////////////////////////////////////////////////
 
 template <typename T>
+ecs_entity_t do_import(world& world) {
+    ecs_trace_1("import %s", _::name_helper<T>::name());
+    ecs_log_push();
+
+    ecs_entity_t scope = ecs_get_scope(world.c_ptr());
+
+    // Allocate module, so the this ptr will remain stable
+    // TODO: make sure memory is cleaned up with world
+    T *module_data = FLECS_NEW(T)(world);
+
+    ecs_set_scope(world.c_ptr(), scope);
+
+    // It should now be possible to lookup the module
+    const char *symbol = _::name_helper<T>::name();
+    ecs_entity_t m = ecs_lookup_symbol(world.c_ptr(), symbol);
+    ecs_assert(m != 0, ECS_MODULE_UNDEFINED, symbol);  
+
+    _::component_info<T>::init(world.c_ptr(), m, false);
+
+    ecs_assert(_::component_info<T>::size() != 0, ECS_INTERNAL_ERROR, NULL);
+
+    // Set module singleton component
+
+    ecs_set_ptr_w_entity(
+        world.c_ptr(), m,
+        _::component_info<T>::id_no_lifecycle(world.c_ptr()), 
+        _::component_info<T>::size(),
+        module_data);
+
+    ecs_log_pop();     
+
+    return m;
+}
+
+template <typename T>
 flecs::entity import(world& world) {
+    const char *symbol = _::name_helper<T>::name();
+
+    ecs_entity_t m = ecs_lookup_symbol(world.c_ptr(), symbol);
+    
     if (!_::component_info<T>::registered()) {
-        ecs_trace_1("import %s", _::name_helper<T>::name());
-        ecs_log_push();
 
-        ecs_entity_t scope = ecs_get_scope(world.c_ptr());
+        /* Module is registered with world, initialize static data */
+        if (m) {
+            _::component_info<T>::init(world.c_ptr(), m, false);
+        
+        /* Module is not yet registered, register it now */
+        } else {
+            m = do_import<T>(world);
+        }
 
-        // Allocate module, so the this ptr will remain stable
-        T *module_data = FLECS_NEW(T)(world);
-
-        ecs_set_scope(world.c_ptr(), scope);
-
-        flecs::entity m = world.lookup(_::component_info<T>::name_no_lifecycle(world.c_ptr()));
-
-        ecs_set_ptr_w_entity(
-            world.c_ptr(),
-            m.id(),
-            _::component_info<T>::id_no_lifecycle(world.c_ptr()), 
-            _::component_info<T>::size(),
-            module_data);
-
-        ecs_log_pop();
-
-        return m;
-    } else {
-        return flecs::entity(world, 
-            _::component_info<T>::id_no_lifecycle(world.c_ptr()));
+    /* Module has been registered, but could have been for another world. Import
+     * if module hasn't been registered for this world. */
+    } else if (!m) {
+        m = do_import<T>(world);
     }
+
+    return flecs::entity(world, m);
 }
 
 

--- a/include/flecs/flecs.hpp
+++ b/include/flecs/flecs.hpp
@@ -3425,14 +3425,6 @@ public:
             ecs_assert(s_id == entity, ECS_INCONSISTENT_COMPONENT_ID, 
                 _::name_helper<T>::name());
 
-            // Ensure the entity has the same name as what was registered.
-            if (s_id >= EcsFirstUserComponentId) {
-                char *path = ecs_get_fullpath(world, entity);
-                ecs_assert(!strcmp(path, s_name.c_str()), 
-                    ECS_INCONSISTENT_COMPONENT_NAME, path);
-                ecs_os_free(path);
-            }
-
             ecs_assert(allow_tag == s_allow_tag, ECS_INTERNAL_ERROR, NULL);
 
             // Component was already registered and data is consistent with new

--- a/include/flecs/flecs.hpp
+++ b/include/flecs/flecs.hpp
@@ -3558,6 +3558,8 @@ public:
                 world, s_id, name,
                 size(), 
                 alignment());
+                
+            (void)entity;
 
             ecs_assert(entity == s_id, ECS_INTERNAL_ERROR, NULL);
 
@@ -3781,7 +3783,9 @@ flecs::entity pod_component(const flecs::world& world, const char *name = nullpt
 
             ecs_assert(!strcmp(name_comp->symbol, symbol), 
                 ECS_COMPONENT_NAME_IN_USE, name);
+
             (void)name_comp;
+            (void)symbol;
         }
 
         /* Register id as usual */

--- a/include/flecs/flecs.hpp
+++ b/include/flecs/flecs.hpp
@@ -3762,6 +3762,9 @@ flecs::entity pod_component(const flecs::world& world, const char *name = nullpt
 
             ecs_assert(!strcmp(name_comp->symbol, symbol), 
                 ECS_COMPONENT_NAME_IN_USE, name);
+
+            (void)name_comp;
+            (void)symbol;
         }
 
         /* Register id as usual */

--- a/include/flecs/flecs.hpp
+++ b/include/flecs/flecs.hpp
@@ -3713,7 +3713,8 @@ flecs::entity pod_component(const flecs::world& world, const char *name = nullpt
         /* If entity is not empty check if the name matches */
         if (ecs_get_type(world_ptr, id) != nullptr) {
             if (id >= EcsFirstUserComponentId) {
-                char *path = ecs_get_fullpath(world_ptr, id);
+                char *path = ecs_get_path_w_sep(
+                    world_ptr, 0, id, 0, "::", nullptr);
                 ecs_assert(!strcmp(path, name), 
                     ECS_INCONSISTENT_COMPONENT_NAME, name);
                 ecs_os_free(path);
@@ -3762,9 +3763,7 @@ flecs::entity pod_component(const flecs::world& world, const char *name = nullpt
 
             ecs_assert(!strcmp(name_comp->symbol, symbol), 
                 ECS_COMPONENT_NAME_IN_USE, name);
-
             (void)name_comp;
-            (void)symbol;
         }
 
         /* Register id as usual */

--- a/include/flecs/flecs.hpp
+++ b/include/flecs/flecs.hpp
@@ -3544,6 +3544,24 @@ public:
             // The identifier returned by the function should be the same as the
             // identifier that was passed in.
             ecs_assert(entity == result.id(), ECS_INTERNAL_ERROR, NULL);
+
+        } else if (world && !ecs_exists(world, s_id)) {
+            const char *n = _::name_helper<T>::name();
+            
+            if (!name) {
+                // If no name was provided, retrieve the name implicitly from
+                // the name_helper class.
+                name = n;
+            }
+
+            ecs_entity_t entity = ecs_new_component(
+                world, s_id, name,
+                size(), 
+                alignment());
+
+            ecs_assert(entity == s_id, ECS_INTERNAL_ERROR, NULL);
+
+            init(world, s_id, allow_tag);
         }
 
         // By now we should have a valid identifier
@@ -3558,7 +3576,7 @@ public:
         bool allow_tag = true) 
     {
         // If no id has been registered yet, do it now.
-        if (!s_id) {
+        if (!s_id || (world && !ecs_exists(world, s_id))) {
             // This will register a component id, but will not register 
             // lifecycle callbacks.
             id_no_lifecycle(world, name, allow_tag);

--- a/src/addons/module.c
+++ b/src/addons/module.c
@@ -190,7 +190,8 @@ ecs_entity_t ecs_new_module(
         e = ecs_new_from_fullpath(world, module_path);
 
         EcsName *name_ptr = ecs_get_mut(world, e, EcsName, NULL);
-        name_ptr->symbol = name;
+        ecs_os_free(name_ptr->symbol);
+        name_ptr->symbol = ecs_os_strdup(name);
 
         ecs_os_free(module_path);
     }

--- a/src/addons/module.c
+++ b/src/addons/module.c
@@ -191,9 +191,10 @@ ecs_entity_t ecs_new_module(
 
         EcsName *name_ptr = ecs_get_mut(world, e, EcsName, NULL);
         ecs_os_free(name_ptr->symbol);
-        name_ptr->symbol = ecs_os_strdup(name);
 
-        ecs_os_free(module_path);
+        /* Assign full path to symbol. This allows for modules to be redefined
+         * in C++ without causing name conflicts */
+        name_ptr->symbol = module_path;
     }
 
     ecs_entity_t result = ecs_new_component(world, e, NULL, size, alignment);

--- a/src/addons/snapshot.c
+++ b/src/addons/snapshot.c
@@ -189,6 +189,7 @@ void ecs_snapshot_restore(
 
     for (t = 0; t < table_count; t ++) {
         ecs_table_t *table = ecs_sparse_get(world->store.tables, ecs_table_t, t);
+
         if (table->flags & EcsTableHasBuiltins) {
             continue;
         }
@@ -218,7 +219,7 @@ void ecs_snapshot_restore(
                         
                         /* Always delete entity, so that even if the entity is
                         * in the current table, there won't be duplicates */
-                        ecs_table_delete(world, r->table, data, row, false);
+                        ecs_table_delete(world, r->table, data, row, true);
                     } else {
                         ecs_eis_set_generation(world, *e_ptr);
                     }
@@ -344,7 +345,7 @@ void ecs_snapshot_free(
     int32_t i, count = ecs_vector_count(snapshot->tables);
     for (i = 0; i < count; i ++) {
         ecs_table_leaf_t *leaf = &tables[i];
-        ecs_table_clear_data(leaf->table, leaf->data);
+        ecs_table_clear_data(snapshot->world, leaf->table, leaf->data);
         ecs_os_free(leaf->data);
     }    
 

--- a/src/api_support.c
+++ b/src/api_support.c
@@ -202,7 +202,7 @@ void ecs_set_symbol(
 
     ecs_set(world, e, EcsName, { 
         .value = e_name, 
-        .symbol = ecs_os_strdup(name)
+        .symbol = (char*)name
     });
 }
 

--- a/src/api_support.c
+++ b/src/api_support.c
@@ -200,10 +200,14 @@ void ecs_set_symbol(
     
     const char *e_name = ecs_name_from_symbol(world, name);
 
-    ecs_set(world, e, EcsName, { 
-        .value = e_name, 
-        .symbol = (char*)name
-    });
+    EcsName *name_ptr = ecs_get_mut(world, e, EcsName, NULL);
+    name_ptr->value = e_name;
+
+    if (name_ptr->symbol) {
+        ecs_os_free(name_ptr->symbol);
+    }
+
+    name_ptr->symbol = ecs_os_strdup(name);
 }
 
 ecs_entity_t ecs_lookup_w_id(
@@ -310,6 +314,7 @@ ecs_entity_t ecs_new_component(
     ecs_assert(world != NULL, ECS_INVALID_PARAMETER, NULL);
     assert(world->magic == ECS_WORLD_MAGIC);
     bool in_progress = world->in_progress;
+    bool found = false;
 
     /* If world is in progress component may be registered, but only when not
      * in multithreading mode. */
@@ -325,13 +330,17 @@ ecs_entity_t ecs_new_component(
     ecs_entity_t result = ecs_lookup_w_id(world, e, name);
     if (!result) {
         result = ecs_new_component_id(world);
-        ecs_set_symbol(world, result, name);
+        found = true;
     }
 
     /* ecs_new_component_id does not add the scope, so add it explicitly */
     ecs_entity_t scope = world->stage.scope;
     if (scope) {
         ecs_add_entity(world, result, ECS_CHILDOF | scope);
+    }
+
+    if (found) {
+        ecs_set_symbol(world, result, name);
     }
 
     bool added = false;

--- a/src/api_support.c
+++ b/src/api_support.c
@@ -202,7 +202,7 @@ void ecs_set_symbol(
 
     ecs_set(world, e, EcsName, { 
         .value = e_name, 
-        .symbol = name 
+        .symbol = ecs_os_strdup(name)
     });
 }
 

--- a/src/bootstrap.c
+++ b/src/bootstrap.c
@@ -15,6 +15,7 @@ static ECS_CTOR(EcsName, ptr, {
 
 static ECS_DTOR(EcsName, ptr, {
     ecs_os_free(ptr->alloc_value);
+    ecs_os_free(ptr->symbol);
     ptr->value = NULL;
     ptr->alloc_value = NULL;
     ptr->symbol = NULL;
@@ -25,6 +26,11 @@ static ECS_COPY(EcsName, dst, src, {
         ecs_os_free(dst->alloc_value);
         dst->alloc_value = NULL;
     }
+
+    if (dst->symbol) {
+        ecs_os_free(dst->symbol);
+        dst->symbol = NULL;
+    }
     
     if (src->alloc_value) {
         dst->alloc_value = ecs_os_strdup(src->alloc_value);
@@ -33,7 +39,10 @@ static ECS_COPY(EcsName, dst, src, {
         dst->alloc_value = NULL;
         dst->value = src->value;
     }
-    dst->symbol = src->symbol;
+
+    if (src->symbol) {
+        dst->symbol = ecs_os_strdup(src->symbol);
+    }
 })
 
 static ECS_MOVE(EcsName, dst, src, {
@@ -84,7 +93,7 @@ void _bootstrap_component(
     c_info[index].size = size;
     c_info[index].alignment = alignment;
     id_data[index].value = &id[ecs_os_strlen("Ecs")]; /* Skip prefix */
-    id_data[index].symbol = id;
+    id_data[index].symbol = ecs_os_strdup(id);
     id_data[index].alloc_value = NULL;
 }
 

--- a/src/entity.c
+++ b/src/entity.c
@@ -1661,7 +1661,13 @@ ecs_entity_t ecs_new_component_id(
         /* If the low component ids are depleted, return a regular entity id */
         return ecs_new_id(world);
     } else {
-        return world->stats.last_component_id ++;
+        ecs_entity_t id;
+        
+        do {
+            id = world->stats.last_component_id ++;
+        } while (ecs_exists(world, id));
+
+        return id;
     }
 }
 

--- a/src/private_api.h
+++ b/src/private_api.h
@@ -26,7 +26,7 @@ ecs_type_t ecs_bootstrap_type(
     ecs_new_component(world, ecs_typeid(name), #name, sizeof(name), ECS_ALIGNOF(name))
 
 #define ecs_bootstrap_tag(world, name)\
-    ecs_set(world, name, EcsName, {.value = &#name[ecs_os_strlen("Ecs")], .symbol = #name});\
+    ecs_set(world, name, EcsName, {.value = &#name[ecs_os_strlen("Ecs")], .symbol = ecs_os_strdup(#name)});\
     ecs_add_entity(world, name, ECS_CHILDOF | ecs_get_scope(world))
 
 

--- a/src/private_api.h
+++ b/src/private_api.h
@@ -26,7 +26,7 @@ ecs_type_t ecs_bootstrap_type(
     ecs_new_component(world, ecs_typeid(name), #name, sizeof(name), ECS_ALIGNOF(name))
 
 #define ecs_bootstrap_tag(world, name)\
-    ecs_set(world, name, EcsName, {.value = &#name[ecs_os_strlen("Ecs")], .symbol = ecs_os_strdup(#name)});\
+    ecs_set(world, name, EcsName, {.value = &#name[ecs_os_strlen("Ecs")], .symbol = (char*)#name});\
     ecs_add_entity(world, name, ECS_CHILDOF | ecs_get_scope(world))
 
 
@@ -346,6 +346,7 @@ void ecs_table_clear_silent(
 
 /* Clear table data. Don't call OnRemove handlers. */
 void ecs_table_clear_data(
+    ecs_world_t *world,
     ecs_table_t *table,
     ecs_data_t *data);    
 

--- a/test/api/src/SystemUnSet.c
+++ b/test/api/src/SystemUnSet.c
@@ -206,6 +206,8 @@ void SystemUnSet_unset_on_delete_1() {
 
     test_int(ctx.c[0][0], ecs_typeid(Position));
     test_int(ctx.s[0][0], 0); 
+
+    ecs_fini(world);
 }
 
 void SystemUnSet_unset_on_delete_2() {
@@ -243,7 +245,9 @@ void SystemUnSet_unset_on_delete_2() {
     test_int(ctx.c[0][0], ecs_typeid(Position));
     test_int(ctx.s[0][0], 0); 
     test_int(ctx.c[0][1], ecs_typeid(Velocity));
-    test_int(ctx.s[0][1], 0);     
+    test_int(ctx.s[0][1], 0);  
+
+    ecs_fini(world);   
 }
 
 void SystemUnSet_unset_on_delete_3() {
@@ -287,7 +291,9 @@ void SystemUnSet_unset_on_delete_3() {
     test_int(ctx.c[0][1], ecs_typeid(Velocity));
     test_int(ctx.s[0][1], 0); 
     test_int(ctx.c[0][2], ecs_typeid(Mass));
-    test_int(ctx.s[0][2], 0);     
+    test_int(ctx.s[0][2], 0);  
+    
+    ecs_fini(world);
 }
 
 void SystemUnSet_unset_on_fini_1() {
@@ -325,7 +331,7 @@ void SystemUnSet_unset_on_fini_1() {
     test_int(ctx.e[2], e3);
 
     test_int(ctx.c[0][0], ecs_typeid(Position));
-    test_int(ctx.s[0][0], 0);          
+    test_int(ctx.s[0][0], 0);      
 }
 
 void SystemUnSet_unset_on_fini_2() {
@@ -371,7 +377,7 @@ void SystemUnSet_unset_on_fini_2() {
     test_int(ctx.c[0][0], ecs_typeid(Position));
     test_int(ctx.s[0][0], 0); 
     test_int(ctx.c[0][1], ecs_typeid(Velocity));
-    test_int(ctx.s[0][1], 0);     
+    test_int(ctx.s[0][1], 0);  
 }
 
 void SystemUnSet_unset_on_fini_3() {

--- a/test/cpp_api/project.json
+++ b/test/cpp_api/project.json
@@ -277,11 +277,14 @@
                 "type_id",
                 "different_comp_same_name",
                 "reregister_after_reset",
+                "reregister_after_reset_w_namespace",
+                "reregister_namespace",
                 "implicit_reregister_after_reset",
                 "reregister_after_reset_different_name",
                 "reimport_module_after_reset",
                 "reimport_module_new_world",
-                "c_interop_module"
+                "c_interop_module",
+                "c_interop_after_reset"
             ]
         }, {
             "id": "Singleton",

--- a/test/cpp_api/project.json
+++ b/test/cpp_api/project.json
@@ -281,6 +281,7 @@
                 "reregister_namespace",
                 "implicit_reregister_after_reset",
                 "reregister_after_reset_different_name",
+                "reimport",
                 "reimport_module_after_reset",
                 "reimport_module_new_world",
                 "c_interop_module",

--- a/test/cpp_api/project.json
+++ b/test/cpp_api/project.json
@@ -280,7 +280,8 @@
                 "implicit_reregister_after_reset",
                 "reregister_after_reset_different_name",
                 "reimport_module_after_reset",
-                "reimport_module_new_world"
+                "reimport_module_new_world",
+                "c_interop_module"
             ]
         }, {
             "id": "Singleton",

--- a/test/cpp_api/project.json
+++ b/test/cpp_api/project.json
@@ -275,7 +275,12 @@
                 "multi_world_component",
                 "multi_world_component_namespace",
                 "type_id",
-                "different_comp_same_name"
+                "different_comp_same_name",
+                "reregister_after_reset",
+                "implicit_reregister_after_reset",
+                "reregister_after_reset_different_name",
+                "reimport_module_after_reset",
+                "reimport_module_new_world"
             ]
         }, {
             "id": "Singleton",

--- a/test/cpp_api/project.json
+++ b/test/cpp_api/project.json
@@ -285,7 +285,8 @@
                 "reimport_module_after_reset",
                 "reimport_module_new_world",
                 "c_interop_module",
-                "c_interop_after_reset"
+                "c_interop_after_reset",
+                "implicit_register_w_new_world"
             ]
         }, {
             "id": "Singleton",

--- a/test/cpp_api/src/World.cpp
+++ b/test/cpp_api/src/World.cpp
@@ -74,8 +74,8 @@ void World_multi_world_component() {
     test_assert(p_1.id() != m_2.id());
     test_assert(m_2.id() > v_2.id());
 
-    auto p_2 = w2.component<Position>();
-    test_assert(p_1.id() == p_2.id());
+    auto m_1 = w2.component<Mass>();
+    test_assert(m_1.id() == m_2.id());
 }
 
 namespace A {
@@ -251,4 +251,29 @@ void World_c_interop_after_reset() {
     flecs::_::component_info<test::interop::module>::reset();
 
     w.import<test::interop::module>();
+}
+
+void World_implicit_register_w_new_world() {
+    {
+        flecs::world w;
+
+        auto e = w.entity().set<Position>({10, 20});
+        test_assert(e.has<Position>());
+        auto *p = e.get<Position>();
+        test_assert(p != NULL);
+        test_int(p->x, 10);
+        test_int(p->y, 20);
+    }
+
+    {
+        /* Recreate world, does not reset static state */
+        flecs::world w;
+
+        auto e = w.entity().set<Position>({10, 20});
+        test_assert(e.has<Position>());
+        auto *p = e.get<Position>();
+        test_assert(p != NULL);
+        test_int(p->x, 10);
+        test_int(p->y, 20);
+    }    
 }

--- a/test/cpp_api/src/World.cpp
+++ b/test/cpp_api/src/World.cpp
@@ -55,6 +55,12 @@ public:
 }
 }
 
+namespace ns {
+    struct FooComp {
+        int value;
+    };
+}
+
 void World_multi_world_component() {
     flecs::world w1;
     flecs::world w2;
@@ -140,6 +146,37 @@ void World_implicit_reregister_after_reset() {
     test_assert(p_id_1 == p_id_2);
 }
 
+void World_reregister_after_reset_w_namespace() {
+    flecs::world w;
+
+    w.component<ns::FooComp>();
+
+    flecs::entity_t p_id_1 = flecs::type_id<ns::FooComp>();
+
+    // Simulate different binary
+    flecs::_::component_info<ns::FooComp>::reset();
+
+    w.component<ns::FooComp>();
+
+    flecs::entity_t p_id_2 = flecs::type_id<ns::FooComp>();
+
+    test_assert(p_id_1 == p_id_2);
+}
+
+void World_reregister_namespace() {
+    flecs::world w;
+
+    w.component<ns::FooComp>();
+
+    flecs::entity_t p_id_1 = flecs::type_id<ns::FooComp>();
+
+    w.component<ns::FooComp>();
+
+    flecs::entity_t p_id_2 = flecs::type_id<ns::FooComp>();
+
+    test_assert(p_id_1 == p_id_2);
+}
+
 void World_reregister_after_reset_different_name() {
     flecs::world w;
 
@@ -191,4 +228,17 @@ void World_c_interop_module() {
 
     auto e_pos = w.lookup("test::interop::module::Position");
     test_assert(e_pos.id() != 0);
+}
+
+void World_c_interop_after_reset() {
+    flecs::world w;
+
+    w.import<test::interop::module>();
+
+    auto e_pos = w.lookup("test::interop::module::Position");
+    test_assert(e_pos.id() != 0);
+
+    flecs::_::component_info<test::interop::module>::reset();
+
+    w.import<test::interop::module>();
 }

--- a/test/cpp_api/src/World.cpp
+++ b/test/cpp_api/src/World.cpp
@@ -191,6 +191,16 @@ void World_reregister_after_reset_different_name() {
     w.component<Position>("Velocity");
 }
 
+void World_reimport() {
+    flecs::world w;
+
+    auto m1 = w.import<FooModule>();
+
+    auto m2 = w.import<FooModule>();
+    
+    test_assert(m1.id() == m2.id());
+}
+
 void World_reimport_module_after_reset() {
     flecs::world w;
 

--- a/test/cpp_api/src/World.cpp
+++ b/test/cpp_api/src/World.cpp
@@ -31,9 +31,11 @@ typedef struct TestInteropModule {
 
 static
 void TestInteropModuleImport(ecs_world_t *world) {
-    ECS_MODULE(world, TestInteropModule);
+    ecs_new_module(world, 0, "TestInteropModule", 
+        sizeof(TestInteropModule), alignof(TestInteropModule));
 
-    ECS_COMPONENT(world, Position);
+    ecs_new_component(world, 0, "Position", 
+        sizeof(Position), alignof(Position));
 }
 
 namespace test {
@@ -187,5 +189,6 @@ void World_c_interop_module() {
 
     w.import<test::interop::module>();
 
-
+    auto e_pos = w.lookup("test::interop::module::Position");
+    test_assert(e_pos.id() != 0);
 }

--- a/test/cpp_api/src/World.cpp
+++ b/test/cpp_api/src/World.cpp
@@ -25,6 +25,34 @@ public:
     }
 };
 
+typedef struct TestInteropModule {
+    int dummy;
+} TestInteropModule;
+
+static
+void TestInteropModuleImport(ecs_world_t *world) {
+    ECS_MODULE(world, TestInteropModule);
+
+    ECS_COMPONENT(world, Position);
+}
+
+namespace test {
+namespace interop {
+
+class module : TestInteropModule {
+public:
+    module(flecs::world& ecs) {
+        TestInteropModuleImport(ecs.c_ptr());
+
+        ecs.module<test::interop::module>();
+
+        ecs.component<Position>("test::interop::module::Position");
+    }
+};
+
+}
+}
+
 void World_multi_world_component() {
     flecs::world w1;
     flecs::world w2;
@@ -152,4 +180,12 @@ void World_reimport_module_new_world() {
         
         test_assert(e1.id() == e2.id());
     }
+}
+
+void World_c_interop_module() {
+    flecs::world w;
+
+    w.import<test::interop::module>();
+
+
 }

--- a/test/cpp_api/src/main.cpp
+++ b/test/cpp_api/src/main.cpp
@@ -247,6 +247,7 @@ void World_reregister_after_reset_w_namespace(void);
 void World_reregister_namespace(void);
 void World_implicit_reregister_after_reset(void);
 void World_reregister_after_reset_different_name(void);
+void World_reimport(void);
 void World_reimport_module_after_reset(void);
 void World_reimport_module_new_world(void);
 void World_c_interop_module(void);
@@ -1147,6 +1148,10 @@ bake_test_case World_testcases[] = {
         World_reregister_after_reset_different_name
     },
     {
+        "reimport",
+        World_reimport
+    },
+    {
         "reimport_module_after_reset",
         World_reimport_module_after_reset
     },
@@ -1306,7 +1311,7 @@ static bake_test_suite suites[] = {
         "World",
         NULL,
         NULL,
-        14,
+        15,
         World_testcases
     },
     {

--- a/test/cpp_api/src/main.cpp
+++ b/test/cpp_api/src/main.cpp
@@ -243,11 +243,14 @@ void World_multi_world_component_namespace(void);
 void World_type_id(void);
 void World_different_comp_same_name(void);
 void World_reregister_after_reset(void);
+void World_reregister_after_reset_w_namespace(void);
+void World_reregister_namespace(void);
 void World_implicit_reregister_after_reset(void);
 void World_reregister_after_reset_different_name(void);
 void World_reimport_module_after_reset(void);
 void World_reimport_module_new_world(void);
 void World_c_interop_module(void);
+void World_c_interop_after_reset(void);
 
 // Testsuite 'Singleton'
 void Singleton_set_get_singleton(void);
@@ -1128,6 +1131,14 @@ bake_test_case World_testcases[] = {
         World_reregister_after_reset
     },
     {
+        "reregister_after_reset_w_namespace",
+        World_reregister_after_reset_w_namespace
+    },
+    {
+        "reregister_namespace",
+        World_reregister_namespace
+    },
+    {
         "implicit_reregister_after_reset",
         World_implicit_reregister_after_reset
     },
@@ -1146,6 +1157,10 @@ bake_test_case World_testcases[] = {
     {
         "c_interop_module",
         World_c_interop_module
+    },
+    {
+        "c_interop_after_reset",
+        World_c_interop_after_reset
     }
 };
 
@@ -1291,7 +1306,7 @@ static bake_test_suite suites[] = {
         "World",
         NULL,
         NULL,
-        11,
+        14,
         World_testcases
     },
     {

--- a/test/cpp_api/src/main.cpp
+++ b/test/cpp_api/src/main.cpp
@@ -252,6 +252,7 @@ void World_reimport_module_after_reset(void);
 void World_reimport_module_new_world(void);
 void World_c_interop_module(void);
 void World_c_interop_after_reset(void);
+void World_implicit_register_w_new_world(void);
 
 // Testsuite 'Singleton'
 void Singleton_set_get_singleton(void);
@@ -1166,6 +1167,10 @@ bake_test_case World_testcases[] = {
     {
         "c_interop_after_reset",
         World_c_interop_after_reset
+    },
+    {
+        "implicit_register_w_new_world",
+        World_implicit_register_w_new_world
     }
 };
 
@@ -1311,7 +1316,7 @@ static bake_test_suite suites[] = {
         "World",
         NULL,
         NULL,
-        15,
+        16,
         World_testcases
     },
     {

--- a/test/cpp_api/src/main.cpp
+++ b/test/cpp_api/src/main.cpp
@@ -247,6 +247,7 @@ void World_implicit_reregister_after_reset(void);
 void World_reregister_after_reset_different_name(void);
 void World_reimport_module_after_reset(void);
 void World_reimport_module_new_world(void);
+void World_c_interop_module(void);
 
 // Testsuite 'Singleton'
 void Singleton_set_get_singleton(void);
@@ -1141,6 +1142,10 @@ bake_test_case World_testcases[] = {
     {
         "reimport_module_new_world",
         World_reimport_module_new_world
+    },
+    {
+        "c_interop_module",
+        World_c_interop_module
     }
 };
 
@@ -1286,7 +1291,7 @@ static bake_test_suite suites[] = {
         "World",
         NULL,
         NULL,
-        10,
+        11,
         World_testcases
     },
     {

--- a/test/cpp_api/src/main.cpp
+++ b/test/cpp_api/src/main.cpp
@@ -242,6 +242,11 @@ void World_multi_world_component(void);
 void World_multi_world_component_namespace(void);
 void World_type_id(void);
 void World_different_comp_same_name(void);
+void World_reregister_after_reset(void);
+void World_implicit_reregister_after_reset(void);
+void World_reregister_after_reset_different_name(void);
+void World_reimport_module_after_reset(void);
+void World_reimport_module_new_world(void);
 
 // Testsuite 'Singleton'
 void Singleton_set_get_singleton(void);
@@ -1116,6 +1121,26 @@ bake_test_case World_testcases[] = {
     {
         "different_comp_same_name",
         World_different_comp_same_name
+    },
+    {
+        "reregister_after_reset",
+        World_reregister_after_reset
+    },
+    {
+        "implicit_reregister_after_reset",
+        World_implicit_reregister_after_reset
+    },
+    {
+        "reregister_after_reset_different_name",
+        World_reregister_after_reset_different_name
+    },
+    {
+        "reimport_module_after_reset",
+        World_reimport_module_after_reset
+    },
+    {
+        "reimport_module_new_world",
+        World_reimport_module_new_world
     }
 };
 
@@ -1261,7 +1286,7 @@ static bake_test_suite suites[] = {
         "World",
         NULL,
         NULL,
-        5,
+        10,
         World_testcases
     },
     {


### PR DESCRIPTION
This PR addresses a number of problems with component registration in C++ that can occur when using multiple worlds, hot reloading of code, and implicit component registration.