### PR TITLE
Fix CMake warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
+cmake_policy(SET CMP0063 NEW)
 
 project(flecs LANGUAGES C)
 


### PR DESCRIPTION
This line allows for no warning to happen during CMake generation

Warning looks like this:

```
CMake Warning (dev) at ThirdParty/flecs/CMakeLists.txt:115 (add_library):
  Policy CMP0063 is not set: Honor visibility properties for all target
  types.  Run "cmake --help-policy CMP0063" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  Target "flecs_static" of type "STATIC_LIBRARY" has the following visibility
  properties set for C:

    C_VISIBILITY_PRESET

  For compatibility CMake is not honoring them for this target.
```