### PR TITLE
#389 Delaying system activation/deactivation

### DIFF
--- a/include/flecs.h
+++ b/include/flecs.h
@@ -784,6 +784,8 @@ FLECS_API extern const ecs_entity_t EcsOnDemand;
 FLECS_API extern const ecs_entity_t EcsMonitor;
 FLECS_API extern const ecs_entity_t EcsDisabledIntern;
 FLECS_API extern const ecs_entity_t EcsInactive;
+FLECS_API extern const ecs_entity_t EcsDelayedActivation;
+FLECS_API extern const ecs_entity_t EcsDelayedDeactivation;
 
 /* Pipeline module tags */
 FLECS_API extern const ecs_entity_t EcsPipeline;

--- a/src/modules/pipeline/pipeline.c
+++ b/src/modules/pipeline/pipeline.c
@@ -410,6 +410,7 @@ void ecs_pipeline_run(
     ecs_vector_t *ops = pq->ops;
     ecs_pipeline_op_t *op = ecs_vector_first(ops, ecs_pipeline_op_t);
     ecs_pipeline_op_t *op_last = ecs_vector_last(ops, ecs_pipeline_op_t);
+    int32_t count = ecs_vector_count(ops);
     int32_t ran_since_merge = 0;
 
     int32_t stage_index = ecs_get_stage_id(stage->thread_ctx);
@@ -481,7 +482,7 @@ ecs_query_t* build_pipeline_query(
     ecs_world_t *world,
     ecs_entity_t pipeline,
     const char *name,
-    bool with_inactive)
+    bool without_inactive)
 {
     const EcsType *type_ptr = ecs_get(world, pipeline, EcsType);
     ecs_assert(type_ptr != NULL, ECS_INTERNAL_ERROR, NULL);
@@ -489,7 +490,7 @@ ecs_query_t* build_pipeline_query(
     int32_t type_count = ecs_vector_count(type_ptr->normalized);
     int32_t term_count = 2;
 
-    if (with_inactive) {
+    if (without_inactive) {
         term_count ++;
     }
 
@@ -516,7 +517,7 @@ ecs_query_t* build_pipeline_query(
         }
     };
 
-    if (with_inactive) {
+    if (without_inactive) {
         terms[2] = (ecs_term_t){
             .inout = EcsIn,
             .oper = EcsNot,

--- a/src/modules/pipeline/worker.c
+++ b/src/modules/pipeline/worker.c
@@ -4,6 +4,9 @@
 
 #include "pipeline.h"
 
+ecs_query_t *DelayedActivation;
+ecs_query_t *DelayedDeactivation;
+
 /* Worker thread */
 static
 void* worker(void *arg) {
@@ -172,6 +175,110 @@ bool ecs_stop_threads(
 
 /* -- Private functions -- */
 
+static
+int compare_entity(
+    ecs_entity_t e1,
+    const void *ptr1,
+    ecs_entity_t e2,
+    const void *ptr2)
+{
+  (void)ptr1;
+  (void)ptr2;
+  return (e1 > e2) - (e1 < e2);
+}
+
+static
+ecs_query_t* build_delayed_activation_query(
+    ecs_world_t *world,
+    const char *name)
+{
+  int32_t term_count = 2;
+  
+  ecs_term_t *terms = ecs_os_malloc(
+      (term_count) * ECS_SIZEOF(ecs_term_t));
+  
+  terms[0] = (ecs_term_t){
+      .inout = EcsIn,
+      .oper = EcsAnd,
+      .pred.entity = ecs_id(EcsSystem),
+      .args[0] = {
+          .entity = EcsThis,
+          .set.mask = EcsSelf | EcsSuperSet
+      }
+  };
+  
+  terms[1] = (ecs_term_t){
+      .inout = EcsIn,
+      .oper = EcsAnd,
+      .pred.entity = EcsDelayedActivation,
+      .args[0] = {
+          .entity = EcsThis,
+          .set.mask = EcsSelf | EcsSuperSet
+      }
+  };
+  
+  ecs_query_t *result = ecs_query_init(world, &(ecs_query_desc_t){
+      .filter = {
+          .name = name,
+          .terms_buffer = terms,
+          .terms_buffer_count = term_count
+      },
+      .order_by = compare_entity,
+  });
+  
+  ecs_assert(result != NULL, ECS_INTERNAL_ERROR, NULL);
+  
+  ecs_os_free(terms);
+  
+  return result;
+}
+
+static
+ecs_query_t* build_delayed_deactivation_query(
+    ecs_world_t *world,
+    const char *name)
+{
+  int32_t term_count = 2;
+  
+  ecs_term_t *terms = ecs_os_malloc(
+      (term_count) * ECS_SIZEOF(ecs_term_t));
+  
+  terms[0] = (ecs_term_t){
+      .inout = EcsIn,
+      .oper = EcsAnd,
+      .pred.entity = ecs_id(EcsSystem),
+      .args[0] = {
+          .entity = EcsThis,
+          .set.mask = EcsSelf | EcsSuperSet
+      }
+  };
+  
+  terms[1] = (ecs_term_t){
+      .inout = EcsIn,
+      .oper = EcsAnd,
+      .pred.entity = EcsDelayedDeactivation,
+      .args[0] = {
+          .entity = EcsThis,
+          .set.mask = EcsSelf | EcsSuperSet
+      }
+  };
+  
+  ecs_query_t *result = ecs_query_init(world, &(ecs_query_desc_t){
+      .filter = {
+          .name = name,
+          .terms_buffer = terms,
+          .terms_buffer_count = term_count
+      },
+      .order_by = compare_entity,
+  });
+  
+  ecs_assert(result != NULL, ECS_INTERNAL_ERROR, NULL);
+  
+  ecs_os_free(terms);
+  
+  return result;
+}
+
 void ecs_worker_begin(
     ecs_world_t *world)
 {
@@ -240,6 +347,24 @@ void ecs_workers_progress(
         ecs_time_measure(&start);
     }
 
+    {
+      ecs_iter_t it = ecs_query_iter(DelayedActivation);
+      while (ecs_query_next(&it)) {
+        EcsSystem *sys = ecs_term(&it, EcsSystem, 1);
+        ecs_system_activate(world, sys->entity, true, false, NULL);
+        ecs_remove_id(world, sys->entity, EcsDelayedActivation);
+      }
+    }
+
+    {
+      ecs_iter_t it = ecs_query_iter(DelayedDeactivation);
+      while (ecs_query_next(&it)) {
+        EcsSystem *sys = ecs_term(&it, EcsSystem, 1);
+        ecs_system_activate(world, sys->entity, false, false, NULL);
+        ecs_remove_id(world, sys->entity, EcsDelayedDeactivation);
+      }
+    }
+
     if (stage_count == 1) {
         ecs_pipeline_update(world, pipeline, true);
         ecs_entity_t old_scope = ecs_set_scope(world, 0);
@@ -266,13 +391,6 @@ void ecs_workers_progress(
 
             /* Merge */
             ecs_staging_end(world);
-
-            int32_t update_count;
-            if ((update_count = ecs_pipeline_update(world, pipeline, false))) {
-                /* The number of operations in the pipeline could have changed
-                 * as result of the merge */
-                sync_count = update_count;
-            }
         }
     }
 
@@ -315,6 +433,9 @@ void ecs_set_threads(
             ecs_table_get_data(table);
         });
     }
+  
+  DelayedActivation = build_delayed_activation_query(world, "Delayed activation");
+  DelayedDeactivation = build_delayed_deactivation_query(world, "Delayed deactivation");
 }
 
 #endif

--- a/src/modules/system/system.h
+++ b/src/modules/system/system.h
@@ -32,6 +32,7 @@ void ecs_system_activate(
     ecs_world_t *world,
     ecs_entity_t system,
     bool activate,
+    bool delayed,
     const EcsSystem *system_data);
 
 /* Internal function to run a system */

--- a/src/query.c
+++ b/src/query.c
@@ -1715,10 +1715,10 @@ void activate_table(
                 int32_t dst_count = ecs_vector_count(dst_array);
                 if (active) {
                     if (!prev_dst_count && dst_count) {
-                        ecs_system_activate(world, query->system, true, NULL);
+                        ecs_system_activate(world, query->system, true, true, NULL);
                     }
                 } else if (ecs_vector_count(src_array) == 0) {
-                    ecs_system_activate(world, query->system, false, NULL);
+                    ecs_system_activate(world, query->system, false, true, NULL);
                 }
             }
 #endif

--- a/src/world.c
+++ b/src/world.c
@@ -51,6 +51,8 @@ const ecs_entity_t EcsOnDemand = (ECS_HI_COMPONENT_ID + 40);
 const ecs_entity_t EcsMonitor = (ECS_HI_COMPONENT_ID + 41);
 const ecs_entity_t EcsDisabledIntern = (ECS_HI_COMPONENT_ID + 42);
 const ecs_entity_t EcsInactive = (ECS_HI_COMPONENT_ID + 43);
+const ecs_entity_t EcsDelayedActivation = (ECS_HI_COMPONENT_ID + 55);
+const ecs_entity_t EcsDelayedDeactivation = (ECS_HI_COMPONENT_ID + 56);
 
 /* Pipelines & builtin pipeline phases */
 const ecs_entity_t EcsPipeline = (ECS_HI_COMPONENT_ID + 44);


### PR DESCRIPTION
In multi-threaded environment system order could be messed up due to mid-frame system activation (result of table activation). This tries to fix this by delaying the activation through additional tags EcsDelayedActivation and EcsDelayedDeactivation.
See #389 for more details.

Code is surely terrible, it is just to illustrate the idea, hope @SanderMertens fixes it up to match the `flecs` ideology.

It works for code in the issue - the order is now respected.