### PR TITLE
#428 Improvements on the bool conversion of entities

### DIFF
--- a/include/flecs/cpp/entity.hpp
+++ b/include/flecs/cpp/entity.hpp
@@ -141,6 +141,14 @@ public:
     operator flecs::id_t() const {
         return m_id;
     }
+  
+    bool operator==(const id& other) const {
+        return m_id == other.m_id;
+    }
+    
+    bool operator!=(const id& other) const {
+        return !(*this == other);
+    }
 
     /* World is optional, but guarantees that entity identifiers extracted from
      * the id are valid */
@@ -207,15 +215,19 @@ public:
      *
      * @return True if the entity is alive, false otherwise.
      */
-    bool is_valid() {
+    bool is_valid() const {
         return m_world && ecs_is_valid(m_world, m_id);
+    }
+  
+    explicit operator bool() const {
+        return is_valid();
     }
 
     /** Check is entity is alive.
      *
      * @return True if the entity is alive, false otherwise.
      */
-    bool is_alive() {
+    bool is_alive() const {
         return m_world && ecs_is_alive(m_world, m_id);
     }
 

--- a/include/flecs/cpp/entity.hpp
+++ b/include/flecs/cpp/entity.hpp
@@ -141,14 +141,6 @@ public:
     operator flecs::id_t() const {
         return m_id;
     }
-  
-    bool operator==(const id& other) const {
-        return m_id == other.m_id;
-    }
-    
-    bool operator!=(const id& other) const {
-        return !(*this == other);
-    }
 
     /* World is optional, but guarantees that entity identifiers extracted from
      * the id are valid */


### PR DESCRIPTION
This PR introduces `operator bool` to `flecs::entity` which prevents `flecs::id`'s `operator flecs::id_t` from being used in conditional expressions (which is error-prone as it translates to a simple m_id != 0). See https://github.com/SanderMertens/flecs/issues/428 for more details.

On the user level this code (which compiles even without this PR) now makes much more sense:
```c++
// State.SelectedChunk is a flecs::entity_view.
if (State.SelectedChunk) {
    auto &Chunk = *State.SelectedChunk.mut(ECS).get_mut<CTileChunk>();
    auto &Tile = Chunk.Tiles[State.SelectedChunkTileIndex.X][State.SelectedChunkTileIndex.Y];
    Tile.Walkable = !Tile.Walkable;
}
```
Before this PR it did not check for the aliveness of the entity, neither did it check for the existence of the world.
With this PR, this code is safe from such scenarios, and `get_mut` would only be executed and dereferenced on a living entity.