### PR TITLE
Add support for atomic increment/decrement to stdcpp OS API example

### DIFF
--- a/examples/os_api/flecs-os_api-stdcpp/src/flecs-os_api-stdcpp.cpp
+++ b/examples/os_api/flecs-os_api-stdcpp/src/flecs-os_api-stdcpp.cpp
@@ -30,9 +30,9 @@ int32_t stdcpp_ainc(int32_t *count) {
     value = __sync_add_and_fetch (count, 1);
     return value;
 #else
-    /* Unsupported */
-    abort();
+    return InterlockedIncrement(reinterpret_cast<LONG*>(count));
 #endif
+    return value;
 }
 
 static
@@ -42,9 +42,9 @@ int32_t stdcpp_adec(int32_t *count) {
     value = __sync_sub_and_fetch (count, 1);
     return value;
 #else
-    /* Unsupported */
-    abort();
+    return InterlockedDecrement(reinterpret_cast<LONG*>(count));
 #endif
+    return value;
 }
 
 static

--- a/examples/os_api/flecs-os_api-stdcpp/src/flecs-os_api-stdcpp.cpp
+++ b/examples/os_api/flecs-os_api-stdcpp/src/flecs-os_api-stdcpp.cpp
@@ -74,7 +74,7 @@ void stdcpp_mutex_unlock(ecs_os_mutex_t m) {
 static
 ecs_os_cond_t stdcpp_cond_new(void) {
     std::condition_variable_any* cond = new std::condition_variable_any{};
-    return (ecs_os_cond_t)cond;
+   return reinterpret_cast<ecs_os_cond_t>(cond);
 }
 
 static 


### PR DESCRIPTION
reinterpret cast the int32_t into a long because of compiler and language guff
to be clear stdint.h guarantees that int32_t is always a 32 bit int but in C specs a int and a long can have different value sizes (even though that is rarely the case) so to please MSVC we need to reinterpret_case int32_t into a Long (for some reason, blame MSVC not me)