### PR TITLE
#461 make entity and entity_view implicitly default constructible

### DIFF
--- a/include/flecs/cpp/entity.hpp
+++ b/include/flecs/cpp/entity.hpp
@@ -38,7 +38,7 @@ namespace flecs
  */
 class entity_view : public id {
 public:
-    explicit entity_view() : flecs::id() { }
+    entity_view() : flecs::id() { }
 
     /** Wrap an existing entity id.
      *
@@ -1179,7 +1179,7 @@ class entity :
 public:
     /** Default constructor.
      */
-    explicit entity()
+    entity()
         : flecs::entity_view() { }
 
     /** Create entity.


### PR DESCRIPTION
Made `entity` and `entity_view` default constructors implicit.

See #461 for more details.