### PR TITLE
Component lifecycle improvements

### DIFF
--- a/include/flecs.h
+++ b/include/flecs.h
@@ -449,15 +449,15 @@ typedef struct ecs_trigger_desc_t {
 
 /** Entity name. */
 typedef struct EcsName {
-    const char *value;     /**< Entity name */
-    char *symbol;          /**< Optional symbol name, if it differs from name */
-    char *alloc_value;     /**< If set, value will be freed on destruction */
+    const char *value;     /* Entity name */
+    char *symbol;          /* Optional symbol name, if it differs from name */
+    char *alloc_value;     /* If set, value will be freed on destruction */
 } EcsName;
 
 /** Component information. */
 typedef struct EcsComponent {
-    ecs_size_t size;           /**< Component size */
-    ecs_size_t alignment;      /**< Component alignment */
+    ecs_size_t size;           /* Component size */
+    ecs_size_t alignment;      /* Component alignment */
 } EcsComponent;
 
 /** Component that stores an ecs_type_t. 
@@ -465,22 +465,30 @@ typedef struct EcsComponent {
  * therefore the creation of named types. This component is typically 
  * instantiated by ECS_TYPE. */
 typedef struct EcsType {
-    ecs_type_t type;        /**< Preserved nested types */
-    ecs_type_t normalized;  /**< Union of type and nested AND types */
+    ecs_type_t type;        /* Preserved nested types */
+    ecs_type_t normalized;  /* Union of type and nested AND types */
 } EcsType;
 
 /** Component that contains lifecycle callbacks for a component. */
 struct EcsComponentLifecycle {
-    ecs_xtor_t ctor;            /**< ctor */
-    ecs_xtor_t dtor;            /**< dtor */
-    ecs_copy_t copy;            /**< copy assignment */
-    ecs_move_t move;            /**< move assignment */
+    ecs_xtor_t ctor;            /* ctor */
+    ecs_xtor_t dtor;            /* dtor */
+    ecs_copy_t copy;            /* copy assignment */
+    ecs_move_t move;            /* move assignment */
 
-    void *ctx;              /**< User defined context */
+    void *ctx;                  /* User defined context */
 
-    ecs_copy_ctor_t copy_ctor;  /**< copy ctor (optional, ctor+copy) */
-    ecs_move_ctor_t move_ctor;  /**< move ctor (optional, ctor+move) */
-    ecs_move_ctor_t merge;      /**< move ctor (optional, ctor+move+dtor) */    
+    ecs_copy_ctor_t copy_ctor;  /* copy ctor (optional, ctor+copy) */
+    ecs_move_ctor_t move_ctor;  /* move ctor (optional, ctor+move) */
+    ecs_move_ctor_t merge;      /* move ctor (optional, ctor+move+dtor) */
+
+    bool ctor_illegal;          /* cannot default construct */
+    bool copy_illegal;          /* cannot copy assign */
+    bool move_illegal;          /* cannot move assign */
+    bool copy_ctor_illegal;     /* cannot copy construct */
+    bool move_ctor_illegal;     /* cannot move construct (or merge) */
+
+    /* Note that a type must be destructible */
 };
 
 /** Component that stores reference to trigger */
@@ -503,25 +511,25 @@ typedef struct EcsQuery {
 
 /** Type that contains information about the world. */
 typedef struct ecs_world_info_t {
-    ecs_entity_t last_component_id;   /**< Last issued component entity id */
-    ecs_entity_t last_id;             /**< Last issued entity id */
-    ecs_entity_t min_id;              /**< First allowed entity id */
-    ecs_entity_t max_id;              /**< Last allowed entity id */
+    ecs_entity_t last_component_id;   /* Last issued component entity id */
+    ecs_entity_t last_id;             /* Last issued entity id */
+    ecs_entity_t min_id;              /* First allowed entity id */
+    ecs_entity_t max_id;              /* Last allowed entity id */
 
-    FLECS_FLOAT delta_time_raw;      /**< Raw delta time (no time scaling) */
-    FLECS_FLOAT delta_time;          /**< Time passed to or computed by ecs_progress */
-    FLECS_FLOAT time_scale;          /**< Time scale applied to delta_time */
-    FLECS_FLOAT target_fps;          /**< Target fps */
-    FLECS_FLOAT frame_time_total;    /**< Total time spent processing a frame */
-    FLECS_FLOAT system_time_total;   /**< Total time spent in systems */
-    FLECS_FLOAT merge_time_total;    /**< Total time spent in merges */
-    FLECS_FLOAT world_time_total;    /**< Time elapsed in simulation */
-    FLECS_FLOAT world_time_total_raw; /**< Time elapsed in simulation (no scaling) */
+    FLECS_FLOAT delta_time_raw;       /* Raw delta time (no time scaling) */
+    FLECS_FLOAT delta_time;           /* Time passed to or computed by ecs_progress */
+    FLECS_FLOAT time_scale;           /* Time scale applied to delta_time */
+    FLECS_FLOAT target_fps;           /* Target fps */
+    FLECS_FLOAT frame_time_total;     /* Total time spent processing a frame */
+    FLECS_FLOAT system_time_total;    /* Total time spent in systems */
+    FLECS_FLOAT merge_time_total;     /* Total time spent in merges */
+    FLECS_FLOAT world_time_total;     /* Time elapsed in simulation */
+    FLECS_FLOAT world_time_total_raw; /* Time elapsed in simulation (no scaling) */
     
-    int32_t frame_count_total;  /**< Total number of frames */
-    int32_t merge_count_total;  /**< Total number of merges */
-    int32_t pipeline_build_count_total; /**< Total number of pipeline builds */
-    int32_t systems_ran_frame;  /**< Total number of systems ran in last frame */
+    int32_t frame_count_total;        /* Total number of frames */
+    int32_t merge_count_total;        /* Total number of merges */
+    int32_t pipeline_build_count_total; /* Total number of pipeline builds */
+    int32_t systems_ran_frame;  /* Total number of systems ran in last frame */
 } ecs_world_info_t;
 
 /** @} */

--- a/include/flecs/cpp/entity.hpp
+++ b/include/flecs/cpp/entity.hpp
@@ -641,9 +641,21 @@ public:
      * 
      * @tparam T the component type to add.
      */
-    template <typename T>
+    template <typename T, typename std::enable_if<
+        _::is_flecs_constructible<T>::value,
+            void>::type* = nullptr>
     const Base& add() const {
         ecs_add_id(this->base_world(), this->base_id(), _::cpp_type<T>::id(this->base_world()));
+        return *this;
+    }
+
+    template <typename T, typename std::enable_if<
+        !_::is_flecs_constructible<T>::value,
+            void>::type* = nullptr>
+    const Base& add() const {
+        flecs_static_assert(_::always_false<T>::value,
+            "add<T>() cannot construct type: add T() or "
+                "T(flecs::world&, flecs::entity)");
         return *this;
     }
 
@@ -694,9 +706,22 @@ public:
      * @tparam Relation the relation type.
      * @param object the object type.
      */
-    template<typename Relation>
+    template<typename Relation, typename std::enable_if<
+        _::is_flecs_constructible<Relation>::value,
+            void>::type* = nullptr>
     const Base& add(entity_t object) const {
         return this->add(_::cpp_type<Relation>::id(this->base_world()), object);
+    }
+
+    template<typename Relation, typename std::enable_if<
+        !_::is_flecs_constructible<Relation>::value,
+            void>::type* = nullptr>
+    const Base& add(entity_t object) const {
+        (void)object;
+        flecs_static_assert(_::always_false<Relation>::value,
+            "add<T>(entity_t) cannot construct type: add T() or "
+                "T(flecs::world&, flecs::entity)");
+        return *this;
     }
 
     /** Shortcut for add(IsA. obj).
@@ -722,9 +747,22 @@ public:
      * @param relation the relation type.
      * @tparam Object the object type.
      */
-    template<typename Object>
+    template<typename Object, typename std::enable_if<
+        _::is_flecs_constructible<Object>::value,
+            void>::type* = nullptr>
     const Base& add_object(entity_t relation) const {
         return this->add(relation,  _::cpp_type<Object>::id(this->base_world()));
+    }
+
+    template<typename Object, typename std::enable_if<
+        !_::is_flecs_constructible<Object>::value,
+            void>::type* = nullptr>
+    const Base& add_object(entity_t relation) const {
+        (void)relation;
+        flecs_static_assert(_::always_false<Object>::value,
+            "add_object<T>(entity_t) cannot construct type: add T() or "
+                "T(flecs::world&, flecs::entity)");
+        return *this;
     }
 
     /** Remove a component from an entity.

--- a/include/flecs/cpp/impl.hpp
+++ b/include/flecs/cpp/impl.hpp
@@ -1,4 +1,5 @@
 
+#include "impl/lifecycle_traits.hpp"
 #include "impl/entity.hpp"
 #include "impl/iter.hpp"
 #include "impl/world.hpp"

--- a/include/flecs/cpp/impl/lifecycle_traits.hpp
+++ b/include/flecs/cpp/impl/lifecycle_traits.hpp
@@ -1,0 +1,24 @@
+
+
+namespace flecs 
+{
+
+namespace _
+{
+
+template <typename T>
+inline void ctor_world_entity_impl(
+    ecs_world_t* world, ecs_entity_t, const ecs_entity_t* ids, void *ptr, 
+    size_t size, int32_t count, void*)
+{
+    (void)size; ecs_assert(size == sizeof(T), ECS_INTERNAL_ERROR, NULL);
+    T *arr = static_cast<T*>(ptr);
+    flecs::world w(world);
+    for (int i = 0; i < count; i ++) {
+        flecs::entity e(world, ids[i]);
+        FLECS_PLACEMENT_NEW(&arr[i], T(w, e));
+    }
+}
+
+} // _
+} // flecs

--- a/include/flecs/cpp/lifecycle_traits.hpp
+++ b/include/flecs/cpp/lifecycle_traits.hpp
@@ -18,36 +18,12 @@ void ctor_impl(
     }
 }
 
-// T(flecs::entity) 
-// Can't coexist with T() or T(flecs::world, flecs::entity)
-template <typename T>
-void ctor_entity_impl(
-    ecs_world_t* world, ecs_entity_t, const ecs_entity_t* ids, void *ptr, 
-    size_t size, int32_t count, void*)
-{
-    (void)size; ecs_assert(size == sizeof(T), ECS_INTERNAL_ERROR, NULL);
-    T *arr = static_cast<T*>(ptr);
-    for (int i = 0; i < count; i ++) {
-        flecs::entity e(world, ids[i]);
-        FLECS_PLACEMENT_NEW(&arr[i], T(e));
-    }
-}
-
 // T(flecs::world, flecs::entity)
 // Can't coexist with T() or T(flecs::entity)
 template <typename T>
 void ctor_world_entity_impl(
     ecs_world_t* world, ecs_entity_t, const ecs_entity_t* ids, void *ptr, 
-    size_t size, int32_t count, void*)
-{
-    (void)size; ecs_assert(size == sizeof(T), ECS_INTERNAL_ERROR, NULL);
-    T *arr = static_cast<T*>(ptr);
-    flecs::world w(world);
-    for (int i = 0; i < count; i ++) {
-        flecs::entity e(world, ids[i]);
-        FLECS_PLACEMENT_NEW(&arr[i], T(w, e));
-    }
-}
+    size_t size, int32_t count, void*);
 
 // ~T()
 template <typename T>
@@ -143,9 +119,15 @@ struct lifecycle_callback_result {
     T callback;  // The callback function
     bool illegal; // If true, callback is not allowed
     
-    static constexpr lifecycle_callback_result is_illegal = {nullptr, true};
-    static constexpr lifecycle_callback_result not_set = {nullptr, true};
+    static const lifecycle_callback_result is_illegal;
+    static const lifecycle_callback_result not_set;
 };
+
+template <typename T>
+const lifecycle_callback_result<T> lifecycle_callback_result<T>::is_illegal = {nullptr, true};
+
+template <typename T>
+const lifecycle_callback_result<T> lifecycle_callback_result<T>::not_set = {nullptr, true};
 
 using ctor_result = lifecycle_callback_result<ecs_xtor_t>;
 using dtor_result = lifecycle_callback_result<ecs_xtor_t>;

--- a/include/flecs/cpp/lifecycle_traits.hpp
+++ b/include/flecs/cpp/lifecycle_traits.hpp
@@ -1,0 +1,351 @@
+namespace flecs 
+{
+
+namespace _ 
+{
+
+// T()
+// Can't coexist with T(flecs::entity) or T(flecs::world, flecs::entity)
+template <typename T>
+void ctor_impl(
+    ecs_world_t*, ecs_entity_t, const ecs_entity_t*, void *ptr, size_t size,
+    int32_t count, void*)
+{
+    (void)size; ecs_assert(size == sizeof(T), ECS_INTERNAL_ERROR, NULL);
+    T *arr = static_cast<T*>(ptr);
+    for (int i = 0; i < count; i ++) {
+        FLECS_PLACEMENT_NEW(&arr[i], T);
+    }
+}
+
+// T(flecs::entity) 
+// Can't coexist with T() or T(flecs::world, flecs::entity)
+template <typename T>
+void ctor_entity_impl(
+    ecs_world_t* world, ecs_entity_t, const ecs_entity_t* ids, void *ptr, 
+    size_t size, int32_t count, void*)
+{
+    (void)size; ecs_assert(size == sizeof(T), ECS_INTERNAL_ERROR, NULL);
+    T *arr = static_cast<T*>(ptr);
+    for (int i = 0; i < count; i ++) {
+        flecs::entity e(world, ids[i]);
+        FLECS_PLACEMENT_NEW(&arr[i], T(e));
+    }
+}
+
+// T(flecs::world, flecs::entity)
+// Can't coexist with T() or T(flecs::entity)
+template <typename T>
+void ctor_world_entity_impl(
+    ecs_world_t* world, ecs_entity_t, const ecs_entity_t* ids, void *ptr, 
+    size_t size, int32_t count, void*)
+{
+    (void)size; ecs_assert(size == sizeof(T), ECS_INTERNAL_ERROR, NULL);
+    T *arr = static_cast<T*>(ptr);
+    flecs::world w(world);
+    for (int i = 0; i < count; i ++) {
+        flecs::entity e(world, ids[i]);
+        FLECS_PLACEMENT_NEW(&arr[i], T(w, e));
+    }
+}
+
+// ~T()
+template <typename T>
+void dtor_impl(
+    ecs_world_t*, ecs_entity_t, const ecs_entity_t*, void *ptr, size_t size,
+    int32_t count, void*)
+{
+    (void)size; ecs_assert(size == sizeof(T), ECS_INTERNAL_ERROR, NULL);
+    T *arr = static_cast<T*>(ptr);
+    for (int i = 0; i < count; i ++) {
+        arr[i].~T();
+    }
+}
+
+// T& operator=(const T&)
+template <typename T>
+void copy_impl(
+    ecs_world_t*, ecs_entity_t, const ecs_entity_t*, const ecs_entity_t*, 
+    void *dst_ptr, const void *src_ptr, size_t size, int32_t count, void*)
+{
+    (void)size; ecs_assert(size == sizeof(T), ECS_INTERNAL_ERROR, NULL);
+    T *dst_arr = static_cast<T*>(dst_ptr);
+    const T *src_arr = static_cast<const T*>(src_ptr);
+    for (int i = 0; i < count; i ++) {
+        dst_arr[i] = src_arr[i];
+    }
+}
+
+// T& operator=(T&&)
+template <typename T>
+void move_impl(
+    ecs_world_t*, ecs_entity_t, const ecs_entity_t*, const ecs_entity_t*,
+    void *dst_ptr, void *src_ptr, size_t size, int32_t count, void*)
+{
+    (void)size; ecs_assert(size == sizeof(T), ECS_INTERNAL_ERROR, NULL);
+    T *dst_arr = static_cast<T*>(dst_ptr);
+    T *src_arr = static_cast<T*>(src_ptr);
+    for (int i = 0; i < count; i ++) {
+        dst_arr[i] = std::move(src_arr[i]);
+    }
+}
+
+// T(T&)
+template <typename T>
+void copy_ctor_impl(
+    ecs_world_t*, ecs_entity_t, const EcsComponentLifecycle*, 
+    const ecs_entity_t*, const ecs_entity_t*, void *dst_ptr, 
+    const void *src_ptr, size_t size, int32_t count, void*)
+{
+    (void)size; ecs_assert(size == sizeof(T), ECS_INTERNAL_ERROR, NULL);
+    T *dst_arr = static_cast<T*>(dst_ptr);
+    const T *src_arr = static_cast<const T*>(src_ptr);
+    for (int i = 0; i < count; i ++) {
+        FLECS_PLACEMENT_NEW(&dst_arr[i], T(src_arr[i]));
+    }
+}
+
+// T(T&&)
+template <typename T>
+void move_ctor_impl(
+    ecs_world_t*, ecs_entity_t, const EcsComponentLifecycle*, 
+    const ecs_entity_t*, const ecs_entity_t*, void *dst_ptr, 
+    void *src_ptr, size_t size, int32_t count, void*)
+{
+    (void)size; ecs_assert(size == sizeof(T), ECS_INTERNAL_ERROR, NULL);
+    T *dst_arr = static_cast<T*>(dst_ptr);
+    T *src_arr = static_cast<T*>(src_ptr);
+    for (int i = 0; i < count; i ++) {
+        FLECS_PLACEMENT_NEW(&dst_arr[i], T(std::move(src_arr[i])));
+    }
+}
+
+// T(T&&), ~T()
+// Typically used when moving to a new table, and removing from the old table
+template <typename T>
+void merge_impl(
+    ecs_world_t*, ecs_entity_t, const EcsComponentLifecycle*, 
+    const ecs_entity_t*, const ecs_entity_t*, void *dst_ptr, 
+    void *src_ptr, size_t size, int32_t count, void*)
+{
+    (void)size; ecs_assert(size == sizeof(T), ECS_INTERNAL_ERROR, NULL);
+    T *dst_arr = static_cast<T*>(dst_ptr);
+    T *src_arr = static_cast<T*>(src_ptr);
+    for (int i = 0; i < count; i ++) {
+        FLECS_PLACEMENT_NEW(&dst_arr[i], T(std::move(src_arr[i])));
+        src_arr[i].~T();
+    }
+}
+
+// Utility to return callback and whether callback is allowed
+template <typename T>
+struct lifecycle_callback_result {
+    T callback;  // The callback function
+    bool illegal; // If true, callback is not allowed
+    
+    static constexpr lifecycle_callback_result is_illegal = {nullptr, true};
+    static constexpr lifecycle_callback_result not_set = {nullptr, true};
+};
+
+using ctor_result = lifecycle_callback_result<ecs_xtor_t>;
+using dtor_result = lifecycle_callback_result<ecs_xtor_t>;
+using copy_result = lifecycle_callback_result<ecs_copy_t>;
+using move_result = lifecycle_callback_result<ecs_move_t>;
+using copy_ctor_result = lifecycle_callback_result<ecs_copy_ctor_t>;
+using move_ctor_result = lifecycle_callback_result<ecs_move_ctor_t>;
+using merge_result = lifecycle_callback_result<ecs_move_ctor_t>;
+
+template <typename T>
+struct has_flecs_ctor {
+    static constexpr bool value = 
+        std::is_constructible<T, flecs::world&, flecs::entity>::value;
+};
+
+template <typename T>
+struct is_flecs_constructible {
+    static constexpr bool value = 
+        std::is_default_constructible<T>::value ||
+        std::is_constructible<T, flecs::world&, flecs::entity>::value;
+};
+
+// Trivially constructible
+template <typename T, typename std::enable_if<
+    std::is_trivially_constructible<T>::value, void>::type* = nullptr>
+ctor_result ctor() {
+    return ctor_result::not_set;
+}
+
+// Not constructible by flecs
+template <typename T, typename std::enable_if<
+    ! std::is_default_constructible<T>::value &&
+    ! has_flecs_ctor<T>::value,
+        void>::type* = nullptr>
+ctor_result ctor() {
+    return ctor_result::is_illegal;
+}
+
+// Default constructible
+template <typename T, typename std::enable_if<
+    ! std::is_trivially_constructible<T>::value &&
+    std::is_default_constructible<T>::value &&
+    ! has_flecs_ctor<T>::value, 
+        void>::type* = nullptr>
+ctor_result ctor() {
+    return {ctor_impl<T>, false};
+}
+
+// Flecs constructible: T(flecs::world, flecs::entity)
+template <typename T, typename std::enable_if<
+    has_flecs_ctor<T>::value, 
+        void>::type* = nullptr>
+ctor_result ctor() {
+    return {ctor_world_entity_impl<T>, false};
+}
+
+// No dtor
+template <typename T, typename std::enable_if<
+    std::is_trivially_destructible<T>::value, void>::type* = nullptr>
+dtor_result dtor() {
+    return dtor_result::not_set;
+}
+
+// Dtor
+template <typename T, typename std::enable_if<
+    std::is_destructible<T>::value &&
+    ! std::is_trivially_destructible<T>::value, void>::type* = nullptr>
+dtor_result dtor() {
+    return {dtor_impl<T>, false};
+}
+
+// Assert when the type cannot be destructed
+template <typename T, typename std::enable_if<
+    ! std::is_destructible<T>::value, void>::type* = nullptr>
+dtor_result dtor() {
+    flecs_static_assert(always_false<T>::value, 
+        "component type must be destructible");
+    return dtor_result::is_illegal;
+}
+
+// Trivially copyable
+template <typename T, typename std::enable_if<
+    std::is_trivially_copyable<T>::value, void>::type* = nullptr>
+copy_result copy() {
+    return copy_result::not_set;
+}
+
+// Not copyable
+template <typename T, typename std::enable_if<
+    ! std::is_trivially_copyable<T>::value &&
+    ! std::is_copy_assignable<T>::value, void>::type* = nullptr>
+copy_result copy() {
+    return copy_result::is_illegal;
+}
+
+// Copy assignment
+template <typename T, typename std::enable_if<
+    std::is_copy_assignable<T>::value &&
+    ! std::is_trivially_copyable<T>::value, void>::type* = nullptr>
+copy_result copy() {
+    return {copy_impl<T>, false};
+}
+
+// Trivially move assignable
+template <typename T, typename std::enable_if<
+    std::is_trivially_move_assignable<T>::value, void>::type* = nullptr>
+move_result move() {
+    return move_result::not_set;
+}
+
+// Component types must be move assignable
+template <typename T, typename std::enable_if<
+    ! std::is_move_assignable<T>::value, void>::type* = nullptr>
+move_result move() {
+    flecs_static_assert(always_false<T>::value,
+        "component type must be move assignable");
+    return move_result::is_illegal;
+}
+
+// Move assignment
+template <typename T, typename std::enable_if<
+    std::is_move_assignable<T>::value &&
+    ! std::is_trivially_move_assignable<T>::value, void>::type* = nullptr>
+move_result move() {
+    return {move_impl<T>, false};
+}
+
+// Trivially copy constructible
+template <typename T, typename std::enable_if<
+    std::is_trivially_copy_constructible<T>::value, void>::type* = nullptr>
+copy_ctor_result copy_ctor() {
+    return copy_ctor_result::not_set;
+}
+
+// No copy ctor
+template <typename T, typename std::enable_if<
+    ! std::is_copy_constructible<T>::value, void>::type* = nullptr>
+copy_ctor_result copy_ctor() {
+    return copy_ctor_result::is_illegal;
+}
+
+// Copy ctor
+template <typename T, typename std::enable_if<
+    std::is_copy_constructible<T>::value &&
+    ! std::is_trivially_copy_constructible<T>::value, void>::type* = nullptr>
+copy_ctor_result copy_ctor() {
+    return {copy_ctor_impl<T>, false};
+}
+
+// Trivially move constructible
+template <typename T, typename std::enable_if<
+    std::is_trivially_move_constructible<T>::value, void>::type* = nullptr>
+move_ctor_result move_ctor() {
+    return move_ctor_result::not_set;
+}
+
+// Component types must be move constructible
+template <typename T, typename std::enable_if<
+    ! std::is_move_constructible<T>::value, void>::type* = nullptr>
+move_ctor_result move_ctor() {
+    flecs_static_assert(always_false<T>::value,
+        "component type must be move constructible");    
+    return move_ctor_result::is_illegal;
+}
+
+// Move ctor
+template <typename T, typename std::enable_if<
+    std::is_move_constructible<T>::value &&
+    ! std::is_trivially_move_constructible<T>::value, void>::type* = nullptr>
+move_ctor_result move_ctor() {
+    return {move_ctor_impl<T>, false};
+}
+
+// Trivial merge (move assign + dtor)
+template <typename T, typename std::enable_if<
+    std::is_trivially_move_constructible<T>::value  &&
+    std::is_trivially_destructible<T>::value, void>::type* = nullptr>
+move_ctor_result merge() {
+    return move_ctor_result::not_set;
+}
+
+// Component types must be move constructible and destructible
+template <typename T, typename std::enable_if<
+    ! std::is_move_constructible<T>::value ||
+    ! std::is_destructible<T>::value, void>::type* = nullptr>
+move_ctor_result merge() {
+    flecs_static_assert(always_false<T>::value,
+        "component type must be move constructible and destructible");
+    return move_ctor_result::is_illegal;
+}
+
+// Merge (move assign + dtor)
+template <typename T, typename std::enable_if<
+    !(std::is_trivially_move_constructible<T>::value  &&
+      std::is_trivially_destructible<T>::value) &&
+    std::is_move_constructible<T>::value &&
+    std::is_destructible<T>::value, void>::type* = nullptr>
+move_ctor_result merge() {
+    return {merge_impl<T>, false};
+}
+
+} // _
+} // flecs

--- a/include/flecs/cpp/module.hpp
+++ b/include/flecs/cpp/module.hpp
@@ -17,9 +17,9 @@ flecs::entity module(const flecs::world& world, const char *name = nullptr) {
     // default ctor doesn't work for modules. Additionally, the module ctor
     // should only be invoked once per import.
     EcsComponentLifecycle cl{};
-    cl.copy = _::component_copy<T>;
-    cl.move = _::component_move<T>;
-    cl.dtor = _::component_dtor<T>;
+    cl.copy = _::copy<T>().callback;
+    cl.move = _::move<T>().callback;
+    cl.dtor = _::dtor<T>().callback;
     ecs_set_component_actions_w_entity(world, result, &cl);
 
     return result;

--- a/include/flecs/cpp/util.hpp
+++ b/include/flecs/cpp/util.hpp
@@ -276,6 +276,15 @@ public:
     }
 };
 
+namespace _
+{
+
+// Utility to prevent static assert from immediately triggering
+template <class... T>
+struct always_false {
+    static const bool value = false;
+};
+
 // Utility to get actual type
 template<typename Type>
 struct base_type {
@@ -288,10 +297,7 @@ template<typename Type>
 struct base_arg_type {
     typedef typename std::remove_pointer<
         typename std::remove_reference<Type>::type>::type type;
-};
-
-namespace _ 
-{
+};    
 
 ////////////////////////////////////////////////////////////////////////////////
 //// Utility to convert template argument pack to array of term ptrs

--- a/include/flecs/flecs.hpp
+++ b/include/flecs/flecs.hpp
@@ -10,6 +10,11 @@
 // The C++ API does not use STL, save for type_traits
 #include <type_traits>
 
+// Allows overriding flecs_static_assert, which is useful when testing
+#ifndef flecs_static_assert
+#define flecs_static_assert(cond, str) static_assert(cond, str)
+#endif
+
 namespace flecs {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -169,6 +174,7 @@ static const flecs::entity_t Throw = EcsThrow;
 
 #include <flecs/cpp/function_traits.hpp>
 #include <flecs/cpp/util.hpp>
+#include <flecs/cpp/lifecycle_traits.hpp>
 #include <flecs/cpp/iter.hpp>
 #include <flecs/cpp/world.hpp>
 #include <flecs/cpp/entity.hpp>

--- a/test/cpp_api/include/cpp_api.h
+++ b/test/cpp_api/include/cpp_api.h
@@ -82,5 +82,196 @@ struct Template {
     T y;
 };
 
+struct NoDefaultCtor {
+    NoDefaultCtor(int x) : x_(x) { }
+    NoDefaultCtor(const NoDefaultCtor& obj) = default;
+    NoDefaultCtor(NoDefaultCtor&& obj) = default;
+
+    NoDefaultCtor& operator=(const NoDefaultCtor& obj) = default;
+    NoDefaultCtor& operator=(NoDefaultCtor&& obj) = default;
+
+    ~NoDefaultCtor() { }
+
+    int x_;
+};
+
+struct DefaultInit {
+    DefaultInit() : x_(99) { test_assert(y_ == 99); }
+    DefaultInit(int x) : x_(x) { test_assert(y_ == 99); }
+    DefaultInit(const DefaultInit& obj) = default;
+    DefaultInit(DefaultInit&& obj) = default;
+
+    DefaultInit& operator=(const DefaultInit& obj) = default;
+    DefaultInit& operator=(DefaultInit&& obj) = default;
+
+    ~DefaultInit() { }
+
+    int x_;
+    int y_ = 99;
+};
+
+struct NoCopy {
+    NoCopy() : x_(99) { }
+    NoCopy(int x) : x_(x) { }
+    NoCopy(const NoCopy& obj) = delete;
+    NoCopy(NoCopy&& obj) = default;
+
+    NoCopy& operator=(const NoCopy& obj) = delete;
+    NoCopy& operator=(NoCopy&& obj) = default;
+
+    ~NoCopy() { }
+
+    int x_;
+};
+
+struct NoMove {
+    NoMove() : x_(99) { }
+    NoMove(int x) : x_(x) { }
+    NoMove(const NoMove& obj) = default;
+    NoMove(NoMove&& obj) = delete;
+
+    NoMove& operator=(const NoMove& obj) = default;
+    NoMove& operator=(NoMove&& obj) = delete;
+
+    ~NoMove() { }
+
+    int x_;
+};
+
+struct NoCopyCtor {
+    NoCopyCtor() : x_(99) { }
+    NoCopyCtor(int x) : x_(x) { }
+    NoCopyCtor(const NoCopyCtor& obj) = delete;
+    NoCopyCtor(NoCopyCtor&& obj) = default;
+
+    NoCopyCtor& operator=(const NoCopyCtor& obj) = default;
+    NoCopyCtor& operator=(NoCopyCtor&& obj) = default;
+
+    ~NoCopyCtor() { }
+
+    int x_;
+};
+
+struct NoCopyAssign {
+    NoCopyAssign() : x_(99) { }
+    NoCopyAssign(int x) : x_(x) { }
+    NoCopyAssign(const NoCopyAssign& obj) = default;
+    NoCopyAssign(NoCopyAssign&& obj) = default;
+
+    NoCopyAssign& operator=(const NoCopyAssign& obj) = delete;
+    NoCopyAssign& operator=(NoCopyAssign&& obj) = default;
+
+    ~NoCopyAssign() { }
+
+    int x_;
+};
+
+struct NoMoveCtor {
+    NoMoveCtor() : x_(99) { }
+    NoMoveCtor(int x) : x_(x) { }
+    NoMoveCtor(const NoMoveCtor& obj) = default;
+    NoMoveCtor(NoMoveCtor&& obj) = delete;
+
+    NoMoveCtor& operator=(const NoMoveCtor& obj) = default;
+    NoMoveCtor& operator=(NoMoveCtor&& obj) = default;
+
+    ~NoMoveCtor() { }
+
+    int x_;
+};
+
+struct NoMoveAssign {
+    NoMoveAssign() : x_(99) { }
+    NoMoveAssign(int x) : x_(x) { }
+    NoMoveAssign(const NoMoveAssign& obj) = default;
+    NoMoveAssign(NoMoveAssign&& obj) = default;
+
+    NoMoveAssign& operator=(const NoMoveAssign& obj) = default;
+    NoMoveAssign& operator=(NoMoveAssign&& obj) = delete;
+
+    ~NoMoveAssign() { }
+
+    int x_;
+};
+
+struct NoDtor {
+    NoDtor() : x_(99) { }
+    NoDtor(int x) : x_(x) { }
+    NoDtor(const NoDtor& obj) = default;
+    NoDtor(NoDtor&& obj) = default;
+
+    NoDtor& operator=(const NoDtor& obj) = delete;
+    NoDtor& operator=(NoDtor&& obj) = default;
+
+    ~NoDtor() = delete;
+
+    int x_;
+};
+
+struct FlecsCtor {
+    FlecsCtor(flecs::world& w, flecs::entity e) : x_(89), e_(e) { }
+
+    FlecsCtor(const FlecsCtor& obj) = delete;
+    FlecsCtor(FlecsCtor&& obj) = default;
+
+    FlecsCtor& operator=(const FlecsCtor& obj) = default;
+    FlecsCtor& operator=(FlecsCtor&& obj) = default;
+
+    ~FlecsCtor() { }
+
+    int x_;
+    flecs::entity e_;
+};
+
+struct FlecsCtorDefaultCtor {
+    FlecsCtorDefaultCtor() : x_(99) { }
+    FlecsCtorDefaultCtor(flecs::world& w, flecs::entity e) : x_(89), e_(e) { }
+
+    FlecsCtorDefaultCtor(const FlecsCtorDefaultCtor& obj) = delete;
+    FlecsCtorDefaultCtor(FlecsCtorDefaultCtor&& obj) = default;
+
+    FlecsCtorDefaultCtor& operator=(const FlecsCtorDefaultCtor& obj) = default;
+    FlecsCtorDefaultCtor& operator=(FlecsCtorDefaultCtor&& obj) = default;
+
+    ~FlecsCtorDefaultCtor() { }
+
+    int x_;
+    flecs::entity e_;
+};
+
+struct DefaultCtorValueCtor {
+    DefaultCtorValueCtor() : x_(99) { }
+    DefaultCtorValueCtor(int x) : x_(x) { }
+
+    DefaultCtorValueCtor(const DefaultCtorValueCtor& obj) = delete;
+    DefaultCtorValueCtor(DefaultCtorValueCtor&& obj) = default;
+
+    DefaultCtorValueCtor& operator=(const DefaultCtorValueCtor& obj) = default;
+    DefaultCtorValueCtor& operator=(DefaultCtorValueCtor&& obj) = default;
+
+    ~DefaultCtorValueCtor() { }
+
+    int x_;
+};
+
+struct FlecsCtorValueCtor {
+    FlecsCtorValueCtor(int x) : x_(x) { }
+    FlecsCtorValueCtor(flecs::world& w, flecs::entity e) : x_(89), e_(e) { }
+
+    FlecsCtorValueCtor(const FlecsCtorValueCtor& obj) = delete;
+    FlecsCtorValueCtor(FlecsCtorValueCtor&& obj) = default;
+
+    FlecsCtorValueCtor& operator=(const FlecsCtorValueCtor& obj) = default;
+    FlecsCtorValueCtor& operator=(FlecsCtorValueCtor&& obj) = default;
+
+    ~FlecsCtorValueCtor() { }
+
+    int x_;
+    flecs::entity e_;
+};
+
+
+void install_test_abort();
+
 #endif
 

--- a/test/cpp_api/include/cpp_api.h
+++ b/test/cpp_api/include/cpp_api.h
@@ -270,6 +270,48 @@ struct FlecsCtorValueCtor {
     flecs::entity e_;
 };
 
+class CountNoDefaultCtor {
+public:
+    CountNoDefaultCtor(int v) {
+        ctor_invoked ++;
+        value = v;
+    }    
+
+    ~CountNoDefaultCtor() {
+        dtor_invoked ++;
+    }
+
+    CountNoDefaultCtor(const CountNoDefaultCtor& obj) {
+        copy_ctor_invoked ++;
+        this->value = obj.value;
+    }
+
+    CountNoDefaultCtor(CountNoDefaultCtor&& obj) {
+        move_ctor_invoked ++;
+        this->value = obj.value;
+    }
+
+    CountNoDefaultCtor& operator=(const CountNoDefaultCtor& obj) {
+        copy_invoked ++;
+        this->value = obj.value;
+        return *this;
+    }
+
+    CountNoDefaultCtor& operator=(CountNoDefaultCtor&& obj) {
+        move_invoked ++;
+        this->value = obj.value;
+        return *this;
+    }   
+
+    int value;
+
+    static int ctor_invoked;
+    static int dtor_invoked;
+    static int copy_invoked;
+    static int move_invoked;
+    static int copy_ctor_invoked;
+    static int move_ctor_invoked;
+};
 
 void install_test_abort();
 

--- a/test/cpp_api/project.json
+++ b/test/cpp_api/project.json
@@ -397,7 +397,8 @@
                 "flecs_ctor",
                 "flecs_ctor_w_default_ctor",
                 "default_ctor_w_value_ctor",
-                "flecs_ctor_w_value_ctor"
+                "flecs_ctor_w_value_ctor",
+                "no_default_ctor_move_ctor_on_set"
             ]
         }, {
             "id": "Refs",

--- a/test/cpp_api/project.json
+++ b/test/cpp_api/project.json
@@ -381,7 +381,23 @@
                 "implicit_component",
                 "implicit_after_query",
                 "deleted_copy",
-                "no_default_ctor"
+                "no_default_ctor",
+                "default_init",
+                "no_default_ctor_add",
+                "no_default_ctor_add_relation",
+                "no_default_ctor_add_object",
+                "no_default_ctor_set",
+                "no_copy_ctor",
+                "no_move_ctor",
+                "no_copy_assign",
+                "no_move_assign",
+                "no_copy",
+                "no_move",
+                "no_dtor",
+                "flecs_ctor",
+                "flecs_ctor_w_default_ctor",
+                "default_ctor_w_value_ctor",
+                "flecs_ctor_w_value_ctor"
             ]
         }, {
             "id": "Refs",

--- a/test/cpp_api/src/ComponentLifecycle.cpp
+++ b/test/cpp_api/src/ComponentLifecycle.cpp
@@ -13,6 +13,13 @@ int Pod::move_invoked = 0;
 int Pod::copy_ctor_invoked = 0;
 int Pod::move_ctor_invoked = 0;
 
+int CountNoDefaultCtor::ctor_invoked = 0;
+int CountNoDefaultCtor::dtor_invoked = 0;
+int CountNoDefaultCtor::copy_invoked = 0;
+int CountNoDefaultCtor::move_invoked = 0;
+int CountNoDefaultCtor::copy_ctor_invoked = 0;
+int CountNoDefaultCtor::move_ctor_invoked = 0;
+
 class Str {
 public:
     std::string value;
@@ -659,4 +666,35 @@ void ComponentLifecycle_flecs_ctor_w_value_ctor() {
     try_add<FlecsCtorValueCtor>(ecs);
 
     try_set<FlecsCtorValueCtor>(ecs);
+}
+
+void ComponentLifecycle_no_default_ctor_move_ctor_on_set() {
+    flecs::world ecs;
+
+    ecs.component<CountNoDefaultCtor>();
+
+    // First set, move construct
+    auto e = ecs.entity().set<CountNoDefaultCtor>({10});
+    test_assert(e.has<CountNoDefaultCtor>());
+
+    const CountNoDefaultCtor* ptr = e.get<CountNoDefaultCtor>();
+    test_assert(ptr != NULL);
+    test_int(ptr->value, 10);
+
+    test_int(CountNoDefaultCtor::ctor_invoked, 1);
+    test_int(CountNoDefaultCtor::dtor_invoked, 1);
+    test_int(CountNoDefaultCtor::copy_invoked, 0);
+    test_int(CountNoDefaultCtor::move_invoked, 0);
+    test_int(CountNoDefaultCtor::copy_ctor_invoked, 0);
+    test_int(CountNoDefaultCtor::move_ctor_invoked, 1);
+
+    // Second set, move assign
+    e.set<CountNoDefaultCtor>({10});
+
+    test_int(CountNoDefaultCtor::ctor_invoked, 2);
+    test_int(CountNoDefaultCtor::dtor_invoked, 2);
+    test_int(CountNoDefaultCtor::copy_invoked, 0);
+    test_int(CountNoDefaultCtor::move_invoked, 1);
+    test_int(CountNoDefaultCtor::copy_ctor_invoked, 0);
+    test_int(CountNoDefaultCtor::move_ctor_invoked, 1);    
 }

--- a/test/cpp_api/src/World.cpp
+++ b/test/cpp_api/src/World.cpp
@@ -1,14 +1,5 @@
 #include <cpp_api.h>
 
-static
-void install_test_abort() {
-    ecs_os_set_api_defaults();
-    ecs_os_api_t os_api = ecs_os_api;
-    os_api.abort_ = test_abort;
-    ecs_os_set_api(&os_api);
-    ecs_tracing_enable(-2);
-}
-
 void World_multi_world_empty() {
     flecs::world *w1 = new flecs::world();
     delete w1;

--- a/test/cpp_api/src/main.cpp
+++ b/test/cpp_api/src/main.cpp
@@ -355,6 +355,22 @@ void ComponentLifecycle_implicit_component(void);
 void ComponentLifecycle_implicit_after_query(void);
 void ComponentLifecycle_deleted_copy(void);
 void ComponentLifecycle_no_default_ctor(void);
+void ComponentLifecycle_default_init(void);
+void ComponentLifecycle_no_default_ctor_add(void);
+void ComponentLifecycle_no_default_ctor_add_relation(void);
+void ComponentLifecycle_no_default_ctor_add_object(void);
+void ComponentLifecycle_no_default_ctor_set(void);
+void ComponentLifecycle_no_copy_ctor(void);
+void ComponentLifecycle_no_move_ctor(void);
+void ComponentLifecycle_no_copy_assign(void);
+void ComponentLifecycle_no_move_assign(void);
+void ComponentLifecycle_no_copy(void);
+void ComponentLifecycle_no_move(void);
+void ComponentLifecycle_no_dtor(void);
+void ComponentLifecycle_flecs_ctor(void);
+void ComponentLifecycle_flecs_ctor_w_default_ctor(void);
+void ComponentLifecycle_default_ctor_w_value_ctor(void);
+void ComponentLifecycle_flecs_ctor_w_value_ctor(void);
 
 // Testsuite 'Refs'
 void Refs_get_ref(void);
@@ -1800,6 +1816,70 @@ bake_test_case ComponentLifecycle_testcases[] = {
     {
         "no_default_ctor",
         ComponentLifecycle_no_default_ctor
+    },
+    {
+        "default_init",
+        ComponentLifecycle_default_init
+    },
+    {
+        "no_default_ctor_add",
+        ComponentLifecycle_no_default_ctor_add
+    },
+    {
+        "no_default_ctor_add_relation",
+        ComponentLifecycle_no_default_ctor_add_relation
+    },
+    {
+        "no_default_ctor_add_object",
+        ComponentLifecycle_no_default_ctor_add_object
+    },
+    {
+        "no_default_ctor_set",
+        ComponentLifecycle_no_default_ctor_set
+    },
+    {
+        "no_copy_ctor",
+        ComponentLifecycle_no_copy_ctor
+    },
+    {
+        "no_move_ctor",
+        ComponentLifecycle_no_move_ctor
+    },
+    {
+        "no_copy_assign",
+        ComponentLifecycle_no_copy_assign
+    },
+    {
+        "no_move_assign",
+        ComponentLifecycle_no_move_assign
+    },
+    {
+        "no_copy",
+        ComponentLifecycle_no_copy
+    },
+    {
+        "no_move",
+        ComponentLifecycle_no_move
+    },
+    {
+        "no_dtor",
+        ComponentLifecycle_no_dtor
+    },
+    {
+        "flecs_ctor",
+        ComponentLifecycle_flecs_ctor
+    },
+    {
+        "flecs_ctor_w_default_ctor",
+        ComponentLifecycle_flecs_ctor_w_default_ctor
+    },
+    {
+        "default_ctor_w_value_ctor",
+        ComponentLifecycle_default_ctor_w_value_ctor
+    },
+    {
+        "flecs_ctor_w_value_ctor",
+        ComponentLifecycle_flecs_ctor_w_value_ctor
     }
 };
 
@@ -2283,7 +2363,7 @@ static bake_test_suite suites[] = {
         "ComponentLifecycle",
         NULL,
         NULL,
-        18,
+        34,
         ComponentLifecycle_testcases
     },
     {

--- a/test/cpp_api/src/main.cpp
+++ b/test/cpp_api/src/main.cpp
@@ -371,6 +371,7 @@ void ComponentLifecycle_flecs_ctor(void);
 void ComponentLifecycle_flecs_ctor_w_default_ctor(void);
 void ComponentLifecycle_default_ctor_w_value_ctor(void);
 void ComponentLifecycle_flecs_ctor_w_value_ctor(void);
+void ComponentLifecycle_no_default_ctor_move_ctor_on_set(void);
 
 // Testsuite 'Refs'
 void Refs_get_ref(void);
@@ -1880,6 +1881,10 @@ bake_test_case ComponentLifecycle_testcases[] = {
     {
         "flecs_ctor_w_value_ctor",
         ComponentLifecycle_flecs_ctor_w_value_ctor
+    },
+    {
+        "no_default_ctor_move_ctor_on_set",
+        ComponentLifecycle_no_default_ctor_move_ctor_on_set
     }
 };
 
@@ -2363,7 +2368,7 @@ static bake_test_suite suites[] = {
         "ComponentLifecycle",
         NULL,
         NULL,
-        34,
+        35,
         ComponentLifecycle_testcases
     },
     {

--- a/test/cpp_api/src/util.cpp
+++ b/test/cpp_api/src/util.cpp
@@ -1,0 +1,10 @@
+#include <cpp_api.h>
+
+void install_test_abort() {
+    ecs_os_set_api_defaults();
+    ecs_os_api_t os_api = ecs_os_api;
+    os_api.abort_ = test_abort;
+    ecs_os_set_api(&os_api);
+
+    ecs_tracing_enable(-4);
+}


### PR DESCRIPTION
This PR enables using types as components that are not default constructible and are not copyable. Types must still be movable and destructible.

The details of what changed:
- non-default constructible types can be registered as components
- non copyable (either with a deleted copy ctor, copy assignment or both) can be registered as components
- when a type has a `T(flecs::world&, flecs::entity)` ctor, the C++ API will use this instead of the default ctor
- types that are not movable or destructible will throw static asserts upon registration/first usage
- when a non-default constructible type is used with add a static assert is thrown
- when a non-default constructible type is set, the first set move constructs, subsequent calls move assign

fixes #419