### PR TITLE
Fix duplicate cond

### DIFF
--- a/flecs.c
+++ b/flecs.c
@@ -17104,7 +17104,7 @@ char* ecs_filter_str(
                 ecs_strbuf_appendstr(&buf, "[in] ");
             } else if (term->inout == EcsInOut) {
                 ecs_strbuf_appendstr(&buf, "[inout] ");
-            } else if (term->inout == EcsInOut) {
+            } else if (term->inout == EcsOut) {
                 ecs_strbuf_appendstr(&buf, "[out] ");
             }
         }

--- a/src/filter.c
+++ b/src/filter.c
@@ -473,7 +473,7 @@ char* ecs_filter_str(
                 ecs_strbuf_appendstr(&buf, "[in] ");
             } else if (term->inout == EcsInOut) {
                 ecs_strbuf_appendstr(&buf, "[inout] ");
-            } else if (term->inout == EcsInOut) {
+            } else if (term->inout == EcsOut) {
                 ecs_strbuf_appendstr(&buf, "[out] ");
             }
         }


### PR DESCRIPTION
Little fix for this warning
```
flecs.c: In function ‘ecs_filter_str’:
flecs.c:17107:36: warning: duplicated ‘if’ condition [-Wduplicated-cond]
17107 |             } else if (term->inout == EcsInOut) {            
      |                        ~~~~~~~~~~~~^~~~~~~~~~~
/home/aganm/Projects/gow/lib/flecs/flecs.c:17105:36: note: previously used here
17105 |             } else if (term->inout == EcsInOut) {

```