### PR TITLE
#417 add with, scope & defer lambda operations

### DIFF
--- a/examples/cpp/08_hierarchy/src/main.cpp
+++ b/examples/cpp/08_hierarchy/src/main.cpp
@@ -88,31 +88,30 @@ int main(int argc, char *argv[]) {
             .oper(flecs::Optional)
         .iter(Transform);
 
-    /* Create root of the hierachy which moves around */
-    auto Root = ecs.entity("Root")
+    // Create entity hierarchy
+    ecs.entity("Root")
         .add<WorldPosition>()
         .set<Position>({0, 0})
-        .set<Velocity>({1, 2});
-
-        auto Child1 = ecs.entity("Child1")
-            .add(flecs::ChildOf, Root)
-            .add<WorldPosition>()
-            .set<Position>({100, 100});
-
-            ecs.entity("GChild1")
-                .add(flecs::ChildOf, Child1)
+        .set<Velocity>({1, 2})
+        .scope([&]{ // From here entities are created with (ChildOf, Root)
+            ecs.entity("Child1")
                 .add<WorldPosition>()
-                .set<Position>({1000, 1000});
+                .set<Position>({100, 100})
+                .scope([&]{ // (ChildOf, Root::Child1)
+                    ecs.entity("GChild1")
+                        .add<WorldPosition>()
+                        .set<Position>({1000, 1000});
+                });
 
-        auto Child2 = ecs.entity("Child2")
-            .add(flecs::ChildOf, Root)
-            .add<WorldPosition>()
-            .set<Position>({200, 200});
-
-            ecs.entity("GChild2")
-                .add(flecs::ChildOf, Child2)
+            ecs.entity("Child2")
                 .add<WorldPosition>()
-                .set<Position>({2000, 2000});
+                .set<Position>({200, 200})
+                .scope([&]{ // (ChildOf, Root::Child2)
+                    ecs.entity("GChild2")
+                        .add<WorldPosition>()
+                        .set<Position>({2000, 2000});
+                });
+        });
 
     ecs.set_target_fps(1);
 

--- a/examples/cpp/18_nested_prefab/src/main.cpp
+++ b/examples/cpp/18_nested_prefab/src/main.cpp
@@ -23,7 +23,7 @@ int main(int argc, char *argv[]) {
          * cause the child prefab to be instantiated whenever an instanceof
          * RootPrefab is created. */
         ecs.prefab("Child")
-            .add(flecs::ChildOf, Root)
+            .child_of(Root)
             .set<Position>({30, 40});
 
     auto e = ecs.entity()

--- a/examples/cpp/19_auto_override_nested_prefab/src/main.cpp
+++ b/examples/cpp/19_auto_override_nested_prefab/src/main.cpp
@@ -26,7 +26,7 @@ int main(int argc, char *argv[]) {
          * string-based type expression to create the type, as the type needs to
          * be fully constructed before registering it with the prefab parent. */
         ecs.prefab("Child")
-            .add(flecs::ChildOf, RootPrefab)
+            .child_of(RootPrefab)
             .is_a(ChildPrefab);
 
     /* Create new entity from Root. */

--- a/examples/cpp/20_nested_variant/src/main.cpp
+++ b/examples/cpp/20_nested_variant/src/main.cpp
@@ -19,23 +19,23 @@ int main(int argc, char *argv[]) {
         .set<Position>({15, 25});
 
     /* Create the root of the prefab hierarchy  */
-    auto Root = ecs.prefab("RootPrefab")
+    auto RootPrefab = ecs.prefab("RootPrefab")
         .set<Position>({10, 20});
         
         /* Create two child prefabs that inherit from ChildBase */
         ecs.prefab("Child1")
-            .add(flecs::ChildOf, Root)
-            .add(flecs::IsA, ChildBase)
+            .child_of(RootPrefab)
+            .is_a(ChildBase)
             .set<Velocity>({30, 40});
 
         ecs.prefab("Child2")
-            .add(flecs::ChildOf, Root)
-            .add(flecs::IsA, ChildBase)
+            .child_of(RootPrefab)
+            .is_a(ChildBase)
             .set<Velocity>({50, 60});            
 
     /* Create instance of Root */
     auto e = ecs.entity()
-        .is_a(Root);
+        .is_a(RootPrefab);
 
     /* Print types of child1 and child2 */
     auto child1 = e.lookup("Child1");
@@ -44,19 +44,23 @@ int main(int argc, char *argv[]) {
     auto child2 = e.lookup("Child2");
     std::cout << "Child2 type = [" << child2.type().str() << "]" << std::endl;
 
-    /* e shares Position from Root */
-    const Position *p = e.get<Position>();
-    std::cout << "Position of e = {" << p->x << ", " << p->y << "}" << std::endl;
+    /* e shares Position from RootPrefab */
+    e.get([](const Position& p) {
+        std::cout << "Position of e = {" << p.x << ", " << p.y << "}" 
+                  << std::endl;
+    });    
 
     /* Children will share Position from ChildBase and Velocity from the Child1
      * and Child2 prefabs respectively */
-    p = child1.get<Position>();
-    const Velocity *v = child1.get<Velocity>();
-    std::cout << "Child1 Position = {" << p->x << ", " << p->y << "} " 
-        << "Velocity = {" << v->x << ", " << v->y << "}" << std::endl;
+    child1.get([](const Position& p, const Velocity& v) {
+        std::cout << "Child1 Position = {" << p.x << ", " << p.y << "} " 
+                  <<        "Velocity = {" << v.x << ", " << v.y << "}" 
+                  << std::endl;
+    });
 
-    p = child2.get<Position>();
-    v = child2.get<Velocity>();
-    std::cout << "Child2 Position = {" << p->x << ", " << p->y << "} " 
-        << "Velocity = {" << v->x << ", " << v->y << "}" << std::endl;        
+    child2.get([](const Position& p, const Velocity& v) {
+        std::cout << "Child2 Position = {" << p.x << ", " << p.y << "} " 
+                  <<        "Velocity = {" << v.x << ", " << v.y << "}" 
+                  << std::endl;
+    });      
 }

--- a/examples/cpp/23_get_children/src/main.cpp
+++ b/examples/cpp/23_get_children/src/main.cpp
@@ -23,11 +23,14 @@ int main(int argc, char *argv[]) {
     flecs::world ecs(argc, argv);
 
     // Create a simple hierarchy with 2 levels
-    auto Parent = ecs.entity("Parent");
-        auto Child1 = ecs.entity("Child1").add(flecs::ChildOf, Parent);
-            ecs.entity("GrandChild").add(flecs::ChildOf, Child1);
-        ecs.entity("Child2").add(flecs::ChildOf, Parent);
-        ecs.entity("Child3").add(flecs::ChildOf, Parent);
-    
-    print_tree(Parent);    
+    auto parent = ecs.entity("Parent").scope([&]{
+        ecs.entity("Child1").scope([&]{
+            ecs.entity("GrandChild");
+        });
+
+        ecs.entity("Child2");
+        ecs.entity("Child3");
+    });
+
+    print_tree(parent);    
 }

--- a/flecs.c
+++ b/flecs.c
@@ -869,8 +869,7 @@ typedef struct ecs_op_n_t {
 } ecs_op_n_t;
 
 typedef struct ecs_op_t {
-    ecs_op_kind_t kind;         /* Operation kind */
-    ecs_entity_t scope;         /* Scope of operation (for new) */       
+    ecs_op_kind_t kind;         /* Operation kind */    
     ecs_entity_t component;     /* Single component (components.count = 1) */
     ecs_entities_t components;  /* Multiple components */
     union {
@@ -902,6 +901,7 @@ struct ecs_stage_t {
     /* Namespacing */
     ecs_table_t *scope_table;      /* Table for current scope */
     ecs_entity_t scope;            /* Entity of current scope */
+    ecs_entity_t with;             /* Id to add by default to new entities */
 
     /* Properties */
     bool auto_merge;               /* Should this stage automatically merge? */
@@ -5520,7 +5520,7 @@ void new(
 {
     ecs_entity_info_t info = {0};
     ecs_table_t *table = ecs_table_traverse_add(
-        world, world->stage.scope_table, to_add, NULL);
+        world, &world->store.root, to_add, NULL);
     new_entity(world, entity, &info, table, to_add);
 }
 
@@ -5936,6 +5936,23 @@ ecs_entity_t ecs_new_id(
     return entity;
 }
 
+ecs_entity_t ecs_set_with(
+    ecs_world_t *world,
+    ecs_id_t id)
+{
+    ecs_stage_t *stage = ecs_stage_from_world(&world);
+    ecs_id_t prev = stage->with;
+    stage->with = id;
+    return prev;
+}
+
+ecs_entity_t ecs_get_with(
+    const ecs_world_t *world)
+{
+    const ecs_stage_t *stage = ecs_stage_from_readonly_world(world);
+    return stage->with;
+}
+
 ecs_entity_t ecs_new_component_id(
     ecs_world_t *world)
 {
@@ -5980,19 +5997,41 @@ ecs_entity_t ecs_new_w_type(
     ecs_type_t type)
 {
     ecs_assert(world != NULL, ECS_INVALID_PARAMETER, NULL);
+    if (!type) {
+        return ecs_new_w_id(world, 0);
+    }
 
     ecs_stage_t *stage = ecs_stage_from_world(&world);    
     ecs_entity_t entity = ecs_new_id(world);
+    ecs_id_t with = stage->with;
+    ecs_entity_t scope = stage->scope;
 
     ecs_entities_t to_add = ecs_type_to_entities(type);
     if (ecs_defer_new(world, stage, entity, &to_add)) {
+        if (with) {
+            ecs_add_id(world, entity, with);
+        }
+        if (scope) {
+            ecs_add_id(world, entity, ecs_pair(EcsChildOf, scope));
+        }
         return entity;
     }
 
-    if (type || world->stage.scope) {
-        new(world, entity, &to_add);
-    } else {
-        ecs_eis_set(world, entity, &(ecs_record_t){ 0 });
+    new(world, entity, &to_add);
+
+    ecs_id_t ids[2];
+    to_add = (ecs_entities_t){ .array = ids, .count = 0 };
+
+    if (with) {
+        ids[to_add.count ++] = with;
+    }
+
+    if (scope) {
+        ids[to_add.count ++] = ecs_pair(EcsChildOf, scope);
+    }
+
+    if (to_add.count) {
+        add_ids(world, entity, &to_add);
     }
 
     ecs_defer_flush(world, stage);    
@@ -6009,26 +6048,31 @@ ecs_entity_t ecs_new_w_id(
     ecs_stage_t *stage = ecs_stage_from_world(&world);    
     ecs_entity_t entity = ecs_new_id(world);
 
-    ecs_entities_t to_add = {
-        .array = &id,
-        .count = 1
-    };
+    ecs_id_t ids[3];
+    ecs_entities_t to_add = { .array = ids, .count = 0 };
+
+    if (id) {
+        ids[to_add.count ++] = id;
+    }
+
+    ecs_id_t with = stage->with;
+    if (with) {
+        ids[to_add.count ++] = with;
+    }
+
+    ecs_entity_t scope = stage->scope;
+    if (scope) {
+        if (!id || !ECS_HAS_RELATION(id, EcsChildOf)) {
+            ids[to_add.count ++] = ecs_pair(EcsChildOf, scope);
+        }
+    }
 
     if (ecs_defer_new(world, stage, entity, &to_add)) {
         return entity;
     } 
 
-    if (id || stage->scope) {
-        ecs_entity_t old_scope = 0;
-        if (ECS_HAS_RELATION(id, EcsChildOf)) {
-            old_scope = ecs_set_scope(world, 0);
-        }
-
+    if (to_add.count) {
         new(world, entity, &to_add);
-
-        if (ECS_HAS_RELATION(id, EcsChildOf)) {
-            ecs_set_scope(world, old_scope);
-        }
     } else {
         ecs_eis_set(world, entity, &(ecs_record_t){ 0 });
     }
@@ -6039,6 +6083,9 @@ ecs_entity_t ecs_new_w_id(
 }
 
 #ifdef FLECS_PARSER
+
+/* Traverse table graph by either adding or removing identifiers parsed from the
+ * passed in expression. */
 static
 ecs_table_t *traverse_from_expr(
     ecs_world_t *world,
@@ -6108,7 +6155,261 @@ ecs_table_t *traverse_from_expr(
 
     return table;
 }
+
+/* Add/remove components based on the parsed expression. This operation is 
+ * slower than traverse_from_expr, but safe to use from a deferred context. */
+static
+void defer_from_expr(
+    ecs_world_t *world,
+    ecs_entity_t entity,
+    const char *name,
+    const char *expr,
+    bool is_add,
+    bool replace_and)
+{
+    const char *ptr = expr;
+    if (ptr) {
+        ecs_term_t term = {0};
+        while (ptr[0] && (ptr = ecs_parse_term(world, name, expr, ptr, &term))) {
+            if (!ecs_term_is_set(&term)) {
+                break;
+            }
+
+            if (ecs_term_finalize(world, name, expr, &term)) {
+                return;
+            }
+
+            if (!ecs_term_is_trivial(&term)) {
+                ecs_parser_error(name, expr, (ptr - expr), 
+                    "invalid non-trivial term in add expression");
+                return;
+            }
+
+            if (term.oper == EcsAnd || !replace_and) {
+                /* Regular AND expression */
+                if (is_add) {
+                    ecs_add_id(world, entity, term.id);
+                } else {
+                    ecs_remove_id(world, entity, term.id);
+                }
+            } else if (term.oper == EcsAndFrom) {
+                /* Add all components from the specified type */
+                const EcsType *t = ecs_get(world, term.id, EcsType);
+                if (!t) {
+                    ecs_parser_error(name, expr, (ptr - expr), 
+                        "expected type for AND role");
+                    return;
+                }
+                
+                ecs_id_t *ids = ecs_vector_first(t->normalized, ecs_id_t);
+                int32_t i, count = ecs_vector_count(t->normalized);
+                for (i = 0; i < count; i ++) {
+                    if (is_add) {
+                        ecs_add_id(world, entity, ids[i]);
+                    } else {
+                        ecs_remove_id(world, entity, ids[i]);
+                    }
+                }
+            }
+
+            ecs_term_fini(&term);
+        }
+    }
+}
 #endif
+
+/* If operation is not deferred, add/remove components by finding the target
+ * table and moving the entity towards it. */
+static 
+void traverse_add_remove(
+    ecs_world_t *world,
+    ecs_entity_t result,
+    const char *name,
+    const ecs_entity_desc_t *desc,
+    ecs_entity_t scope,
+    ecs_id_t with,
+    bool new_entity,
+    bool name_assigned)
+{
+    const char *sep = desc->sep;
+
+    /* Find existing table */
+    ecs_entity_info_t info = {0};
+    ecs_table_t *src_table = NULL, *table = NULL;
+    if (!new_entity) {
+        if (ecs_get_info(world, result, &info)) {
+            table = info.table;
+        }
+    }
+
+    ecs_entity_t added_buffer[ECS_MAX_ADD_REMOVE];
+    ecs_entities_t added = { .array = added_buffer };
+
+    ecs_entity_t removed_buffer[ECS_MAX_ADD_REMOVE];
+    ecs_entities_t removed = { .array = removed_buffer };
+
+    /* Find destination table */
+
+    /* If this is a new entity without a name, add the scope. If a name is
+     * provided, the scope will be added by the add_path_w_sep function */
+    if (new_entity) {
+        if (new_entity && scope && !name && !name_assigned) {
+            ecs_entity_t id = ecs_pair(EcsChildOf, scope);
+            ecs_entities_t arr = { .array = &id, .count = 1 };
+            table = ecs_table_traverse_add(world, table, &arr, &added);
+            ecs_assert(table != NULL, ECS_INVALID_PARAMETER, NULL);
+        }
+
+        if (with) {
+            ecs_entities_t arr = { .array = &with, .count = 1 };
+            table = ecs_table_traverse_add(world, table, &arr, &added);
+            ecs_assert(table != NULL, ECS_INVALID_PARAMETER, NULL);            
+        }
+    }
+
+    /* If a name is provided but not yet assigned, add the Name component */
+    if (name && !name_assigned) {
+        ecs_entity_t id = ecs_id(EcsName);
+        ecs_entities_t arr = { .array = &id, .count = 1 };
+        table = ecs_table_traverse_add(world, table, &arr, &added);
+        ecs_assert(table != NULL, ECS_INVALID_PARAMETER, NULL);            
+    }
+
+    /* Add components from the 'add' id array */
+    int32_t i = 0;
+    ecs_id_t id;
+    const ecs_id_t *ids = desc->add;
+    while ((i < ECS_MAX_ADD_REMOVE) && (id = ids[i ++])) {
+        ecs_entities_t arr = { .array = &id, .count = 1 };
+        table = ecs_table_traverse_add(world, table, &arr, &added);
+        ecs_assert(table != NULL, ECS_INVALID_PARAMETER, NULL);
+    }
+
+    /* Add components from the 'remove' id array */
+    i = 0;
+    ids = desc->remove;
+    while ((i < ECS_MAX_ADD_REMOVE) && (id = ids[i ++])) {
+        ecs_entities_t arr = { .array = &id, .count = 1 };
+        table = ecs_table_traverse_remove(world, table, &arr, &removed);
+        ecs_assert(table != NULL, ECS_INVALID_PARAMETER, NULL);
+    }
+
+    /* Add components from the 'add_expr' expression */
+    if (desc->add_expr) {
+#ifdef FLECS_PARSER
+        table = traverse_from_expr(
+            world, table, name, desc->add_expr, &added, true, true);
+#else
+        ecs_abort(ECS_UNSUPPORTED, "parser addon is not available");
+#endif
+    }
+
+    /* Remove components from the 'remove_expr' expression */
+    if (desc->remove_expr) {
+#ifdef FLECS_PARSER
+    table = traverse_from_expr(
+        world, table, name, desc->remove_expr, &removed, false, true);
+#else
+        ecs_abort(ECS_UNSUPPORTED, "parser addon is not available");
+#endif
+    }
+
+    /* Commit entity to destination table */
+    if (src_table != table) {
+        commit(world, result, &info, table, &added, &removed);
+    }
+
+    /* Set name */
+    if (name && !name_assigned) {
+        ecs_add_path_w_sep(world, result, scope, name, sep, NULL);   
+    }
+
+    if (desc->symbol) {
+        EcsName *name_ptr = ecs_get_mut(world, result, EcsName, NULL);
+        if (name_ptr->symbol) {
+            ecs_assert(!ecs_os_strcmp(desc->symbol, name_ptr->symbol),
+                ECS_INCONSISTENT_NAME, desc->symbol);
+        } else {
+            name_ptr->symbol = ecs_os_strdup(desc->symbol);
+        }
+    }
+}
+
+/* When in deferred mode, we need to add/remove components one by one using
+ * the regular operations. */
+static 
+void deferred_add_remove(
+    ecs_world_t *world,
+    ecs_entity_t entity,
+    const char *name,
+    const ecs_entity_desc_t *desc,
+    ecs_entity_t scope,
+    ecs_id_t with,
+    bool new_entity,
+    bool name_assigned)
+{
+    const char *sep = desc->sep;
+
+    /* If this is a new entity without a name, add the scope. If a name is
+     * provided, the scope will be added by the add_path_w_sep function */
+    if (new_entity) {
+        if (new_entity && scope && !name && !name_assigned) {
+            ecs_add_id(world, entity, ecs_pair(EcsChildOf, scope));
+        }
+
+        if (with) {
+            ecs_add_id(world, entity, with);
+        }
+    }
+
+    /* Add components from the 'add' id array */
+    int32_t i = 0;
+    ecs_id_t id;
+    const ecs_id_t *ids = desc->add;
+    while ((i < ECS_MAX_ADD_REMOVE) && (id = ids[i ++])) {
+        ecs_add_id(world, entity, id);
+    }
+
+    /* Add components from the 'remove' id array */
+    i = 0;
+    ids = desc->remove;
+    while ((i < ECS_MAX_ADD_REMOVE) && (id = ids[i ++])) {
+        ecs_remove_id(world, entity, id);
+    }
+
+    /* Add components from the 'add_expr' expression */
+    if (desc->add_expr) {
+#ifdef FLECS_PARSER
+        defer_from_expr(world, entity, name, desc->add_expr, true, true);
+#else
+        ecs_abort(ECS_UNSUPPORTED, "parser addon is not available");
+#endif
+    }
+
+    /* Remove components from the 'remove_expr' expression */
+    if (desc->remove_expr) {
+#ifdef FLECS_PARSER
+        defer_from_expr(world, entity, name, desc->remove_expr, true, false);
+#else
+        ecs_abort(ECS_UNSUPPORTED, "parser addon is not available");
+#endif
+    }
+
+    /* Set name */
+    if (name && !name_assigned) {
+        ecs_add_path_w_sep(world, entity, scope, name, sep, NULL);   
+    }
+
+    /* Currently it's not supported to set the symbol from a deferred context */
+    if (desc->symbol) {
+        const EcsName *ptr = ecs_get(world, entity, EcsName);
+        (void)ptr;
+        
+        ecs_assert(ptr != NULL, ECS_UNSUPPORTED, NULL);
+        ecs_assert(!ecs_os_strcmp(ptr->symbol, desc->symbol), 
+            ECS_UNSUPPORTED, NULL);
+    }
+}
 
 ecs_entity_t ecs_entity_init(
     ecs_world_t *world,
@@ -6117,7 +6418,9 @@ ecs_entity_t ecs_entity_init(
     ecs_assert(world != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(desc != NULL, ECS_INTERNAL_ERROR, NULL);
 
+    ecs_stage_t *stage = ecs_stage_from_world(&world);
     ecs_entity_t scope = ecs_get_scope(world);
+    ecs_id_t with = ecs_get_with(world);
 
     const char *name = desc->name;
     const char *sep = desc->sep;
@@ -6185,99 +6488,13 @@ ecs_entity_t ecs_entity_init(
         }
     }
 
-    /* Find existing table */
-    ecs_entity_info_t info = {0};
-    ecs_table_t *src_table = NULL, *table = NULL;
-    if (!new_entity) {
-        if (ecs_get_info(world, result, &info)) {
-            table = info.table;
-        }
+    if (stage->defer) {
+        deferred_add_remove(world, result, name, desc, 
+            scope, with, new_entity, name_assigned);
+    } else {
+        traverse_add_remove(world, result, name, desc,
+            scope, with, new_entity, name_assigned);
     }
-
-    ecs_entity_t added_buffer[ECS_MAX_ADD_REMOVE];
-    ecs_entities_t added = { .array = added_buffer };
-
-    ecs_entity_t removed_buffer[ECS_MAX_ADD_REMOVE];
-    ecs_entities_t removed = { .array = removed_buffer };
-
-    /* Find destination table */
-
-    /* If this is a new entity without a name, add the scope. If a name is
-     * provided, the scope will be added by the add_path_w_sep function */
-    if (new_entity && scope && !name && !name_assigned) {
-        ecs_entity_t id = ecs_pair(EcsChildOf, scope);
-        ecs_entities_t arr = { .array = &id, .count = 1 };
-        table = ecs_table_traverse_add(world, table, &arr, &added);
-        ecs_assert(table != NULL, ECS_INVALID_PARAMETER, NULL);
-    }
-
-    /* If a name is provided but not yet assigned, add the Name component */
-    if (name && !name_assigned) {
-        ecs_entity_t id = ecs_id(EcsName);
-        ecs_entities_t arr = { .array = &id, .count = 1 };
-        table = ecs_table_traverse_add(world, table, &arr, &added);
-        ecs_assert(table != NULL, ECS_INVALID_PARAMETER, NULL);            
-    }
-
-    /* Add components from the 'add' id array */
-    int32_t i = 0;
-    ecs_id_t id;
-    const ecs_id_t *ids = desc->add;
-    while ((i < ECS_MAX_ADD_REMOVE) && (id = ids[i ++])) {
-        ecs_entities_t arr = { .array = &id, .count = 1 };
-        table = ecs_table_traverse_add(world, table, &arr, &added);
-        ecs_assert(table != NULL, ECS_INVALID_PARAMETER, NULL);
-    }
-
-    /* Add components from the 'remove' id array */
-    i = 0;
-    ids = desc->remove;
-    while ((i < ECS_MAX_ADD_REMOVE) && (id = ids[i])) {
-        ecs_entities_t arr = { .array = &id, .count = 1 };
-        table = ecs_table_traverse_remove(world, table, &arr, &removed);
-        ecs_assert(table != NULL, ECS_INVALID_PARAMETER, NULL);
-        i ++;
-    }
-
-    /* Add components from the 'add_expr' expression */
-    if (desc->add_expr) {
-#ifdef FLECS_PARSER
-        table = traverse_from_expr(
-            world, table, name, desc->add_expr, &added, true, true);
-#else
-        ecs_abort(ECS_UNSUPPORTED, "parser addon is not available");
-#endif
-    }
-
-    /* Remove components from the 'remove_expr' expression */
-    if (desc->remove_expr) {
-#ifdef FLECS_PARSER
-    table = traverse_from_expr(
-        world, table, name, desc->remove_expr, &removed, false, true);
-#else
-        ecs_abort(ECS_UNSUPPORTED, "parser addon is not available");
-#endif
-    }
-
-    /* Commit entity to destination table */
-    if (src_table != table) {
-        commit(world, result, &info, table, &added, &removed);
-    }
-
-    /* Set name */
-    if (name && !name_assigned) {
-        ecs_add_path_w_sep(world, result, scope, name, sep, NULL);   
-    }
-
-    if (desc->symbol) {
-        EcsName *name_ptr = ecs_get_mut(world, result, EcsName, NULL);
-        if (name_ptr->symbol) {
-            ecs_assert(!ecs_os_strcmp(desc->symbol, name_ptr->symbol),
-                ECS_INCONSISTENT_NAME, desc->symbol);
-        } else {
-            name_ptr->symbol = ecs_os_strdup(desc->symbol);
-        }
-    }    
 
     return result;
 }
@@ -7925,10 +8142,6 @@ bool ecs_defer_flush(
 
                 switch(op->kind) {
                 case EcsOpNew:
-                    if (op->scope) {
-                        ecs_add_pair(world, e, EcsChildOf, op->scope);
-                    }
-                    /* Fallthrough */
                 case EcsOpAdd:
                     if (valid_components(world, &op->components)) {
                         world->add_count ++;
@@ -8043,16 +8256,14 @@ bool defer_add_remove(
     ecs_entities_t *components)
 {
     if (stage->defer) {
-        ecs_entity_t scope = stage->scope;
         if (components) {
-            if (!components->count && !scope) {
+            if (!components->count) {
                 return true;
             }
         }
 
         ecs_op_t *op = new_defer_op(stage);
         op->kind = op_kind;
-        op->scope = scope;
         op->is._1.entity = entity;
 
         new_defer_component_ids(op, components);
@@ -14493,7 +14704,7 @@ ecs_world_t *ecs_mini(void) {
     world->stats.systems_ran_frame = 0;
     world->stats.pipeline_build_count_total = 0;
     
-    world->range_check_enabled = true;
+    world->range_check_enabled = false;
 
     world->fps_sleep = 0;
 

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -2602,6 +2602,29 @@ FLECS_API
 ecs_entity_t ecs_get_scope(
     const ecs_world_t *world);
 
+/** Set current with id.
+ * New entities are automatically created with the specified id.
+ *
+ * @param world The world.
+ * @param id The id.
+ * @return The previous id.
+ */
+FLECS_API
+ecs_entity_t ecs_set_with(
+    ecs_world_t *world,
+    ecs_id_t id);
+
+/** Get current with id.
+ * Get the id set with ecs_set_with.
+ *
+ * @param world The world.
+ * @param id The id.
+ * @return The previous id.
+ */
+FLECS_API
+ecs_entity_t ecs_get_with(
+    const ecs_world_t *world);
+
 /** Set a name prefix for newly created entities.
  * This is a utility that lets C modules use prefixed names for C types and
  * C functions, while using names for the entity names that do not have the 

--- a/include/flecs/addons/deprecated/entity.hpp
+++ b/include/flecs/addons/deprecated/entity.hpp
@@ -105,7 +105,7 @@ public:
         return *this;
     }
 
-    ECS_DEPRECATED("use add(flecs::ChildOf, parent)")
+    ECS_DEPRECATED("use child_of(parent)")
     const Base& add_childof(const Base& parent) const {
         ecs_add_id(this->base_world(), this->base_id(), ECS_CHILDOF | parent.id());
         return *this;          

--- a/include/flecs/addons/deprecated/type.hpp
+++ b/include/flecs/addons/deprecated/type.hpp
@@ -41,7 +41,7 @@ public:
         return static_cast<Base*>(this)->add(ECS_INSTANCEOF | e.id());
     }
 
-    ECS_DEPRECATED("use add(flecs::ChildOf, parent)")
+    ECS_DEPRECATED("use child_of(parent)")
     type& add_childof(const entity& e) {
         return static_cast<Base*>(this)->add(ECS_CHILDOF | e.id());
     }  

--- a/include/flecs/cpp/impl/world.hpp
+++ b/include/flecs/cpp/impl/world.hpp
@@ -96,6 +96,12 @@ inline int world::count(flecs::filter filter) const {
     return ecs_count_w_filter(m_world, filter.c_ptr());
 }
 
+/** All entities created in function are created in scope. All operations
+    * called in function (such as lookup) are relative to scope.
+    */
+template <typename Func>
+void scope(id_t parent, const Func& func);
+
 inline void world::init_builtin_components() {
     pod_component<Component>("flecs::core::Component");
     pod_component<Type>("flecs::core::Type");
@@ -132,8 +138,8 @@ inline void world::use(flecs::entity e, const char *alias) {
     ecs_use(m_world, eid, alias);
 }
 
-inline flecs::entity world::set_scope(const flecs::entity& scope) const {
-    return flecs::entity(ecs_set_scope(m_world, scope.id()));
+inline flecs::entity world::set_scope(const flecs::entity& s) const {
+    return flecs::entity(ecs_set_scope(m_world, s.id()));
 }
 
 inline flecs::entity world::get_scope() const {

--- a/include/flecs/cpp/module.hpp
+++ b/include/flecs/cpp/module.hpp
@@ -54,7 +54,7 @@ ecs_entity_t do_import(world& world, const char *symbol) {
 
     T* module_ptr = static_cast<T*>(
         ecs_get_mut_w_id( world.c_ptr(), m,
-            _::cpp_type<T>::id_no_lifecycle(world.c_ptr(), nullptr, false), 
+            _::cpp_type<T>::id_explicit(world.c_ptr(), nullptr, false), 
                 NULL));
 
     *module_ptr = std::move(*module_data);

--- a/include/flecs/cpp/type.hpp
+++ b/include/flecs/cpp/type.hpp
@@ -66,6 +66,10 @@ public:
         return this->add(flecs::IsA, object);
     }
 
+    type& child_of(entity_t object) {
+        return this->add(flecs::ChildOf, object);
+    }    
+
     template <typename Relation>
     type& add(entity_t object) {
         return this->add(_::cpp_type<Relation>::id(world().c_ptr()), object);

--- a/include/flecs/cpp/world.hpp
+++ b/include/flecs/cpp/world.hpp
@@ -693,6 +693,63 @@ public:
         ecs_unlock(m_world);
     }
 
+    /** All entities created in function are created with id.
+     */
+    template <typename Func>
+    void with(id_t with_id, const Func& func) const {
+        ecs_id_t prev = ecs_set_with(m_world, with_id);
+        func();
+        ecs_set_with(m_world, prev);    
+    }
+
+    /** All entities created in function are created with type.
+     */
+    template <typename T, typename Func>
+    void with(const Func& func) const {
+        with(this->id<T>(), func);
+    }
+
+    /** All entities created in function are created with relation.
+     */
+    template <typename Relation, typename Object, typename Func>
+    void with(const Func& func) const {
+        with(ecs_pair(this->id<Relation>(), this->id<Object>()), func);
+    }
+
+    /** All entities created in function are created with relation.
+     */
+    template <typename Relation, typename Func>
+    void with(id_t object, const Func& func) const {
+        with(ecs_pair(this->id<Relation>(), object), func);
+    } 
+
+    /** All entities created in function are created with relation.
+     */
+    template <typename Func>
+    void with(id_t relation, id_t object, const Func& func) const {
+        with(ecs_pair(relation, object), func);
+    }
+
+    /** All entities created in function are created in scope. All operations
+     * called in function (such as lookup) are relative to scope.
+     */
+    template <typename Func>
+    void scope(id_t parent, const Func& func) const {
+        ecs_entity_t prev = ecs_set_scope(m_world, parent);
+        func();
+        ecs_set_scope(m_world, prev);
+    }
+
+    /** Defer all operations called in function. If the world is already in
+     * deferred mode, do nothing.
+     */
+    template <typename Func>
+    void defer(const Func& func) const {
+        ecs_defer_begin(m_world);
+        func();
+        ecs_defer_end(m_world);
+    }
+
     /** Create a prefab.
      */
     template <typename... Args>

--- a/src/private_types.h
+++ b/src/private_types.h
@@ -368,8 +368,7 @@ typedef struct ecs_op_n_t {
 } ecs_op_n_t;
 
 typedef struct ecs_op_t {
-    ecs_op_kind_t kind;         /* Operation kind */
-    ecs_entity_t scope;         /* Scope of operation (for new) */       
+    ecs_op_kind_t kind;         /* Operation kind */    
     ecs_entity_t component;     /* Single component (components.count = 1) */
     ecs_entities_t components;  /* Multiple components */
     union {
@@ -401,6 +400,7 @@ struct ecs_stage_t {
     /* Namespacing */
     ecs_table_t *scope_table;      /* Table for current scope */
     ecs_entity_t scope;            /* Entity of current scope */
+    ecs_entity_t with;             /* Id to add by default to new entities */
 
     /* Properties */
     bool auto_merge;               /* Should this stage automatically merge? */

--- a/src/stage.c
+++ b/src/stage.c
@@ -40,16 +40,14 @@ bool defer_add_remove(
     ecs_entities_t *components)
 {
     if (stage->defer) {
-        ecs_entity_t scope = stage->scope;
         if (components) {
-            if (!components->count && !scope) {
+            if (!components->count) {
                 return true;
             }
         }
 
         ecs_op_t *op = new_defer_op(stage);
         op->kind = op_kind;
-        op->scope = scope;
         op->is._1.entity = entity;
 
         new_defer_component_ids(op, components);

--- a/test/api/project.json
+++ b/test/api/project.json
@@ -50,7 +50,11 @@
                     "find_id_remove_1_comp",
                     "find_id_remove_2_comp",
                     "init_w_scope_name",
-                    "init_w_core_name"
+                    "init_w_core_name",
+                    "init_w_with",
+                    "init_w_with_w_name",
+                    "init_w_with_w_scope",
+                    "init_w_with_w_name_scope"
                 ]
             }, {
             "id": "New",
@@ -79,7 +83,17 @@
                 "new_component_id_skip_used",
                 "new_component_id_skip_to_hi_id",
                 "new_w_entity_0",
-                "create_w_explicit_id_2_worlds"
+                "create_w_explicit_id_2_worlds",
+                "new_w_id_0_w_with",
+                "new_w_id_w_with",
+                "new_w_type_0_w_with",
+                "new_w_type_w_with",
+                "new_w_id_w_with_w_scope",
+                "new_w_type_w_with_w_scope",
+                "new_w_id_w_with_defer",
+                "new_w_id_w_with_defer_w_scope",
+                "new_w_type_w_with_defer",
+                "new_w_type_w_with_defer_w_scope"
             ]
         }, {
             "id": "New_w_Count",

--- a/test/api/src/Entity.c
+++ b/test/api/src/Entity.c
@@ -802,3 +802,85 @@ void Entity_init_w_core_name() {
 
     ecs_fini(world);
 }
+
+void Entity_init_w_with() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, Tag);
+
+    ecs_set_with(world, Tag);
+
+    ecs_entity_t e = ecs_entity_init(world, &(ecs_entity_desc_t){ });
+    test_assert(e != 0);
+    test_assert(ecs_has_id(world, e, Tag));
+
+    test_int(ecs_set_with(world, 0), Tag);
+
+    ecs_fini(world);
+}
+
+void Entity_init_w_with_w_name() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, Tag);
+
+    ecs_set_with(world, Tag);
+
+    ecs_entity_t e = ecs_entity_init(world, &(ecs_entity_desc_t){ 
+        .name = "foo"
+    });
+
+    test_assert(e != 0);
+    test_assert(ecs_has_id(world, e, Tag));
+    test_str(ecs_get_name(world, e), "foo");
+
+    test_int(ecs_set_with(world, 0), Tag);
+
+    ecs_fini(world);
+}
+
+void Entity_init_w_with_w_scope() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, Tag);
+
+    ecs_entity_t parent = ecs_new_id(world);
+
+    ecs_set_with(world, Tag);
+    ecs_set_scope(world, parent);
+
+    ecs_entity_t e = ecs_entity_init(world, &(ecs_entity_desc_t){ });
+    test_assert(e != 0);
+    test_assert(ecs_has_id(world, e, Tag));
+    test_assert(ecs_has_id(world, e, ecs_pair(EcsChildOf, parent)));
+
+    test_int(ecs_set_with(world, 0), Tag);
+    test_int(ecs_set_scope(world, 0), parent);
+
+    ecs_fini(world);
+}
+
+void Entity_init_w_with_w_name_scope() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, Tag);
+
+    ecs_entity_t parent = ecs_new_id(world);
+
+    ecs_set_with(world, Tag);
+    ecs_set_scope(world, parent);
+
+    ecs_entity_t e = ecs_entity_init(world, &(ecs_entity_desc_t){
+        .name = "foo"
+    });
+
+    test_assert(e != 0);
+    test_assert(ecs_has_id(world, e, Tag));
+    test_assert(ecs_has_id(world, e, ecs_pair(EcsChildOf, parent)));
+    test_str(ecs_get_name(world, e), "foo");
+
+    test_int(ecs_set_with(world, 0), Tag);
+    test_int(ecs_set_scope(world, 0), parent);
+
+    ecs_fini(world);
+}

--- a/test/api/src/New.c
+++ b/test/api/src/New.c
@@ -389,3 +389,233 @@ void New_create_w_explicit_id_2_worlds() {
     ecs_fini(world_1);
     ecs_fini(world_2);
 }
+
+void New_new_w_id_0_w_with() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, Tag);
+
+    ecs_set_with(world, Tag);
+
+    ecs_entity_t e = ecs_new_w_id(world, 0);
+    test_assert(e != 0);
+    test_assert(ecs_has(world, e, Tag));
+
+    test_int(ecs_set_with(world, 0), Tag);
+
+    ecs_fini(world);
+}
+
+void New_new_w_id_w_with() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, Tag);
+    ECS_TAG(world, Tag2);
+
+    ecs_set_with(world, Tag);
+
+    ecs_entity_t e = ecs_new_w_id(world, Tag2);
+    test_assert(e != 0);
+    test_assert(ecs_has(world, e, Tag));
+    test_assert(ecs_has(world, e, Tag2));
+
+    test_int(ecs_set_with(world, 0), Tag);
+
+    ecs_fini(world);
+}
+
+void New_new_w_id_w_with_w_scope() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, Tag);
+    ECS_TAG(world, Tag2);
+
+    ecs_set_with(world, Tag);
+
+    ecs_entity_t parent = ecs_new_id(world);
+    ecs_set_scope(world, parent);
+
+    ecs_entity_t e = ecs_new_w_id(world, Tag2);
+    test_assert(e != 0);
+    test_assert(ecs_has(world, e, Tag));
+    test_assert(ecs_has(world, e, Tag2));
+    test_assert(ecs_has_pair(world, e, EcsChildOf, parent));
+
+    test_int(ecs_set_with(world, 0), Tag);
+    test_int(ecs_set_scope(world, 0), parent);
+
+    ecs_fini(world);
+}
+
+void New_new_w_id_w_with_defer() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, Tag);
+    ECS_TAG(world, Tag2);
+
+    ecs_set_with(world, Tag);
+
+    ecs_defer_begin(world);
+
+    ecs_entity_t e = ecs_new_w_id(world, Tag2);
+    test_assert(e != 0);
+    
+    test_assert(!ecs_has(world, e, Tag));
+    test_assert(!ecs_has(world, e, Tag2));
+
+    ecs_defer_end(world);
+
+    test_assert(ecs_has(world, e, Tag));
+    test_assert(ecs_has(world, e, Tag2));
+
+    test_int(ecs_set_with(world, 0), Tag);
+
+    ecs_fini(world);
+}
+
+void New_new_w_id_w_with_defer_w_scope() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, Tag);
+    ECS_TAG(world, Tag2);
+
+    ecs_set_with(world, Tag);
+
+    ecs_entity_t parent = ecs_new_id(world);
+    ecs_set_scope(world, parent);
+
+    ecs_defer_begin(world);
+
+    ecs_entity_t e = ecs_new_w_id(world, Tag2);
+    test_assert(e != 0);
+
+    test_assert(!ecs_has(world, e, Tag));
+    test_assert(!ecs_has(world, e, Tag2));
+    test_assert(!ecs_has_pair(world, e, EcsChildOf, parent));
+
+    ecs_defer_end(world);
+
+    test_assert(ecs_has(world, e, Tag));
+    test_assert(ecs_has(world, e, Tag2));
+    test_assert(ecs_has_pair(world, e, EcsChildOf, parent));
+
+    test_int(ecs_set_with(world, 0), Tag);
+    test_int(ecs_set_scope(world, 0), parent);
+
+    ecs_fini(world);
+}
+
+void New_new_w_type_0_w_with() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, Tag);
+
+    ecs_set_with(world, Tag);
+
+    ecs_entity_t e = ecs_new(world, 0);
+    test_assert(e != 0);
+    test_assert(ecs_has(world, e, Tag));
+
+    test_int(ecs_set_with(world, 0), Tag);
+
+    ecs_fini(world);
+}
+
+void New_new_w_type_w_with() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, Tag);
+    ECS_COMPONENT(world, Position);
+
+    ecs_set_with(world, Tag);
+
+    ecs_entity_t e = ecs_new(world, Position);
+    test_assert(e != 0);
+    test_assert(ecs_has(world, e, Tag));
+    test_assert(ecs_has(world, e, Position));
+
+    test_int(ecs_set_with(world, 0), Tag);
+
+    ecs_fini(world);
+}
+
+void New_new_w_type_w_with_w_scope() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, Tag);
+    ECS_COMPONENT(world, Position);
+
+    ecs_set_with(world, Tag);
+
+    ecs_entity_t parent = ecs_new_id(world);
+    ecs_set_scope(world, parent);
+
+    ecs_entity_t e = ecs_new(world, Position);
+    test_assert(e != 0);
+    test_assert(ecs_has(world, e, Tag));
+    test_assert(ecs_has(world, e, Position));
+    test_assert(ecs_has_pair(world, e, EcsChildOf, parent));
+
+    test_int(ecs_set_with(world, 0), Tag);
+    test_int(ecs_set_scope(world, 0), parent);
+
+    ecs_fini(world);
+}
+
+void New_new_w_type_w_with_defer() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, Tag);
+    ECS_COMPONENT(world, Position);
+
+    ecs_set_with(world, Tag);
+
+    ecs_defer_begin(world);
+
+    ecs_entity_t e = ecs_new(world, Position);
+    test_assert(e != 0);
+    
+    test_assert(!ecs_has(world, e, Tag));
+    test_assert(!ecs_has(world, e, Position));
+
+    ecs_defer_end(world);
+
+    test_assert(ecs_has(world, e, Tag));
+    test_assert(ecs_has(world, e, Position));
+
+    test_int(ecs_set_with(world, 0), Tag);
+
+    ecs_fini(world);
+}
+
+void New_new_w_type_w_with_defer_w_scope() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, Tag);
+    ECS_COMPONENT(world, Position);
+
+    ecs_set_with(world, Tag);
+
+    ecs_entity_t parent = ecs_new_id(world);
+    ecs_set_scope(world, parent);
+
+    ecs_defer_begin(world);
+
+    ecs_entity_t e = ecs_new(world, Position);
+    test_assert(e != 0);
+
+    test_assert(!ecs_has(world, e, Tag));
+    test_assert(!ecs_has(world, e, Position));
+    test_assert(!ecs_has_pair(world, e, EcsChildOf, parent));
+
+    ecs_defer_end(world);
+
+    test_assert(ecs_has(world, e, Tag));
+    test_assert(ecs_has(world, e, Position));
+    test_assert(ecs_has_pair(world, e, EcsChildOf, parent));
+
+    test_int(ecs_set_with(world, 0), Tag);
+    test_int(ecs_set_scope(world, 0), parent);
+
+    ecs_fini(world);
+}

--- a/test/api/src/main.c
+++ b/test/api/src/main.c
@@ -44,6 +44,10 @@ void Entity_find_id_remove_1_comp(void);
 void Entity_find_id_remove_2_comp(void);
 void Entity_init_w_scope_name(void);
 void Entity_init_w_core_name(void);
+void Entity_init_w_with(void);
+void Entity_init_w_with_w_name(void);
+void Entity_init_w_with_w_scope(void);
+void Entity_init_w_with_w_name_scope(void);
 
 // Testsuite 'New'
 void New_setup(void);
@@ -71,6 +75,16 @@ void New_new_component_id_skip_used(void);
 void New_new_component_id_skip_to_hi_id(void);
 void New_new_w_entity_0(void);
 void New_create_w_explicit_id_2_worlds(void);
+void New_new_w_id_0_w_with(void);
+void New_new_w_id_w_with(void);
+void New_new_w_type_0_w_with(void);
+void New_new_w_type_w_with(void);
+void New_new_w_id_w_with_w_scope(void);
+void New_new_w_type_w_with_w_scope(void);
+void New_new_w_id_w_with_defer(void);
+void New_new_w_id_w_with_defer_w_scope(void);
+void New_new_w_type_w_with_defer(void);
+void New_new_w_type_w_with_defer_w_scope(void);
 
 // Testsuite 'New_w_Count'
 void New_w_Count_empty(void);
@@ -1959,6 +1973,22 @@ bake_test_case Entity_testcases[] = {
     {
         "init_w_core_name",
         Entity_init_w_core_name
+    },
+    {
+        "init_w_with",
+        Entity_init_w_with
+    },
+    {
+        "init_w_with_w_name",
+        Entity_init_w_with_w_name
+    },
+    {
+        "init_w_with_w_scope",
+        Entity_init_w_with_w_scope
+    },
+    {
+        "init_w_with_w_name_scope",
+        Entity_init_w_with_w_name_scope
     }
 };
 
@@ -2058,6 +2088,46 @@ bake_test_case New_testcases[] = {
     {
         "create_w_explicit_id_2_worlds",
         New_create_w_explicit_id_2_worlds
+    },
+    {
+        "new_w_id_0_w_with",
+        New_new_w_id_0_w_with
+    },
+    {
+        "new_w_id_w_with",
+        New_new_w_id_w_with
+    },
+    {
+        "new_w_type_0_w_with",
+        New_new_w_type_0_w_with
+    },
+    {
+        "new_w_type_w_with",
+        New_new_w_type_w_with
+    },
+    {
+        "new_w_id_w_with_w_scope",
+        New_new_w_id_w_with_w_scope
+    },
+    {
+        "new_w_type_w_with_w_scope",
+        New_new_w_type_w_with_w_scope
+    },
+    {
+        "new_w_id_w_with_defer",
+        New_new_w_id_w_with_defer
+    },
+    {
+        "new_w_id_w_with_defer_w_scope",
+        New_new_w_id_w_with_defer_w_scope
+    },
+    {
+        "new_w_type_w_with_defer",
+        New_new_w_type_w_with_defer
+    },
+    {
+        "new_w_type_w_with_defer_w_scope",
+        New_new_w_type_w_with_defer_w_scope
     }
 };
 
@@ -8652,14 +8722,14 @@ static bake_test_suite suites[] = {
         "Entity",
         NULL,
         NULL,
-        35,
+        39,
         Entity_testcases
     },
     {
         "New",
         New_setup,
         NULL,
-        24,
+        34,
         New_testcases
     },
     {

--- a/test/cpp_api/project.json
+++ b/test/cpp_api/project.json
@@ -94,7 +94,29 @@
                 "set_2_after_fluent",
                 "set_2_before_fluent",
                 "set_2_after_set_1",
-                "set_2_after_set_2"
+                "set_2_after_set_2",
+                "with_self",
+                "with_relation_type_self",
+                "with_relation_self",
+                "with_self_w_name",
+                "with_self_nested",
+                "with_after_builder_method",
+                "with_before_builder_method",
+                "with_scope",
+                "with_scope_nested",
+                "with_scope_nested_same_name_as_parent",
+                "scope_after_builder_method",
+                "scope_before_builder_method",                
+                "no_recursive_lookup",
+                "defer_new_w_name",
+                "defer_new_w_nested_name",
+                "defer_new_w_scope_name",
+                "defer_new_w_scope_nested_name",
+                "defer_new_w_deferred_scope_nested_name",
+                "defer_new_w_scope",
+                "defer_new_w_with",
+                "defer_new_w_name_scope_with",
+                "defer_w_with_implicit_component"
             ]
         }, {
             "id": "Pairs",
@@ -131,7 +153,9 @@
                 "each_pair_by_type",
                 "each_pair_w_childof",
                 "each_pair_w_recycled_rel",
-                "each_pair_w_recycled_obj"
+                "each_pair_w_recycled_obj",
+                "has_tag_w_object",
+                "has_object_tag"
             ]
         }, {
             "id": "Switch",
@@ -453,7 +477,16 @@
                 "implicit_register_w_new_world",
                 "count",
                 "staged_count",
-                "async_stage_add"
+                "async_stage_add",
+                "with_tag",
+                "with_tag_type",
+                "with_relation",
+                "with_relation_type",
+                "with_relation_object_type",
+                "with_tag_nested",
+                "with_scope",
+                "with_scope_nested",
+                "recursive_lookup"
             ]
         }, {
             "id": "Singleton",

--- a/test/cpp_api/src/Pairs.cpp
+++ b/test/cpp_api/src/Pairs.cpp
@@ -631,8 +631,8 @@ void Pairs_each_pair_w_childof() {
     auto p_2 = world.entity();
 
     auto e = world.entity()
-        .add(flecs::ChildOf, p_1)
-        .add(flecs::ChildOf, p_2);
+        .child_of(p_1)
+        .child_of(p_2);
 
     int32_t count = 0;
 
@@ -718,4 +718,24 @@ void Pairs_each_pair_w_recycled_obj() {
     });
 
     test_int(count, 2);
+}
+
+void Pairs_has_tag_w_object() {
+    flecs::world world;
+
+    struct Likes { };
+
+    auto Bob = world.entity();
+    auto e = world.entity().add<Likes>(Bob);
+    test_assert(e.has<Likes>(Bob));
+}
+
+void Pairs_has_object_tag() {
+    flecs::world world;
+
+    struct Bob { };
+
+    auto Likes = world.entity();
+    auto e = world.entity().add_object<Bob>(Likes);
+    test_assert(e.has_object<Bob>(Likes));
 }

--- a/test/cpp_api/src/QueryBuilder.cpp
+++ b/test/cpp_api/src/QueryBuilder.cpp
@@ -462,9 +462,9 @@ void QueryBuilder_childof_superset_term() {
     auto base = ecs.entity().set<Other>({10});
 
     auto 
-    e = ecs.entity().add(flecs::ChildOf, base); e.set<Self>({e});
-    e = ecs.entity().add(flecs::ChildOf, base); e.set<Self>({e});
-    e = ecs.entity().add(flecs::ChildOf, base); e.set<Self>({e});
+    e = ecs.entity().child_of(base); e.set<Self>({e});
+    e = ecs.entity().child_of(base); e.set<Self>({e});
+    e = ecs.entity().child_of(base); e.set<Self>({e});
 
     int32_t count = 0;
 
@@ -492,9 +492,9 @@ void QueryBuilder_childof_self_superset_term() {
     auto base = ecs.entity().set<Other>({10});
 
     auto 
-    e = ecs.entity().add(flecs::ChildOf, base); e.set<Self>({e});
-    e = ecs.entity().add(flecs::ChildOf, base); e.set<Self>({e});
-    e = ecs.entity().add(flecs::ChildOf, base); e.set<Self>({e});
+    e = ecs.entity().child_of(base); e.set<Self>({e});
+    e = ecs.entity().child_of(base); e.set<Self>({e});
+    e = ecs.entity().child_of(base); e.set<Self>({e});
     e = ecs.entity().set<Other>({20}); e.set<Self>({e});
     e = ecs.entity().set<Other>({20}); e.set<Self>({e});
 
@@ -585,9 +585,9 @@ void QueryBuilder_childof_superset_term_w_each() {
     auto base = ecs.entity().set<Other>({10});
 
     auto 
-    e = ecs.entity().add(flecs::ChildOf, base); e.set<Self>({e});
-    e = ecs.entity().add(flecs::ChildOf, base); e.set<Self>({e});
-    e = ecs.entity().add(flecs::ChildOf, base); e.set<Self>({e});
+    e = ecs.entity().child_of(base); e.set<Self>({e});
+    e = ecs.entity().child_of(base); e.set<Self>({e});
+    e = ecs.entity().child_of(base); e.set<Self>({e});
 
     int32_t count = 0;
 
@@ -610,9 +610,9 @@ void QueryBuilder_childof_self_superset_term_w_each() {
     auto base = ecs.entity().set<Other>({10});
 
     auto 
-    e = ecs.entity().add(flecs::ChildOf, base); e.set<Self>({e});
-    e = ecs.entity().add(flecs::ChildOf, base); e.set<Self>({e});
-    e = ecs.entity().add(flecs::ChildOf, base); e.set<Self>({e});
+    e = ecs.entity().child_of(base); e.set<Self>({e});
+    e = ecs.entity().child_of(base); e.set<Self>({e});
+    e = ecs.entity().child_of(base); e.set<Self>({e});
     e = ecs.entity().set<Other>({10}); e.set<Self>({e});
     e = ecs.entity().set<Other>({10}); e.set<Self>({e});
 
@@ -689,9 +689,9 @@ void QueryBuilder_childof_superset_shortcut() {
     auto base = ecs.entity().set<Other>({10});
 
     auto 
-    e = ecs.entity().add(flecs::ChildOf, base); e.set<Self>({e});
-    e = ecs.entity().add(flecs::ChildOf, base); e.set<Self>({e});
-    e = ecs.entity().add(flecs::ChildOf, base); e.set<Self>({e});
+    e = ecs.entity().child_of(base); e.set<Self>({e});
+    e = ecs.entity().child_of(base); e.set<Self>({e});
+    e = ecs.entity().child_of(base); e.set<Self>({e});
 
     int32_t count = 0;
 
@@ -714,9 +714,9 @@ void QueryBuilder_childof_superset_shortcut_w_self() {
     auto base = ecs.entity().set<Other>({10});
 
     auto 
-    e = ecs.entity().add(flecs::ChildOf, base); e.set<Self>({e});
-    e = ecs.entity().add(flecs::ChildOf, base); e.set<Self>({e});
-    e = ecs.entity().add(flecs::ChildOf, base); e.set<Self>({e});
+    e = ecs.entity().child_of(base); e.set<Self>({e});
+    e = ecs.entity().child_of(base); e.set<Self>({e});
+    e = ecs.entity().child_of(base); e.set<Self>({e});
     e = ecs.entity().set<Other>({10}); e.set<Self>({e});
     e = ecs.entity().set<Other>({10}); e.set<Self>({e});
 

--- a/test/cpp_api/src/System.cpp
+++ b/test/cpp_api/src/System.cpp
@@ -953,9 +953,9 @@ void System_each_w_mut_children_it() {
     flecs::world world;
 
     auto parent = world.entity().set<Position>({0, 0});
-    auto e1 = world.entity().set<Position>({0, 0}).add(flecs::ChildOf, parent);
-    auto e2 = world.entity().set<Position>({0, 0}).add(flecs::ChildOf, parent);
-    auto e3 = world.entity().set<Position>({0, 0}).add(flecs::ChildOf, parent);
+    auto e1 = world.entity().set<Position>({0, 0}).child_of(parent);
+    auto e2 = world.entity().set<Position>({0, 0}).child_of(parent);
+    auto e3 = world.entity().set<Position>({0, 0}).child_of(parent);
 
     world.system<const Position>()
         .iter([](const flecs::iter& it, const Position* p) {
@@ -980,9 +980,9 @@ void System_readonly_children_iter() {
 
     auto parent = world.entity();
     world.entity().set<Entity>({ parent });
-    world.entity().set<Position>({1, 0}).add(flecs::ChildOf, parent);
-    world.entity().set<Position>({1, 0}).add(flecs::ChildOf, parent);
-    world.entity().set<Position>({1, 0}).add(flecs::ChildOf, parent);
+    world.entity().set<Position>({1, 0}).child_of(parent);
+    world.entity().set<Position>({1, 0}).child_of(parent);
+    world.entity().set<Position>({1, 0}).child_of(parent);
 
     world.system<const Entity>()
         .iter([](const flecs::iter& it, const Entity* c) {

--- a/test/cpp_api/src/Type.cpp
+++ b/test/cpp_api/src/Type.cpp
@@ -37,7 +37,7 @@ void Type_add_childof() {
 
     auto parent = flecs::entity(world);
     auto type = flecs::type(world)
-        .add(flecs::ChildOf, parent);
+        .child_of(parent);
 
     auto entity = flecs::entity(world);
     test_assert(entity.id() != 0);

--- a/test/cpp_api/src/World.cpp
+++ b/test/cpp_api/src/World.cpp
@@ -145,47 +145,47 @@ void World_multi_world_module() {
 
 
 void World_type_id() {
-    flecs::world w;
+    flecs::world ecs;
 
-    auto p = w.component<Position>();
+    auto p = ecs.component<Position>();
 
     test_assert(p.id() == flecs::type_id<Position>());
 }
 
 void World_different_comp_same_name() {
-    flecs::world w;
+    flecs::world ecs;
 
     install_test_abort();
     test_expect_abort();
 
-    w.component<Position>("Position");
-    w.component<Velocity>("Position");
+    ecs.component<Position>("Position");
+    ecs.component<Velocity>("Position");
 }
 
 void World_reregister_after_reset() {
-    flecs::world w;
+    flecs::world ecs;
 
-    auto p1 = w.component<Position>("Position");
+    auto p1 = ecs.component<Position>("Position");
 
     // Simulate different binary
     flecs::_::cpp_type<Position>::reset();
 
-    auto p2 = w.component<Position>("Position");
+    auto p2 = ecs.component<Position>("Position");
 
     test_assert(p1.id() == p2.id());
 }
 
 void World_implicit_reregister_after_reset() {
-    flecs::world w;
+    flecs::world ecs;
 
-    w.entity().add<Position>();
+    ecs.entity().add<Position>();
 
     flecs::entity_t p_id_1 = flecs::type_id<Position>();
 
     // Simulate different binary
     flecs::_::cpp_type<Position>::reset();
 
-    w.entity().add<Position>();
+    ecs.entity().add<Position>();
 
     flecs::entity_t p_id_2 = flecs::type_id<Position>();
 
@@ -193,16 +193,16 @@ void World_implicit_reregister_after_reset() {
 }
 
 void World_reregister_after_reset_w_namespace() {
-    flecs::world w;
+    flecs::world ecs;
 
-    w.component<ns::FooComp>();
+    ecs.component<ns::FooComp>();
 
     flecs::entity_t p_id_1 = flecs::type_id<ns::FooComp>();
 
     // Simulate different binary
     flecs::_::cpp_type<ns::FooComp>::reset();
 
-    w.component<ns::FooComp>();
+    ecs.component<ns::FooComp>();
 
     flecs::entity_t p_id_2 = flecs::type_id<ns::FooComp>();
 
@@ -210,13 +210,13 @@ void World_reregister_after_reset_w_namespace() {
 }
 
 void World_reregister_namespace() {
-    flecs::world w;
+    flecs::world ecs;
 
-    w.component<ns::FooComp>();
+    ecs.component<ns::FooComp>();
 
     flecs::entity_t p_id_1 = flecs::type_id<ns::FooComp>();
 
-    w.component<ns::FooComp>();
+    ecs.component<ns::FooComp>();
 
     flecs::entity_t p_id_2 = flecs::type_id<ns::FooComp>();
 
@@ -224,38 +224,38 @@ void World_reregister_namespace() {
 }
 
 void World_reregister_after_reset_different_name() {
-    flecs::world w;
+    flecs::world ecs;
 
     install_test_abort();
     test_expect_abort();    
 
-    w.component<Position>("Position");
+    ecs.component<Position>("Position");
 
     // Simulate different binary
     flecs::_::cpp_type<Position>::reset();
 
-    w.component<Position>("Velocity");
+    ecs.component<Position>("Velocity");
 }
 
 void World_reimport() {
-    flecs::world w;
+    flecs::world ecs;
 
-    auto m1 = w.import<FooModule>();
+    auto m1 = ecs.import<FooModule>();
 
-    auto m2 = w.import<FooModule>();
+    auto m2 = ecs.import<FooModule>();
     
     test_assert(m1.id() == m2.id());
 }
 
 void World_reimport_module_after_reset() {
-    flecs::world w;
+    flecs::world ecs;
 
-    auto m1 = w.import<FooModule>();
+    auto m1 = ecs.import<FooModule>();
 
     // Simulate different binary
     flecs::_::cpp_type<FooModule>::reset();
 
-    auto m2 = w.import<FooModule>();
+    auto m2 = ecs.import<FooModule>();
     
     test_assert(m1.id() == m2.id());
 }
@@ -263,15 +263,15 @@ void World_reimport_module_after_reset() {
 void World_reimport_module_new_world() {
     flecs::entity e1;
     {
-        flecs::world w;
+        flecs::world ecs;
 
-        e1 = w.import<FooModule>();
+        e1 = ecs.import<FooModule>();
     }
 
     {
-        flecs::world w;
+        flecs::world ecs;
 
-        auto e2 = w.import<FooModule>();
+        auto e2 = ecs.import<FooModule>();
         
         test_assert(e1.id() == e2.id());
     }
@@ -295,32 +295,32 @@ void World_reimport_namespaced_module() {
 
 
 void World_c_interop_module() {
-    flecs::world w;
+    flecs::world ecs;
 
-    w.import<test::interop::module>();
+    ecs.import<test::interop::module>();
 
-    auto e_pos = w.lookup("test::interop::module::Position");
+    auto e_pos = ecs.lookup("test::interop::module::Position");
     test_assert(e_pos.id() != 0);
 }
 
 void World_c_interop_after_reset() {
-    flecs::world w;
+    flecs::world ecs;
 
-    w.import<test::interop::module>();
+    ecs.import<test::interop::module>();
 
-    auto e_pos = w.lookup("test::interop::module::Position");
+    auto e_pos = ecs.lookup("test::interop::module::Position");
     test_assert(e_pos.id() != 0);
 
     flecs::_::cpp_type<test::interop::module>::reset();
 
-    w.import<test::interop::module>();
+    ecs.import<test::interop::module>();
 }
 
 void World_implicit_register_w_new_world() {
     {
-        flecs::world w;
+        flecs::world ecs;
 
-        auto e = w.entity().set<Position>({10, 20});
+        auto e = ecs.entity().set<Position>({10, 20});
         test_assert(e.has<Position>());
         auto *p = e.get<Position>();
         test_assert(p != NULL);
@@ -330,9 +330,9 @@ void World_implicit_register_w_new_world() {
 
     {
         /* Recreate world, does not reset static state */
-        flecs::world w;
+        flecs::world ecs;
 
-        auto e = w.entity().set<Position>({10, 20});
+        auto e = ecs.entity().set<Position>({10, 20});
         test_assert(e.has<Position>());
         auto *p = e.get<Position>();
         test_assert(p != NULL);
@@ -342,32 +342,32 @@ void World_implicit_register_w_new_world() {
 }
 
 void World_count() {
-    flecs::world w;
+    flecs::world ecs;
 
-    test_int(w.count<Position>(), 0);
+    test_int(ecs.count<Position>(), 0);
 
-    w.entity().add<Position>();
-    w.entity().add<Position>();
-    w.entity().add<Position>();
-    w.entity().add<Position>().add<Mass>();
-    w.entity().add<Position>().add<Mass>();
-    w.entity().add<Position>().add<Velocity>();
+    ecs.entity().add<Position>();
+    ecs.entity().add<Position>();
+    ecs.entity().add<Position>();
+    ecs.entity().add<Position>().add<Mass>();
+    ecs.entity().add<Position>().add<Mass>();
+    ecs.entity().add<Position>().add<Velocity>();
 
-    test_int(w.count<Position>(), 6);
+    test_int(ecs.count<Position>(), 6);
 }
 
 void World_staged_count() {
-    flecs::world w;
+    flecs::world ecs;
 
-    flecs::world stage = w.get_stage(0);
+    flecs::world stage = ecs.get_stage(0);
 
-    w.staging_begin();
+    ecs.staging_begin();
 
     test_int(stage.count<Position>(), 0);
 
-    w.staging_end();
+    ecs.staging_end();
 
-    w.staging_begin();
+    ecs.staging_begin();
 
     stage.entity().add<Position>();
     stage.entity().add<Position>();
@@ -378,21 +378,315 @@ void World_staged_count() {
 
     test_int(stage.count<Position>(), 0);
 
-    w.staging_end();
+    ecs.staging_end();
 
     test_int(stage.count<Position>(), 6);
 }
 
 void World_async_stage_add() {
-    flecs::world w;
+    flecs::world ecs;
 
-    w.component<Position>();
+    ecs.component<Position>();
 
-    auto e = w.entity();
+    auto e = ecs.entity();
 
-    flecs::world async = w.async_stage();
+    flecs::world async = ecs.async_stage();
     e.mut(async).add<Position>();
     test_assert(!e.has<Position>());
     async.merge();
     test_assert(e.has<Position>());
+}
+
+void World_with_tag() {
+    flecs::world ecs;
+
+    auto Tag = ecs.entity();
+
+    ecs.with(Tag, [&]{
+        auto e1 = ecs.entity(); e1.set<Self>({e1});
+        auto e2 = ecs.entity(); e2.set<Self>({e2});
+        auto e3 = ecs.entity(); e3.set<Self>({e3});
+    });
+
+    // Ensures that while Self is (implicitly) registered within the with, it
+    // does not get any contents from the with.
+    auto self = ecs.component<Self>();
+    test_assert(!self.has(Tag));    
+
+    auto q = ecs.query_builder<>().term(Tag).build();
+
+    int32_t count = 0;
+
+    q.each([&](flecs::entity e) {
+        test_assert(e.has(Tag));
+
+        test_bool(e.get([&](const Self& s) {
+            test_assert(s.value == e);
+        }), true);
+
+        count ++;
+    });
+
+    count ++;
+}
+
+void World_with_tag_type() {
+    flecs::world ecs;
+
+    struct Tag { };
+
+    ecs.with<Tag>([&]{
+        auto e1 = ecs.entity(); e1.set<Self>({e1});
+        auto e2 = ecs.entity(); e2.set<Self>({e2});
+        auto e3 = ecs.entity(); e3.set<Self>({e3});
+    });
+
+    // Ensures that while Self is (implicitly) registered within the with, it
+    // does not get any contents from the with.
+    auto self = ecs.component<Self>();
+    test_assert(!self.has<Tag>());
+
+    auto q = ecs.query_builder<>().term<Tag>().build();
+
+    int32_t count = 0;
+
+    q.each([&](flecs::entity e) {
+        test_assert(e.has<Tag>());
+
+        test_bool(e.get([&](const Self& s) {
+            test_assert(s.value == e);
+        }), true);
+
+        count ++;
+    });
+
+    count ++;
+}
+
+void World_with_relation() {
+    flecs::world ecs;
+
+    auto Likes = ecs.entity();
+    auto Bob = ecs.entity();
+
+    ecs.with(Likes, Bob, [&]{
+        auto e1 = ecs.entity(); e1.set<Self>({e1});
+        auto e2 = ecs.entity(); e2.set<Self>({e2});
+        auto e3 = ecs.entity(); e3.set<Self>({e3});
+    });
+
+    // Ensures that while Self is (implicitly) registered within the with, it
+    // does not get any contents from the with.
+    auto self = ecs.component<Self>();
+    test_assert(!self.has(Likes, Bob));
+
+    auto q = ecs.query_builder<>().term(Likes, Bob).build();
+
+    int32_t count = 0;
+
+    q.each([&](flecs::entity e) {
+        test_assert(e.has(Likes, Bob));
+
+        test_bool(e.get([&](const Self& s) {
+            test_assert(s.value == e);
+        }), true);
+
+        count ++;
+    });
+
+    count ++;
+}
+
+void World_with_relation_type() {
+    flecs::world ecs;
+
+    struct Likes { };
+    auto Bob = ecs.entity();
+
+    ecs.with<Likes>(Bob, [&]{
+        auto e1 = ecs.entity(); e1.set<Self>({e1});
+        auto e2 = ecs.entity(); e2.set<Self>({e2});
+        auto e3 = ecs.entity(); e3.set<Self>({e3});
+    });
+
+    // Ensures that while Self is (implicitly) registered within the with, it
+    // does not get any contents from the with.
+    auto self = ecs.component<Self>();
+    test_assert(!self.has<Likes>(Bob));
+
+    auto q = ecs.query_builder<>().term<Likes>(Bob).build();
+
+    int32_t count = 0;
+
+    q.each([&](flecs::entity e) {
+        test_assert(e.has<Likes>(Bob));
+
+        test_bool(e.get([&](const Self& s) {
+            test_assert(s.value == e);
+        }), true);
+
+        count ++;
+    });
+
+    count ++;
+}
+
+void World_with_relation_object_type() {
+    flecs::world ecs;
+
+    struct Likes { };
+    struct Bob { };
+
+    ecs.with<Likes, Bob>([&]{
+        auto e1 = ecs.entity(); e1.set<Self>({e1});
+        auto e2 = ecs.entity(); e2.set<Self>({e2});
+        auto e3 = ecs.entity(); e3.set<Self>({e3});
+    });
+
+    // Ensures that while Self is (implicitly) registered within the with, it
+    // does not get any contents from the with.
+    auto self = ecs.component<Self>();
+    test_assert(!(self.has<Likes, Bob>()));
+
+    auto q = ecs.query_builder<>().term<Likes, Bob>().build();
+
+    int32_t count = 0;
+
+    q.each([&](flecs::entity e) {
+        test_assert((e.has<Likes, Bob>()));
+
+        test_bool(e.get([&](const Self& s) {
+            test_assert(s.value == e);
+        }), true);
+
+        count ++;
+    });
+
+    count ++;
+}
+
+void World_with_scope() {
+    flecs::world ecs;
+
+    auto parent = ecs.entity("P");
+
+    ecs.scope(parent, [&]{
+        auto e1 = ecs.entity("C1"); e1.set<Self>({e1});
+        auto e2 = ecs.entity("C2"); e2.set<Self>({e2});
+        auto e3 = ecs.entity("C3"); e3.set<Self>({e3});
+
+        // Ensure relative lookups work
+        test_assert(ecs.lookup("C1") == e1);
+        test_assert(ecs.lookup("C2") == e2);
+        test_assert(ecs.lookup("C3") == e3);
+
+        test_assert(parent.lookup("C1") == e1);
+        test_assert(parent.lookup("C2") == e2);
+        test_assert(parent.lookup("C3") == e3);
+
+        test_assert(ecs.lookup("::P::C1") == e1);
+        test_assert(ecs.lookup("::P::C2") == e2);
+        test_assert(ecs.lookup("::P::C3") == e3);
+    });
+
+    test_assert(parent.lookup("C1") != 0);
+    test_assert(parent.lookup("C2") != 0);
+    test_assert(parent.lookup("C3") != 0);
+
+    test_assert(ecs.lookup("P::C1") == parent.lookup("C1"));
+    test_assert(ecs.lookup("P::C2") == parent.lookup("C2"));
+    test_assert(ecs.lookup("P::C3") == parent.lookup("C3"));
+
+    // Ensures that while Self is (implicitly) registered within the with, it
+    // does not become a child of the parent.
+    auto self = ecs.component<Self>();
+    test_assert(!self.has(flecs::ChildOf, parent));
+
+    int count = 0;
+    auto q = ecs.query_builder<>().term(flecs::ChildOf, parent).build();
+
+    q.each([&](flecs::entity e) {
+        test_assert(e.has(flecs::ChildOf, parent));
+
+        test_bool(e.get([&](const Self& s){
+            test_assert(s.value == e);
+        }), true);
+
+        count ++;
+    });
+
+    test_int(count, 3);
+}
+
+void World_with_tag_nested() {
+    flecs::world ecs;
+
+    auto Tier1 = ecs.entity();
+    
+    ecs.with(Tier1, [&]{
+        ecs.entity("Tier2").with([&]{
+            ecs.entity("Tier3");
+        });
+    });
+
+    auto Tier2 = ecs.lookup("Tier2");
+    test_assert(Tier2 != 0);
+
+    auto Tier3 = ecs.lookup("Tier3");
+    test_assert(Tier3 != 0);
+
+    test_assert(Tier2.has(Tier1));
+    test_assert(Tier3.has(Tier2));
+}
+
+void World_with_scope_nested() {
+    flecs::world ecs;
+
+    auto parent = ecs.entity("P");
+
+    ecs.scope(parent, [&]{
+        auto child = ecs.entity("C").scope([&]{
+            auto gchild = ecs.entity("GC");
+            test_assert(gchild == ecs.lookup("GC"));
+            test_assert(gchild == ecs.lookup("::P::C::GC"));
+        });
+
+        // Ensure relative lookups work
+        test_assert(ecs.lookup("C") == child);
+        test_assert(ecs.lookup("::P::C") == child);
+        test_assert(ecs.lookup("::P::C::GC") != 0);
+    });
+
+    test_assert(0 == ecs.lookup("C"));
+    test_assert(0 == ecs.lookup("GC"));
+    test_assert(0 == ecs.lookup("C::GC"));
+
+    auto child = ecs.lookup("P::C");
+    test_assert(0 != child);
+    test_assert(child.has(flecs::ChildOf, parent));
+
+    auto gchild = ecs.lookup("P::C::GC");
+    test_assert(0 != gchild);
+    test_assert(gchild.has(flecs::ChildOf, child));
+}
+
+void World_recursive_lookup() {
+    flecs::world ecs;
+
+    auto A = ecs.entity("A");
+    auto B = ecs.entity("B");
+
+    auto P = ecs.entity("P");
+    P.scope([&]{
+        auto CA = ecs.entity("A");
+        test_assert(CA != A);
+
+        test_assert(CA == ecs.lookup("A"));
+        test_assert(CA == ecs.lookup("P::A"));
+        test_assert(CA == ecs.lookup("::P::A"));
+        test_assert(A == ecs.lookup("::A"));
+
+        test_assert(B == ecs.lookup("B"));
+        test_assert(B == ecs.lookup("::B"));
+    });
 }

--- a/test/cpp_api/src/main.cpp
+++ b/test/cpp_api/src/main.cpp
@@ -88,6 +88,28 @@ void Entity_set_2_after_fluent(void);
 void Entity_set_2_before_fluent(void);
 void Entity_set_2_after_set_1(void);
 void Entity_set_2_after_set_2(void);
+void Entity_with_self(void);
+void Entity_with_relation_type_self(void);
+void Entity_with_relation_self(void);
+void Entity_with_self_w_name(void);
+void Entity_with_self_nested(void);
+void Entity_with_after_builder_method(void);
+void Entity_with_before_builder_method(void);
+void Entity_with_scope(void);
+void Entity_with_scope_nested(void);
+void Entity_with_scope_nested_same_name_as_parent(void);
+void Entity_scope_after_builder_method(void);
+void Entity_scope_before_builder_method(void);
+void Entity_no_recursive_lookup(void);
+void Entity_defer_new_w_name(void);
+void Entity_defer_new_w_nested_name(void);
+void Entity_defer_new_w_scope_name(void);
+void Entity_defer_new_w_scope_nested_name(void);
+void Entity_defer_new_w_deferred_scope_nested_name(void);
+void Entity_defer_new_w_scope(void);
+void Entity_defer_new_w_with(void);
+void Entity_defer_new_w_name_scope_with(void);
+void Entity_defer_w_with_implicit_component(void);
 
 // Testsuite 'Pairs'
 void Pairs_add_component_pair(void);
@@ -123,6 +145,8 @@ void Pairs_each_pair_by_type(void);
 void Pairs_each_pair_w_childof(void);
 void Pairs_each_pair_w_recycled_rel(void);
 void Pairs_each_pair_w_recycled_obj(void);
+void Pairs_has_tag_w_object(void);
+void Pairs_has_object_tag(void);
 
 // Testsuite 'Switch'
 void Switch_add_case(void);
@@ -415,6 +439,15 @@ void World_implicit_register_w_new_world(void);
 void World_count(void);
 void World_staged_count(void);
 void World_async_stage_add(void);
+void World_with_tag(void);
+void World_with_tag_type(void);
+void World_with_relation(void);
+void World_with_relation_type(void);
+void World_with_relation_object_type(void);
+void World_with_tag_nested(void);
+void World_with_scope(void);
+void World_with_scope_nested(void);
+void World_recursive_lookup(void);
 
 // Testsuite 'Singleton'
 void Singleton_set_get_singleton(void);
@@ -743,6 +776,94 @@ bake_test_case Entity_testcases[] = {
     {
         "set_2_after_set_2",
         Entity_set_2_after_set_2
+    },
+    {
+        "with_self",
+        Entity_with_self
+    },
+    {
+        "with_relation_type_self",
+        Entity_with_relation_type_self
+    },
+    {
+        "with_relation_self",
+        Entity_with_relation_self
+    },
+    {
+        "with_self_w_name",
+        Entity_with_self_w_name
+    },
+    {
+        "with_self_nested",
+        Entity_with_self_nested
+    },
+    {
+        "with_after_builder_method",
+        Entity_with_after_builder_method
+    },
+    {
+        "with_before_builder_method",
+        Entity_with_before_builder_method
+    },
+    {
+        "with_scope",
+        Entity_with_scope
+    },
+    {
+        "with_scope_nested",
+        Entity_with_scope_nested
+    },
+    {
+        "with_scope_nested_same_name_as_parent",
+        Entity_with_scope_nested_same_name_as_parent
+    },
+    {
+        "scope_after_builder_method",
+        Entity_scope_after_builder_method
+    },
+    {
+        "scope_before_builder_method",
+        Entity_scope_before_builder_method
+    },
+    {
+        "no_recursive_lookup",
+        Entity_no_recursive_lookup
+    },
+    {
+        "defer_new_w_name",
+        Entity_defer_new_w_name
+    },
+    {
+        "defer_new_w_nested_name",
+        Entity_defer_new_w_nested_name
+    },
+    {
+        "defer_new_w_scope_name",
+        Entity_defer_new_w_scope_name
+    },
+    {
+        "defer_new_w_scope_nested_name",
+        Entity_defer_new_w_scope_nested_name
+    },
+    {
+        "defer_new_w_deferred_scope_nested_name",
+        Entity_defer_new_w_deferred_scope_nested_name
+    },
+    {
+        "defer_new_w_scope",
+        Entity_defer_new_w_scope
+    },
+    {
+        "defer_new_w_with",
+        Entity_defer_new_w_with
+    },
+    {
+        "defer_new_w_name_scope_with",
+        Entity_defer_new_w_name_scope_with
+    },
+    {
+        "defer_w_with_implicit_component",
+        Entity_defer_w_with_implicit_component
     }
 };
 
@@ -878,6 +999,14 @@ bake_test_case Pairs_testcases[] = {
     {
         "each_pair_w_recycled_obj",
         Pairs_each_pair_w_recycled_obj
+    },
+    {
+        "has_tag_w_object",
+        Pairs_has_tag_w_object
+    },
+    {
+        "has_object_tag",
+        Pairs_has_object_tag
     }
 };
 
@@ -1971,6 +2100,42 @@ bake_test_case World_testcases[] = {
     {
         "async_stage_add",
         World_async_stage_add
+    },
+    {
+        "with_tag",
+        World_with_tag
+    },
+    {
+        "with_tag_type",
+        World_with_tag_type
+    },
+    {
+        "with_relation",
+        World_with_relation
+    },
+    {
+        "with_relation_type",
+        World_with_relation_type
+    },
+    {
+        "with_relation_object_type",
+        World_with_relation_object_type
+    },
+    {
+        "with_tag_nested",
+        World_with_tag_nested
+    },
+    {
+        "with_scope",
+        World_with_scope
+    },
+    {
+        "with_scope_nested",
+        World_with_scope_nested
+    },
+    {
+        "recursive_lookup",
+        World_recursive_lookup
     }
 };
 
@@ -2018,14 +2183,14 @@ static bake_test_suite suites[] = {
         "Entity",
         NULL,
         NULL,
-        79,
+        101,
         Entity_testcases
     },
     {
         "Pairs",
         NULL,
         NULL,
-        33,
+        35,
         Pairs_testcases
     },
     {
@@ -2130,7 +2295,7 @@ static bake_test_suite suites[] = {
         "World",
         NULL,
         NULL,
-        21,
+        30,
         World_testcases
     },
     {


### PR DESCRIPTION
Add following new functions to C++ API:

```cpp
ecs.defer([&]{ // Defer all operations in block
    ecs.with<SpaceShip>([&]{ // Add tag to all new entities in block
        ecs.entity("Carrier").scope([&]{ // All new entities in block are created as children of Carrier
            // created with (ChildOf, Carrier)
            ecs.entity("Fighter1");
            ecs.entity("Fighter2");
            ecs.entity("Fighter3");
        });
    });
}); // Deferred operations are executed
```
```cpp
auto parent = ecs.entity();
auto child = ecs.entity()
  .child_of(parent); // Same as add(flecs::ChildOf, parent); 
```

Fixes #417 