### PR TITLE
#359 repair c++ vector.first and .last methods

### DIFF
--- a/include/flecs/private/vector.h
+++ b/include/flecs/private/vector.h
@@ -488,11 +488,11 @@ public:
     }
 
     T& first() {
-        return static_cast<T*>(_ecs_vector_first(m_vector, ECS_VECTOR_T(T)));
+        return *static_cast<T*>(_ecs_vector_first(m_vector, ECS_VECTOR_T(T)));
     }
 
     T& last() {
-        return static_cast<T*>(_ecs_vector_last(m_vector, ECS_VECTOR_T(T)));
+        return *static_cast<T*>(_ecs_vector_last(m_vector, ECS_VECTOR_T(T)));
     }
 
     int32_t count() {


### PR DESCRIPTION
This branch attempts to repair the `flecs::vector::first` and `flecs:vector::last` methods.

closes #359 