### PR TITLE
#124 cleanup C++ API, docs

### DIFF
--- a/docs/Relations.md
+++ b/docs/Relations.md
@@ -1,0 +1,467 @@
+# Relations
+The relationships feature allows for the creation of entity graphs, by specifying which relations entities have to each other. Relations are similar to regular components and tags, in that they can contain data or no data, and can be added and removed. The following example demonstrates a simple example that uses relations:
+
+```c
+ecs_entity_t Likes = ecs_new_id(world);
+ecs_entity_t Bob = ecs_new_id(world);
+ecs_entity_t Alice = ecs_new_id(world);
+
+// Bob Likes Alice
+ecs_add_pair(world, Bob, Likes, Alice);
+
+// Bob Likes Alice no more
+ecs_remove_pair(world, Bob, Likes, Alice);
+```
+```cpp
+auto Likes = world.entity();
+auto Bob = world.entity();
+auto Alice = world.entity();
+
+// Bob Likes Alice
+Bob.add(Likes, Alice);
+
+// Bob Likes Alice no more
+Bob.remove(Likes, Alice);
+```
+
+In this example, we would refer to `Bob` as the "subject", `Likes` as the "relation" and `Alice` as the "object". A relation when combined with an object is called a "relation pair". A pair combined with a subject is called a "relation triple".
+
+The same relation can be added multiple times to an entity, as long as its object is different:
+
+```c
+ecs_entity_t Bob = ecs_new_id(world);
+ecs_entity_t Eats = ecs_new_id(world);
+ecs_entity_t Apples = ecs_new_id(world);
+ecs_entity_t Pears = ecs_new_id(world);
+
+ecs_add_pair(world, Bob, Eats, Apples);
+ecs_add_pair(world, Bob, Eats, Pears);
+
+ecs_has_pair(world, Bob, Eats, Apples); // true
+ecs_has_pair(world, Bob, Eats, Pears); // true
+```
+```cpp
+auto Bob = world.entity();
+auto Eats = world.entity();
+auto Apples = world.entity();
+auto Pears = world.entity();
+
+Bob.add(Eats, Apples);
+Bob.add(Eats, Pears);
+
+Bob.has(Eats, Apples); // true
+Bob.has(Eats, Pears); // true
+```
+
+An application can query for relationships with the `(Relation, Object)` notation:
+
+```c
+// Find all entities that eat apples
+ecs_query_t *q = ecs_query_new(world, "(Eats, Apples)");
+
+// Find all entities that eat anything
+ecs_query_t *q = ecs_query_new(world, "(Eats, *)");
+
+// Or with the ecs_query_init function:
+ecs_query_t *q = ecs_query_init(world, &(ecs_query_desc_t){
+    .filter.terms = {{ecs_pair(Eats, Apples)}}
+});
+```
+```cpp
+// Find all entities that eat apples
+auto q = world.query("(Eats, Apples)");
+
+// Find all entities that eat anything
+auto q = world.query("(Eats, *)");
+
+// Or with the query builder API:
+auto q = world.query_builder<>()
+  .term(Eats, Apples)
+  .build();
+```
+
+This example just shows a simple relation query. Relation queries are much more powerful than this as they provide the ability to match against entity graphs of arbitrary size. For more information on relation queries see the [Query manual](Query.md).
+
+## Relation components
+So far we've just seen relations with regular entities. When used in combination with components, relations can be associated with data:
+
+```c
+typedef struct {
+    float amount;
+} Requires;
+
+ECS_COMPONENT(world, Requires);
+ECS_TAG(world, GigaWatts);
+
+ecs_entity_t delorean = ecs_new_id(world);
+
+ecs_set_pair(world, delorean, Requires, GigaWatts, {1.21});
+
+const Requires *r = ecs_get_pair(world, delorean, Requires, GigaWatts);
+printf("%f gigawatts!\n", r->amount);
+```
+```cpp
+struct Requires {
+  float amount;
+};
+
+struct Gigawatts { };
+
+auto delorean = world.entity()
+  .set<Requires, Gigawatts>({1.21});
+
+auto r = delorean.get<Requires, Gigawatts>();
+cout << r->value << " gigawatts!" << endl;
+```
+
+Relations composed out of types can use the `flecs::pair` template in the C++ API:
+
+```cpp
+using RequiresGigawatts = flecs::pair<Requires, Gigawatts>;
+
+auto delorean = world.entity()
+  .set<RequiresGigawatts>({1.21});
+
+auto r = delorean.get<RequiresGigaWatts>();
+cout << r->value << " gigawatts!" << endl;
+```
+
+An advantage of the `flecs::pair` template is that it can be used with function-style get/set operations:
+
+```cpp
+// rvalue required as API converts value from 'Requires' to 'RequiresGigawatts'
+e.set([](RequiresGigawatts&& r) {
+  r->value = 1.21; // Overloaded '->' operator to get the pair value 
+})
+
+e.get([](const RequiresGigawatts& r) {
+  cout << r->value << " gigawatts!" << endl;
+});
+```
+
+In the above examples we added data to the "relation" part of the pair. If the relation part is a tag, we can also attach data to the object:
+
+```c
+typedef struct {
+  const char *value;
+} Event;
+
+ECS_TAG(world, Begin);
+ECS_TAG(world, End);
+ECS_COMPONENT(world, Event);
+
+ecs_entity_t universe = ecs_new_id(world);
+
+// Set data on the Event object, instead of the Begin, End relations:
+ecs_set_pair_object(world, universe, Begin, Event, {"Big Bang"});
+ecs_set_pair_object(world, universe, End, Event, {"Heat Death"});
+
+const Event *e = ecs_get_pair_object(world, universe, Begin, Event);
+printf("In the beginning there was the %s\n", e->value);
+```
+```cpp
+struct Event {
+  const char *value;
+};
+
+struct Begin { };
+struct End { };
+
+using BeginEvent = flecs::pair<Begin, Event>;
+using EndEvent = flecs::pair<End, Event>;
+
+// Set data on the Event object, instead of the Begin, End relations:
+auto universe = world.entity();
+  .set_object<Begin, Event>({"Big Bang"})
+  .set_object<End, Event>({"Heat Death"});
+
+universe.get([](const BeginEvent& e) {
+  cout << "In the beginning there was the " << e.value << endl;
+});
+```
+
+### Using relations to add components multiple times
+A limitation of components is that they can only be added once to an entity. Relations make it possible to get around this limitation, as a component _can_ be added multiple times, as long as the pair is unique. Pairs can be constructed on the fly from new entity identifiers, which means this is possible:
+
+```c
+typedef struct {
+  float x;
+  float y;
+} Position;
+
+ecs_entity_t e = ecs_new_id(world);
+
+ecs_entity_t first = ecs_new_id(world);
+ecs_entity_t second = ecs_new_id(world);
+ecs_entity_t third = ecs_new_id(world);
+
+// Add component position 3 times, for 3 different objects
+ecs_add_pair(world, e, Position, first, {1, 2});
+ecs_add_pair(world, e, Position, second, {3, 4});
+ecs_add_pair(world, e, Position, third, {5, 6});
+```
+```cpp
+struct Position {
+  float x;
+  float y;
+}
+
+auto e = world.entity();
+
+auto first = world.entity();
+auto second = world.entity();
+auto third = world.entity();
+
+// Add component position 3 times, for 3 different objects
+e.set<Position>(first, {1, 2});
+e.set<Position>(second, {3, 4});
+e.set<Position>(third, {5, 6});
+```
+
+## Relation wildcards
+When querying for relation pairs, it is often useful to be able to find all instances for a given relation or object. To accomplish this, an application can use wildcard expressions. Consider the following example, that queries for all entities with a `Likes` relation:
+
+```c
+ecs_query_t *q = ecs_query_init(world, &(ecs_query_desc_t){
+  .filter.terms = {
+    {ecs_pair(Likes, EcsWildcard)}
+  }
+});
+
+ecs_iter_t it = ecs_query_iter(q);
+
+while (ecs_query_next(&it)) {
+  ecs_id_t id = ecs_term_id(&it, 1); // Obtain pair id
+
+  // Get relation & object
+  ecs_entity_t rel = ecs_pair_relation(world, id);
+  ecs_entity_t obj = ecs_pair_object(world, id);
+
+  for (int i = 0; i < it.count; it++) {
+    printf("entity %d has relation %s, %s\n", 
+      it.entities[i],
+      ecs_get_name(world, rel), 
+      ecs_get_name(world, obj));
+  }
+}
+```
+```cpp
+auto q = world.query_builder()
+  .term(Likes, flecs::Wildcard)
+  .build();
+
+q.iter([]flecs::iter& it) {
+  auto id = it.term_id(1);
+
+  for (auto i : it) {
+    cout << "entity " << it.entity(i) << " has relation "
+      << id.relation().name() << ", "
+      << id.object().name() << endl;
+  }
+});
+```
+
+Wildcards may appear in query expressions, using the `*` character:
+
+```c
+ecs_query_t *q = ecs_query_init(world, &(ecs_query_desc_t){
+  .filter.expr = "(Likes, *)"
+});
+```
+```cpp
+auto q = world.query("(Likes, *)");
+```
+
+Wildcards may used for the relation or object part of a pair, or both:
+
+```cpp
+"(Likes, *)" // Matches all Likes relations
+"(*, Alice)" // Matches all relations with Alice as object
+"(*, *)"     // Matches all relations
+```
+
+## Inspecting relations
+An application can use pair wildcard expressions to find all instances of a relationship for an entity. The following example shows how to find all `Eats` relationships for an entity:
+
+```c
+// Bob eats apples and pears
+ecs_entity_t Eats = ecs_new_id(world);
+ecs_entity_t Apples = ecs_new_id(world);
+ecs_entity_t Pears = ecs_new_id(world);
+
+ecs_entity_t Bob = ecs_new_id(world);
+ecs_add_pair(world, Bob, Eats, Apples);
+ecs_add_pair(world, Bob, Eats, Pears);
+
+// Find all (Eats, *) relations in Bob's type
+ecs_type_t bob_type = ecs_get_type(world, Bob);
+ecs_id_t wildcard = ecs_pair(Eats, EcsWildcard);
+ecs_id_t *ids = ecs_vector_first(bob_type);
+int32_t cur = 0;
+
+while (-1 != (cur = ecs_type_match(type, cur, wildcard))) {
+  ecs_entity_t obj = ecs_pair_object(ids[cur]);
+  printf("Bob eats %s\n", ecs_get_name(world, obj));
+}
+```
+```cpp
+// Bob eats apples and pears
+auto Bob = world.entity();
+auto Eats = world.entity();
+auto Apples = world.entity();
+auto Pears = world.entity();
+
+Bob.add(Eats, Apples);
+Bob.add(Eats, Pears);
+
+// Find all (Eats, *) relations in Bob's type
+bob.match(world.pair(Eats, flecs::Wildcard), [](flecs::id id) {
+  cout << "Bob eats " << id.object().name() << endl;
+});
+
+// For object wildcard pairs, each() can be used:
+bob.each(Eats, [](flecs::entity obj) {
+  cout << "Bob eats " << obj.name() << endl;
+})
+```
+
+## Relation cleanup
+When either the relation or object entity of a relation is deleted, by default all of the instances of the relation are removed from the store. Consider the following example:
+
+```c
+ecs_entity_t Likes = ecs_new_id(world);
+ecs_entity_t Bob = ecs_new_id(world);
+ecs_entity_t Alice = ecs_new_id(world);
+
+ecs_add_pair(world, Bob, Likes, Alice);
+
+// This removes (Likes, Alice) from Bob, and all other entities that had a 
+// relation with Alice
+ecs_delete(world, Alice);
+```
+```cpp
+auto Likes = world.entity();
+auto Bob = world.entity();
+auto Alice = world.entity();
+
+Bob.add(Likes, Alice);
+
+// This removes (Likes, Alice) from Bob, and all other entities that had a 
+// relation with Alice
+Alice.destruct();
+```
+
+This behavior can be customized with cleanup policies as the above behavior is not always what you want. A typical example is the builtin `ChildOf` relation, where child entities should be deleted when the parent is deleted:
+
+```c
+ecs_entity_t Spaceship = ecs_new_id(world);
+ecs_entity_t Cockpit = ecs_new_id(world);
+
+ecs_add_pair(world, Cockpit, EcsChildOf, Spaceship);
+
+// This deletes both the spaceship and the cockpit entity
+ecs_delete(world, Spaceship);
+```
+```cpp
+auto Spaceship = world.entity();
+auto Cockpit = world.entity();
+
+Cockpit.child_of(Spaceship);
+
+// This deletes both the spaceship and the cockpit entity
+Spaceship.destruct();
+```
+
+To customize this behavior, an application can add the `OnDeleteObject` policy to the relationship. The following examples show how:
+
+```c
+ecs_entity_t Likes = ecs_new_id(world);
+ecs_entity_t Bob = ecs_new_id(world);
+ecs_entity_t Alice = ecs_new_id(world);
+
+ecs_add_pair(world, Bob, Likes, Alice);
+
+// When Alice is deleted, remove (Likes, Alice) from Bob
+ecs_add_pair(world, Likes, EcsOnDeleteObject, EcsRemove);
+
+// When Alice is deleted, delete Bob 
+ecs_add_pair(world, Likes, EcsOnDeleteObject, EcsDelete);
+
+// When Alice is deleted, throw an error (assert)
+ecs_add_pair(world, Likes, EcsOnDeleteObject, EcsThrow);
+```
+```cpp
+auto Likes = world.entity();
+auto Bob = world.entity();
+auto Alice = world.entity();
+
+Bob.add(Likes, Alice);
+
+// When Alice is deleted, remove (Likes, Alice) from Bob
+Likes.add(flecs::OnDeleteObject, flecs::Remove)
+
+// When Alice is deleted, delete Bob 
+Likes.add(flecs::OnDeleteObject, flecs::Delete);
+
+// When Alice is deleted, throw an error (assert)
+Likes.add(flecs::OnDeleteObject, flecs::Throw);
+```
+
+An application may also specify what cleanup action should be performed if the relation itself is deleted with the `OnDelete` policy:
+
+```c
+ecs_entity_t Likes = ecs_new_id(world);
+ecs_entity_t Bob = ecs_new_id(world);
+ecs_entity_t Alice = ecs_new_id(world);
+
+ecs_add_pair(world, Bob, Likes, Alice);
+
+// When Likes is deleted, remove (Likes, Alice) from Bob
+ecs_add_pair(world, Likes, EcsOnDelete, EcsRemove);
+
+// When Likes is deleted, delete Bob 
+ecs_add_pair(world, Likes, EcsOnDelete, EcsDelete);
+
+// When Likes is deleted, throw an error (assert)
+ecs_add_pair(world, Likes, EcsOnDelete, EcsThrow);
+```
+```cpp
+auto Likes = world.entity();
+auto Bob = world.entity();
+auto Alice = world.entity();
+
+Bob.add(Likes, Alice);
+
+// When Likes is deleted, remove (Likes, Alice) from Bob
+Likes.add(flecs::OnDelete, flecs::Remove)
+
+// When Likes is deleted, delete Bob 
+Likes.add(flecs::OnDelete, flecs::Delete);
+
+// When Likes is deleted, throw an error (assert)
+Likes.add(flecs::OnDelete, flecs::Throw);
+```
+
+By default, components are created with the `(OnDelete, Throw)` policy.
+
+## Relation performance
+A relation that does not have any data has the same performance as a regular tag. A relation that does have data has the same performance as a component.
+
+To understand how this works consider that on the storage level a component or tag is represented by a unique id and a size. The id identifies the component, whereas the size is the size of the component data. If an id represents a tag, the size is 0. An entity can only have a single instance of each unique id, which means that you can only add component `Position` once to the same entity.
+
+On the storage level, relations are nothing more than unique ids, which are generated from a (relation, object) pair by the API. Each unique (relation, object) combination produces a unique id that can then be added or removed from an entity in the storage. For the most part the storage is unaware of whether an id represents a relation, component or tag which means their performance is equivalent.
+
+The following code example shows how the API generates a unique id from a pair before passing it down to the storage:
+
+```c
+// This function call
+const Requires *r = ecs_get_pair(world, e, Requires, Gigawatts);
+
+// Is equivalent to this code
+ecs_id_t pair_id = ecs_pair(ecs_id(Requires), Gigawatts);
+const Required *r = ecs_get_id(world, e, pair_id); // Regular get
+
+// The pair_id is generated by storing the relation id in the upper 32 bits of
+// the identifier and the object in the lower 32 bits:
+ecs_id_t pair_id = Requires_id << 32 | Gigawatts;
+```

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -413,9 +413,6 @@ typedef struct ecs_trigger_desc_t {
     /* Term specifying the id to subscribe for */
     ecs_term_t term;
 
-    /* Optional name. */
-    const char *name;
-
     /* Filter expression. May only contain a single term. If this field is set,
      * the term field is ignored. */
     const char *expr;
@@ -438,6 +435,7 @@ typedef struct ecs_trigger_desc_t {
     /* Callback to free binding_ctx */     
     ecs_ctx_free_t binding_ctx_free;
 } ecs_trigger_desc_t;
+
 
 /** @} */
 

--- a/include/flecs/addons/deprecated/iter.hpp
+++ b/include/flecs/addons/deprecated/iter.hpp
@@ -33,16 +33,13 @@ public:
     ECS_DEPRECATED("use type()")
     type table_type() const; 
 
-    template <typename T,
-        typename std::enable_if<std::is_const<T>::value, void>::type* = nullptr>
+    template <typename T, if_t< is_const<T>::value > = 0>
     ECS_DEPRECATED("use term<const T>(int32_t)")
     flecs::column<T> column(int32_t col) const {
         return base()->template term<T>(col);
     }
 
-    template <typename T,
-        typename std::enable_if<
-            std::is_const<T>::value == false, void>::type* = nullptr>
+    template <typename T, if_not_t< is_const<T>::value > = 0>
     ECS_DEPRECATED("use term<T>(int32_t)")
     flecs::column<T> column(int32_t col) const {
         ecs_assert(!ecs_is_readonly(iter(), col), 
@@ -67,16 +64,13 @@ public:
         return base()->template shared<T>(col);
     }
 
-    template <typename T,
-        typename std::enable_if<std::is_const<T>::value, void>::type* = nullptr>    
+    template <typename T, if_t< is_const<T>::value > = 0> 
     ECS_DEPRECATED("no replacement")
     T& element(int32_t col, int32_t row) const {
         return base()->template get_element<T>(col, row);
     }
 
-    template <typename T,
-        typename std::enable_if<
-            std::is_const<T>::value == false, void>::type* = nullptr>
+    template <typename T, if_not_t< is_const<T>::value > = 0>
     ECS_DEPRECATED("no replacement")
     T& element(int32_t col, int32_t row) const {
         ecs_assert(!ecs_is_readonly(iter(), col), 

--- a/include/flecs/cpp/builder.hpp
+++ b/include/flecs/cpp/builder.hpp
@@ -478,32 +478,28 @@ private:
         return *static_cast<Base*>(this);
     }
 
-    template <typename T,
-        typename std::enable_if< std::is_const<T>::value == true, void>::type* = nullptr>
+    template <typename T, if_t< is_const<T>::value > = 0>
     constexpr flecs::inout_kind_t type_to_inout() const {
         return flecs::In;
     }
 
-    template <typename T,
-        typename std::enable_if< std::is_reference<T>::value == true, void>::type* = nullptr>
+    template <typename T, if_t< is_reference<T>::value > = 0>
     constexpr flecs::inout_kind_t type_to_inout() const {
         return flecs::Out;
     }
 
-    template <typename T,
-        typename std::enable_if<std::is_const<T>::value == false && std::is_reference<T>::value == false, void>::type* = nullptr>
+    template <typename T, if_not_t< 
+        is_const<T>::value || is_reference<T>::value > = 0>
     constexpr flecs::inout_kind_t type_to_inout() const {
         return flecs::InOutDefault;
     }
 
-    template <typename T,
-        typename std::enable_if< std::is_pointer<T>::value == true, void>::type* = nullptr>
+    template <typename T, if_t< is_pointer<T>::value > = 0>
     constexpr flecs::oper_kind_t type_to_oper() const {
         return flecs::Optional;
     }
 
-    template <typename T,
-        typename std::enable_if< std::is_pointer<T>::value == false, void>::type* = nullptr>
+    template <typename T, if_not_t< is_pointer<T>::value > = 0>
     constexpr flecs::oper_kind_t type_to_oper() const {
         return flecs::And;
     }

--- a/include/flecs/cpp/function_traits.hpp
+++ b/include/flecs/cpp/function_traits.hpp
@@ -88,34 +88,24 @@ struct function_traits_no_cv<T, decltype((void)&T::operator())>
 // Front facing template that decays T before ripping it apart.
 template <typename T>
 struct function_traits
-    : function_traits_no_cv<typename std::decay<T>::type> {};
+    : function_traits_no_cv< decay_t<T> > {};
 
-// SFINAE utility to test if object is function
-template <typename T, typename U = void>
-struct is_function;
+} // _
 
 template <typename T>
-struct is_function<T, typename std::enable_if<function_traits<T>::is_callable>::type> {
-    using type = void;
+struct is_callable {
+    static constexpr bool value = _::function_traits<T>::is_callable;
 };
-
-// SFINAE utility to test if object is not a function
-template <typename T, typename U = void>
-struct no_function;
 
 template <typename T>
-struct no_function<T, typename std::enable_if<function_traits<T>::is_callable == false>::type> {
-    using type = void;
+struct arity {
+    static constexpr bool value = _::function_traits<T>::arity;
 };
 
-// SFINAE utility to check argument count
-template <typename T, size_t N, typename U = void>
-struct if_function_arity;
+template <typename T>
+using return_type_t = typename _::function_traits<T>::return_type;
 
-template <typename T, size_t N>
-struct if_function_arity<T, N, typename std::enable_if<function_traits<T>::arity == N>::type> {
-    using type = void;
-};
+template <typename T>
+using arg_list_t = typename _::function_traits<T>::args;
 
-}
-}
+} // flecs

--- a/include/flecs/cpp/impl/iter.hpp
+++ b/include/flecs/cpp/impl/iter.hpp
@@ -1,5 +1,5 @@
 
-namespace flecs 
+namespace flecs
 {
 
 inline flecs::entity iter::system() const {

--- a/include/flecs/cpp/impl/world.hpp
+++ b/include/flecs/cpp/impl/world.hpp
@@ -152,12 +152,6 @@ inline entity world::lookup(const char *name) const {
 }
 
 template <typename T>
-void world::set(T value) const {
-    flecs::entity e(m_world, _::cpp_type<T>::id(m_world));
-    e.set<T>(value);
-}
-
-template <typename T>
 T* world::get_mut() const {
     flecs::entity e(m_world, _::cpp_type<T>::id(m_world));
     return e.get_mut<T>();

--- a/include/flecs/cpp/iter.hpp
+++ b/include/flecs/cpp/iter.hpp
@@ -351,9 +351,7 @@ public:
      * @param index The term index.
      * @return The term data.
      */
-    template <typename T,
-        typename std::enable_if<std::is_const<T>::value, void>::type* = nullptr>
-        
+    template <typename T, if_t< is_const<T>::value > = 0>         
     flecs::column<T> term(int32_t index) const {
         return get_term<T>(index);
     }
@@ -366,10 +364,7 @@ public:
      * @param index The term index.
      * @return The term data.
      */
-    template <typename T,
-        typename std::enable_if<
-            std::is_const<T>::value == false, void>::type* = nullptr>
-
+    template <typename T, if_not_t< is_const<T>::value > = 0>
     flecs::column<T> term(int32_t index) const {
         ecs_assert(!ecs_term_is_readonly(m_iter, index), 
             ECS_COLUMN_ACCESS_VIOLATION, NULL);

--- a/include/flecs/cpp/pair.hpp
+++ b/include/flecs/cpp/pair.hpp
@@ -1,0 +1,117 @@
+
+namespace flecs {
+
+namespace _ {
+    struct pair_base { };   
+} // _
+
+
+// Type that represents a pair and can encapsulate a temporary value
+template <typename R, typename O, typename Type = R>
+struct pair : _::pair_base { 
+    // Traits used to deconstruct the pair
+    using type = Type;
+    using relation = R;
+    using object = O;
+
+    pair(Type& v) : ref_(v) { }
+
+    // This allows the class to be used as a temporary object
+    pair(const Type& v) : ref_(const_cast<Type&>(v)) { }
+
+    operator Type&() { 
+        return ref_;
+    }
+
+    operator const Type&() const { 
+        return ref_;
+    }    
+
+    Type* operator->() {
+        return &ref_;
+    }
+
+    const Type* operator->() const {
+        return &ref_;
+    }
+
+    Type& operator*() {
+        return &ref_;
+    }
+
+    const Type& operator*() const {
+        return ref_;
+    }
+    
+private:
+    Type& ref_;
+};
+
+// A pair_object is a pair where the type is determined by the object
+template <typename R, typename O>
+using pair_object = pair<R, O, O>;
+
+
+// Utilities to test if type is a pair
+template <typename T>
+struct is_pair {
+    static constexpr bool value = is_base_of<_::pair_base, remove_reference_t<T> >::value;
+};
+
+
+// Get actual type, relation or object from pair while preserving cv qualifiers.
+template <typename P>
+using pair_relation_t = transcribe_cv_t<remove_reference_t<P>, typename remove_reference_t<P>::relation>;
+
+template <typename P>
+using pair_object_t = transcribe_cv_t<remove_reference_t<P>, typename remove_reference_t<P>::object>;
+
+template <typename P>
+using pair_type_t = transcribe_cv_t<remove_reference_t<P>, typename remove_reference_t<P>::type>;
+
+
+// Get actual type from a regular type or pair
+template <typename T, typename U = int>
+struct actual_type;
+
+template <typename T>
+struct actual_type<T, if_not_t< is_pair<T>::value >> {
+    using type = T;
+};
+
+template <typename T>
+struct actual_type<T, if_t< is_pair<T>::value >> {
+    using type = pair_type_t<T>;
+};
+
+template <typename T>
+using actual_type_t = typename actual_type<T>::type;
+
+
+// Get type without const, *, &
+template<typename T>
+struct base_type {
+    using type = remove_pointer_t< decay_t< actual_type_t<T> > >;
+};
+
+template <typename T>
+using base_type_t = typename base_type<T>::type;
+
+
+// Get type without *, & (retains const which is useful for function args)
+template<typename T>
+struct base_arg_type {
+    using type = remove_pointer_t< remove_reference_t< actual_type_t<T> > >;
+};
+
+template <typename T>
+using base_arg_type_t = typename base_arg_type<T>::type;
+
+
+// Test if type is the same as its actual type
+template <typename T>
+struct is_actual {
+    static constexpr bool value = std::is_same<T, actual_type_t<T> >::value;
+};
+
+} // flecs

--- a/include/flecs/cpp/query.hpp
+++ b/include/flecs/cpp/query.hpp
@@ -166,7 +166,7 @@ protected:
 
 template<typename ... Components>
 class query : public query_base {
-    using Terms = typename _::term_ptrs<Components...>::Terms;
+    using Terms = typename _::term_ptrs<Components...>::array;
 
 public:
     query() { }

--- a/include/flecs/flecs.hpp
+++ b/include/flecs/flecs.hpp
@@ -84,7 +84,7 @@ class system_builder;
 
 namespace _
 {
-template <typename T>
+template <typename T, typename U = int>
 class cpp_type;
 }
 
@@ -172,16 +172,17 @@ static const flecs::entity_t Throw = EcsThrow;
 
 }
 
-#include <flecs/cpp/function_traits.hpp>
 #include <flecs/cpp/util.hpp>
+#include <flecs/cpp/pair.hpp>
+#include <flecs/cpp/function_traits.hpp>
 #include <flecs/cpp/lifecycle_traits.hpp>
 #include <flecs/cpp/iter.hpp>
 #include <flecs/cpp/world.hpp>
 #include <flecs/cpp/entity.hpp>
+#include <flecs/cpp/component.hpp>
 #include <flecs/cpp/invoker.hpp>
 #include <flecs/cpp/builder.hpp>
 #include <flecs/cpp/type.hpp>
-#include <flecs/cpp/component.hpp>
 #include <flecs/cpp/module.hpp>
 #include <flecs/cpp/filter.hpp>
 #include <flecs/cpp/snapshot.hpp>

--- a/test/cpp_api/project.json
+++ b/test/cpp_api/project.json
@@ -71,6 +71,7 @@
                 "get_nonempty_type",
                 "set_no_copy",
                 "set_copy",
+                "set_deduced",
                 "add_owned",
                 "set_owned",
                 "implicit_name_to_char",
@@ -154,8 +155,24 @@
                 "each_pair_w_childof",
                 "each_pair_w_recycled_rel",
                 "each_pair_w_recycled_obj",
+                "match_pair",
+                "match_pair_obj_wildcard",
+                "match_pair_rel_wildcard",
+                "match_pair_both_wildcard",
                 "has_tag_w_object",
-                "has_object_tag"
+                "has_object_tag",
+                "add_pair_type",
+                "remove_pair_type",
+                "set_pair_type",
+                "has_pair_type",
+                "get_1_pair_arg",
+                "get_2_pair_arg",
+                "set_1_pair_arg",
+                "set_2_pair_arg",
+                "get_inline_pair_type",
+                "set_inline_pair_type",
+                "get_pair_type_object",
+                "set_pair_type_object"
             ]
         }, {
             "id": "Switch",

--- a/test/cpp_api/src/ComponentLifecycle.cpp
+++ b/test/cpp_api/src/ComponentLifecycle.cpp
@@ -387,7 +387,7 @@ void ComponentLifecycle_implicit_after_query() {
 }
 
 template <typename T, typename std::enable_if<
-    !flecs::_::has_flecs_ctor<T>::value, void>::type* = nullptr>
+    !flecs::has_flecs_ctor<T>::value, void>::type* = nullptr>
 static void try_add(flecs::world& ecs) {
     flecs::entity e = ecs.entity().add<T>();
     
@@ -401,7 +401,7 @@ static void try_add(flecs::world& ecs) {
 }
 
 template <typename T, typename std::enable_if<
-    flecs::_::has_flecs_ctor<T>::value, void>::type* = nullptr>
+    flecs::has_flecs_ctor<T>::value, void>::type* = nullptr>
 static void try_add(flecs::world& ecs) {
     flecs::entity e = ecs.entity().add<T>();
     test_assert(e.has<T>());
@@ -443,7 +443,7 @@ static void try_add_object(flecs::world& ecs) {
 }
 
 template <typename T, typename std::enable_if<
-    !flecs::_::has_flecs_ctor<T>::value, void>::type* = nullptr>
+    !flecs::has_flecs_ctor<T>::value, void>::type* = nullptr>
 static void try_set(flecs::world& ecs) {
     flecs::entity e = ecs.entity().set<T>({10});
 
@@ -452,7 +452,7 @@ static void try_set(flecs::world& ecs) {
 }
 
 template <typename T, typename std::enable_if<
-    flecs::_::has_flecs_ctor<T>::value, void>::type* = nullptr>
+    flecs::has_flecs_ctor<T>::value, void>::type* = nullptr>
 static void try_set(flecs::world& ecs) {
     flecs::entity e = ecs.entity().set<T>({10});
 
@@ -464,7 +464,7 @@ static void try_set(flecs::world& ecs) {
 }
 
 template <typename T, typename std::enable_if<
-    !flecs::_::has_flecs_ctor<T>::value, void>::type* = nullptr>
+    !flecs::has_flecs_ctor<T>::value, void>::type* = nullptr>
 static void try_set_default(flecs::world& ecs) {
     flecs::entity e = ecs.entity().set(T());
 
@@ -475,7 +475,7 @@ static void try_set_default(flecs::world& ecs) {
 }
 
 template <typename T, typename std::enable_if<
-    flecs::_::has_flecs_ctor<T>::value, void>::type* = nullptr>
+    flecs::has_flecs_ctor<T>::value, void>::type* = nullptr>
 static void try_set_default(flecs::world& ecs) {
     flecs::entity e = ecs.entity().set(T());
 

--- a/test/cpp_api/src/Entity.cpp
+++ b/test/cpp_api/src/Entity.cpp
@@ -880,6 +880,19 @@ void Entity_set_copy() {
     test_int(p->value, 10);
 }
 
+void Entity_set_deduced() {
+    flecs::world world;
+
+    auto e = world.entity()
+        .set(Position{10, 20});
+
+    test_assert(e.has<Position>());
+
+    const Position *p = e.get<Position>();
+    test_int(p->x, 10);
+    test_int(p->y, 20);
+}
+
 void Entity_add_owned() {
     flecs::world world;
 
@@ -2037,3 +2050,4 @@ void Entity_scope_before_builder_method() {
     auto C = ecs.lookup("P::C");
     test_assert(C != 0);
 }
+

--- a/test/cpp_api/src/Pairs.cpp
+++ b/test/cpp_api/src/Pairs.cpp
@@ -5,9 +5,9 @@ typedef struct Pair {
 } Pair;
 
 void Pairs_add_component_pair() {
-    flecs::world world;
+    flecs::world ecs;
 
-    auto entity = world.entity()
+    auto entity = ecs.entity()
         .add<Pair, Position>();
 
     test_assert(entity.id() != 0);
@@ -18,12 +18,12 @@ void Pairs_add_component_pair() {
 }
 
 void Pairs_add_tag_pair() {
-    flecs::world world;
+    flecs::world ecs;
 
-    flecs::component<Position>(world, "Position");
-    auto Pair = world.entity("Pair");
+    ecs.component<Position>();
+    auto Pair = ecs.entity("Pair");
 
-    auto entity = world.entity()
+    auto entity = ecs.entity()
         .add_object<Position>(Pair);
 
     test_assert(entity.id() != 0);
@@ -33,12 +33,12 @@ void Pairs_add_tag_pair() {
 }
 
 void Pairs_add_tag_pair_to_tag() {
-    flecs::world world;
+    flecs::world ecs;
 
-    auto Tag = world.entity("Tag");
-    auto Pair = world.entity("Pair");
+    auto Tag = ecs.entity("Tag");
+    auto Pair = ecs.entity("Pair");
 
-    auto entity = world.entity()
+    auto entity = ecs.entity()
         .add(Pair, Tag);
 
     test_assert(entity.id() != 0);
@@ -47,12 +47,12 @@ void Pairs_add_tag_pair_to_tag() {
 }
 
 void Pairs_remove_component_pair() {
-    flecs::world world;
+    flecs::world ecs;
 
-    flecs::component<Position>(world, "Position");
-    flecs::component<Pair>(world, "Pair");
+    ecs.component<Position>();
+    ecs.component<Pair>();
 
-    auto entity = world.entity()
+    auto entity = ecs.entity()
         .add<Pair, Position>();
 
     test_assert(entity.id() != 0);
@@ -66,12 +66,12 @@ void Pairs_remove_component_pair() {
 }
 
 void Pairs_remove_tag_pair() {
-    flecs::world world;
+    flecs::world ecs;
 
-    flecs::component<Position>(world, "Position");
-    auto Pair = world.entity("Pair");
+    ecs.component<Position>();
+    auto Pair = ecs.entity("Pair");
 
-    auto entity = world.entity()
+    auto entity = ecs.entity()
         .add_object<Position>(Pair);
 
     test_assert(entity.id() != 0);
@@ -84,12 +84,12 @@ void Pairs_remove_tag_pair() {
 }
 
 void Pairs_remove_tag_pair_to_tag() {
-    flecs::world world;
+    flecs::world ecs;
 
-    auto Tag = world.entity("Tag");
-    auto Pair = world.entity("Pair");
+    auto Tag = ecs.entity("Tag");
+    auto Pair = ecs.entity("Pair");
 
-    auto entity = world.entity()
+    auto entity = ecs.entity()
         .add(Pair, Tag);
 
     test_assert(entity.id() != 0);
@@ -101,9 +101,9 @@ void Pairs_remove_tag_pair_to_tag() {
 }
 
 void Pairs_set_component_pair() {
-    flecs::world world;
+    flecs::world ecs;
 
-    auto entity = world.entity()
+    auto entity = ecs.entity()
         .set<Pair, Position>({10});
 
     test_assert(entity.id() != 0);
@@ -117,11 +117,11 @@ void Pairs_set_component_pair() {
 }
 
 void Pairs_set_tag_pair() {
-    flecs::world world;
+    flecs::world ecs;
 
-    auto Pair = world.entity("Pair");
+    auto Pair = ecs.entity("Pair");
 
-    auto entity = world.entity()
+    auto entity = ecs.entity()
         .set_object<Position>(Pair, {10, 20});
 
     test_assert(entity.id() != 0);
@@ -135,16 +135,16 @@ void Pairs_set_tag_pair() {
 }
 
 void Pairs_system_1_pair_instance() {
-    flecs::world world;
+    flecs::world ecs;
 
-    world.entity()
+    ecs.entity()
         .set<Pair, Position>({10});
 
     int invoke_count = 0;
     int entity_count = 0;
     int trait_value = 0;
 
-    world.system<>(nullptr, "PAIR | Pair")
+    ecs.system<>(nullptr, "PAIR | Pair")
         .iter([&](flecs::iter it) {
             flecs::column<Pair> tr(it, 1);
             invoke_count ++;            
@@ -154,7 +154,7 @@ void Pairs_system_1_pair_instance() {
             }
         });
 
-    world.progress();
+    ecs.progress();
 
     test_int(invoke_count, 1);
     test_int(entity_count, 1);
@@ -162,9 +162,9 @@ void Pairs_system_1_pair_instance() {
 }
 
 void Pairs_system_2_pair_instances() {
-    flecs::world world;
+    flecs::world ecs;
 
-    world.entity()
+    ecs.entity()
         .set<Pair, Position>({10})
         .set<Pair, Velocity>({20});
 
@@ -172,7 +172,7 @@ void Pairs_system_2_pair_instances() {
     int entity_count = 0;
     int trait_value = 0;
 
-    world.system<>(nullptr, "PAIR | Pair")
+    ecs.system<>(nullptr, "PAIR | Pair")
         .iter([&](flecs::iter it) {
             flecs::column<Pair> tr(it, 1);
             invoke_count ++;            
@@ -182,7 +182,7 @@ void Pairs_system_2_pair_instances() {
             }
         });
 
-    world.progress();
+    ecs.progress();
 
     test_int(invoke_count, 2);
     test_int(entity_count, 2);
@@ -190,12 +190,12 @@ void Pairs_system_2_pair_instances() {
 }
 
 void Pairs_override_pair() {
-    flecs::world world;
+    flecs::world ecs;
 
-    auto base = world.entity()
+    auto base = ecs.entity()
         .set<Pair, Position>({10});
 
-    auto instance = world.entity()
+    auto instance = ecs.entity()
         .add(flecs::IsA, base);
 
     test_assert((instance.has<Pair, Position>()));
@@ -217,14 +217,14 @@ void Pairs_override_pair() {
 }
 
 void Pairs_override_tag_pair() {
-    flecs::world world;
+    flecs::world ecs;
 
-    auto Pair = world.entity();
+    auto Pair = ecs.entity();
 
-    auto base = world.entity()
+    auto base = ecs.entity()
         .set_object<Position>(Pair, {10, 20});
 
-    auto instance = world.entity()
+    auto instance = ecs.entity()
         .add(flecs::IsA, base);
 
     test_assert((instance.has_object<Position>(Pair)));
@@ -249,9 +249,9 @@ void Pairs_override_tag_pair() {
 }
 
 void Pairs_get_mut_pair() {
-    flecs::world world;
+    flecs::world ecs;
 
-    auto e = world.entity();
+    auto e = ecs.entity();
 
     bool added = false;
     Pair *t = e.get_mut<Pair, Position>(&added);
@@ -265,9 +265,9 @@ void Pairs_get_mut_pair() {
 }
 
 void Pairs_get_mut_pair_existing() {
-    flecs::world world;
+    flecs::world ecs;
 
-    auto e = world.entity()
+    auto e = ecs.entity()
         .set<Pair, Position>({20});
 
     bool added = false;
@@ -283,11 +283,11 @@ void Pairs_get_mut_pair_existing() {
 }
 
 void Pairs_get_mut_pair_tag() {
-    flecs::world world;
+    flecs::world ecs;
 
-    auto Pair = world.entity();
+    auto Pair = ecs.entity();
 
-    auto e = world.entity();
+    auto e = ecs.entity();
 
     bool added = false;
     Position *p = e.get_mut_object<Position>(Pair, &added);
@@ -303,11 +303,11 @@ void Pairs_get_mut_pair_tag() {
 }
 
 void Pairs_get_mut_pair_tag_existing() {
-    flecs::world world;
+    flecs::world ecs;
 
-    auto Pair = world.entity();
+    auto Pair = ecs.entity();
 
-    auto e = world.entity()
+    auto e = ecs.entity()
         .set_object<Position>(Pair, {10, 20});
 
     bool added = false;
@@ -324,71 +324,71 @@ void Pairs_get_mut_pair_tag_existing() {
 }
 
 void Pairs_type_w_pair() {
-    flecs::world world;
+    flecs::world ecs;
 
-    auto Type = world.type()
+    auto Type = ecs.type()
         .add<Pair, Position>();
 
-    auto e = world.entity()
+    auto e = ecs.entity()
         .add(Type);
 
     test_assert((e.has<Pair, Position>()));
 }
 
 void Pairs_type_w_pair_tag() {
-    flecs::world world;
+    flecs::world ecs;
 
-    auto Tag = world.entity();
+    auto Tag = ecs.entity();
 
-    auto Type = world.type()
+    auto Type = ecs.type()
         .add<Pair>(Tag);
 
-    auto e = world.entity()
+    auto e = ecs.entity()
         .add(Type);
 
     test_assert((e.has<Pair>(Tag)));
 }
 
 void Pairs_type_w_pair_tags() {
-    flecs::world world;
+    flecs::world ecs;
 
-    auto Tag = world.entity();
-    auto Pair = world.entity();
+    auto Tag = ecs.entity();
+    auto Pair = ecs.entity();
 
-    auto Type = world.type()
+    auto Type = ecs.type()
         .add(Pair, Tag);
 
-    auto e = world.entity()
+    auto e = ecs.entity()
         .add(Type);
 
     test_assert((e.has(Pair, Tag)));
 }
 
 void Pairs_type_w_tag_pair() {
-    flecs::world world;
+    flecs::world ecs;
 
-    auto Tag = world.entity();
+    auto Tag = ecs.entity();
 
-    auto Type = world.type()
+    auto Type = ecs.type()
         .add<Pair>(Tag);
 
-    auto e = world.entity()
+    auto e = ecs.entity()
         .add(Type);
 
     test_assert((e.has<Pair>(Tag)));
 }
 
 void Pairs_override_pair_w_type() {
-    flecs::world world;
+    flecs::world ecs;
 
-    auto Prefab = world.prefab("Prefab")
+    auto Prefab = ecs.prefab("Prefab")
         .set<Pair, Position>({10});
 
-    auto Type = world.type()
+    auto Type = ecs.type()
         .add(flecs::IsA, Prefab)
         .add<Pair, Position>();
 
-    auto e = world.entity()
+    auto e = ecs.entity()
         .add(Type);
 
     test_assert((e.has<Pair, Position>()));
@@ -405,18 +405,18 @@ void Pairs_override_pair_w_type() {
 }
 
 void Pairs_override_pair_w_type_tag() {
-    flecs::world world;
+    flecs::world ecs;
 
-    auto Tag = world.entity();
+    auto Tag = ecs.entity();
 
-    auto Prefab = world.prefab("Prefab")
+    auto Prefab = ecs.prefab("Prefab")
         .set<Pair>(Tag, {10});
 
-    auto Type = world.type()
+    auto Type = ecs.type()
         .add(flecs::IsA, Prefab)
         .add<Pair>(Tag);
 
-    auto e = world.entity()
+    auto e = ecs.entity()
         .add(Type);
 
     test_assert((e.has<Pair>(Tag)));
@@ -433,18 +433,18 @@ void Pairs_override_pair_w_type_tag() {
 }
 
 void Pairs_override_tag_pair_w_type() {
-    flecs::world world;
+    flecs::world ecs;
 
-    auto Pair = world.entity();
+    auto Pair = ecs.entity();
 
-    auto Prefab = world.prefab("Prefab")
+    auto Prefab = ecs.prefab("Prefab")
         .set_object<Position>(Pair, {10, 20});
 
-    auto Type = world.type()
+    auto Type = ecs.type()
         .add(flecs::IsA, Prefab)
         .add_object<Position>(Pair);
 
-    auto e = world.entity()
+    auto e = ecs.entity()
         .add(Type);
 
     test_assert((e.has_object<Position>(Pair)));
@@ -463,10 +463,10 @@ void Pairs_override_tag_pair_w_type() {
 }
 
 void Pairs_get_relation_from_id() {
-    flecs::world world;
+    flecs::world ecs;
 
-    auto rel = world.entity();
-    auto obj = world.entity();
+    auto rel = ecs.entity();
+    auto obj = ecs.entity();
 
     flecs::id pair(rel, obj);
 
@@ -478,10 +478,10 @@ void Pairs_get_relation_from_id() {
 }
 
 void Pairs_get_object_from_id() {
-    flecs::world world;
+    flecs::world ecs;
 
-    auto rel = world.entity();
-    auto obj = world.entity();
+    auto rel = ecs.entity();
+    auto obj = ecs.entity();
 
     flecs::id pair(rel, obj);
 
@@ -493,16 +493,16 @@ void Pairs_get_object_from_id() {
 }
 
 void Pairs_get_recycled_relation_from_id() {
-    flecs::world world;
+    flecs::world ecs;
 
-    auto rel = world.entity();
-    auto obj = world.entity();
+    auto rel = ecs.entity();
+    auto obj = ecs.entity();
 
     rel.destruct();
     obj.destruct();
 
-    rel = world.entity();
-    obj = world.entity();
+    rel = ecs.entity();
+    obj = ecs.entity();
 
     // Make sure ids are recycled
     test_assert((uint32_t)rel.id() != rel.id());
@@ -518,16 +518,16 @@ void Pairs_get_recycled_relation_from_id() {
 }
 
 void Pairs_get_recycled_object_from_id() {
-    flecs::world world;
+    flecs::world ecs;
 
-    auto rel = world.entity();
-    auto obj = world.entity();
+    auto rel = ecs.entity();
+    auto obj = ecs.entity();
 
     rel.destruct();
     obj.destruct();
 
-    rel = world.entity();
-    obj = world.entity();
+    rel = ecs.entity();
+    obj = ecs.entity();
 
     // Make sure ids are recycled
     test_assert((uint32_t)rel.id() != rel.id());
@@ -543,12 +543,12 @@ void Pairs_get_recycled_object_from_id() {
 }
 
 void Pairs_each() {
-    flecs::world world;
+    flecs::world ecs;
 
-    auto p_1 = world.entity();
-    auto p_2 = world.entity();
+    auto p_1 = ecs.entity();
+    auto p_2 = ecs.entity();
 
-    auto e = world.entity()
+    auto e = ecs.entity()
         .add(p_1)
         .add(p_2);
 
@@ -570,13 +570,13 @@ void Pairs_each() {
 }
 
 void Pairs_each_pair() {
-    flecs::world world;
+    flecs::world ecs;
 
-    auto pair = world.component<Pair>();
-    auto pos = world.component<Position>();
-    auto vel = world.component<Velocity>();
+    auto pair = ecs.component<Pair>();
+    auto pos = ecs.component<Position>();
+    auto vel = ecs.component<Velocity>();
 
-    auto e = world.entity()
+    auto e = ecs.entity()
         .add<Pair, Position>()
         .add<Pair, Velocity>();
 
@@ -598,12 +598,12 @@ void Pairs_each_pair() {
 }
 
 void Pairs_each_pair_by_type() {
-    flecs::world world;
+    flecs::world ecs;
 
-    auto pos = world.component<Position>();
-    auto vel = world.component<Velocity>();
+    auto pos = ecs.component<Position>();
+    auto vel = ecs.component<Velocity>();
 
-    auto e = world.entity()
+    auto e = ecs.entity()
         .add<Pair, Position>()
         .add<Pair, Velocity>();
 
@@ -625,12 +625,12 @@ void Pairs_each_pair_by_type() {
 }
 
 void Pairs_each_pair_w_childof() {
-    flecs::world world;
+    flecs::world ecs;
 
-    auto p_1 = world.entity();
-    auto p_2 = world.entity();
+    auto p_1 = ecs.entity();
+    auto p_2 = ecs.entity();
 
-    auto e = world.entity()
+    auto e = ecs.entity()
         .child_of(p_1)
         .child_of(p_2);
 
@@ -652,18 +652,18 @@ void Pairs_each_pair_w_childof() {
 }
 
 void Pairs_each_pair_w_recycled_rel() {
-    flecs::world world;
+    flecs::world ecs;
 
-    auto e_1 = world.entity();
-    auto e_2 = world.entity();
+    auto e_1 = ecs.entity();
+    auto e_2 = ecs.entity();
 
-    world.entity().destruct(); // force recycling
+    ecs.entity().destruct(); // force recycling
 
-    auto pair = world.entity();
+    auto pair = ecs.entity();
 
     test_assert((uint32_t)pair.id() != pair.id()); // ensure recycled
 
-    auto e = world.entity()
+    auto e = ecs.entity()
         .add(pair, e_1)
         .add(pair, e_2);
 
@@ -686,19 +686,19 @@ void Pairs_each_pair_w_recycled_rel() {
 }
 
 void Pairs_each_pair_w_recycled_obj() {
-    flecs::world world;
+    flecs::world ecs;
 
-    auto pair = world.component<Pair>();
+    auto pair = ecs.component<Pair>();
 
-    world.entity().destruct(); // force recycling
-    auto e_1 = world.entity();
+    ecs.entity().destruct(); // force recycling
+    auto e_1 = ecs.entity();
     test_assert((uint32_t)e_1.id() != e_1.id()); // ensure recycled
 
-    world.entity().destruct();
-    auto e_2 = world.entity();    
+    ecs.entity().destruct();
+    auto e_2 = ecs.entity();    
     test_assert((uint32_t)e_2.id() != e_2.id());
 
-    auto e = world.entity()
+    auto e = ecs.entity()
         .add<Pair>(e_1)
         .add<Pair>(e_2);
 
@@ -720,22 +720,285 @@ void Pairs_each_pair_w_recycled_obj() {
     test_int(count, 2);
 }
 
+void Pairs_match_pair() {
+    flecs::world ecs;
+
+    auto Eats = ecs.entity();
+    auto Dislikes = ecs.entity();
+
+    auto Apples = ecs.entity();
+    auto Pears = ecs.entity();
+    auto Bananas = ecs.entity();
+
+    auto e = ecs.entity()
+        .set<Position>({10, 20}) // should not be matched
+        .add(Eats, Apples)
+        .add(Eats, Pears)
+        .add(Dislikes, Bananas);
+
+    int32_t count = 0;
+
+    e.match(ecs.pair(Eats, Apples), 
+        [&](flecs::id id) {
+            test_assert(id.relation() == Eats);
+            test_assert(id.object() == Apples);
+            count ++;
+        });
+    
+    test_int(count, 1);
+}
+
+void Pairs_match_pair_obj_wildcard() {
+    flecs::world ecs;
+
+    auto Eats = ecs.entity();
+    auto Dislikes = ecs.entity();
+
+    auto Apples = ecs.entity();
+    auto Pears = ecs.entity();
+    auto Bananas = ecs.entity();
+
+    auto e = ecs.entity()
+        .set<Position>({10, 20}) // should not be matched
+        .add(Eats, Apples)
+        .add(Eats, Pears)
+        .add(Dislikes, Bananas);
+
+    int32_t count = 0;
+
+    e.match(ecs.pair(Eats, flecs::Wildcard), 
+        [&](flecs::id id) {
+            test_assert(id.relation() == Eats);
+            test_assert(id.object() == Apples || id.object() == Pears);
+            count ++;
+        });
+    
+    test_int(count, 2);
+}
+
+void Pairs_match_pair_rel_wildcard() {
+    flecs::world ecs;
+
+    auto Eats = ecs.entity();
+    auto Dislikes = ecs.entity();
+
+    auto Apples = ecs.entity();
+    auto Pears = ecs.entity();
+    auto Bananas = ecs.entity();
+
+    auto e = ecs.entity()
+        .set<Position>({10, 20}) // should not be matched
+        .add(Eats, Apples)
+        .add(Eats, Pears)
+        .add(Dislikes, Bananas);
+
+    int32_t count = 0;
+
+    e.match(ecs.pair(flecs::Wildcard, Pears), 
+        [&](flecs::id id) {
+            test_assert(id.relation() == Eats);
+            test_assert(id.object() == Pears);
+            count ++;
+        });
+    
+    test_int(count, 1);
+}
+
+void Pairs_match_pair_both_wildcard() {
+    flecs::world ecs;
+
+    auto Eats = ecs.entity();
+    auto Dislikes = ecs.entity();
+
+    auto Apples = ecs.entity();
+    auto Pears = ecs.entity();
+    auto Bananas = ecs.entity();
+
+    auto e = ecs.entity()
+        .set<Position>({10, 20}) // should not be matched
+        .add(Eats, Apples)
+        .add(Eats, Pears)
+        .add(Dislikes, Bananas);
+
+    int32_t count = 0;
+
+    e.match(ecs.pair(flecs::Wildcard, flecs::Wildcard), 
+        [&](flecs::id id) {
+            count ++;
+        });
+    
+    test_int(count, 3);
+}
+
 void Pairs_has_tag_w_object() {
-    flecs::world world;
+    flecs::world ecs;
 
     struct Likes { };
 
-    auto Bob = world.entity();
-    auto e = world.entity().add<Likes>(Bob);
+    auto Bob = ecs.entity();
+    auto e = ecs.entity().add<Likes>(Bob);
     test_assert(e.has<Likes>(Bob));
 }
 
 void Pairs_has_object_tag() {
-    flecs::world world;
+    flecs::world ecs;
 
     struct Bob { };
 
-    auto Likes = world.entity();
-    auto e = world.entity().add_object<Bob>(Likes);
+    auto Likes = ecs.entity();
+    auto e = ecs.entity().add_object<Bob>(Likes);
     test_assert(e.has_object<Bob>(Likes));
+}
+
+struct Eats { int amount; };
+struct Apples { };
+struct Pears { };
+
+using EatsApples = flecs::pair<Eats, Apples>;
+using EatsPears = flecs::pair<Eats, Pears>;
+
+void Pairs_add_pair_type() {
+    flecs::world ecs;
+
+    auto e = ecs.entity().add<EatsApples>();
+    test_assert((e.has<Eats, Apples>()));
+    test_assert((e.has<EatsApples>()));
+}
+
+void Pairs_remove_pair_type() {
+    flecs::world ecs;
+
+    auto e = ecs.entity().add<EatsApples>();
+    test_assert((e.has<Eats, Apples>()));
+    test_assert((e.has<EatsApples>()));
+
+    e.remove<EatsApples>();
+    test_assert(!(e.has<Eats, Apples>()));
+    test_assert(!(e.has<EatsApples>()));    
+}
+
+void Pairs_set_pair_type() {
+    flecs::world ecs;
+
+    auto e = ecs.entity().set<EatsApples>({10});
+    test_assert((e.has<Eats, Apples>()));
+    test_assert((e.has<EatsApples>()));
+
+    const Eats *ptr = e.get<EatsApples>();
+    test_int(ptr->amount, 10);
+
+    test_assert((ptr == e.get<Eats, Apples>()));
+}
+
+void Pairs_has_pair_type() {
+    flecs::world ecs;
+
+    auto e = ecs.entity().add<Eats, Apples>();
+    test_assert((e.has<Eats, Apples>()));
+    test_assert((e.has<EatsApples>()));
+}
+
+void Pairs_get_1_pair_arg() {
+    flecs::world ecs;
+
+    auto e = ecs.entity().set<EatsApples>({10});
+    test_assert((e.has<Eats, Apples>()));
+    test_assert((e.has<EatsApples>()));
+
+    test_bool(e.get([](const EatsApples& a) {
+        test_int(a->amount, 10);
+    }), true);
+}
+
+void Pairs_get_2_pair_arg() {
+    flecs::world ecs;
+
+    auto e = ecs.entity()
+        .set<EatsApples>({10})
+        .set<EatsPears>({20});
+
+    test_assert((e.has<Eats, Apples>()));
+    test_assert((e.has<Eats, Pears>()));
+    test_assert((e.has<EatsApples>()));
+    test_assert((e.has<EatsPears>()));
+
+    test_bool(e.get([](const EatsApples& a, const EatsPears& p) {
+        test_int(a->amount, 10);
+        test_int(p->amount, 20);
+    }), true);
+}
+
+void Pairs_set_1_pair_arg() {
+    flecs::world ecs;
+
+    auto e = ecs.entity()
+        .set([](EatsApples&& a) {
+            a->amount = 10;
+        });
+
+    auto eats = e.get<EatsApples>();
+    test_int(eats->amount, 10);
+}
+
+void Pairs_set_2_pair_arg() {
+    flecs::world ecs;
+
+    auto e = ecs.entity()
+        .set([](EatsApples&& a, EatsPears&& p) {
+            a->amount = 10;
+            p->amount = 20;
+        });
+
+    auto eats = e.get<EatsApples>();
+    test_int(eats->amount, 10);
+
+    eats = e.get<EatsPears>();
+    test_int(eats->amount, 20);
+}
+
+void Pairs_get_inline_pair_type() {
+    flecs::world ecs;
+
+    auto e = ecs.entity().set<EatsApples>({10});
+    test_assert((e.has<Eats, Apples>()));
+    test_assert((e.has<EatsApples>()));
+
+    test_bool(e.get([](const flecs::pair<Eats, Apples>& a) {
+        test_int(a->amount, 10);
+    }), true);
+}
+
+void Pairs_set_inline_pair_type() {
+    flecs::world ecs;
+
+    auto e = ecs.entity()
+        .set([](flecs::pair<Eats, Apples>&& a) {
+            a->amount = 10;
+        });
+
+    auto eats = e.get<EatsApples>();
+    test_int(eats->amount, 10);
+}
+
+void Pairs_get_pair_type_object() {
+    flecs::world ecs;
+
+    auto e = ecs.entity().set_object<Apples, Eats>({10});
+    test_assert((e.has<Apples, Eats>()));
+
+    test_bool(e.get([](const flecs::pair_object<Apples, Eats>& a) {
+        test_int(a->amount, 10);
+    }), true);
+}
+
+void Pairs_set_pair_type_object() {
+    flecs::world ecs;
+
+    auto e = ecs.entity()
+        .set([](flecs::pair_object<Apples, Eats>&& a) {
+            a->amount = 10;
+        });
+
+    auto eats = e.get_object<Apples, Eats>();
+    test_int(eats->amount, 10);
 }

--- a/test/cpp_api/src/main.cpp
+++ b/test/cpp_api/src/main.cpp
@@ -64,6 +64,7 @@ void Entity_get_type(void);
 void Entity_get_nonempty_type(void);
 void Entity_set_no_copy(void);
 void Entity_set_copy(void);
+void Entity_set_deduced(void);
 void Entity_add_owned(void);
 void Entity_set_owned(void);
 void Entity_implicit_name_to_char(void);
@@ -145,8 +146,24 @@ void Pairs_each_pair_by_type(void);
 void Pairs_each_pair_w_childof(void);
 void Pairs_each_pair_w_recycled_rel(void);
 void Pairs_each_pair_w_recycled_obj(void);
+void Pairs_match_pair(void);
+void Pairs_match_pair_obj_wildcard(void);
+void Pairs_match_pair_rel_wildcard(void);
+void Pairs_match_pair_both_wildcard(void);
 void Pairs_has_tag_w_object(void);
 void Pairs_has_object_tag(void);
+void Pairs_add_pair_type(void);
+void Pairs_remove_pair_type(void);
+void Pairs_set_pair_type(void);
+void Pairs_has_pair_type(void);
+void Pairs_get_1_pair_arg(void);
+void Pairs_get_2_pair_arg(void);
+void Pairs_set_1_pair_arg(void);
+void Pairs_set_2_pair_arg(void);
+void Pairs_get_inline_pair_type(void);
+void Pairs_set_inline_pair_type(void);
+void Pairs_get_pair_type_object(void);
+void Pairs_set_pair_type_object(void);
 
 // Testsuite 'Switch'
 void Switch_add_case(void);
@@ -705,6 +722,10 @@ bake_test_case Entity_testcases[] = {
         Entity_set_copy
     },
     {
+        "set_deduced",
+        Entity_set_deduced
+    },
+    {
         "add_owned",
         Entity_add_owned
     },
@@ -1024,12 +1045,76 @@ bake_test_case Pairs_testcases[] = {
         Pairs_each_pair_w_recycled_obj
     },
     {
+        "match_pair",
+        Pairs_match_pair
+    },
+    {
+        "match_pair_obj_wildcard",
+        Pairs_match_pair_obj_wildcard
+    },
+    {
+        "match_pair_rel_wildcard",
+        Pairs_match_pair_rel_wildcard
+    },
+    {
+        "match_pair_both_wildcard",
+        Pairs_match_pair_both_wildcard
+    },
+    {
         "has_tag_w_object",
         Pairs_has_tag_w_object
     },
     {
         "has_object_tag",
         Pairs_has_object_tag
+    },
+    {
+        "add_pair_type",
+        Pairs_add_pair_type
+    },
+    {
+        "remove_pair_type",
+        Pairs_remove_pair_type
+    },
+    {
+        "set_pair_type",
+        Pairs_set_pair_type
+    },
+    {
+        "has_pair_type",
+        Pairs_has_pair_type
+    },
+    {
+        "get_1_pair_arg",
+        Pairs_get_1_pair_arg
+    },
+    {
+        "get_2_pair_arg",
+        Pairs_get_2_pair_arg
+    },
+    {
+        "set_1_pair_arg",
+        Pairs_set_1_pair_arg
+    },
+    {
+        "set_2_pair_arg",
+        Pairs_set_2_pair_arg
+    },
+    {
+        "get_inline_pair_type",
+        Pairs_get_inline_pair_type
+    },
+    {
+        "set_inline_pair_type",
+        Pairs_set_inline_pair_type
+    },
+    {
+        "get_pair_type_object",
+        Pairs_get_pair_type_object
+    },
+    {
+        "set_pair_type_object",
+        Pairs_set_pair_type_object
     }
 };
 
@@ -2298,14 +2383,14 @@ static bake_test_suite suites[] = {
         "Entity",
         NULL,
         NULL,
-        101,
+        102,
         Entity_testcases
     },
     {
         "Pairs",
         NULL,
         NULL,
-        35,
+        51,
         Pairs_testcases
     },
     {


### PR DESCRIPTION
This PR cleans up a lot of the template code in the C++ API and adds a manual for entity relationships. A few new features are introduced:

A `pair` template was used to the C++ API that can be used in place of specifying both types for a pair:

```cpp
struct Eats {
  float amount;
};

struct Apples { };
struct Pears { };

using EatsApples = flecs::pair<Eats, Apples>;
using EatsPears = flecs::pair<Eats, Pears>;

auto e = ecs.entity()
  .set<EatsApples>({ 10 })
  .set<EatsPears>({ 20 });

// Using a pair type is equivalent to specifying the types separately:
e.has<Eats, Apples>(); // true
e.has<Eats, Pears>(); // true

// Pair types can be used with function-style set/get operations:
e.get([](const EatsPears& p) {
  std::cout << "Eats pears: " << p->amount << std::endl;
});
```

A match function was added to iterate all contents of an entity matching a wildcard pattern:
```cpp
e.match(ecs.pair(Eats, flecs::Wildcard), [](flecs::id id) {
  std::cout << "Eats " << id.object().name() << std::endl;
});
```

A few issues were fixed in the C++ API:
- setting a relation on an entity now moves where possible
- setting a singleton on the world now moves where possible