### PR TITLE
CMake: improvements (honor compiler flags, add several options, fix install and export targets)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.5)
 
 project(flecs LANGUAGES C)
 
+option(FLECS_PIC "Compile static flecs lib with position-independent-code (PIC)" ON)
+
 # include utilities for compiler options and warnings
 
 include(cmake/target_default_compile_warnings.cmake)
@@ -97,6 +99,10 @@ add_library(flecs_static STATIC ${INC} ${SRC})
 
 target_default_compile_options_c(flecs_static)
 target_default_compile_warnings_c(flecs_static)
+
+if(FLECS_PIC)
+    set_property(TARGET flecs_static PROPERTY POSITION_INDEPENDENT_CODE ON)
+endif()
 
 target_include_directories(flecs_static PUBLIC include)
 target_compile_definitions(flecs_static PUBLIC flecs_STATIC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,13 +96,16 @@ set(FLECS_TARGETS "")
 # build the shared library
 if(FLECS_SHARED_LIBS)
     add_library(flecs SHARED ${INC} ${SRC})
+    add_library(flecs::flecs ALIAS flecs)
 
     target_default_compile_options_c(flecs)
     if(FLECS_DEVELOPER_WARNINGS)
         target_default_compile_warnings_c(flecs)
     endif()
 
-    target_include_directories(flecs PUBLIC include)
+    target_include_directories(flecs PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>)
 
     list(APPEND FLECS_TARGETS flecs)
 endif()
@@ -110,6 +113,7 @@ endif()
 # build the static library
 if(FLECS_STATIC_LIBS)
     add_library(flecs_static STATIC ${INC} ${SRC})
+    add_library(flecs::flecs_static ALIAS flecs)
 
     target_default_compile_options_c(flecs_static)
     if(FLECS_DEVELOPER_WARNINGS)
@@ -120,7 +124,9 @@ if(FLECS_STATIC_LIBS)
         set_property(TARGET flecs_static PROPERTY POSITION_INDEPENDENT_CODE ON)
     endif()
 
-    target_include_directories(flecs_static PUBLIC include)
+    target_include_directories(flecs_static PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>)
     target_compile_definitions(flecs_static PUBLIC flecs_STATIC)
 
     list(APPEND FLECS_TARGETS flecs_static)
@@ -135,6 +141,12 @@ install(DIRECTORY "${PROJECT_SOURCE_DIR}/include/"
         PATTERN "*.hpp")
 
 install(TARGETS ${FLECS_TARGETS}
+        EXPORT flecs-export
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+install(EXPORT flecs-export
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/flecs
+        NAMESPACE flecs::
+        FILE flecs-config.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,12 +122,14 @@ if(FLECS_STATIC_LIBS)
 endif()
 
 # define the install steps
-
+include(include(GNUInstallDirs)
 install(DIRECTORY "${PROJECT_SOURCE_DIR}/include/"
-        DESTINATION include
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         FILES_MATCHING
         PATTERN "*.h"
         PATTERN "*.hpp")
 
 install(TARGETS ${FLECS_TARGETS}
-        DESTINATION lib)
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,7 @@ endif()
 # build the static library
 if(FLECS_STATIC_LIBS)
     add_library(flecs_static STATIC ${INC} ${SRC})
-    add_library(flecs::flecs_static ALIAS flecs)
+    add_library(flecs::flecs_static ALIAS flecs_static)
 
     target_default_compile_options_c(flecs_static)
     if(FLECS_DEVELOPER_WARNINGS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,7 @@ if(FLECS_STATIC_LIBS)
 endif()
 
 # define the install steps
-include(include(GNUInstallDirs)
+include(GNUInstallDirs)
 install(DIRECTORY "${PROJECT_SOURCE_DIR}/include/"
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         FILES_MATCHING

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(flecs LANGUAGES C)
 option(FLECS_STATIC_LIBS "Build static flecs lib" ON)
 option(FLECS_PIC "Compile static flecs lib with position-independent-code (PIC)" ON)
 option(FLECS_SHARED_LIBS "Build shared flecs lib" ON)
+option(FLECS_DEVELOPER_WARNINGS "Enable more warnings" OFF)
 
 if(NOT FLECS_STATIC_LIBS AND NOT FLECS_SHARED_LIBS)
     message(FATAL_ERROR "At least one of FLECS_STATIC_LIBS or FLECS_SHARED_LIBS options must be enabled")
@@ -97,7 +98,9 @@ if(FLECS_SHARED_LIBS)
     add_library(flecs SHARED ${INC} ${SRC})
 
     target_default_compile_options_c(flecs)
-    target_default_compile_warnings_c(flecs)
+    if(FLECS_DEVELOPER_WARNINGS)
+        target_default_compile_warnings_c(flecs)
+    endif()
 
     target_include_directories(flecs PUBLIC include)
 
@@ -109,7 +112,9 @@ if(FLECS_STATIC_LIBS)
     add_library(flecs_static STATIC ${INC} ${SRC})
 
     target_default_compile_options_c(flecs_static)
-    target_default_compile_warnings_c(flecs_static)
+    if(FLECS_DEVELOPER_WARNINGS)
+        target_default_compile_warnings_c(flecs_static)
+    endif()
 
     if(FLECS_PIC)
         set_property(TARGET flecs_static PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,14 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.1)
 
 project(flecs LANGUAGES C)
 
+option(FLECS_STATIC_LIBS "Build static flecs lib" ON)
 option(FLECS_PIC "Compile static flecs lib with position-independent-code (PIC)" ON)
+option(FLECS_SHARED_LIBS "Build shared flecs lib" ON)
+
+if(NOT FLECS_STATIC_LIBS AND NOT FLECS_SHARED_LIBS)
+    message(FATAL_ERROR "At least one of FLECS_STATIC_LIBS or FLECS_SHARED_LIBS options must be enabled")
+endif()
 
 # include utilities for compiler options and warnings
 
@@ -84,28 +90,36 @@ set(SRC
         src/vector.c
         src/world.c)
 
+set(FLECS_TARGETS "")
+
 # build the shared library
+if(FLECS_SHARED_LIBS)
+    add_library(flecs SHARED ${INC} ${SRC})
 
-add_library(flecs SHARED ${INC} ${SRC})
+    target_default_compile_options_c(flecs)
+    target_default_compile_warnings_c(flecs)
 
-target_default_compile_options_c(flecs)
-target_default_compile_warnings_c(flecs)
+    target_include_directories(flecs PUBLIC include)
 
-target_include_directories(flecs PUBLIC include)
-
-# build the static library
-
-add_library(flecs_static STATIC ${INC} ${SRC})
-
-target_default_compile_options_c(flecs_static)
-target_default_compile_warnings_c(flecs_static)
-
-if(FLECS_PIC)
-    set_property(TARGET flecs_static PROPERTY POSITION_INDEPENDENT_CODE ON)
+    list(APPEND FLECS_TARGETS flecs)
 endif()
 
-target_include_directories(flecs_static PUBLIC include)
-target_compile_definitions(flecs_static PUBLIC flecs_STATIC)
+# build the static library
+if(FLECS_STATIC_LIBS)
+    add_library(flecs_static STATIC ${INC} ${SRC})
+
+    target_default_compile_options_c(flecs_static)
+    target_default_compile_warnings_c(flecs_static)
+
+    if(FLECS_PIC)
+        set_property(TARGET flecs_static PROPERTY POSITION_INDEPENDENT_CODE ON)
+    endif()
+
+    target_include_directories(flecs_static PUBLIC include)
+    target_compile_definitions(flecs_static PUBLIC flecs_STATIC)
+
+    list(APPEND FLECS_TARGETS flecs_static)
+endif()
 
 # define the install steps
 
@@ -115,8 +129,5 @@ install(DIRECTORY "${PROJECT_SOURCE_DIR}/include/"
         PATTERN "*.h"
         PATTERN "*.hpp")
 
-install(TARGETS flecs
-        DESTINATION lib)
-
-install(TARGETS flecs_static
+install(TARGETS ${FLECS_TARGETS}
         DESTINATION lib)

--- a/cmake/target_default_compile_options.cmake
+++ b/cmake/target_default_compile_options.cmake
@@ -16,14 +16,6 @@ function(target_default_compile_options_c THIS)
             C_STANDARD_REQUIRED ON
             C_VISIBILITY_PRESET hidden)
 
-    if (CMAKE_C_COMPILER_ID STREQUAL "Clang"
-            OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"
-            OR CMAKE_C_COMPILER_ID STREQUAL "GNU")
-
-        target_compile_options(${THIS} PRIVATE
-                -fno-stack-protector
-                $<$<CONFIG:DEBUG>:-DDEBUG>)
-    endif()
 endfunction()
 
 function(target_default_compile_options_cxx THIS)
@@ -32,14 +24,5 @@ function(target_default_compile_options_cxx THIS)
             LINKER_LANGUAGE CXX
             CXX_STANDARD 11
             CXX_STANDARD_REQUIRED ON)
-
-    if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"
-            OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"
-            OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-
-        target_compile_options(${THIS} PRIVATE
-                -fno-stack-protector
-                $<$<CONFIG:DEBUG>:-DDEBUG>)
-    endif ()
 
 endfunction()

--- a/cmake/target_default_compile_options.cmake
+++ b/cmake/target_default_compile_options.cmake
@@ -30,7 +30,8 @@ function(target_default_compile_options_c THIS)
     set_target_properties(${THIS} PROPERTIES
             LINKER_LANGUAGE C
             C_STANDARD 99
-            C_STANDARD_REQUIRED ON)
+            C_STANDARD_REQUIRED ON
+            C_VISIBILITY_PRESET hidden)
 
     if (CMAKE_C_COMPILER_ID STREQUAL "Clang"
             OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"
@@ -38,7 +39,6 @@ function(target_default_compile_options_c THIS)
 
         target_compile_options(${THIS} PRIVATE
                 -fPIC
-                -fvisibility=hidden
                 -fno-stack-protector
                 $<$<CONFIG:DEBUG>:-g -O0 -DDEBUG>
                 $<$<CONFIG:RELEASE>:-O3 -DNDEBUG>
@@ -76,7 +76,6 @@ function(target_default_compile_options_cxx THIS)
 
         target_compile_options(${THIS} PRIVATE
                 -fPIC
-                -fvisibility=hidden
                 -fno-stack-protector
                 $<$<CONFIG:DEBUG>:-g -O0 -DDEBUG>
                 $<$<CONFIG:RELEASE>:-O3 -DNDEBUG>

--- a/cmake/target_default_compile_options.cmake
+++ b/cmake/target_default_compile_options.cmake
@@ -1,20 +1,3 @@
-cmake_minimum_required(VERSION 3.5)
-
-# do not rely on cmake presets
-# and use target configuration
-
-set(CMAKE_C_FLAGS "")
-set(CMAKE_C_FLAGS_DEBUG "")
-set(CMAKE_C_FLAGS_RELEASE "")
-set(CMAKE_C_FLAGS_RELWITHDEBINFO "")
-set(CMAKE_C_FLAGS_MINSIZEREL "")
-
-set(CMAKE_CXX_FLAGS "")
-set(CMAKE_CXX_FLAGS_DEBUG "")
-set(CMAKE_CXX_FLAGS_RELEASE "")
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "")
-set(CMAKE_CXX_FLAGS_MINSIZEREL "")
-
 # this seems redundant as the target
 # property is set. but for apple clang
 # this seems to be needed
@@ -40,27 +23,8 @@ function(target_default_compile_options_c THIS)
         target_compile_options(${THIS} PRIVATE
                 -fPIC
                 -fno-stack-protector
-                $<$<CONFIG:DEBUG>:-g -O0 -DDEBUG>
-                $<$<CONFIG:RELEASE>:-O3 -DNDEBUG>
-                $<$<CONFIG:RELWITHDEBINFO>:-g -O2 -DNDEBUG>
-                $<$<CONFIG:MINSIZEREL>:-Os -DNDEBUG>)
-
-    elseif (CMAKE_C_COMPILER_ID STREQUAL "MSVC")
-
-        target_compile_options(${THIS} PRIVATE
-                $<$<CONFIG:DEBUG>:/Zi /Od /Ob0 /RTC1>
-                $<$<CONFIG:RELEASE>:/O2 /Ob2 /DNDEBUG>
-                $<$<CONFIG:RELWITHDEBINFO>:/Zi /O2 /Ob1 /DNDEBUG>
-                $<$<CONFIG:MINSIZEREL>:/O1 /Ob1 /DNDEBUG>)
-
-    else ()
-
-        message(WARNING
-                "No Options specified for ${CMAKE_C_COMPILER_ID}. "
-                "Consider using one of the following compilers: Clang, GNU, MSVC, AppleClang.")
-
-    endif ()
-
+                $<$<CONFIG:DEBUG>:-DDEBUG>)
+    endif()
 endfunction()
 
 function(target_default_compile_options_cxx THIS)
@@ -75,27 +39,8 @@ function(target_default_compile_options_cxx THIS)
             OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 
         target_compile_options(${THIS} PRIVATE
-                -fPIC
                 -fno-stack-protector
-                $<$<CONFIG:DEBUG>:-g -O0 -DDEBUG>
-                $<$<CONFIG:RELEASE>:-O3 -DNDEBUG>
-                $<$<CONFIG:RELWITHDEBINFO>:-g -O2 -DNDEBUG>
-                $<$<CONFIG:MINSIZEREL>:-Os -DNDEBUG>)
-
-    elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-
-        target_compile_options(${THIS} PRIVATE
-                $<$<CONFIG:DEBUG>:/Zi /Od /Ob0 /RTC1>
-                $<$<CONFIG:RELEASE>:/O2 /Ob2 /DNDEBUG>
-                $<$<CONFIG:RELWITHDEBINFO>:/Zi /O2 /Ob1 /DNDEBUG>
-                $<$<CONFIG:MINSIZEREL>:/O1 /Ob1 /DNDEBUG>)
-
-    else ()
-
-        message(WARNING
-                "No Options specified for ${CMAKE_CXX_COMPILER_ID}. "
-                "Consider using one of the following compilers: Clang, GNU, MSVC, AppleClang.")
-
+                $<$<CONFIG:DEBUG>:-DDEBUG>)
     endif ()
 
 endfunction()

--- a/cmake/target_default_compile_options.cmake
+++ b/cmake/target_default_compile_options.cmake
@@ -21,7 +21,6 @@ function(target_default_compile_options_c THIS)
             OR CMAKE_C_COMPILER_ID STREQUAL "GNU")
 
         target_compile_options(${THIS} PRIVATE
-                -fPIC
                 -fno-stack-protector
                 $<$<CONFIG:DEBUG>:-DDEBUG>)
     endif()

--- a/cmake/target_default_compile_warnings.cmake
+++ b/cmake/target_default_compile_warnings.cmake
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.5)
-
 function(target_default_compile_warnings_c THIS)
 
     if (CMAKE_C_COMPILER_ID STREQUAL "Clang"
@@ -10,10 +8,7 @@ function(target_default_compile_warnings_c THIS)
                 $<$<CONFIG:Debug>:-Wshadow>
                 $<$<CONFIG:Debug>:-Wunused>
                 -Wall -Wextra
-                -Wnon-virtual-dtor
-                -Wold-style-cast
                 -Wcast-align
-                -Woverloaded-virtual
                 -Wpedantic
                 -Wconversion
                 -Wsign-conversion
@@ -27,10 +22,7 @@ function(target_default_compile_warnings_c THIS)
                 $<$<CONFIG:Debug>:-Wshadow>
                 $<$<CONFIG:Debug>:-Wunused>
                 -Wall -Wextra
-                -Wnon-virtual-dtor
-                -Wold-style-cast
                 -Wcast-align
-                -Woverloaded-virtual
                 -Wpedantic
                 -Wconversion
                 -Wsign-conversion


### PR DESCRIPTION
This PR improves CMake build of flecs:

- add options to build static or shared or both (I would have loved preventing to build both static and shared -because it forces to use 2 different imported targets for shared and static- but since it's already there I can't remove this feature without eventually breaking several downstream projects)
- add an option to enable full warnings
- add an option to disable PIC on non Windows plarforms
- honor `CMAKE_*_FLAGS*` from user
- rely on `C_VISIBILITY_PRESET` property instead of -fvisibility=hidden
- remove invalid warnings options for C
- export targets in `flecs-config.cmake` to be able to consume flecs with `find_package(flecs)`, then `target_link_libraries(myapp flecs::flecs)` or `target_link_libraries(myapp flecs::flecs_static)`. These namespaced targets also work with `add_subdirectory()`.

closes https://github.com/SanderMertens/flecs/issues/319