### PR TITLE
Query cache refactor

### DIFF
--- a/flecs.c
+++ b/flecs.c
@@ -22408,8 +22408,6 @@ int finalize_term_id(
     ecs_entity_t obj = entity_from_identifier(&term->args[1]);
     ecs_id_t role = term->role;
 
-    // printf("finalize term id (%d, %d) role = %d\n", pred, obj, role);
-
     if (ECS_HAS_ROLE(pred, PAIR)) {
         if (obj) {
             term_error(world, term, name, 
@@ -25008,7 +25006,7 @@ ecs_query_table_list_t* ensure_node_list(
 
 /* Remove node from list */
 static
-void remove_node(
+void remove_table_node(
     ecs_query_t *query,
     ecs_query_table_node_t *node)
 {
@@ -25104,7 +25102,7 @@ void remove_node(
 
 /* Add node to list */
 static
-void insert_node(
+void insert_table_node(
     ecs_query_t *query,
     ecs_query_table_node_t *node)
 {
@@ -25807,7 +25805,7 @@ add_pair:
     /* Insert match to iteration list if table is not empty */
     if (!table || ecs_table_count(table) != 0) {
         ecs_assert(table == qt->hdr.table, ECS_INTERNAL_ERROR, NULL);
-        insert_node(query, &table_data->node);
+        insert_table_node(query, &table_data->node);
     }
 
     /* Use tail recursion when adding table for multiple pairs */
@@ -26579,11 +26577,11 @@ void update_table(
                 ecs_assert(ecs_table_count(table) == 0, 
                     ECS_INTERNAL_ERROR, NULL);
 
-                remove_node(query, &cur->node);
+                remove_table_node(query, &cur->node);
             } else {
                 ecs_assert(ecs_table_count(table) != 0, 
                     ECS_INTERNAL_ERROR, NULL);
-                insert_node(query, &cur->node);
+                insert_table_node(query, &cur->node);
             }
         }
     }
@@ -26679,8 +26677,8 @@ void resolve_cascade_subject_for_table(
     if (ecs_table_count(table)) {
         /* The subject (or depth of the subject) may have changed, so reinsert
          * the node to make sure it's in the right group */
-        remove_node(query, &table_data->node);
-        insert_node(query, &table_data->node);
+        remove_table_node(query, &table_data->node);
+        insert_table_node(query, &table_data->node);
     }
 }
 
@@ -26721,7 +26719,7 @@ void remove_table(
         ecs_os_free(cur->bitset_columns);
 
         if (!elem->hdr.empty) {
-            remove_node(query, &cur->node);
+            remove_table_node(query, &cur->node);
         }
 
         next = cur->next_match;

--- a/flecs.c
+++ b/flecs.c
@@ -915,6 +915,7 @@ typedef struct ecs_table_cache_t {
 /** Must appear as first member in payload of table cache */
 typedef struct ecs_table_cache_hdr_t {
     ecs_table_t *table;
+    bool empty;
 } ecs_table_cache_hdr_t;
 
 /* Sparse query column */
@@ -936,12 +937,12 @@ typedef struct ecs_query_table_match_t ecs_query_table_match_t;
  * The list of nodes dictates the order in which tables should be iterated by a
  * query. A single node may refer to the table multiple times with different
  * offset/count parameters, which enables features such as sorting. */
-typedef struct ecs_query_table_node_t {
+struct ecs_query_table_node_t {
     ecs_query_table_match_t *match;  /* Reference to the match */
     int32_t offset;                  /* Starting point in table  */
     int32_t count;                   /* Number of entities to iterate in table */
     ecs_query_table_node_t *next, *prev;
-} ecs_query_table_node_t;
+};
 
 /** Type containing data for a table matched with a query. 
  * A single table can have multiple matches, if the query contains wildcards. */
@@ -969,6 +970,7 @@ struct ecs_query_table_match_t {
 typedef struct ecs_query_table_t {
     ecs_table_cache_hdr_t hdr;       /* Header for ecs_table_cache_t */
     ecs_query_table_match_t *first;  /* List with matches for table */
+    ecs_query_table_match_t *last;   /* Last discovered match for table */
     int32_t *monitor;                /* Used to monitor table for changes */
 } ecs_query_table_t;
 
@@ -976,6 +978,7 @@ typedef struct ecs_query_table_t {
 typedef struct ecs_query_table_list_t {
     ecs_query_table_node_t *first;
     ecs_query_table_node_t *last;
+    int32_t count;
 } ecs_query_table_list_t;
 
 #define EcsQueryNeedsTables (1)      /* Query needs matching with tables */ 
@@ -1049,7 +1052,6 @@ struct ecs_query_t {
     int32_t match_count;        /* How often have tables been (un)matched */
     int32_t prev_match_count;   /* Used to track if sorting is needed */
 
-    bool needs_reorder;         /* Whether next iteration should reorder */
     bool constraints_satisfied; /* Are all term constraints satisfied */
 };
 
@@ -1358,30 +1360,30 @@ void ecs_table_cache_fini(
 
 void* _ecs_table_cache_insert(
     ecs_table_cache_t *cache,
-    const ecs_table_t *table,
-    ecs_size_t size);
+    ecs_size_t size,
+    const ecs_table_t *table);
 
-#define ecs_table_cache_insert(cache, table, T)\
-    ECS_CAST(T*, _ecs_table_cache_insert(cache, table, ECS_SIZEOF(T)))
+#define ecs_table_cache_insert(cache, T, table)\
+    ECS_CAST(T*, _ecs_table_cache_insert(cache, ECS_SIZEOF(T), table))
 
 void _ecs_table_cache_remove(
     ecs_table_cache_t *cache,
-    ecs_table_t *table);
+    const ecs_table_t *table);
 
 #define ecs_table_cache_remove(cache, table)\
     _ecs_table_cache_remove(cache, table)
 
 void* _ecs_table_cache_get(
-    ecs_table_cache_t *cache,
+    const ecs_table_cache_t *cache,
     ecs_size_t size,
-    ecs_table_t *table);
+    const ecs_table_t *table);
 
 #define ecs_table_cache_get(cache, T, table)\
     ECS_CAST(T*, _ecs_table_cache_get(cache, ECS_SIZEOF(T), table))
 
 void _ecs_table_cache_set_empty(
     ecs_table_cache_t *cache,
-    ecs_table_t *table,
+    const ecs_table_t *table,
     bool empty);
 
 #define ecs_table_cache_set_empty(cache, table, empty)\
@@ -9042,6 +9044,7 @@ void* _ecs_vector_add(
     ecs_size_t elem_size,
     int16_t offset)
 {
+    ecs_assert(array_inout != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_vector_t *vector = *array_inout;
     int32_t count, size;
 
@@ -12622,7 +12625,7 @@ int compare_entity(
 }
 
 static
-int group_by_phase(
+uint64_t group_by_phase(
     ecs_world_t *world,
     ecs_type_t type,
     ecs_entity_t pipeline,
@@ -12658,7 +12661,7 @@ int group_by_phase(
     ecs_assert(result != 0, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(result < INT_MAX, ECS_INTERNAL_ERROR, NULL);
 
-    return (int)result;
+    return result;
 }
 
 typedef enum ComponentWriteState {
@@ -21762,8 +21765,13 @@ void flecs_notify_queries(
 
     int32_t i, count = flecs_sparse_count(world->queries);
     for (i = 0; i < count; i ++) {
-        flecs_query_notify(world, 
-            flecs_sparse_get_dense(world->queries, ecs_query_t, i), event);
+        ecs_query_t *query = flecs_sparse_get_dense(
+            world->queries, ecs_query_t, i);
+        if (query->flags & EcsQueryIsSubquery) {
+            continue;
+        }
+        
+        flecs_query_notify(world, query, event);
     }    
 }
 
@@ -24073,7 +24081,7 @@ void* ecs_get_observer_binding_ctx(
 static
 int32_t move_table(
     ecs_table_cache_t *cache,
-    ecs_table_t *table,
+    const ecs_table_t *table,
     int32_t index,
     ecs_vector_t **dst_array,
     ecs_vector_t *src_array,
@@ -24095,7 +24103,7 @@ int32_t move_table(
             int32_t, elem->table->id);
         ecs_assert(old_index_ptr != NULL, ECS_INTERNAL_ERROR, NULL);
 
-        int32_t old_index = old_index_ptr[0];
+        old_index = old_index_ptr[0];
         if (!empty) {
             if (old_index >= 0) {
                 /* old_index should be negative if not empty, since
@@ -24103,7 +24111,6 @@ int32_t move_table(
                  * However, if the last table in the source array is also
                  * the table being moved, this can happen. */
                 ecs_assert(table == elem->table, ECS_INTERNAL_ERROR, NULL);
-                // continue
             } else {
                 /* If not empty, src = the empty list, and index should
                  * be negative. */
@@ -24119,15 +24126,15 @@ int32_t move_table(
          * src array, so no other administration needs to be updated. */
     }
 
+    if (!empty) {
+        old_index = index * -1 - 1;
+    } else {
+        old_index = index;
+    }
+
     /* Actually move the table. Only move from src to dst if we have a
      * dst_array, otherwise just remove it from src. */
     if (dst_array) {
-        if (!empty) {
-            old_index = index * -1 - 1;
-        } else {
-            old_index = index;
-        }
-
         new_index = ecs_vector_count(*dst_array);
         ecs_vector_move_index_t(dst_array, src_array, size, 8, old_index);
 
@@ -24135,7 +24142,8 @@ int32_t move_table(
         elem = ecs_vector_last_t(*dst_array, size, 8);
         ecs_assert(elem->table == table, ECS_INTERNAL_ERROR, NULL);
         ecs_assert(ecs_vector_count(*dst_array) == (new_index + 1), 
-            ECS_INTERNAL_ERROR, NULL);  
+            ECS_INTERNAL_ERROR, NULL);
+        elem->empty = empty;
     } else {
         ecs_vector_remove_t(src_array, size, 8, old_index);
     }
@@ -24158,6 +24166,7 @@ void _ecs_table_cache_init(
     ecs_poly_t *parent,
     void(*free_payload)(ecs_poly_t*, void*))
 {
+    ecs_assert(cache != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(size >= ECS_SIZEOF(ecs_table_cache_hdr_t), 
         ECS_INTERNAL_ERROR, NULL);
     cache->index = ecs_map_new(int32_t, 0);
@@ -24173,14 +24182,15 @@ void free_payload(
     ecs_table_cache_t *cache,
     ecs_vector_t *tables)
 {
-    void(*free_payload)(ecs_poly_t*, void*) = cache->free_payload;
-    if (free_payload) {
+    void(*free_payload_func)(ecs_poly_t*, void*) = cache->free_payload;
+    if (free_payload_func) {
         ecs_poly_t *parent = cache->parent;
         ecs_size_t size = cache->size;
         int32_t i, count = ecs_vector_count(tables);
+
         for (i = 0; i < count; i ++) {
             void *ptr = ecs_vector_get_t(tables, size, 8, i);
-            free_payload(parent, ptr);
+            free_payload_func(parent, ptr);
         }
     }
 
@@ -24190,6 +24200,7 @@ void free_payload(
 void ecs_table_cache_fini(
     ecs_table_cache_t *cache)
 {
+    ecs_assert(cache != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_map_free(cache->index);
     free_payload(cache, cache->tables);
     free_payload(cache, cache->empty_tables);
@@ -24197,10 +24208,14 @@ void ecs_table_cache_fini(
 
 void* _ecs_table_cache_insert(
     ecs_table_cache_t *cache,
-    const ecs_table_t *table,
-    ecs_size_t size)
+    ecs_size_t size,
+    const ecs_table_t *table)
 {
+    ecs_assert(cache != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(size == cache->size, ECS_INTERNAL_ERROR, NULL);
+
+    ecs_assert(!table || (_ecs_table_cache_get(cache, size, table) == NULL), 
+        ECS_INTERNAL_ERROR, NULL);
 
     int32_t index;
     ecs_table_cache_hdr_t *result;
@@ -24226,14 +24241,18 @@ void* _ecs_table_cache_insert(
     
     ecs_os_memset(result, 0, size);
     result->table = (ecs_table_t*)table;
+    result->empty = empty;
 
     return result;
 }
 
 void _ecs_table_cache_remove(
     ecs_table_cache_t *cache,
-    ecs_table_t *table)
+    const ecs_table_t *table)
 {
+    ecs_assert(cache != NULL, ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(table != NULL, ECS_INTERNAL_ERROR, NULL);
+
     int32_t *index = ecs_map_get(cache->index, int32_t, table->id);
     if (!index) {
         return;
@@ -24251,13 +24270,17 @@ void _ecs_table_cache_remove(
     } else {
         move_table(cache, table, index[0], NULL, cache->tables, true);
     }
+
+    ecs_map_remove(cache->index, table->id);
 }
 
 void* _ecs_table_cache_get(
-    ecs_table_cache_t *cache,
+    const ecs_table_cache_t *cache,
     ecs_size_t size,
-    ecs_table_t *table)
+    const ecs_table_t *table)
 {
+    ecs_assert(cache != NULL, ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(table != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(size == cache->size, ECS_INTERNAL_ERROR, NULL);
 
     int32_t *index = ecs_map_get(cache->index, int32_t, table->id);
@@ -24273,16 +24296,19 @@ void* _ecs_table_cache_get(
             cache->empty_tables, size, 8, index[0] * -1 - 1);
     }
 
-    ecs_assert(result->table == table, ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(!result || result->table == table, ECS_INTERNAL_ERROR, NULL);
 
     return result;
 }
 
 void _ecs_table_cache_set_empty(
     ecs_table_cache_t *cache,
-    ecs_table_t *table,
+    const ecs_table_t *table,
     bool empty)
 {
+    ecs_assert(cache != NULL, ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(table != NULL, ECS_INTERNAL_ERROR, NULL);
+
     int32_t *index = ecs_map_get(cache->index, int32_t, table->id);
     if (!index) {
         return;
@@ -24842,6 +24868,7 @@ void compute_group_id(
     }
 }
 
+static
 ecs_query_table_list_t* get_group(
     ecs_query_t *query,
     uint64_t group_id)
@@ -24849,6 +24876,7 @@ ecs_query_table_list_t* get_group(
     return ecs_map_get(query->groups, ecs_query_table_list_t, group_id);
 }
 
+static
 ecs_query_table_list_t* ensure_group(
     ecs_query_t *query,
     uint64_t group_id)
@@ -24857,6 +24885,7 @@ ecs_query_table_list_t* ensure_group(
 }
 
 /* Find the last node of the group after which this group should be inserted */
+static
 ecs_query_table_node_t* find_group_insertion_node(
     ecs_query_t *query,
     uint64_t group_id)
@@ -24879,7 +24908,7 @@ ecs_query_table_node_t* find_group_insertion_node(
             continue;
         }
 
-        if ((group_id - id) < (group_id - closest_id)) {
+        if (!closest_list || ((group_id - id) < (group_id - closest_id))) {
             closest_id = id;
             closest_list = list;
         }
@@ -24893,12 +24922,13 @@ ecs_query_table_node_t* find_group_insertion_node(
 }
 
 /* Initialize group with first node */
+static
 void create_group(
     ecs_query_t *query,
     ecs_query_table_node_t *node)
 {
     ecs_query_table_match_t *match = node->match;
-    uint32_t group_id = match->group_id;
+    uint64_t group_id = match->group_id;
 
     /* If query has grouping enabled & this is a new/empty group, find
      * the insertion point for the group */
@@ -24985,6 +25015,10 @@ void remove_node(
     ecs_query_table_node_t *prev = node->prev;
     ecs_query_table_node_t *next = node->next;
 
+    ecs_assert(prev != node, ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(next != node, ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(!prev || prev != next, ECS_INTERNAL_ERROR, NULL);
+
     ecs_query_table_list_t *list = get_node_list(query, node);
 
     if (!list || !list->first) {
@@ -24995,12 +25029,20 @@ void remove_node(
         return;
     }
 
+    ecs_assert(prev != NULL || query->list.first == node, 
+        ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(next != NULL || query->list.last == node, 
+        ECS_INTERNAL_ERROR, NULL);
+
     if (prev) {
         prev->next = next;
     }
     if (next) {
         next->prev = prev;
     }
+
+    ecs_assert(list->count > 0, ECS_INTERNAL_ERROR, NULL);
+    list->count --;
 
     if (query->group_by) {
         ecs_query_table_match_t *match = node->match;
@@ -25017,6 +25059,9 @@ void remove_node(
             query->list.last = prev;
             next = prev;
         }
+
+        ecs_assert(query->list.count > 0, ECS_INTERNAL_ERROR, NULL);
+        query->list.count --;
 
         /* Make sure group list only contains nodes that belong to the group */
         if (prev && prev->match->group_id != group_id) {
@@ -25047,6 +25092,14 @@ void remove_node(
 
     node->prev = NULL;
     node->next = NULL;
+
+#ifdef FLECS_SYSTEMS_H
+    if (query->list.first == NULL && query->system && !query->world->is_fini) {
+        ecs_system_activate(query->world, query->system, false, NULL);
+    }
+#endif
+
+    query->match_count ++;
 }
 
 /* Add node to list */
@@ -25059,10 +25112,16 @@ void insert_node(
     ecs_assert(node->prev == NULL && node->next == NULL, 
         ECS_INTERNAL_ERROR, NULL);
 
+    /* If this is the first match, activate system */
+#ifdef FLECS_SYSTEMS_H
+    if (!query->list.first && query->system) {
+        ecs_system_activate(query->world, query->system, true, NULL);
+    }
+#endif
+
     compute_group_id(query, node->match);
 
     ecs_query_table_list_t *list = ensure_node_list(query, node);
-
     if (list->last) {
         ecs_assert(query->list.first != NULL, ECS_INTERNAL_ERROR, NULL);
         ecs_assert(query->list.last != NULL, ECS_INTERNAL_ERROR, NULL);
@@ -25099,6 +25158,16 @@ void insert_node(
         }
     }
 
+    if (query->group_by) {
+        query->list.count ++;
+    }
+
+    list->count ++;
+    query->match_count ++;
+
+    ecs_assert(node->prev != node, ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(node->next != node, ECS_INTERNAL_ERROR, NULL);
+
     ecs_assert(list->first != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(list->last != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(list->last == node, ECS_INTERNAL_ERROR, NULL);
@@ -25108,16 +25177,22 @@ void insert_node(
     ecs_assert(query->list.last->next == NULL, ECS_INTERNAL_ERROR, NULL);
 }
 
+static
 ecs_query_table_match_t* cache_add(
-    ecs_query_t *query,
     ecs_query_table_t *elem)
 {
     ecs_query_table_match_t *result = ecs_os_calloc_t(ecs_query_table_match_t);
     ecs_query_table_node_t *node = &result->node;
 
     node->match = result;
-    result->next_match = elem->first;
-    elem->first = result;
+    if (!elem->first) {
+        elem->first = result;
+        elem->last = result;
+    } else {
+        ecs_assert(elem->last != NULL, ECS_INTERNAL_ERROR, NULL);
+        elem->last->next_match = result;
+        elem->last = result;
+    }
 
     return result;
 }
@@ -25129,13 +25204,13 @@ ecs_query_table_match_t* cache_add(
  * The result of the function is the number of parents with the provided 
  * component for a given relation. */
 static
-int32_t group_by_cascade(
+uint64_t group_by_cascade(
     ecs_world_t *world,
     ecs_type_t type,
     ecs_entity_t component,
     void *ctx)
 {
-    int32_t result = 0;
+    uint64_t result = 0;
     int32_t i, count = ecs_vector_count(type);
     ecs_entity_t *array = ecs_vector_first(type, ecs_entity_t);
     ecs_term_t *term = ctx;
@@ -25583,11 +25658,11 @@ void add_table(
     ecs_query_table_match_t *table_data;
     ecs_vector_t *references = NULL;
 
-    ecs_query_table_t *elem = ecs_table_cache_insert(
-        &query->cache, table, ecs_query_table_t);
+    ecs_query_table_t *qt = ecs_table_cache_insert(
+        &query->cache, ecs_query_table_t, table);
 
 add_pair:
-    table_data = cache_add(query, elem);
+    table_data = cache_add(qt);
     table_data->table = table;
     if (table) {
         table_type = table->type;
@@ -25731,6 +25806,7 @@ add_pair:
 
     /* Insert match to iteration list if table is not empty */
     if (!table || ecs_table_count(table) != 0) {
+        ecs_assert(table == qt->hdr.table, ECS_INTERNAL_ERROR, NULL);
         insert_node(query, &table_data->node);
     }
 
@@ -25888,8 +25964,6 @@ void match_tables(
             add_table(world, query, table);
         }
     }
-
-    // order_grouped_tables(query);
 }
 
 #define ELEM(ptr, size, index) ECS_OFFSET(ptr, size * index)
@@ -25998,192 +26072,187 @@ void sort_table(
 }
 
 /* Helper struct for building sorted table ranges */
-// typedef struct sort_helper_t {
-//     ecs_query_table_match_t *table;
-//     ecs_entity_t *entities;
-//     const void *ptr;
-//     int32_t row;
-//     int32_t elem_size;
-//     int32_t count;
-//     bool shared;
-// } sort_helper_t;
+typedef struct sort_helper_t {
+    ecs_query_table_match_t *match;
+    ecs_entity_t *entities;
+    const void *ptr;
+    int32_t row;
+    int32_t elem_size;
+    int32_t count;
+    bool shared;
+} sort_helper_t;
 
-// static
-// const void* ptr_from_helper(
-//     sort_helper_t *helper)
-// {
-//     ecs_assert(helper->row < helper->count, ECS_INTERNAL_ERROR, NULL);
-//     ecs_assert(helper->elem_size >= 0, ECS_INTERNAL_ERROR, NULL);
-//     ecs_assert(helper->row >= 0, ECS_INTERNAL_ERROR, NULL);
-//     if (helper->shared) {
-//         return helper->ptr;
-//     } else {
-//         return ELEM(helper->ptr, helper->elem_size, helper->row);
-//     }
-// }
+static
+const void* ptr_from_helper(
+    sort_helper_t *helper)
+{
+    ecs_assert(helper->row < helper->count, ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(helper->elem_size >= 0, ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(helper->row >= 0, ECS_INTERNAL_ERROR, NULL);
+    if (helper->shared) {
+        return helper->ptr;
+    } else {
+        return ELEM(helper->ptr, helper->elem_size, helper->row);
+    }
+}
 
-// static
-// ecs_entity_t e_from_helper(
-//     sort_helper_t *helper)
-// {
-//     if (helper->row < helper->count) {
-//         return helper->entities[helper->row];
-//     } else {
-//         return 0;
-//     }
-// }
+static
+ecs_entity_t e_from_helper(
+    sort_helper_t *helper)
+{
+    if (helper->row < helper->count) {
+        return helper->entities[helper->row];
+    } else {
+        return 0;
+    }
+}
 
-// static
-// void build_sorted_table_range(
-//     ecs_query_t *query,
-//     int32_t start,
-//     int32_t end)
-// {
-//     ecs_world_t *world = query->world;
-//     ecs_entity_t component = query->order_by_component;
-//     ecs_order_by_action_t compare = query->order_by;
+static
+void build_sorted_table_range(
+    ecs_query_t *query,
+    ecs_query_table_list_t *list)
+{
+    ecs_world_t *world = query->world;
+    ecs_entity_t component = query->order_by_component;
+    ecs_order_by_action_t compare = query->order_by;
+    
+    if (!list->count) {
+        return;
+    }
 
-//     /* Fetch data from all matched tables */
-//     cache_iter_t it = cache_iter(query);
-//     ecs_query_table_match_t *table;
-//     sort_helper_t *helper = ecs_os_malloc((end - start) * ECS_SIZEOF(sort_helper_t));
+    int to_sort = 0;
+    sort_helper_t *helper = ecs_os_malloc_n(sort_helper_t, list->count);
+    ecs_query_table_node_t *cur, *end = list->last->next;
+    for (cur = list->first; cur != end; cur = cur->next) {
+        ecs_query_table_match_t *match = cur->match;
+        ecs_table_t *table = match->table;
+        ecs_data_t *data = &table->storage;
+        ecs_vector_t *entities;
+        if (!(entities = data->entities) || !ecs_table_count(table)) {
+            continue;
+        }
 
-//     int i, to_sort = 0;
-//     for (i = start; i < end; i ++) {
-//         ecs_query_table_match_t *table_data = &tables[i];
-//         ecs_table_t *table = table_data->table;
-//         ecs_data_t *data = &table->storage;
-//         ecs_vector_t *entities;
-//         if (!(entities = data->entities) || !ecs_table_count(table)) {
-//             continue;
-//         }
+        int32_t index = ecs_type_index_of(table->type, 0, component);
+        if (index != -1) {
+            ecs_column_t *column = &data->columns[index];
+            int16_t size = column->size;
+            int16_t align = column->alignment;
+            helper[to_sort].ptr = ecs_vector_first_t(column->data, size, align);
+            helper[to_sort].elem_size = size;
+            helper[to_sort].shared = false;
+        } else if (component) {
+            /* Find component in prefab */
+            ecs_entity_t base;
+            ecs_type_match(world, table, table->type, 0, component, 
+                EcsIsA, 1, 0, &base);
 
-//         int32_t index = ecs_type_index_of(table->type, 0, component);
-//         if (index != -1) {
-//             ecs_column_t *column = &data->columns[index];
-//             int16_t size = column->size;
-//             int16_t align = column->alignment;
-//             helper[to_sort].ptr = ecs_vector_first_t(column->data, size, align);
-//             helper[to_sort].elem_size = size;
-//             helper[to_sort].shared = false;
-//         } else if (component) {
-//             /* Find component in prefab */
-//             ecs_entity_t base;
-//             ecs_type_match(world, table, table->type, 0, component, 
-//                 EcsIsA, 1, 0, &base);
+            /* If a base was not found, the query should not have allowed using
+             * the component for sorting */
+            ecs_assert(base != 0, ECS_INTERNAL_ERROR, NULL);
 
-//             /* If a base was not found, the query should not have allowed using
-//              * the component for sorting */
-//             ecs_assert(base != 0, ECS_INTERNAL_ERROR, NULL);
+            const EcsComponent *cptr = ecs_get(world, component, EcsComponent);
+            ecs_assert(cptr != NULL, ECS_INTERNAL_ERROR, NULL);
 
-//             const EcsComponent *cptr = ecs_get(world, component, EcsComponent);
-//             ecs_assert(cptr != NULL, ECS_INTERNAL_ERROR, NULL);
+            helper[to_sort].ptr = ecs_get_id(world, base, component);
+            helper[to_sort].elem_size = cptr->size;
+            helper[to_sort].shared = true;
+        } else {
+            helper[to_sort].ptr = NULL;
+            helper[to_sort].elem_size = 0;
+            helper[to_sort].shared = false;
+        }
 
-//             helper[to_sort].ptr = ecs_get_id(world, base, component);
-//             helper[to_sort].elem_size = cptr->size;
-//             helper[to_sort].shared = true;
-//         } else {
-//             helper[to_sort].ptr = NULL;
-//             helper[to_sort].elem_size = 0;
-//             helper[to_sort].shared = false;
-//         }
+        helper[to_sort].match = match;
+        helper[to_sort].entities = ecs_vector_first(entities, ecs_entity_t);
+        helper[to_sort].row = 0;
+        helper[to_sort].count = ecs_table_count(table);
+        to_sort ++;      
+    }
 
-//         helper[to_sort].table = table_data;
-//         helper[to_sort].entities = ecs_vector_first(entities, ecs_entity_t);
-//         helper[to_sort].row = 0;
-//         helper[to_sort].count = ecs_table_count(table);
-//         to_sort ++;      
-//     }
+    bool proceed;
+    do {
+        int32_t j, min = 0;
+        proceed = true;
 
-//     ecs_query_table_node_t *cur = NULL;
+        ecs_entity_t e1;
+        while (!(e1 = e_from_helper(&helper[min]))) {
+            min ++;
+            if (min == to_sort) {
+                proceed = false;
+                break;
+            }
+        }
 
-//     bool proceed;
-//     do {
-//         int32_t j, min = 0;
-//         proceed = true;
+        if (!proceed) {
+            break;
+        }
 
-//         ecs_entity_t e1;
-//         while (!(e1 = e_from_helper(&helper[min]))) {
-//             min ++;
-//             if (min == to_sort) {
-//                 proceed = false;
-//                 break;
-//             }
-//         }
+        for (j = min + 1; j < to_sort; j++) {
+            ecs_entity_t e2 = e_from_helper(&helper[j]);
+            if (!e2) {
+                continue;
+            }
 
-//         if (!proceed) {
-//             break;
-//         }
+            const void *ptr1 = ptr_from_helper(&helper[min]);
+            const void *ptr2 = ptr_from_helper(&helper[j]);
 
-//         for (j = min + 1; j < to_sort; j++) {
-//             ecs_entity_t e2 = e_from_helper(&helper[j]);
-//             if (!e2) {
-//                 continue;
-//             }
+            if (compare(e1, ptr1, e2, ptr2) > 0) {
+                min = j;
+                e1 = e_from_helper(&helper[min]);
+            }
+        }
 
-//             const void *ptr1 = ptr_from_helper(&helper[min]);
-//             const void *ptr2 = ptr_from_helper(&helper[j]);
+        sort_helper_t *cur_helper = &helper[min];
+        if (!cur || cur->match != cur_helper->match) {
+            cur = ecs_vector_add(&query->table_slices, ecs_query_table_node_t);
+            ecs_assert(cur != NULL, ECS_INTERNAL_ERROR, NULL);
+            cur->match = cur_helper->match;
+            cur->offset = cur_helper->row;
+            cur->count = 1;
+        } else {
+            cur->count ++;
+        }
 
-//             if (compare(e1, ptr1, e2, ptr2) > 0) {
-//                 min = j;
-//                 e1 = e_from_helper(&helper[min]);
-//             }
-//         }
+        cur_helper->row ++;
+    } while (proceed);
 
-//         sort_helper_t *cur_helper = &helper[min];
-//         if (!cur || cur->table != cur_helper->table) {
-//             cur = ecs_vector_add(&query->table_slices, ecs_query_table_node_t);
-//             ecs_assert(cur != NULL, ECS_INTERNAL_ERROR, NULL);
-//             cur->table = cur_helper->table;
-//             cur->start_row = cur_helper->row;
-//             cur->count = 1;
-//         } else {
-//             cur->count ++;
-//         }
+    /* Iterate through the vector of slices to set the prev/next ptrs. This
+     * can't be done while building the vector, as reallocs may occur */
+    int32_t i, count = ecs_vector_count(query->table_slices);    
+    ecs_query_table_node_t *nodes = ecs_vector_first(
+        query->table_slices, ecs_query_table_node_t);
+    for (i = 0; i < count; i ++) {
+        nodes[i].prev = &nodes[i - 1];
+        nodes[i].next = &nodes[i + 1];
+    }
 
-//         cur_helper->row ++;
-//     } while (proceed);
+    nodes[0].prev = NULL;
+    nodes[i - 1].next = NULL;
 
-//     ecs_os_free(helper);
-// }
+    ecs_os_free(helper);
+}
 
-// static
-// void build_sorted_tables(
-//     ecs_query_t *query)
-// {
-//     /* Clean previous sorted tables */
-//     ecs_vector_free(query->table_slices);
-//     query->table_slices = NULL;
+static
+void build_sorted_tables(
+    ecs_query_t *query)
+{
+    ecs_vector_clear(query->table_slices);
 
-//     int32_t i, count = ecs_vector_count(query->tables);
-//     ecs_query_table_match_t *tables = ecs_vector_first(query->tables, ecs_query_table_match_t);
-//     ecs_query_table_match_t *table = NULL;
-
-//     int32_t start = 0, rank = 0;
-//     for (i = 0; i < count; i ++) {
-//         table = &tables[i];
-//         if (rank != table->rank) {
-//             if (start != i) {
-//                 build_sorted_table_range(query, start, i);
-//                 start = i;
-//             }
-//             rank = table->rank;
-//         }
-//     }
-
-//     if (start != i) {
-//         build_sorted_table_range(query, start, i);
-//     }
-// }
+    if (query->group_by) {
+        ecs_map_iter_t it = ecs_map_iter(query->groups);
+        ecs_query_table_list_t *list;
+        while ((list = ecs_map_next(&it, ecs_query_table_list_t, NULL))) {
+            build_sorted_table_range(query, list);
+        }
+    } else {
+        build_sorted_table_range(query, &query->list);
+    }
+}
 
 static
 bool tables_dirty(
     ecs_query_t *query)
 {
-    // if (query->needs_reorder) {
-    //     order_grouped_tables(query);
-    // }
-
     bool is_dirty = false;
 
     ecs_vector_t *vec = query->cache.tables;
@@ -26204,7 +26273,6 @@ bool tables_dirty(
         for (t = 0; t < type_count + 1; t ++) {
             is_dirty = is_dirty || (dirty_state[t] != qt->monitor[t]);
         }
-
     }
 
     is_dirty = is_dirty || (query->match_count != query->prev_match_count);
@@ -26302,7 +26370,7 @@ void sort_tables(
     }
 
     if (tables_sorted || query->match_count != query->prev_match_count) {
-        // build_sorted_tables(query);
+        build_sorted_tables(query);
         query->match_count ++; /* Increase version if tables changed */
     }
 }
@@ -26488,7 +26556,6 @@ bool match_table(
  * tables are not considered by the system in the main loop. */
 static
 void update_table(
-    ecs_world_t *world,
     ecs_query_t *query,
     ecs_table_t *table,
     bool empty)
@@ -26511,6 +26578,7 @@ void update_table(
             if (empty) {
                 ecs_assert(ecs_table_count(table) == 0, 
                     ECS_INTERNAL_ERROR, NULL);
+
                 remove_node(query, &cur->node);
             } else {
                 ecs_assert(ecs_table_count(table) != 0, 
@@ -26520,20 +26588,8 @@ void update_table(
         }
     }
 
-    if (query->system) {
-        if (!prev_count && cur_count) {
-            ecs_system_activate(world, query->system, true, NULL);
-        } else if (prev_count && !cur_count) {
-            ecs_system_activate(world, query->system, false, NULL);
-        }
-    }
-
-    /* Signal query it needs to reorder tables. Doing this in place could slow
-     * down scenario's where a large number of tables is matched with an ordered
-     * query. Since each table would trigger the activate signal, there would be
-     * as many sorts as added tables, vs. only one when ordering happens when an
-     * iterator is obtained. */
-    query->needs_reorder = true;
+    ecs_assert(cur_count || query->list.first == NULL, 
+        ECS_INTERNAL_ERROR, NULL);
 }
 
 static
@@ -26619,6 +26675,13 @@ void resolve_cascade_subject_for_table(
         references[ref_index].entity = 0;
         table_data->subjects[term_index] = 0;
     }
+
+    if (ecs_table_count(table)) {
+        /* The subject (or depth of the subject) may have changed, so reinsert
+         * the node to make sure it's in the right group */
+        remove_node(query, &table_data->node);
+        insert_node(query, &table_data->node);
+    }
 }
 
 static
@@ -26657,7 +26720,9 @@ void remove_table(
         ecs_os_free(cur->sparse_columns);
         ecs_os_free(cur->bitset_columns);
 
-        remove_node(query, &cur->node);
+        if (!elem->hdr.empty) {
+            remove_node(query, &cur->node);
+        }
 
         next = cur->next_match;
 
@@ -26791,9 +26856,6 @@ void rematch_tables(
         }
     }
 
-    // group_tables(world, query);
-    // order_grouped_tables(query);
-
     /* Enable/disable system if constraints are (not) met. If the system is
      * already dis/enabled this operation has no side effects. */
     query->constraints_satisfied = satisfy_constraints(world, &query->filter);      
@@ -26849,11 +26911,11 @@ void flecs_query_notify(
         break;        
     case EcsQueryTableEmpty:
         /* Table is empty, deactivate */
-        update_table(world, query, event->table, true);
+        update_table(query, event->table, true);
         break;
     case EcsQueryTableNonEmpty:
         /* Table is non-empty, activate */
-        update_table(world, query, event->table, false);
+        update_table(query, event->table, false);
         break;
     case EcsQueryOrphan:
         ecs_assert(query->flags & EcsQueryIsSubquery, ECS_INTERNAL_ERROR, NULL);
@@ -26884,16 +26946,15 @@ void query_order_by(
     ecs_vector_free(query->table_slices);
     query->table_slices = NULL;
 
-    // sort_tables(world, query);    
+    sort_tables(world, query);  
 
     if (!query->table_slices) {
-        // build_sorted_tables(query);
+        build_sorted_tables(query);
     }
 }
 
 static
 void query_group_by(
-    ecs_world_t *world,
     ecs_query_t *query,
     ecs_entity_t sort_component,
     ecs_group_by_action_t group_by)
@@ -26934,11 +26995,13 @@ ecs_query_t* ecs_query_init(
     ecs_table_cache_init(
         &result->cache, ecs_query_table_t, result, remove_table);
 
+    process_signature(world, result);
+
     /* Group before matching so we won't have to move tables around later */
     int32_t cascade_by = result->cascade_by;
     if (cascade_by) {
-        result->group_by = group_by_cascade;
-        result->group_by_id = result->filter.terms[cascade_by - 1].id;
+        query_group_by(result, result->filter.terms[cascade_by - 1].id,
+            group_by_cascade);
         result->group_by_ctx = &result->filter.terms[cascade_by - 1];
     }
 
@@ -26946,7 +27009,7 @@ ecs_query_t* ecs_query_init(
         /* Can't have a cascade term and group by at the same time, as cascade
          * uses the group_by mechanism */
         ecs_assert(!result->cascade_by, ECS_INVALID_PARAMETER, NULL);
-        query_group_by(world, result, desc->group_by_id, desc->group_by);
+        query_group_by(result, desc->group_by_id, desc->group_by);
         result->group_by_ctx = desc->group_by_ctx;
         result->group_by_ctx_free = desc->group_by_ctx_free;
     }
@@ -26968,8 +27031,6 @@ ecs_query_t* ecs_query_init(
             }
         }        
     }
-
-    process_signature(world, result);
 
     ecs_trace_2("query #[green]%s#[reset] created with expression #[red]%s", 
         query_name(world, result), result->filter.expr);
@@ -27074,11 +27135,7 @@ ecs_iter_t ecs_query_iter_page(
 
     ecs_world_t *world = (ecs_world_t*)ecs_get_world(stage);
 
-    if (query->needs_reorder) {
-        // order_grouped_tables(query);
-    }
-
-    // sort_tables(world, query);
+    sort_tables(world, query);
 
     if (!world->is_readonly && query->flags & EcsQueryHasRefs) {
         flecs_eval_component_monitors(world);
@@ -27102,6 +27159,10 @@ ecs_iter_t ecs_query_iter_page(
             .remaining = limit
         }
     };
+
+    if (query->order_by && query->list.count) {
+        it.node = ecs_vector_first(query->table_slices, ecs_query_table_node_t);
+    }
 
     return (ecs_iter_t){
         .real_world = world,
@@ -27577,11 +27638,6 @@ bool ecs_query_next(
     if (!query->constraints_satisfied) {
         goto done;
     }
-
-    ecs_query_table_node_t *slice = ecs_vector_first(
-        query->table_slices, ecs_query_table_node_t);
-
-    ecs_assert(!slice || query->order_by, ECS_INTERNAL_ERROR, NULL);
     
     ecs_page_cursor_t cur;
     int32_t prev_count = it->total_count;
@@ -27598,41 +27654,40 @@ bool ecs_query_next(
             cur.count = node->count;
             if (!cur.count) {
                 cur.count = ecs_table_count(table);
+
+                /* List should never contain empty tables */
+                ecs_assert(cur.count != 0, ECS_INTERNAL_ERROR, NULL);
             }
 
-            if (cur.count) {
-                ecs_vector_t *bitset_columns = match->bitset_columns;
-                ecs_vector_t *sparse_columns = match->sparse_columns;
+            ecs_vector_t *bitset_columns = match->bitset_columns;
+            ecs_vector_t *sparse_columns = match->sparse_columns;
 
-                if (bitset_columns) {
-                    if (bitset_column_next(table, bitset_columns, iter, 
-                        &cur) == -1) 
-                    {
-                        /* No more enabled components for table */
-                        continue; 
-                    } else {
-                        next = node;
-                    }
+            if (bitset_columns) {
+                if (bitset_column_next(table, bitset_columns, iter, 
+                    &cur) == -1) 
+                {
+                    /* No more enabled components for table */
+                    continue; 
+                } else {
+                    next = node;
                 }
+            }
 
-                if (sparse_columns) {
-                    if (sparse_column_next(table, match,
-                        sparse_columns, iter, &cur) == -1)
-                    {
-                        /* No more elements in sparse column */
-                        continue;    
-                    } else {
-                        next = node;
-                    }
+            if (sparse_columns) {
+                if (sparse_column_next(table, match,
+                    sparse_columns, iter, &cur) == -1)
+                {
+                    /* No more elements in sparse column */
+                    continue;    
+                } else {
+                    next = node;
                 }
+            }
 
-                int ret = ecs_page_iter_next(piter, &cur);
-                if (ret < 0) {
-                    goto done;
-                } else if (ret > 0) {
-                    continue;
-                }
-            } else {
+            int ret = ecs_page_iter_next(piter, &cur);
+            if (ret < 0) {
+                goto done;
+            } else if (ret > 0) {
                 continue;
             }
 
@@ -27741,7 +27796,6 @@ bool ecs_query_orphaned(
     ecs_poly_assert(query, ecs_query_t);
     return query->flags & EcsQueryIsOrphaned;
 }
-
 
 static
 uint64_t ids_hash(const void *ptr) {

--- a/flecs.c
+++ b/flecs.c
@@ -13575,7 +13575,7 @@ ecs_entity_t ensure_entity(
         if (is_subject) {
             ecs_entity_t scope = ecs_get_scope(world);
             if (scope) {
-                ecs_add_id(world, e, scope);
+                ecs_add_pair(world, e, EcsChildOf, scope);
             }
 
             ecs_entity_t with = ecs_get_with(world);
@@ -13637,6 +13637,7 @@ int create_term(
 
     if (subj) {
         if (!obj) {
+            printf("add pred '%s'\n", ecs_id_str(world, pred));
             ecs_add_id(world, subj, pred);
         } else {
             ecs_add_pair(world, subj, pred, obj);
@@ -13679,6 +13680,7 @@ int create_term(
         if (subj) {
             int32_t i, frame_count = state->with_frames[state->sp];
             for (i = 0; i < frame_count; i ++) {
+                printf("add 'with' %s\n", ecs_id_str(world, state->with[i]));
                 ecs_add_id(world, subj, state->with[i]);
             }
         }
@@ -13773,6 +13775,7 @@ const char* parse_stmt(
                     if (state->last_object) {
                         scope = ecs_pair(
                             state->last_predicate, state->last_object);
+                        printf("} -> set with '%s'\n", ecs_id_str(world, scope));
                         ecs_set_with(world, scope);
                     } else {
                         scope = ecs_pair(EcsChildOf, state->last_predicate);
@@ -13798,14 +13801,17 @@ const char* parse_stmt(
             ptr = skip_fluff(ptr + 1);
             ecs_id_t id = state->scope[state->sp];
             if (!id || ECS_HAS_ROLE(id, PAIR)) {
+                printf("} -> set with '%s'\n", ecs_id_str(world, id));
                 ecs_set_with(world, id);
             }
 
             if (!id || !ECS_HAS_ROLE(id, PAIR)) {
+                printf("} -> set scope '%s'\n", ecs_id_str(world, id));
                 ecs_set_scope(world, id);
             }
 
             state->with_frame = state->with_frames[state->sp];
+            printf("with_frame = %d\n", state->with_frame);
             stmt_parsed = true;
         }
 

--- a/flecs.h
+++ b/flecs.h
@@ -2533,7 +2533,8 @@ typedef struct ecs_filter_iter_t {
 typedef struct ecs_query_iter_t {
     ecs_query_t *query;
     ecs_page_iter_t page_iter;
-    int32_t index;
+    int32_t cache_index;
+    int32_t table_index;
     int32_t sparse_smallest;
     int32_t sparse_first;
     int32_t bitset_first;
@@ -2683,7 +2684,6 @@ struct ecs_iter_t {
 
     ecs_term_t *terms;            /* Terms of query being evaluated */
     int32_t table_count;          /* Active table count for query */
-    int32_t inactive_table_count; /* Inactive table count for query */
     int32_t term_count;           /* Number of terms in query */
     int32_t term_index;           /* Index of term that triggered an event.
                                    * This field will be set to the 'index' field
@@ -7665,6 +7665,14 @@ FLECS_API void ecs_gauge_reduce(
     ecs_add_path_w_sep(world, entity, 0, path, ".", NULL)
 
 
+/* -- Queries -- */
+
+#define ecs_query_table_count(query)\
+    ecs_vector_count(query->cache.tables)
+
+#define ecs_query_empty_table_count(query)\
+    ecs_vector_count(query->cache.empty_tables)
+
 /* -- Iterators -- */
 
 #define ecs_term_id(it, index)\
@@ -9335,12 +9343,6 @@ public:
      * @param row Row being iterated over.
      */
     flecs::entity entity(size_t row) const;
-
-    /** Obtain the total number of inactive tables the query is matched with.
-     */
-    int32_t inactive_table_count() const {
-        return m_iter->inactive_table_count;
-    }
 
     /** Returns whether term is owned.
      * 

--- a/flecs.h
+++ b/flecs.h
@@ -2203,7 +2203,7 @@ typedef int (*ecs_order_by_action_t)(
     const void *ptr2);
 
 /** Callback used for ranking types */
-typedef int32_t (*ecs_group_by_action_t)(
+typedef uint64_t (*ecs_group_by_action_t)(
     ecs_world_t *world,
     ecs_type_t type,
     ecs_id_t id,

--- a/flecs.h
+++ b/flecs.h
@@ -933,6 +933,9 @@ int32_t _ecs_vector_move_index(
 #define ecs_vector_move_index(dst, src, T, index) \
     _ecs_vector_move_index(dst, src, ECS_VECTOR_T(T), index)
 
+#define ecs_vector_move_index_t(dst, src, size, alignment, index) \
+    _ecs_vector_move_index(dst, src, ECS_VECTOR_U(size, alignment), index)
+
 /** Remove element at specified index. Moves the last value to the index. */
 FLECS_API
 int32_t _ecs_vector_remove(

--- a/flecs.h
+++ b/flecs.h
@@ -2446,6 +2446,9 @@ typedef struct ecs_id_record_t ecs_id_record_t;
 /* Mixins */
 typedef struct ecs_mixins_t ecs_mixins_t;
 
+/* Cached query table data */
+typedef struct ecs_query_table_node_t ecs_query_table_node_t;
+
 ////////////////////////////////////////////////////////////////////////////////
 //// Non-opaque types
 ////////////////////////////////////////////////////////////////////////////////
@@ -2533,8 +2536,7 @@ typedef struct ecs_filter_iter_t {
 typedef struct ecs_query_iter_t {
     ecs_query_t *query;
     ecs_page_iter_t page_iter;
-    int32_t cache_index;
-    int32_t table_index;
+    ecs_query_table_node_t *node;
     int32_t sparse_smallest;
     int32_t sparse_first;
     int32_t bitset_first;
@@ -2690,7 +2692,6 @@ struct ecs_iter_t {
                                    * of a trigger/observer term. */
     int32_t variable_count;       /* Number of variables for query */
     
-    void *table_columns;          /* Table component data */
     ecs_entity_t *entities;       /* Entity identifiers */
 
     void *param;                  /* Param passed to ecs_run */

--- a/flecs.h
+++ b/flecs.h
@@ -14826,7 +14826,6 @@ public:
 
         ecs_iter_t it = ecs_filter_iter(m_world, f.c_ptr());
 
-        printf("filter = %s\n", ecs_filter_str(m_world, f.c_ptr()));
         m_snapshot = ecs_snapshot_take_w_iter(&it, ecs_filter_next);
     }    
 

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -148,7 +148,7 @@ typedef int (*ecs_order_by_action_t)(
     const void *ptr2);
 
 /** Callback used for ranking types */
-typedef int32_t (*ecs_group_by_action_t)(
+typedef uint64_t (*ecs_group_by_action_t)(
     ecs_world_t *world,
     ecs_type_t type,
     ecs_id_t id,

--- a/include/flecs/addons/cpp/iter.hpp
+++ b/include/flecs/addons/cpp/iter.hpp
@@ -285,12 +285,6 @@ public:
      */
     flecs::entity entity(size_t row) const;
 
-    /** Obtain the total number of inactive tables the query is matched with.
-     */
-    int32_t inactive_table_count() const {
-        return m_iter->inactive_table_count;
-    }
-
     /** Returns whether term is owned.
      * 
      * @param index The term index.

--- a/include/flecs/addons/cpp/snapshot.hpp
+++ b/include/flecs/addons/cpp/snapshot.hpp
@@ -56,7 +56,6 @@ public:
 
         ecs_iter_t it = ecs_filter_iter(m_world, f.c_ptr());
 
-        printf("filter = %s\n", ecs_filter_str(m_world, f.c_ptr()));
         m_snapshot = ecs_snapshot_take_w_iter(&it, ecs_filter_next);
     }    
 

--- a/include/flecs/addons/flecs_c.h
+++ b/include/flecs/addons/flecs_c.h
@@ -281,6 +281,14 @@
     ecs_add_path_w_sep(world, entity, 0, path, ".", NULL)
 
 
+/* -- Queries -- */
+
+#define ecs_query_table_count(query)\
+    ecs_vector_count(query->cache.tables)
+
+#define ecs_query_empty_table_count(query)\
+    ecs_vector_count(query->cache.empty_tables)
+
 /* -- Iterators -- */
 
 #define ecs_term_id(it, index)\

--- a/include/flecs/private/api_types.h
+++ b/include/flecs/private/api_types.h
@@ -48,6 +48,9 @@ typedef struct ecs_id_record_t ecs_id_record_t;
 /* Mixins */
 typedef struct ecs_mixins_t ecs_mixins_t;
 
+/* Cached query table data */
+typedef struct ecs_cached_table_node_t ecs_cached_table_node_t;
+
 ////////////////////////////////////////////////////////////////////////////////
 //// Non-opaque types
 ////////////////////////////////////////////////////////////////////////////////
@@ -135,7 +138,7 @@ typedef struct ecs_filter_iter_t {
 typedef struct ecs_query_iter_t {
     ecs_query_t *query;
     ecs_page_iter_t page_iter;
-    int32_t index;
+    ecs_cached_table_node_t *node;
     int32_t sparse_smallest;
     int32_t sparse_first;
     int32_t bitset_first;
@@ -285,7 +288,6 @@ struct ecs_iter_t {
 
     ecs_term_t *terms;            /* Terms of query being evaluated */
     int32_t table_count;          /* Active table count for query */
-    int32_t inactive_table_count; /* Inactive table count for query */
     int32_t term_count;           /* Number of terms in query */
     int32_t term_index;           /* Index of term that triggered an event.
                                    * This field will be set to the 'index' field

--- a/include/flecs/private/api_types.h
+++ b/include/flecs/private/api_types.h
@@ -49,7 +49,7 @@ typedef struct ecs_id_record_t ecs_id_record_t;
 typedef struct ecs_mixins_t ecs_mixins_t;
 
 /* Cached query table data */
-typedef struct ecs_cached_table_node_t ecs_cached_table_node_t;
+typedef struct ecs_query_table_node_t ecs_query_table_node_t;
 
 ////////////////////////////////////////////////////////////////////////////////
 //// Non-opaque types
@@ -138,7 +138,7 @@ typedef struct ecs_filter_iter_t {
 typedef struct ecs_query_iter_t {
     ecs_query_t *query;
     ecs_page_iter_t page_iter;
-    ecs_cached_table_node_t *node;
+    ecs_query_table_node_t *node;
     int32_t sparse_smallest;
     int32_t sparse_first;
     int32_t bitset_first;
@@ -294,7 +294,6 @@ struct ecs_iter_t {
                                    * of a trigger/observer term. */
     int32_t variable_count;       /* Number of variables for query */
     
-    void *table_columns;          /* Table component data */
     ecs_entity_t *entities;       /* Entity identifiers */
 
     void *param;                  /* Param passed to ecs_run */

--- a/include/flecs/private/vector.h
+++ b/include/flecs/private/vector.h
@@ -255,6 +255,9 @@ int32_t _ecs_vector_move_index(
 #define ecs_vector_move_index(dst, src, T, index) \
     _ecs_vector_move_index(dst, src, ECS_VECTOR_T(T), index)
 
+#define ecs_vector_move_index_t(dst, src, size, alignment, index) \
+    _ecs_vector_move_index(dst, src, ECS_VECTOR_U(size, alignment), index)
+
 /** Remove element at specified index. Moves the last value to the index. */
 FLECS_API
 int32_t _ecs_vector_remove(

--- a/meson.build
+++ b/meson.build
@@ -43,6 +43,7 @@ flecs_src = files(
     'src/poly.c',
     'src/query.c',
     'src/stage.c',
+    'src/table_cache.c',
     'src/table_graph.c',
     'src/table.c',
     'src/trigger.c',

--- a/src/addons/pipeline/pipeline.c
+++ b/src/addons/pipeline/pipeline.c
@@ -25,7 +25,7 @@ int compare_entity(
 }
 
 static
-int group_by_phase(
+uint64_t group_by_phase(
     ecs_world_t *world,
     ecs_type_t type,
     ecs_entity_t pipeline,
@@ -61,7 +61,7 @@ int group_by_phase(
     ecs_assert(result != 0, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(result < INT_MAX, ECS_INTERNAL_ERROR, NULL);
 
-    return (int)result;
+    return result;
 }
 
 typedef enum ComponentWriteState {

--- a/src/addons/pipeline/pipeline.c
+++ b/src/addons/pipeline/pipeline.c
@@ -660,7 +660,7 @@ void ecs_deactivate_systems(
         for (i = 0; i < it.count; i ++) {
             ecs_query_t *query = sys[i].query;
             if (query) {
-                if (!ecs_vector_count(query->tables)) {
+                if (!ecs_query_table_count(query)) {
                     ecs_add_id(world, it.entities[i], EcsInactive);
                 }
             }

--- a/src/addons/plecs.c
+++ b/src/addons/plecs.c
@@ -46,7 +46,7 @@ ecs_entity_t ensure_entity(
         if (is_subject) {
             ecs_entity_t scope = ecs_get_scope(world);
             if (scope) {
-                ecs_add_id(world, e, scope);
+                ecs_add_pair(world, e, EcsChildOf, scope);
             }
 
             ecs_entity_t with = ecs_get_with(world);

--- a/src/addons/snapshot.c
+++ b/src/addons/snapshot.c
@@ -316,7 +316,6 @@ bool ecs_snapshot_next(
         ecs_assert(data != NULL, ECS_INTERNAL_ERROR, NULL);
 
         it->table = table;
-        it->table_columns = data->columns;
         it->count = flecs_table_data_count(data);
         it->entities = ecs_vector_first(data->entities, ecs_entity_t);
         it->is_valid = true;

--- a/src/addons/stats.c
+++ b/src/addons/stats.c
@@ -208,19 +208,19 @@ void ecs_get_query_stats(
 
     int32_t t = s->t = t_next(s->t);
 
-    int32_t i, entity_count = 0, count = ecs_vector_count(query->tables);
-    ecs_matched_table_t *matched_tables = ecs_vector_first(
-        query->tables, ecs_matched_table_t);
+    int32_t i, entity_count = 0, count = ecs_query_table_count(query);
+    ecs_cached_table_node_t *matched_tables = ecs_vector_first(
+        query->cache.tables, ecs_cached_table_node_t);
     for (i = 0; i < count; i ++) {
-        ecs_matched_table_t *matched = &matched_tables[i];
+        ecs_cached_table_node_t *matched = &matched_tables[i];
         if (matched->table) {
             entity_count += ecs_table_count(matched->table);
         }
     }
 
     record_gauge(&s->matched_table_count, t, count);
-    record_gauge(&s->matched_empty_table_count, t, 
-        ecs_vector_count(query->empty_tables));
+    record_gauge(&s->matched_empty_table_count, t,
+        ecs_query_empty_table_count(query));
     record_gauge(&s->matched_entity_count, t, entity_count);
 }
 

--- a/src/addons/stats.c
+++ b/src/addons/stats.c
@@ -209,10 +209,10 @@ void ecs_get_query_stats(
     int32_t t = s->t = t_next(s->t);
 
     int32_t i, entity_count = 0, count = ecs_query_table_count(query);
-    ecs_cached_table_node_t *matched_tables = ecs_vector_first(
-        query->cache.tables, ecs_cached_table_node_t);
+    ecs_query_table_match_t *matched_tables = ecs_vector_first(
+        query->cache.tables, ecs_query_table_match_t);
     for (i = 0; i < count; i ++) {
-        ecs_cached_table_node_t *matched = &matched_tables[i];
+        ecs_query_table_match_t *matched = &matched_tables[i];
         if (matched->table) {
             entity_count += ecs_table_count(matched->table);
         }

--- a/src/addons/system/system.c
+++ b/src/addons/system/system.c
@@ -49,7 +49,7 @@ void ecs_system_activate(
         if (ecs_has_id(world, system, EcsDisabled) || 
             ecs_has_id(world, system, EcsDisabledIntern)) 
         {
-            if (!ecs_vector_count(system_data->query->tables)) {
+            if (!ecs_query_table_count(system_data->query)) {
                 /* If deactivating a disabled system that isn't matched with
                  * any active tables, there is nothing to deactivate. */
                 return;
@@ -82,7 +82,7 @@ void ecs_enable_system(
         return;
     }
 
-    if (ecs_vector_count(query->tables)) {
+    if (ecs_query_table_count(query)) {
         /* Only (de)activate system if it has non-empty tables. */
         ecs_system_activate(world, system, enabled, system_data);
         system_data = ecs_get_mut(world, system, EcsSystem, NULL);
@@ -342,7 +342,7 @@ void ecs_colsystem_dtor(
         }
 
         /* Invoke Deactivated action for active systems */
-        if (system->query && ecs_vector_count(system->query->tables)) {
+        if (system->query && ecs_query_table_count(system->query)) {
             invoke_status_action(world, e, ptr, EcsSystemDeactivated);
         }
 
@@ -444,7 +444,7 @@ ecs_entity_t ecs_system_init(
         /* If tables have been matched with this system it is active, and we
          * should activate the in terms, if any. This will ensure that any
          * OnDemand systems get enabled. */
-        if (ecs_vector_count(query->tables)) {
+        if (ecs_query_table_count(query)) {
             ecs_system_activate(world, result, true, system);
         } else {
             /* If system isn't matched with any tables, mark it as inactive. This
@@ -461,7 +461,7 @@ ecs_entity_t ecs_system_init(
 
             /* If column system has active (non-empty) tables, also generate the
             * activate status. */
-            if (ecs_vector_count(system->query->tables)) {
+            if (ecs_query_table_count(system->query)) {
                 invoke_status_action(world, result, system, EcsSystemActivated);
             }
         }

--- a/src/datastructures/vector.c
+++ b/src/datastructures/vector.c
@@ -173,7 +173,9 @@ int32_t _ecs_vector_move_index(
     int16_t offset,
     int32_t index)
 {
-    ecs_assert((*dst)->elem_size == elem_size, ECS_INTERNAL_ERROR, NULL);
+    if (dst && *dst) {
+        ecs_assert((*dst)->elem_size == elem_size, ECS_INTERNAL_ERROR, NULL);
+    }
     ecs_assert(src->elem_size == elem_size, ECS_INTERNAL_ERROR, NULL);
 
     void *dst_elem = _ecs_vector_add(dst, elem_size, offset);

--- a/src/datastructures/vector.c
+++ b/src/datastructures/vector.c
@@ -137,6 +137,7 @@ void* _ecs_vector_add(
     ecs_size_t elem_size,
     int16_t offset)
 {
+    ecs_assert(array_inout != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_vector_t *vector = *array_inout;
     int32_t count, size;
 

--- a/src/filter.c
+++ b/src/filter.c
@@ -1110,7 +1110,6 @@ void populate_from_table(
     it->count = ecs_table_count(table);
 
     const ecs_data_t *data = &table->storage;
-    it->table_columns = data->columns;
     it->entities = ecs_vector_first(data->entities, ecs_entity_t);
 }
 
@@ -1454,7 +1453,6 @@ bool ecs_term_next(
     it->sizes = &iter->size;
     it->ptrs = &iter->ptr;
 
-    it->table_columns = &table->storage.columns;
     it->count = ecs_table_count(table);
     it->entities = ecs_vector_first(table->storage.entities, ecs_entity_t);
     it->is_valid = true;

--- a/src/filter.c
+++ b/src/filter.c
@@ -267,8 +267,6 @@ int finalize_term_id(
     ecs_entity_t obj = entity_from_identifier(&term->args[1]);
     ecs_id_t role = term->role;
 
-    // printf("finalize term id (%d, %d) role = %d\n", pred, obj, role);
-
     if (ECS_HAS_ROLE(pred, PAIR)) {
         if (obj) {
             term_error(world, term, name, 

--- a/src/iter.c
+++ b/src/iter.c
@@ -124,7 +124,7 @@ void* ecs_iter_column_w_size(
         return NULL;
     }
 
-    ecs_column_t *columns = it->table_columns;
+    ecs_column_t *columns = table->storage.columns;
     ecs_column_t *column = &columns[column_index];
     ecs_assert(!size || (ecs_size_t)size == column->size, ECS_INVALID_PARAMETER, NULL);
 
@@ -146,7 +146,7 @@ size_t ecs_iter_column_size(
         return 0;
     }
 
-    ecs_column_t *columns = it->table_columns;
+    ecs_column_t *columns = table->storage.columns;
     ecs_column_t *column = &columns[column_index];
     
     return flecs_to_size_t(column->size);

--- a/src/observer.c
+++ b/src/observer.c
@@ -79,7 +79,6 @@ void observer_callback(ecs_iter_t *it) {
         user_it.self = o->self;
         user_it.ctx = o->ctx;
         user_it.term_count = o->filter.term_count_actual;
-        user_it.table_columns = table->storage.columns;
 
         o->action(&user_it);
         o->last_event_id = world->event_id;

--- a/src/private_api.h
+++ b/src/private_api.h
@@ -2,6 +2,7 @@
 #define FLECS_PRIVATE_H
 
 #include "private_types.h"
+#include "table_cache.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 //// Core bootstrap functions

--- a/src/private_types.h
+++ b/src/private_types.h
@@ -238,6 +238,7 @@ typedef struct ecs_table_cache_t {
 /** Must appear as first member in payload of table cache */
 typedef struct ecs_table_cache_hdr_t {
     ecs_table_t *table;
+    bool empty;
 } ecs_table_cache_hdr_t;
 
 /* Sparse query column */
@@ -259,12 +260,12 @@ typedef struct ecs_query_table_match_t ecs_query_table_match_t;
  * The list of nodes dictates the order in which tables should be iterated by a
  * query. A single node may refer to the table multiple times with different
  * offset/count parameters, which enables features such as sorting. */
-typedef struct ecs_query_table_node_t {
+struct ecs_query_table_node_t {
     ecs_query_table_match_t *match;  /* Reference to the match */
     int32_t offset;                  /* Starting point in table  */
     int32_t count;                   /* Number of entities to iterate in table */
     ecs_query_table_node_t *next, *prev;
-} ecs_query_table_node_t;
+};
 
 /** Type containing data for a table matched with a query. 
  * A single table can have multiple matches, if the query contains wildcards. */
@@ -292,6 +293,7 @@ struct ecs_query_table_match_t {
 typedef struct ecs_query_table_t {
     ecs_table_cache_hdr_t hdr;       /* Header for ecs_table_cache_t */
     ecs_query_table_match_t *first;  /* List with matches for table */
+    ecs_query_table_match_t *last;   /* Last discovered match for table */
     int32_t *monitor;                /* Used to monitor table for changes */
 } ecs_query_table_t;
 
@@ -299,6 +301,7 @@ typedef struct ecs_query_table_t {
 typedef struct ecs_query_table_list_t {
     ecs_query_table_node_t *first;
     ecs_query_table_node_t *last;
+    int32_t count;
 } ecs_query_table_list_t;
 
 #define EcsQueryNeedsTables (1)      /* Query needs matching with tables */ 
@@ -372,7 +375,6 @@ struct ecs_query_t {
     int32_t match_count;        /* How often have tables been (un)matched */
     int32_t prev_match_count;   /* Used to track if sorting is needed */
 
-    bool needs_reorder;         /* Whether next iteration should reorder */
     bool constraints_satisfied; /* Are all term constraints satisfied */
 };
 

--- a/src/private_types.h
+++ b/src/private_types.h
@@ -104,7 +104,6 @@ typedef struct ecs_table_event_t {
 
     /* Query event */
     ecs_query_t *query;
-    int32_t matched_table_index;
 
     /* Component info event */
     ecs_entity_t component;
@@ -226,6 +225,19 @@ struct ecs_table_t {
     int32_t lock;
 };
 
+/** Table cache */
+typedef struct ecs_table_cache_t {
+    ecs_map_t *index; /* <table_id, index> */
+    ecs_vector_t *tables;
+    ecs_vector_t *empty_tables;
+    ecs_size_t payload_size;
+} ecs_table_cache_t;
+
+/** Must appear as first member in payload of table cache */
+typedef struct ecs_table_cache_hdr_t {
+    ecs_table_t *table;
+} ecs_table_cache_hdr_t;
+
 /* Sparse query column */
 typedef struct flecs_sparse_column_t {
     ecs_sw_column_t *sw_column;
@@ -254,6 +266,13 @@ typedef struct ecs_matched_table_t {
     int32_t *monitor;              /* Used to monitor table for changes */
     int32_t rank;                  /* Rank used to sort tables */
 } ecs_matched_table_t;
+
+/** A single table can occur multiple times in the cache when a term matches
+ * multiple table columns. */
+typedef struct ecs_matched_tables_t {
+    ecs_table_cache_hdr_t hdr;
+    ecs_vector_t *tables; /* vector<matched_table_t> */
+} ecs_matched_tables_t;
 
 /** Type used to track location of table in queries' table lists.
  * When a table becomes empty or non-empty a signal is sent to a query, which
@@ -321,6 +340,8 @@ struct ecs_query_t {
     ecs_world_t *world;
 
     /* Tables matched with query */
+    ecs_table_cache_t cache;
+
     ecs_vector_t *tables;
     ecs_vector_t *empty_tables;
     ecs_map_t *table_indices;

--- a/src/query.c
+++ b/src/query.c
@@ -162,7 +162,7 @@ ecs_query_table_list_t* ensure_node_list(
 
 /* Remove node from list */
 static
-void remove_node(
+void remove_table_node(
     ecs_query_t *query,
     ecs_query_table_node_t *node)
 {
@@ -258,7 +258,7 @@ void remove_node(
 
 /* Add node to list */
 static
-void insert_node(
+void insert_table_node(
     ecs_query_t *query,
     ecs_query_table_node_t *node)
 {
@@ -961,7 +961,7 @@ add_pair:
     /* Insert match to iteration list if table is not empty */
     if (!table || ecs_table_count(table) != 0) {
         ecs_assert(table == qt->hdr.table, ECS_INTERNAL_ERROR, NULL);
-        insert_node(query, &table_data->node);
+        insert_table_node(query, &table_data->node);
     }
 
     /* Use tail recursion when adding table for multiple pairs */
@@ -1733,11 +1733,11 @@ void update_table(
                 ecs_assert(ecs_table_count(table) == 0, 
                     ECS_INTERNAL_ERROR, NULL);
 
-                remove_node(query, &cur->node);
+                remove_table_node(query, &cur->node);
             } else {
                 ecs_assert(ecs_table_count(table) != 0, 
                     ECS_INTERNAL_ERROR, NULL);
-                insert_node(query, &cur->node);
+                insert_table_node(query, &cur->node);
             }
         }
     }
@@ -1833,8 +1833,8 @@ void resolve_cascade_subject_for_table(
     if (ecs_table_count(table)) {
         /* The subject (or depth of the subject) may have changed, so reinsert
          * the node to make sure it's in the right group */
-        remove_node(query, &table_data->node);
-        insert_node(query, &table_data->node);
+        remove_table_node(query, &table_data->node);
+        insert_table_node(query, &table_data->node);
     }
 }
 
@@ -1875,7 +1875,7 @@ void remove_table(
         ecs_os_free(cur->bitset_columns);
 
         if (!elem->hdr.empty) {
-            remove_node(query, &cur->node);
+            remove_table_node(query, &cur->node);
         }
 
         next = cur->next_match;

--- a/src/table_cache.c
+++ b/src/table_cache.c
@@ -1,0 +1,178 @@
+#include "private_api.h"
+
+/* Move table from empty to non-empty list, or vice versa */
+static
+int32_t move_table(
+    ecs_table_cache_t *cache,
+    ecs_table_t *table,
+    int32_t index,
+    ecs_vector_t **dst_array,
+    ecs_vector_t *src_array,
+    bool empty)
+{
+    (void)table;
+
+    int32_t new_index = 0, old_index = 0;
+    ecs_size_t size = cache->payload_size;
+    int32_t last_src_index = ecs_vector_count(src_array) - 1;
+    ecs_assert(last_src_index >= 0, ECS_INTERNAL_ERROR, NULL);
+
+    ecs_table_cache_hdr_t *elem = ecs_vector_last_t(src_array, size, 8);
+    
+    /* The last table of the source array will be moved to the location of the
+     * table to move, do some bookkeeping to keep things consistent. */
+    if (last_src_index) {
+        int32_t *old_index_ptr = ecs_map_get(cache->index, 
+            int32_t, elem->table->id);
+        ecs_assert(old_index_ptr != NULL, ECS_INTERNAL_ERROR, NULL);
+
+        int32_t old_index = old_index_ptr[0];
+        if (!empty) {
+            if (old_index >= 0) {
+                /* old_index should be negative if not empty, since
+                 * we're moving from the empty list to the non-empty list. 
+                 * However, if the last table in the source array is also
+                 * the table being moved, this can happen. */
+                ecs_assert(table == elem->table, ECS_INTERNAL_ERROR, NULL);
+                // continue
+            } else {
+                /* If not empty, src = the empty list, and index should
+                 * be negative. */
+                old_index = old_index * -1 - 1; /* Normalize */
+            }
+        }
+
+        if (old_index == last_src_index) {
+            old_index_ptr[0] = index;
+        }
+    } else {
+        /* If last_src_index is 0, the table to move was the only table in the
+         * src array, so no other administration needs to be updated. */
+    }
+
+    /* Actually move the table. Only move from src to dst if we have a
+     * dst_array, otherwise just remove it from src. */
+    if (dst_array) {
+        if (!empty) {
+            old_index = index * -1 - 1;
+        } else {
+            old_index = index;
+        }
+
+        new_index = ecs_vector_count(*dst_array);
+        ecs_vector_move_index_t(dst_array, src_array, size, 8, old_index);
+
+        /* Make sure table is where we expect it */
+        elem = ecs_vector_last_t(*dst_array, size, 8);
+        ecs_assert(elem->table == table, ECS_INTERNAL_ERROR, NULL);
+        ecs_assert(ecs_vector_count(*dst_array) == (new_index + 1), 
+            ECS_INTERNAL_ERROR, NULL);  
+    } else {
+        ecs_vector_remove_t(src_array, size, 8, old_index);
+    }
+
+    /* Ensure that src array has now one element less */
+    ecs_assert(ecs_vector_count(src_array) == last_src_index, 
+        ECS_INTERNAL_ERROR, NULL);
+
+    if (empty) {
+        /* Table is now empty, index is negative */
+        new_index = new_index * -1 - 1;
+    }
+
+    return new_index;
+}
+
+void _ecs_table_cache_init(
+    ecs_table_cache_t *cache,
+    ecs_size_t size)
+{
+    ecs_assert(size >= ECS_SIZEOF(ecs_table_cache_hdr_t), 
+        ECS_INTERNAL_ERROR, NULL);
+    cache->index = ecs_map_new(int32_t, 0);
+    cache->empty_tables = NULL;
+    cache->tables = NULL;
+    cache->payload_size = size;
+}
+
+void ecs_table_cache_fini(
+    ecs_table_cache_t *cache)
+{
+    ecs_map_free(cache->index);
+    ecs_vector_free(cache->empty_tables);
+    ecs_vector_free(cache->tables);
+}
+
+void* _ecs_table_cache_insert(
+    ecs_table_cache_t *cache,
+    const ecs_table_t *table,
+    ecs_size_t size)
+{
+    int32_t index;
+    ecs_table_cache_hdr_t *result;
+    bool empty;
+
+    if (!table) {
+        empty = false;
+    } else {
+        empty = ecs_table_count(table) == 0;
+    }
+
+    if (empty) {
+        result = ecs_vector_add_t(&cache->empty_tables, size, 8);
+        index = -ecs_vector_count(cache->empty_tables);
+    } else {
+        index = ecs_vector_count(cache->tables);
+        result = ecs_vector_add_t(&cache->tables, size, 8);
+    }
+
+    if (table) {
+        ecs_map_set(cache->index, table->id, &index);
+    }
+
+    result->table = (ecs_table_t*)table;
+
+    return result;
+}
+
+void _ecs_table_cache_remove(
+    ecs_table_cache_t *cache,
+    ecs_table_t *table)
+{
+    int32_t *index = ecs_map_get(cache->index, int32_t, table->id);
+    if (!index) {
+        return;
+    }
+
+    if (index[0] < 0) {
+        move_table(cache, table, index[0], NULL, cache->empty_tables, false);
+    } else {
+        move_table(cache, table, index[0], NULL, cache->tables, true);
+    }
+}
+
+void _ecs_table_cache_set_empty(
+    ecs_table_cache_t *cache,
+    ecs_table_t *table,
+    bool empty)
+{
+    int32_t *index = ecs_map_get(cache->index, int32_t, table->id);
+    if (!index) {
+        return;
+    }
+
+    /* If table is already in the correct array nothing needs to be done */
+    if (empty && index[0] < 0) {
+        return;
+    } else if (!empty && index[0] >= 0) {
+        return;
+    }
+
+    if (index[0] < 0) {
+        index[0] = move_table(
+            cache, table, index[0], &cache->tables, cache->empty_tables, empty);
+    } else {
+        index[0] = move_table(
+            cache, table, index[0], &cache->empty_tables, cache->tables, empty);
+    }
+}

--- a/src/table_cache.h
+++ b/src/table_cache.h
@@ -13,10 +13,11 @@ extern "C" {
 void _ecs_table_cache_init(
     ecs_table_cache_t *cache,
     ecs_size_t size,
-    void(*free_payload)(void*));
+    ecs_poly_t *parent,
+    void(*free_payload)(ecs_poly_t *parent, void*));
 
-#define ecs_table_cache_init(cache, T, free_payload)\
-    _ecs_table_cache_init(cache, ECS_SIZEOF(T), free_payload)
+#define ecs_table_cache_init(cache, T, parent, free_payload)\
+    _ecs_table_cache_init(cache, ECS_SIZEOF(T), parent, free_payload)
 
 void ecs_table_cache_fini(
     ecs_table_cache_t *cache);

--- a/src/table_cache.h
+++ b/src/table_cache.h
@@ -1,6 +1,6 @@
 /**
  * @file table_cache.h
- * @brief Data structure for fast table iteration/lookups 
+ * @brief Data structure for fast table iteration/lookups.
  */
 
 #ifndef FLECS_TABLE_CACHE_H_
@@ -12,10 +12,11 @@ extern "C" {
 
 void _ecs_table_cache_init(
     ecs_table_cache_t *cache,
-    ecs_size_t size);
+    ecs_size_t size,
+    void(*free_payload)(void*));
 
-#define ecs_table_cache_init(cache, T)\
-    _ecs_table_cache_init(cache, ECS_SIZEOF(T))
+#define ecs_table_cache_init(cache, T, free_payload)\
+    _ecs_table_cache_init(cache, ECS_SIZEOF(T), free_payload)
 
 void ecs_table_cache_fini(
     ecs_table_cache_t *cache);
@@ -34,6 +35,14 @@ void _ecs_table_cache_remove(
 
 #define ecs_table_cache_remove(cache, table)\
     _ecs_table_cache_remove(cache, table)
+
+void* _ecs_table_cache_get(
+    ecs_table_cache_t *cache,
+    ecs_size_t size,
+    ecs_table_t *table);
+
+#define ecs_table_cache_get(cache, T, table)\
+    ECS_CAST(T*, _ecs_table_cache_get(cache, ECS_SIZEOF(T), table))
 
 void _ecs_table_cache_set_empty(
     ecs_table_cache_t *cache,

--- a/src/table_cache.h
+++ b/src/table_cache.h
@@ -1,0 +1,50 @@
+/**
+ * @file table_cache.h
+ * @brief Data structure for fast table iteration/lookups 
+ */
+
+#ifndef FLECS_TABLE_CACHE_H_
+#define FLECS_TABLE_CACHE_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void _ecs_table_cache_init(
+    ecs_table_cache_t *cache,
+    ecs_size_t size);
+
+#define ecs_table_cache_init(cache, T)\
+    _ecs_table_cache_init(cache, ECS_SIZEOF(T))
+
+void ecs_table_cache_fini(
+    ecs_table_cache_t *cache);
+
+void* _ecs_table_cache_insert(
+    ecs_table_cache_t *cache,
+    const ecs_table_t *table,
+    ecs_size_t size);
+
+#define ecs_table_cache_insert(cache, table, T)\
+    ECS_CAST(T*, _ecs_table_cache_insert(cache, table, ECS_SIZEOF(T)))
+
+void _ecs_table_cache_remove(
+    ecs_table_cache_t *cache,
+    ecs_table_t *table);
+
+#define ecs_table_cache_remove(cache, table)\
+    _ecs_table_cache_remove(cache, table)
+
+void _ecs_table_cache_set_empty(
+    ecs_table_cache_t *cache,
+    ecs_table_t *table,
+    bool empty);
+
+#define ecs_table_cache_set_empty(cache, table, empty)\
+    _ecs_table_cache_set_empty(cache, table, empty)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/table_cache.h
+++ b/src/table_cache.h
@@ -24,30 +24,30 @@ void ecs_table_cache_fini(
 
 void* _ecs_table_cache_insert(
     ecs_table_cache_t *cache,
-    const ecs_table_t *table,
-    ecs_size_t size);
+    ecs_size_t size,
+    const ecs_table_t *table);
 
-#define ecs_table_cache_insert(cache, table, T)\
-    ECS_CAST(T*, _ecs_table_cache_insert(cache, table, ECS_SIZEOF(T)))
+#define ecs_table_cache_insert(cache, T, table)\
+    ECS_CAST(T*, _ecs_table_cache_insert(cache, ECS_SIZEOF(T), table))
 
 void _ecs_table_cache_remove(
     ecs_table_cache_t *cache,
-    ecs_table_t *table);
+    const ecs_table_t *table);
 
 #define ecs_table_cache_remove(cache, table)\
     _ecs_table_cache_remove(cache, table)
 
 void* _ecs_table_cache_get(
-    ecs_table_cache_t *cache,
+    const ecs_table_cache_t *cache,
     ecs_size_t size,
-    ecs_table_t *table);
+    const ecs_table_t *table);
 
 #define ecs_table_cache_get(cache, T, table)\
     ECS_CAST(T*, _ecs_table_cache_get(cache, ECS_SIZEOF(T), table))
 
 void _ecs_table_cache_set_empty(
     ecs_table_cache_t *cache,
-    ecs_table_t *table,
+    const ecs_table_t *table,
     bool empty);
 
 #define ecs_table_cache_set_empty(cache, table, empty)\

--- a/src/world.c
+++ b/src/world.c
@@ -1232,8 +1232,13 @@ void flecs_notify_queries(
 
     int32_t i, count = flecs_sparse_count(world->queries);
     for (i = 0; i < count; i ++) {
-        flecs_query_notify(world, 
-            flecs_sparse_get_dense(world->queries, ecs_query_t, i), event);
+        ecs_query_t *query = flecs_sparse_get_dense(
+            world->queries, ecs_query_t, i);
+        if (query->flags & EcsQueryIsSubquery) {
+            continue;
+        }
+        
+        flecs_query_notify(world, query, event);
     }    
 }
 

--- a/test/api/project.json
+++ b/test/api/project.json
@@ -432,6 +432,7 @@
                 "with_n_tags_2_levels",
                 "with_after_scope",
                 "with_after_with",
+                "scope_inside_with_inside_scope",
                 "with_inside_scope"
             ]            
         }, {

--- a/test/api/src/Hierarchies.c
+++ b/test/api/src/Hierarchies.c
@@ -1081,7 +1081,6 @@ void Hierarchies_delete_tree_count_tables() {
     ecs_query_t *q = ecs_query_new(world, "Position");
     ecs_iter_t it = ecs_query_iter(world, q);
     test_int(it.table_count, 3);
-    test_int(it.inactive_table_count, 0);
 
     ecs_delete(world, parent);
     
@@ -1091,7 +1090,6 @@ void Hierarchies_delete_tree_count_tables() {
 
     it = ecs_query_iter(world, q);
     test_int(it.table_count, 0);
-    test_int(it.inactive_table_count, 1); /* Parent table is still there */
 
     ecs_fini(world);
 }
@@ -1115,7 +1113,6 @@ void Hierarchies_delete_tree_staged() {
     ecs_query_t *q = ecs_query_new(world, "Position");
     ecs_iter_t it = ecs_query_iter(world, q);
     test_int(it.table_count, 3);
-    test_int(it.inactive_table_count, 0);
 
     ecs_defer_begin(world);
     ecs_delete(world, parent);
@@ -1127,7 +1124,6 @@ void Hierarchies_delete_tree_staged() {
 
     it = ecs_query_iter(world, q);
     test_int(it.table_count, 0);
-    test_int(it.inactive_table_count, 1); /* Parent table is still there */
 
     ecs_fini(world);
 }

--- a/test/api/src/Pairs.c
+++ b/test/api/src/Pairs.c
@@ -160,13 +160,13 @@ void Pairs_type_w_two_pairs() {
     ecs_entity_t hi = ECS_PAIR_RELATION(c);
     ecs_entity_t lo = ECS_PAIR_OBJECT(c);
     test_int(hi, ecs_id(Rel));
-    test_int(lo, ecs_id(Velocity));
+    test_int(lo, ecs_id(Position));
 
     c = ctx.c[1][0];
     hi = ECS_PAIR_RELATION(c);
     lo = ECS_PAIR_OBJECT(c);
     test_int(hi, ecs_id(Rel));
-    test_int(lo, ecs_id(Position));
+    test_int(lo, ecs_id(Velocity));
 
     test_int(ctx.s[0][0], 0);
     test_int(ctx.s[1][0], 0);

--- a/test/api/src/Plecs.c
+++ b/test/api/src/Plecs.c
@@ -1475,7 +1475,7 @@ void Plecs_with_after_with() {
     ecs_fini(world);
 }
 
-void Plecs_with_inside_scope() {
+void Plecs_scope_inside_with_inside_scope() {
     ecs_world_t *world = ecs_init();
     
     const char *expr =
@@ -1510,7 +1510,38 @@ void Plecs_with_inside_scope() {
     test_assert(ecs_has_pair(world, moon, EcsChildOf, earth));
     test_assert(ecs_has_pair(world, mars, EcsChildOf, sun));
 
+    test_assert(!ecs_has_id(world, earth, sun));
+    test_assert(!ecs_has_id(world, moon, earth));
+    test_assert(!ecs_has_id(world, mars, sun));
+
     test_assert(!ecs_has_pair(world, planet, EcsChildOf, sun));
 
     ecs_fini(world);
+}
+
+void Plecs_with_inside_scope() {
+    ecs_world_t *world = ecs_init();
+    
+    const char *expr =
+    HEAD "Earth {"
+    LINE "  with Continent {"
+    LINE "    Europe"
+    LINE "  }"
+    LINE "  Europe"
+    LINE "}";
+
+    test_assert(ecs_plecs_from_str(world, NULL, expr) == 0);
+
+    ecs_entity_t earth = ecs_lookup_fullpath(world, "Earth");
+    ecs_entity_t continent = ecs_lookup_fullpath(world, "Continent");
+    ecs_entity_t europe = ecs_lookup_fullpath(world, "Earth.Europe");
+
+    test_assert(earth != 0);
+    test_assert(continent != 0);
+    test_assert(europe != 0);
+
+    test_assert( ecs_has_pair(world, europe, EcsChildOf, earth));
+    test_assert( !ecs_has_pair(world, continent, EcsChildOf, earth));
+    test_assert( !ecs_has_id(world, europe, earth));
+    test_assert( !ecs_has_id(world, continent, earth));
 }

--- a/test/api/src/Plecs.c
+++ b/test/api/src/Plecs.c
@@ -1544,4 +1544,6 @@ void Plecs_with_inside_scope() {
     test_assert( !ecs_has_pair(world, continent, EcsChildOf, earth));
     test_assert( !ecs_has_id(world, europe, earth));
     test_assert( !ecs_has_id(world, continent, earth));
+
+    ecs_fini(world);
 }

--- a/test/api/src/Query.c
+++ b/test/api/src/Query.c
@@ -1286,7 +1286,7 @@ void Query_get_filter() {
 }
 
 static
-int32_t group_by_first_id(
+uint64_t group_by_first_id(
     ecs_world_t *world,
     ecs_type_t type,
     ecs_id_t id,

--- a/test/api/src/Query.c
+++ b/test/api/src/Query.c
@@ -348,7 +348,6 @@ void Query_subquery_inactive() {
     table_count = 0, entity_count = 0;
     it = ecs_query_iter(world, sq);
     test_int(it.table_count, 0);
-    test_int(it.inactive_table_count, 1);
 
     table_count = 0, entity_count = 0;
     it = ecs_query_iter(world, sq);

--- a/test/api/src/Rules.c
+++ b/test/api/src/Rules.c
@@ -781,9 +781,9 @@ void Rules_wildcard_as_subject() {
     ECS_ENTITY(world, Tag, Final);
 
     ecs_entity_t e1 = ecs_new(world, Tag);
-    ecs_entity_t e2 = ecs_new(world, Tag);
+    ecs_new(world, Tag);
 
-    ecs_entity_t child = ecs_new_w_pair(world, EcsChildOf, e1);
+    ecs_new_w_pair(world, EcsChildOf, e1);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t) {
         .expr = "Tag, ChildOf(*, This)"

--- a/test/api/src/SystemMisc.c
+++ b/test/api/src/SystemMisc.c
@@ -749,7 +749,7 @@ static int test_table_count_invoked;
 
 static void TestTableCount(ecs_iter_t *it) {
     test_int(it->table_count, 2);
-    test_int(it->inactive_table_count, 1);
+
     test_table_count_invoked ++;
 }
 

--- a/test/api/src/main.c
+++ b/test/api/src/main.c
@@ -407,6 +407,7 @@ void Plecs_with_n_tags(void);
 void Plecs_with_n_tags_2_levels(void);
 void Plecs_with_after_scope(void);
 void Plecs_with_after_with(void);
+void Plecs_scope_inside_with_inside_scope(void);
 void Plecs_with_inside_scope(void);
 
 // Testsuite 'GlobalComponentIds'
@@ -3588,6 +3589,10 @@ bake_test_case Plecs_testcases[] = {
     {
         "with_after_with",
         Plecs_with_after_with
+    },
+    {
+        "scope_inside_with_inside_scope",
+        Plecs_scope_inside_with_inside_scope
     },
     {
         "with_inside_scope",
@@ -9880,7 +9885,7 @@ static bake_test_suite suites[] = {
         "Plecs",
         NULL,
         NULL,
-        63,
+        64,
         Plecs_testcases
     },
     {


### PR DESCRIPTION
This PR changes the implementation of the query cache to a data structure that allows for faster cache updates when tables are created or deleted.

The biggest performance improvements can be expected for queries that use `cascade` or `group_by`, as insertion performance went from O(log N) to O(1). The new cache also enables new future use cases, such as grouping columns across tables, and selectively iterate tables in a specific group (like, "iterate all entities for this world tile") in O(1) lookup time.

The main reason for this change though was to extract the data structure that separates empty tables from non-empty tables from queries, so that it can be reused for the world table administration. This will allow for faster term/filter/rule iteration as they no longer have to skip empty tables, and can iterate a plain vector vs. a map iterator, which should be measurably faster. 

Another benefit of this data structure is that iteration order will become more predictable. While applications generally should not make assumptions about the order in which a query returns results, (unordered) map ordering is erratic which can be annoying for things like writing tests.