### PR TITLE
Fix warning: null destination pointer

### DIFF
--- a/flecs.c
+++ b/flecs.c
@@ -1309,7 +1309,7 @@ char *ecs_vasprintf(
 
     va_copy(tmpa, args);
 
-    size = vsnprintf(result, ecs_to_size_t(size), fmt, tmpa);
+    size = vsnprintf(result, 0, fmt, tmpa);
 
     va_end(tmpa);
 

--- a/src/log.c
+++ b/src/log.c
@@ -11,7 +11,7 @@ char *ecs_vasprintf(
 
     va_copy(tmpa, args);
 
-    size = vsnprintf(result, ecs_to_size_t(size), fmt, tmpa);
+    size = vsnprintf(result, 0, fmt, tmpa);
 
     va_end(tmpa);
 


### PR DESCRIPTION
A simple fix to silence this warning:

```
flecs.c:1312:12: warning: null destination pointer [-Wformat-truncation=]
1312 |      size = vsnprintf(result, ecs_to_size_t(size), fmt, tmpa);
     |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This warning shows in gcc 10 when using -Wformat option.