### PR TITLE
Handle a null world in is_valid and is_alive

### DIFF
--- a/include/flecs/cpp/entity.hpp
+++ b/include/flecs/cpp/entity.hpp
@@ -209,7 +209,7 @@ public:
      * @return True if the entity is alive, false otherwise.
      */
     bool is_valid() {
-        return ecs_is_valid(m_world, m_id);
+        return m_world && ecs_is_valid(m_world, m_id);
     }
 
     /** Check is entity is alive.
@@ -217,7 +217,7 @@ public:
      * @return True if the entity is alive, false otherwise.
      */
     bool is_alive() {
-        return ecs_is_alive(m_world, m_id);
+        return m_world && ecs_is_alive(m_world, m_id);
     }
 
     /** Return the entity name.


### PR DESCRIPTION
If `m_world` is null on a `flecs::entity` then `is_valid()` asserts, which doesn't make any sense on a validity check.  This small PR just returns false for `is_valid()` and `is_alive()` if the `m_world` value is null