### PR TITLE
Revert changes to ECS_UNUSED

### DIFF
--- a/include/flecs/private/api_defines.h
+++ b/include/flecs/private/api_defines.h
@@ -80,9 +80,9 @@ typedef int32_t ecs_size_t;
 #endif
 
 #if defined(__GNUC__)
-#define ECS_UNUSED(v) __attribute__((unused)) v
+#define ECS_UNUSED __attribute__((unused))
 #else
-#define ECS_UNUSED(v) (void)v
+#define ECS_UNUSED
 #endif
 
 #ifndef FLECS_NO_DEPRECATED_WARNINGS


### PR DESCRIPTION
This was a breaking change for flecs-meta which utilizes ECS_UNUSED for globals, part of 4aade63c13985a0933f975082fc63b90ef6f0e4c.