### PR TITLE
flecs.hpp: fix error #elif with no expression

### DIFF
--- a/include/flecs/flecs.hpp
+++ b/include/flecs/flecs.hpp
@@ -3217,7 +3217,7 @@ namespace _
       return typeName;
     }
   };
-#elif
+#else
 #error "implicit component registration not supported"
 #endif
 


### PR DESCRIPTION
This is a tiny fix in flecs.hpp, there is an #elif without expression instead of #else