### PR TITLE
CMake: remove invalid options for C

### DIFF
--- a/cmake/target_default_compile_warnings.cmake
+++ b/cmake/target_default_compile_warnings.cmake
@@ -10,10 +10,7 @@ function(target_default_compile_warnings_c THIS)
                 $<$<CONFIG:Debug>:-Wshadow>
                 $<$<CONFIG:Debug>:-Wunused>
                 -Wall -Wextra
-                -Wnon-virtual-dtor
-                -Wold-style-cast
                 -Wcast-align
-                -Woverloaded-virtual
                 -Wpedantic
                 -Wconversion
                 -Wsign-conversion
@@ -27,10 +24,7 @@ function(target_default_compile_warnings_c THIS)
                 $<$<CONFIG:Debug>:-Wshadow>
                 $<$<CONFIG:Debug>:-Wunused>
                 -Wall -Wextra
-                -Wnon-virtual-dtor
-                -Wold-style-cast
                 -Wcast-align
-                -Woverloaded-virtual
                 -Wpedantic
                 -Wconversion
                 -Wsign-conversion


### PR DESCRIPTION
`-Wnon-virtual-dtor`, `-Wold-style-cast` and `-Woverloaded-virtual` options are invalid in C.

gcc doesn't fail but displays those kind of warnings:

```
cc1: warning: command line option '-Wnon-virtual-dtor' is valid for C++/ObjC++ but not for C
cc1: warning: command line option '-Wold-style-cast' is valid for C++/ObjC++ but not for C
cc1: warning: command line option '-Woverloaded-virtual' is valid for C++/ObjC++ but not for C
```