### PR TITLE
Update hash.c to allow valgrind to always be defined, and support address sanitizer

### DIFF
--- a/src/datastructures/hash.c
+++ b/src/datastructures/hash.c
@@ -8,8 +8,10 @@
  * into the hashing function, but only at word boundaries. This should be safe,
  * but trips up address sanitizers and valgrind.
  * This ensures clean valgrind logs in debug mode & the best perf in release */
-#ifndef NDEBUG
+#if !defined(NDEBUG) || defined(ADDRESS_SANITIZER)
+#ifndef VALGRIND
 #define VALGRIND
+#endif
 #endif
 
 /*


### PR DESCRIPTION
Fixes building when user has defined `VALGRIND` and tries to build a debug build, for
compilers that do not allow `VALGRIND` to be defined twice. Also adds support for address sanitizer's
most common warding define.