### PR TITLE
Update ci.yml to add missing compilers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Install GCC
+        run: |
+          sudo apt-get install -y gcc-${{ matrix.compiler-version }}
+          sudo apt-get install -y g++-${{ matrix.compiler-version }}
+      
       - name: Install bake
         run: |
           git clone https://github.com/SanderMertens/bake
@@ -101,6 +106,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Install Clang
+        run: |
+          sudo apt-get install -y clang-${{ matrix.compiler-version }}
+          sudo apt-get install -y clang++-${{ matrix.compiler-version }}      
+      
       - name: Install bake
         run: |
           git clone https://github.com/SanderMertens/bake


### PR DESCRIPTION
GitHub removed versions <9 for gcc/clang from virtual environments. Add rules to manually install them in the image.