### PR TITLE
Add delete_with, remove_all functions

### DIFF
--- a/flecs.h
+++ b/flecs.h
@@ -4123,6 +4123,30 @@ void ecs_delete_children(
     ecs_world_t *world,
     ecs_entity_t parent);
 
+/** Delete all entities with the specified id.
+ * This will delete all entities (tables) that have the specified id. The id 
+ * may be a wildcard and/or a pair.
+ * 
+ * @param world The world.
+ * @param id The id.
+ */
+FLECS_API
+void ecs_delete_with(
+    ecs_world_t *world,
+    ecs_id_t id);
+
+/** Remove all instances of the specified id.
+ * This will remove the specified id from all entities (tables). Teh id may be
+ * a wildcard and/or a pair.
+ * 
+ * @param world The world.
+ * @param id The id.
+ */
+FLECS_API
+void ecs_remove_all(
+    ecs_world_t *world,
+    ecs_id_t id);
+
 /** @} */
 
 

--- a/flecs.h
+++ b/flecs.h
@@ -10908,6 +10908,50 @@ public:
         ecs_set_scope(m_world, prev);
     }
 
+    /** Delete all entities with specified id. */
+    void delete_with(id_t id) const {
+        ecs_delete_with(m_world, id);
+    }
+
+    /** Delete all entities with specified relation. */
+    void delete_with(entity_t rel, entity_t obj) const {
+        delete_with(ecs_pair(rel, obj));
+    }
+
+    /** Delete all entities with specified component. */
+    template <typename T>
+    void delete_with() const {
+        delete_with(_::cpp_type<T>::id());
+    }
+
+    /** Delete all entities with specified relation. */
+    template <typename R, typename O>
+    void delete_with() const {
+        delete_with(_::cpp_type<R>::id(), _::cpp_type<O>::id());
+    }
+
+    /** Remove all instances of specified id. */
+    void remove_all(id_t id) const {
+        ecs_remove_all(m_world, id);
+    }
+
+    /** Remove all instances of specified relation. */
+    void remove_all(entity_t rel, entity_t obj) const {
+        remove_all(ecs_pair(rel, obj));
+    }
+
+    /** Remove all instances of specified component. */
+    template <typename T>
+    void remove_all() const {
+        remove_all(_::cpp_type<T>::id());
+    }
+
+    /** Remove all instances of specified relation. */
+    template <typename R, typename O>
+    void remove_all() const {
+        remove_all(_::cpp_type<R>::id(), _::cpp_type<O>::id());
+    }
+
     /** Defer all operations called in function. If the world is already in
      * deferred mode, do nothing.
      */

--- a/flecs.h
+++ b/flecs.h
@@ -10909,8 +10909,8 @@ public:
     }
 
     /** Delete all entities with specified id. */
-    void delete_with(id_t id) const {
-        ecs_delete_with(m_world, id);
+    void delete_with(id_t the_id) const {
+        ecs_delete_with(m_world, the_id);
     }
 
     /** Delete all entities with specified relation. */
@@ -10931,8 +10931,8 @@ public:
     }
 
     /** Remove all instances of specified id. */
-    void remove_all(id_t id) const {
-        ecs_remove_all(m_world, id);
+    void remove_all(id_t the_id) const {
+        ecs_remove_all(m_world, the_id);
     }
 
     /** Remove all instances of specified relation. */

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -1510,6 +1510,30 @@ void ecs_delete_children(
     ecs_world_t *world,
     ecs_entity_t parent);
 
+/** Delete all entities with the specified id.
+ * This will delete all entities (tables) that have the specified id. The id 
+ * may be a wildcard and/or a pair.
+ * 
+ * @param world The world.
+ * @param id The id.
+ */
+FLECS_API
+void ecs_delete_with(
+    ecs_world_t *world,
+    ecs_id_t id);
+
+/** Remove all instances of the specified id.
+ * This will remove the specified id from all entities (tables). Teh id may be
+ * a wildcard and/or a pair.
+ * 
+ * @param world The world.
+ * @param id The id.
+ */
+FLECS_API
+void ecs_remove_all(
+    ecs_world_t *world,
+    ecs_id_t id);
+
 /** @} */
 
 

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -1497,19 +1497,6 @@ void ecs_delete(
     ecs_world_t *world,
     ecs_entity_t entity);
 
-
-/** Delete children of an entity.
- * This operation deletes all children of a parent entity. If a parent has no
- * children this operation has no effect.
- *
- * @param world The world.
- * @param parent The parent entity.
- */
-FLECS_API
-void ecs_delete_children(
-    ecs_world_t *world,
-    ecs_entity_t parent);
-
 /** Delete all entities with the specified id.
  * This will delete all entities (tables) that have the specified id. The id 
  * may be a wildcard and/or a pair.

--- a/include/flecs/addons/cpp/world.hpp
+++ b/include/flecs/addons/cpp/world.hpp
@@ -766,6 +766,50 @@ public:
         ecs_set_scope(m_world, prev);
     }
 
+    /** Delete all entities with specified id. */
+    void delete_with(id_t the_id) const {
+        ecs_delete_with(m_world, the_id);
+    }
+
+    /** Delete all entities with specified relation. */
+    void delete_with(entity_t rel, entity_t obj) const {
+        delete_with(ecs_pair(rel, obj));
+    }
+
+    /** Delete all entities with specified component. */
+    template <typename T>
+    void delete_with() const {
+        delete_with(_::cpp_type<T>::id());
+    }
+
+    /** Delete all entities with specified relation. */
+    template <typename R, typename O>
+    void delete_with() const {
+        delete_with(_::cpp_type<R>::id(), _::cpp_type<O>::id());
+    }
+
+    /** Remove all instances of specified id. */
+    void remove_all(id_t the_id) const {
+        ecs_remove_all(m_world, the_id);
+    }
+
+    /** Remove all instances of specified relation. */
+    void remove_all(entity_t rel, entity_t obj) const {
+        remove_all(ecs_pair(rel, obj));
+    }
+
+    /** Remove all instances of specified component. */
+    template <typename T>
+    void remove_all() const {
+        remove_all(_::cpp_type<T>::id());
+    }
+
+    /** Remove all instances of specified relation. */
+    template <typename R, typename O>
+    void remove_all() const {
+        remove_all(_::cpp_type<R>::id(), _::cpp_type<O>::id());
+    }
+
     /** Defer all operations called in function. If the world is already in
      * deferred mode, do nothing.
      */

--- a/include/flecs/addons/flecs_c.h
+++ b/include/flecs/addons/flecs_c.h
@@ -132,6 +132,12 @@
     ecs_remove_id(world, subject, ecs_pair(relation, object))
 
 
+/* -- Bulk remove/delete -- */
+
+#define ecs_delete_children(world, parent)\
+    ecs_delete_with(world, ecs_pair(EcsChildOf, parent))
+
+
 /* -- Set -- */
 
 #define ecs_set_ptr(world, entity, component, ptr)\

--- a/src/entity.c
+++ b/src/entity.c
@@ -2293,13 +2293,13 @@ void on_delete_action(
 static
 void on_delete_any_w_entity(
     ecs_world_t *world,
-    ecs_id_t entity,
+    ecs_id_t id,
     ecs_entity_t action)
 {
     /* Make sure any references to the entity are cleaned up */
-    on_delete_action(world, entity, action);
-    on_delete_action(world, ecs_pair(entity, EcsWildcard), action);
-    on_delete_action(world, ecs_pair(EcsWildcard, entity), action);
+    on_delete_action(world, id, action);
+    on_delete_action(world, ecs_pair(id, EcsWildcard), action);
+    on_delete_action(world, ecs_pair(EcsWildcard, id), action);
 }
 
 void ecs_delete_children(
@@ -2307,6 +2307,20 @@ void ecs_delete_children(
     ecs_entity_t parent)
 {
     on_delete_any_w_entity(world, parent, 0);
+}
+
+void ecs_delete_with(
+    ecs_world_t *world,
+    ecs_id_t id)
+{
+    on_delete_action(world, id, EcsDelete);
+}
+
+void ecs_remove_all(
+    ecs_world_t *world,
+    ecs_id_t id)
+{
+    on_delete_action(world, id, EcsRemove);
 }
 
 void ecs_delete(

--- a/src/entity.c
+++ b/src/entity.c
@@ -2303,13 +2303,6 @@ void on_delete_any_w_entity(
     on_delete_action(world, ecs_pair(EcsWildcard, id), action);
 }
 
-void ecs_delete_children(
-    ecs_world_t *world,
-    ecs_entity_t parent)
-{
-    on_delete_any_w_entity(world, parent, 0);
-}
-
 void ecs_delete_with(
     ecs_world_t *world,
     ecs_id_t id)

--- a/src/private_api.h
+++ b/src/private_api.h
@@ -257,6 +257,12 @@ bool flecs_defer_clear(
     ecs_stage_t *stage,
     ecs_entity_t entity);
 
+bool flecs_defer_on_delete_action(
+    ecs_world_t *world,
+    ecs_stage_t *stage,
+    ecs_id_t id,
+    ecs_entity_t action);
+
 bool flecs_defer_enable(
     ecs_world_t *world,
     ecs_stage_t *stage,
@@ -279,7 +285,7 @@ bool flecs_defer_remove(
 bool flecs_defer_set(
     ecs_world_t *world,
     ecs_stage_t *stage,
-    ecs_op_kind_t op_kind,
+    ecs_defer_op_kind_t op_kind,
     ecs_entity_t entity,
     ecs_entity_t component,
     ecs_size_t size,

--- a/src/private_types.h
+++ b/src/private_types.h
@@ -399,7 +399,7 @@ typedef struct ecs_event_triggers_t {
 } ecs_event_triggers_t;
 
 /** Types for deferred operations */
-typedef enum ecs_op_kind_t {
+typedef enum ecs_defer_op_kind_t {
     EcsOpNew,
     EcsOpClone,
     EcsOpBulkNew,
@@ -410,30 +410,31 @@ typedef enum ecs_op_kind_t {
     EcsOpModified,
     EcsOpDelete,
     EcsOpClear,
+    EcsOpOnDeleteAction,
     EcsOpEnable,
     EcsOpDisable
-} ecs_op_kind_t;
+} ecs_defer_op_kind_t;
 
-typedef struct ecs_op_1_t {
+typedef struct ecs_defer_op_1_t {
     ecs_entity_t entity;        /* Entity id */
     void *value;                /* Value (used for set / get_mut) */
     ecs_size_t size;            /* Size of value */
     bool clone_value;           /* Clone entity with value (used for clone) */ 
-} ecs_op_1_t;
+} ecs_defer_op_1_t;
 
-typedef struct ecs_op_n_t {
+typedef struct ecs_defer_op_n_t {
     ecs_entity_t *entities;  
     int32_t count;
-} ecs_op_n_t;
+} ecs_defer_op_n_t;
 
-typedef struct ecs_op_t {
-    ecs_op_kind_t kind;         /* Operation kind */    
+typedef struct ecs_defer_op_t {
+    ecs_defer_op_kind_t kind;         /* Operation kind */    
     ecs_id_t id;                /* (Component) id */
     union {
-        ecs_op_1_t _1;
-        ecs_op_n_t _n;
+        ecs_defer_op_1_t _1;
+        ecs_defer_op_n_t _n;
     } is;
-} ecs_op_t;
+} ecs_defer_op_t;
 
 /** A stage is a data structure in which delta's are stored until it is safe to
  * merge those delta's with the main world stage. A stage allows flecs systems
@@ -459,8 +460,8 @@ struct ecs_stage_t {
     /* Namespacing */
     ecs_table_t *scope_table;    /* Table for current scope */
     ecs_entity_t scope;          /* Entity of current scope */
-    ecs_entity_t base;           /* Currently instantiated top-level base */
     ecs_entity_t with;           /* Id to add by default to new entities */
+    ecs_entity_t base;           /* Currently instantiated top-level base */
 
     /* Properties */
     bool auto_merge;             /* Should this stage automatically merge? */

--- a/test/api/project.json
+++ b/test/api/project.json
@@ -2038,7 +2038,9 @@
                 "register_component_while_staged",
                 "register_component_while_deferred",
                 "defer_enable",
-                "defer_disable"
+                "defer_disable",
+                "defer_delete_with",
+                "defer_remove_all"
             ]
         }, {
             "id": "SingleThreadStaging",

--- a/test/api/project.json
+++ b/test/api/project.json
@@ -687,7 +687,16 @@
                 "delete_table_in_on_remove_during_fini",
                 "delete_other_in_on_remove_during_fini",
                 "on_delete_remove_id_w_role",
-                "on_delete_merge_pair_component"
+                "on_delete_merge_pair_component",
+                "delete_with_tag",
+                "delete_with_component",
+                "delete_with_pair",
+                "delete_with_object_wildcard",
+                "delete_with_relation_wildcard",
+                "delete_all_with_entity",
+                "remove_childof_entity",
+                "remove_childof_wildcard",
+                "delete_child_of_delete_with"
             ]
         }, {
             "id": "Set",

--- a/test/api/src/DeferredActions.c
+++ b/test/api/src/DeferredActions.c
@@ -1791,3 +1791,58 @@ void DeferredActions_defer_disable() {
 
     ecs_fini(world);
 }
+
+void DeferredActions_defer_delete_with() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+
+    ecs_entity_t e_1 = ecs_new(world, TagA);
+    ecs_entity_t e_2 = ecs_new(world, TagA);
+    ecs_entity_t e_3 = ecs_new(world, TagA);
+    ecs_add(world, e_1, TagB);
+
+    ecs_defer_begin(world);
+    ecs_delete_with(world, TagA);
+    test_assert(ecs_is_alive(world, e_1));
+    test_assert(ecs_is_alive(world, e_2));
+    test_assert(ecs_is_alive(world, e_3));
+    ecs_defer_end(world);
+
+    test_assert(!ecs_is_alive(world, e_1));
+    test_assert(!ecs_is_alive(world, e_2));
+    test_assert(!ecs_is_alive(world, e_3));
+
+    ecs_fini(world);
+}
+
+void DeferredActions_defer_remove_all() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+
+    ecs_entity_t e_1 = ecs_new(world, TagA);
+    ecs_entity_t e_2 = ecs_new(world, TagA);
+    ecs_entity_t e_3 = ecs_new(world, TagA);
+    ecs_add(world, e_1, TagB);
+
+    ecs_defer_begin(world);
+    ecs_remove_all(world, TagA);
+    test_assert(ecs_is_alive(world, e_1));
+    test_assert(ecs_is_alive(world, e_2));
+    test_assert(ecs_is_alive(world, e_3));
+    ecs_defer_end(world);
+
+    test_assert(ecs_is_alive(world, e_1));
+    test_assert(ecs_is_alive(world, e_2));
+    test_assert(ecs_is_alive(world, e_3));
+
+    test_assert(!ecs_has_id(world, e_1, TagA));
+    test_assert(!ecs_has_id(world, e_2, TagA));
+    test_assert(!ecs_has_id(world, e_3, TagA));
+    test_assert(ecs_has_id(world, e_1, TagB));
+
+    ecs_fini(world);
+}

--- a/test/api/src/OnDelete.c
+++ b/test/api/src/OnDelete.c
@@ -1473,6 +1473,10 @@ void OnDelete_remove_childof_entity() {
     test_assert(!ecs_has_pair(world, e_1, EcsChildOf, parent_1));
     test_assert(!ecs_has_pair(world, e_2, EcsChildOf, parent_1));
     test_assert(!ecs_has_pair(world, e_3, EcsChildOf, parent_1));
+    
+    test_assert(!ecs_has_pair(world, e_1, EcsChildOf, parent_2));
+    test_assert(!ecs_has_pair(world, e_2, EcsChildOf, parent_2));
+    test_assert(!ecs_has_pair(world, e_3, EcsChildOf, parent_2));
     test_assert(ecs_has_pair(world, e_4, EcsChildOf, parent_2));
 
     test_assert(ecs_has_id(world, e_3, Tag));
@@ -1524,6 +1528,9 @@ void OnDelete_remove_childof_wildcard() {
     test_assert(!ecs_has_pair(world, e_3, child_of, parent_1));
     test_assert(!ecs_has_pair(world, e_4, child_of, parent_2));
 
+    test_assert(!ecs_has_id(world, e_1, Tag));
+    test_assert(!ecs_has_id(world, e_2, Tag));
+    test_assert(!ecs_has_id(world, e_4, Tag));
     test_assert(ecs_has_id(world, e_3, Tag));
 
     ecs_fini(world);

--- a/test/api/src/OnDelete.c
+++ b/test/api/src/OnDelete.c
@@ -1229,3 +1229,346 @@ void OnDelete_on_delete_merge_pair_component() {
 
     ecs_fini(world);
 }
+
+void OnDelete_delete_with_tag() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+
+    ecs_entity_t e_1 = ecs_new_w_id(world, TagA);
+    ecs_entity_t e_2 = ecs_new_w_id(world, TagA);
+    ecs_entity_t e_3 = ecs_new_w_id(world, TagA);
+
+    ecs_add_id(world, e_3, TagB);
+
+    test_assert(e_1 != 0);
+    test_assert(e_2 != 0);
+    test_assert(e_3 != 0);
+
+    test_assert(ecs_is_alive(world, e_1));
+    test_assert(ecs_is_alive(world, e_2));
+    test_assert(ecs_is_alive(world, e_3));
+
+    ecs_delete_with(world, TagA);
+
+    test_assert(!ecs_is_alive(world, e_1));
+    test_assert(!ecs_is_alive(world, e_2));
+    test_assert(!ecs_is_alive(world, e_3));
+
+    ecs_fini(world);
+}
+
+void OnDelete_delete_with_component() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_COMPONENT(world, Position);
+    ECS_COMPONENT(world, Velocity);
+
+    ecs_entity_t e_1 = ecs_new(world, Position);
+    ecs_entity_t e_2 = ecs_new(world, Position);
+    ecs_entity_t e_3 = ecs_new(world, Position);
+
+    ecs_add(world, e_3, Velocity);
+
+    test_assert(e_1 != 0);
+    test_assert(e_2 != 0);
+    test_assert(e_3 != 0);
+
+    test_assert(ecs_is_alive(world, e_1));
+    test_assert(ecs_is_alive(world, e_2));
+    test_assert(ecs_is_alive(world, e_3));
+
+    ecs_delete_with(world, ecs_id(Position));
+
+    test_assert(!ecs_is_alive(world, e_1));
+    test_assert(!ecs_is_alive(world, e_2));
+    test_assert(!ecs_is_alive(world, e_3));
+
+    ecs_fini(world);
+}
+
+void OnDelete_delete_with_pair() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, Rel);
+    ECS_TAG(world, Obj);
+    ECS_TAG(world, Tag);
+
+    ecs_entity_t e_1 = ecs_new_w_pair(world, Rel, Obj);
+    ecs_entity_t e_2 = ecs_new_w_pair(world, Rel, Obj);
+    ecs_entity_t e_3 = ecs_new_w_pair(world, Rel, Obj);
+
+    ecs_add_id(world, e_3, Tag);
+
+    test_assert(e_1 != 0);
+    test_assert(e_2 != 0);
+    test_assert(e_3 != 0);
+
+    test_assert(ecs_is_alive(world, e_1));
+    test_assert(ecs_is_alive(world, e_2));
+    test_assert(ecs_is_alive(world, e_3));
+
+    ecs_delete_with(world, ecs_pair(Rel, Obj));
+
+    test_assert(!ecs_is_alive(world, e_1));
+    test_assert(!ecs_is_alive(world, e_2));
+    test_assert(!ecs_is_alive(world, e_3));
+
+    ecs_fini(world);
+}
+
+void OnDelete_delete_with_object_wildcard() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, Rel);
+    ECS_TAG(world, ObjA);
+    ECS_TAG(world, ObjB);
+    ECS_TAG(world, Tag);
+
+    ecs_entity_t e_1 = ecs_new_w_pair(world, Rel, ObjA);
+    ecs_entity_t e_2 = ecs_new_w_pair(world, Rel, ObjB);
+    ecs_entity_t e_3 = ecs_new_w_pair(world, Rel, ObjB);
+
+    ecs_add_id(world, e_3, Tag);
+
+    test_assert(e_1 != 0);
+    test_assert(e_2 != 0);
+    test_assert(e_3 != 0);
+
+    test_assert(ecs_is_alive(world, e_1));
+    test_assert(ecs_is_alive(world, e_2));
+    test_assert(ecs_is_alive(world, e_3));
+
+    ecs_delete_with(world, ecs_pair(Rel, EcsWildcard));
+
+    test_assert(!ecs_is_alive(world, e_1));
+    test_assert(!ecs_is_alive(world, e_2));
+    test_assert(!ecs_is_alive(world, e_3));
+
+    ecs_fini(world);
+}
+
+void OnDelete_delete_with_relation_wildcard() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, RelA);
+    ECS_TAG(world, RelB);
+    ECS_TAG(world, Obj);
+    ECS_TAG(world, Tag);
+
+    ecs_entity_t e_1 = ecs_new_w_pair(world, RelA, Obj);
+    ecs_entity_t e_2 = ecs_new_w_pair(world, RelB, Obj);
+    ecs_entity_t e_3 = ecs_new_w_pair(world, RelB, Obj);
+
+    ecs_add_id(world, e_3, Tag);
+
+    test_assert(e_1 != 0);
+    test_assert(e_2 != 0);
+    test_assert(e_3 != 0);
+
+    test_assert(ecs_is_alive(world, e_1));
+    test_assert(ecs_is_alive(world, e_2));
+    test_assert(ecs_is_alive(world, e_3));
+
+    ecs_delete_with(world, ecs_pair(EcsWildcard, Obj));
+
+    test_assert(!ecs_is_alive(world, e_1));
+    test_assert(!ecs_is_alive(world, e_2));
+    test_assert(!ecs_is_alive(world, e_3));
+
+    ecs_fini(world);
+}
+
+void OnDelete_delete_all_with_entity() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, RelA);
+    ECS_TAG(world, RelB);
+    ECS_TAG(world, Obj);
+    ECS_TAG(world, Tag);
+
+    ecs_entity_t e_1 = ecs_new_w_pair(world, RelA, Obj);
+    ecs_entity_t e_2 = ecs_new_w_pair(world, RelB, Obj);
+    ecs_entity_t e_3 = ecs_new_w_pair(world, RelB, Obj);
+    ecs_entity_t e_4 = ecs_new_w_pair(world, Obj, RelA);
+    ecs_entity_t e_5 = ecs_new_w_pair(world, Obj, RelB);
+    ecs_entity_t e_6 = ecs_new_w_id(world, Obj);
+
+    ecs_add_id(world, e_3, Tag);
+
+    test_assert(e_1 != 0);
+    test_assert(e_2 != 0);
+    test_assert(e_3 != 0);
+    test_assert(e_4 != 0);
+    test_assert(e_5 != 0);
+    test_assert(e_6 != 0);
+
+    test_assert(ecs_is_alive(world, e_1));
+    test_assert(ecs_is_alive(world, e_2));
+    test_assert(ecs_is_alive(world, e_3));
+    test_assert(ecs_is_alive(world, e_4));
+    test_assert(ecs_is_alive(world, e_5));
+    test_assert(ecs_is_alive(world, e_6));
+
+    ecs_delete_with(world, Obj);
+    test_assert(ecs_is_alive(world, e_1));
+    test_assert(ecs_is_alive(world, e_2));
+    test_assert(ecs_is_alive(world, e_3));
+    test_assert(ecs_is_alive(world, e_4));
+    test_assert(ecs_is_alive(world, e_5));
+    test_assert(!ecs_is_alive(world, e_6));
+
+    ecs_delete_with(world, ecs_pair(Obj, EcsWildcard));
+    test_assert(ecs_is_alive(world, e_1));
+    test_assert(ecs_is_alive(world, e_2));
+    test_assert(ecs_is_alive(world, e_3));
+    test_assert(!ecs_is_alive(world, e_4));
+    test_assert(!ecs_is_alive(world, e_5));
+    test_assert(!ecs_is_alive(world, e_6));
+
+    ecs_delete_with(world, ecs_pair(EcsWildcard, Obj));
+    test_assert(!ecs_is_alive(world, e_1));
+    test_assert(!ecs_is_alive(world, e_2));
+    test_assert(!ecs_is_alive(world, e_3));
+    test_assert(!ecs_is_alive(world, e_4));
+    test_assert(!ecs_is_alive(world, e_5));
+    test_assert(!ecs_is_alive(world, e_6));
+
+    ecs_fini(world);
+}
+
+void OnDelete_remove_childof_entity() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, Tag);
+
+    ecs_entity_t parent_1 = ecs_new_id(world);
+    ecs_entity_t parent_2 = ecs_new_id(world);
+
+    ecs_entity_t e_1 = ecs_new_w_pair(world, EcsChildOf, parent_1);
+    ecs_entity_t e_2 = ecs_new_w_pair(world, EcsChildOf, parent_1);
+    ecs_entity_t e_3 = ecs_new_w_pair(world, EcsChildOf, parent_1);
+    ecs_entity_t e_4 = ecs_new_w_pair(world, EcsChildOf, parent_2);
+
+    ecs_add_id(world, e_3, Tag);
+
+    test_assert(e_1 != 0);
+    test_assert(e_2 != 0);
+    test_assert(e_3 != 0);
+    test_assert(e_4 != 0);
+
+    test_assert(ecs_is_alive(world, e_1));
+    test_assert(ecs_is_alive(world, e_2));
+    test_assert(ecs_is_alive(world, e_3));
+    test_assert(ecs_is_alive(world, e_4));
+
+    ecs_remove_all(world, ecs_pair(EcsChildOf, parent_1));
+
+    test_assert(ecs_is_alive(world, e_1));
+    test_assert(ecs_is_alive(world, e_2));
+    test_assert(ecs_is_alive(world, e_3));
+    test_assert(ecs_is_alive(world, e_4));
+
+    test_assert(!ecs_has_pair(world, e_1, EcsChildOf, parent_1));
+    test_assert(!ecs_has_pair(world, e_2, EcsChildOf, parent_1));
+    test_assert(!ecs_has_pair(world, e_3, EcsChildOf, parent_1));
+    test_assert(ecs_has_pair(world, e_4, EcsChildOf, parent_2));
+
+    test_assert(ecs_has_id(world, e_3, Tag));
+
+    ecs_fini(world);
+}
+
+void OnDelete_remove_childof_wildcard() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, Tag);
+
+    /* Create custom childof relation so we won't try to remove ChildOf from
+     * builtin entities */
+    ecs_entity_t child_of = ecs_new_id(world);
+
+    /* Simulate same behavior as ChildOf */
+    ecs_add_pair(world, child_of, EcsOnDeleteObject, EcsDelete);
+
+    ecs_entity_t parent_1 = ecs_new_id(world);
+    ecs_entity_t parent_2 = ecs_new_id(world);
+
+    ecs_entity_t e_1 = ecs_new_w_pair(world, child_of, parent_1);
+    ecs_entity_t e_2 = ecs_new_w_pair(world, child_of, parent_1);
+    ecs_entity_t e_3 = ecs_new_w_pair(world, child_of, parent_1);
+    ecs_entity_t e_4 = ecs_new_w_pair(world, child_of, parent_2);
+
+    ecs_add_id(world, e_3, Tag);
+
+    test_assert(e_1 != 0);
+    test_assert(e_2 != 0);
+    test_assert(e_3 != 0);
+    test_assert(e_4 != 0);
+
+    test_assert(ecs_is_alive(world, e_1));
+    test_assert(ecs_is_alive(world, e_2));
+    test_assert(ecs_is_alive(world, e_3));
+    test_assert(ecs_is_alive(world, e_4));
+
+    ecs_remove_all(world, ecs_pair(child_of, EcsWildcard));
+
+    test_assert(ecs_is_alive(world, e_1));
+    test_assert(ecs_is_alive(world, e_2));
+    test_assert(ecs_is_alive(world, e_3));
+    test_assert(ecs_is_alive(world, e_4));
+
+    test_assert(!ecs_has_pair(world, e_1, child_of, parent_1));
+    test_assert(!ecs_has_pair(world, e_2, child_of, parent_1));
+    test_assert(!ecs_has_pair(world, e_3, child_of, parent_1));
+    test_assert(!ecs_has_pair(world, e_4, child_of, parent_2));
+
+    test_assert(ecs_has_id(world, e_3, Tag));
+
+    ecs_fini(world);
+}
+
+void OnDelete_delete_child_of_delete_with() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, Rel);
+
+    ecs_entity_t obj = ecs_new_id(world);
+
+    ecs_entity_t e_1 = ecs_new_w_pair(world, Rel, obj);
+    ecs_entity_t e_2 = ecs_new_w_pair(world, Rel, obj);
+    ecs_entity_t e_3 = ecs_new_w_pair(world, Rel, obj);
+
+    ecs_entity_t c_1 = ecs_new_w_pair(world, EcsChildOf, e_1);
+    ecs_entity_t c_2 = ecs_new_w_pair(world, EcsChildOf, e_2);
+    ecs_entity_t c_3 = ecs_new_w_pair(world, EcsChildOf, e_3);
+
+    test_assert(e_1 != 0);
+    test_assert(e_2 != 0);
+    test_assert(e_3 != 0);
+
+    test_assert(c_1 != 0);
+    test_assert(c_2 != 0);
+    test_assert(c_3 != 0);
+
+    test_assert(ecs_is_alive(world, e_1));
+    test_assert(ecs_is_alive(world, e_2));
+    test_assert(ecs_is_alive(world, e_3));
+
+    test_assert(ecs_is_alive(world, c_1));
+    test_assert(ecs_is_alive(world, c_2));
+    test_assert(ecs_is_alive(world, c_3));
+
+    ecs_delete_with(world, ecs_pair(Rel, obj));
+
+    test_assert(!ecs_is_alive(world, e_1));
+    test_assert(!ecs_is_alive(world, e_2));
+    test_assert(!ecs_is_alive(world, e_3));
+
+    test_assert(!ecs_is_alive(world, c_1));
+    test_assert(!ecs_is_alive(world, c_2));
+    test_assert(!ecs_is_alive(world, c_3));
+
+    ecs_fini(world);
+}

--- a/test/api/src/main.c
+++ b/test/api/src/main.c
@@ -1926,6 +1926,8 @@ void DeferredActions_register_component_while_staged(void);
 void DeferredActions_register_component_while_deferred(void);
 void DeferredActions_defer_enable(void);
 void DeferredActions_defer_disable(void);
+void DeferredActions_defer_delete_with(void);
+void DeferredActions_defer_remove_all(void);
 
 // Testsuite 'SingleThreadStaging'
 void SingleThreadStaging_setup(void);
@@ -9430,6 +9432,14 @@ bake_test_case DeferredActions_testcases[] = {
     {
         "defer_disable",
         DeferredActions_defer_disable
+    },
+    {
+        "defer_delete_with",
+        DeferredActions_defer_delete_with
+    },
+    {
+        "defer_remove_all",
+        DeferredActions_defer_remove_all
     }
 };
 
@@ -10438,7 +10448,7 @@ static bake_test_suite suites[] = {
         "DeferredActions",
         NULL,
         NULL,
-        60,
+        62,
         DeferredActions_testcases
     },
     {

--- a/test/api/src/main.c
+++ b/test/api/src/main.c
@@ -647,6 +647,15 @@ void OnDelete_delete_table_in_on_remove_during_fini(void);
 void OnDelete_delete_other_in_on_remove_during_fini(void);
 void OnDelete_on_delete_remove_id_w_role(void);
 void OnDelete_on_delete_merge_pair_component(void);
+void OnDelete_delete_with_tag(void);
+void OnDelete_delete_with_component(void);
+void OnDelete_delete_with_pair(void);
+void OnDelete_delete_with_object_wildcard(void);
+void OnDelete_delete_with_relation_wildcard(void);
+void OnDelete_delete_all_with_entity(void);
+void OnDelete_remove_childof_entity(void);
+void OnDelete_remove_childof_wildcard(void);
+void OnDelete_delete_child_of_delete_with(void);
 
 // Testsuite 'Set'
 void Set_set_empty(void);
@@ -4533,6 +4542,42 @@ bake_test_case OnDelete_testcases[] = {
     {
         "on_delete_merge_pair_component",
         OnDelete_on_delete_merge_pair_component
+    },
+    {
+        "delete_with_tag",
+        OnDelete_delete_with_tag
+    },
+    {
+        "delete_with_component",
+        OnDelete_delete_with_component
+    },
+    {
+        "delete_with_pair",
+        OnDelete_delete_with_pair
+    },
+    {
+        "delete_with_object_wildcard",
+        OnDelete_delete_with_object_wildcard
+    },
+    {
+        "delete_with_relation_wildcard",
+        OnDelete_delete_with_relation_wildcard
+    },
+    {
+        "delete_all_with_entity",
+        OnDelete_delete_all_with_entity
+    },
+    {
+        "remove_childof_entity",
+        OnDelete_remove_childof_entity
+    },
+    {
+        "remove_childof_wildcard",
+        OnDelete_remove_childof_wildcard
+    },
+    {
+        "delete_child_of_delete_with",
+        OnDelete_delete_child_of_delete_with
     }
 };
 
@@ -10141,7 +10186,7 @@ static bake_test_suite suites[] = {
         "OnDelete",
         NULL,
         NULL,
-        50,
+        59,
         OnDelete_testcases
     },
     {

--- a/test/cpp_api/project.json
+++ b/test/cpp_api/project.json
@@ -724,7 +724,15 @@
                 "entity_as_component_2_worlds_implicit_namespaced",
                 "type_as_component",
                 "type_w_name_as_component",
-                "component_as_component"
+                "component_as_component",
+                "delete_with_id",
+                "delete_with_type",
+                "delete_with_pair",
+                "delete_with_pair_type",
+                "remove_all_id",
+                "remove_all_type",
+                "remove_all_pair",
+                "remove_all_pair_type"
             ]
         }, {
             "id": "Singleton",

--- a/test/cpp_api/src/World.cpp
+++ b/test/cpp_api/src/World.cpp
@@ -993,3 +993,156 @@ void World_type_w_name_as_component() {
 
     test_str(t.name(), "Foo");
 }
+
+void World_delete_with_id() {
+    flecs::world ecs;
+
+    flecs::id tag = ecs.entity();
+    auto e_1 = ecs.entity().add(tag);
+    auto e_2 = ecs.entity().add(tag);
+    auto e_3 = ecs.entity().add(tag);
+
+    ecs.delete_with(tag);
+
+    test_assert(!e_1.is_alive());
+    test_assert(!e_2.is_alive());
+    test_assert(!e_3.is_alive());
+}
+
+void World_delete_with_type() {
+    flecs::world ecs;
+
+    auto e_1 = ecs.entity().add<Tag>();
+    auto e_2 = ecs.entity().add<Tag>();
+    auto e_3 = ecs.entity().add<Tag>();
+
+    ecs.delete_with<Tag>();
+
+    test_assert(!e_1.is_alive());
+    test_assert(!e_2.is_alive());
+    test_assert(!e_3.is_alive());
+}
+
+void World_delete_with_pair() {
+    flecs::world ecs;
+
+    flecs::id rel = ecs.entity();
+    flecs::id obj = ecs.entity();
+    auto e_1 = ecs.entity().add(rel, obj);
+    auto e_2 = ecs.entity().add(rel, obj);
+    auto e_3 = ecs.entity().add(rel, obj);
+
+    ecs.delete_with(rel, obj);
+
+    test_assert(!e_1.is_alive());
+    test_assert(!e_2.is_alive());
+    test_assert(!e_3.is_alive());
+}
+
+void World_delete_with_pair_type() {
+    flecs::world ecs;
+
+    struct Rel { };
+    struct Obj { };
+
+    auto e_1 = ecs.entity().add<Rel, Obj>();
+    auto e_2 = ecs.entity().add<Rel, Obj>();
+    auto e_3 = ecs.entity().add<Rel, Obj>();
+
+    ecs.delete_with<Rel, Obj>();
+
+    test_assert(!e_1.is_alive());
+    test_assert(!e_2.is_alive());
+    test_assert(!e_3.is_alive());
+}
+
+void World_remove_all_id() {
+    flecs::world ecs;
+
+    flecs::id tag_a = ecs.entity();
+    flecs::id tag_b = ecs.entity();
+    auto e_1 = ecs.entity().add(tag_a);
+    auto e_2 = ecs.entity().add(tag_a);
+    auto e_3 = ecs.entity().add(tag_a).add(tag_b);
+
+    ecs.remove_all(tag_a);
+
+    test_assert(e_1.is_alive());
+    test_assert(e_2.is_alive());
+    test_assert(e_3.is_alive());
+
+    test_assert(!e_1.has(tag_a));
+    test_assert(!e_2.has(tag_a));
+    test_assert(!e_3.has(tag_a));
+    
+    test_assert(e_3.has(tag_b));
+}
+
+void World_remove_all_type() {
+    flecs::world ecs;
+
+    auto e_1 = ecs.entity().add<Position>();
+    auto e_2 = ecs.entity().add<Position>();
+    auto e_3 = ecs.entity().add<Position>().add<Velocity>();
+
+    ecs.remove_all<Position>();
+
+    test_assert(e_1.is_alive());
+    test_assert(e_2.is_alive());
+    test_assert(e_3.is_alive());
+
+    test_assert(!e_1.has<Position>());
+    test_assert(!e_2.has<Position>());
+    test_assert(!e_3.has<Position>());
+    
+    test_assert(e_3.has<Velocity>());
+}
+
+void World_remove_all_pair() {
+    flecs::world ecs;
+
+    flecs::id rel = ecs.entity();
+    flecs::id obj_a = ecs.entity();
+    flecs::id obj_b = ecs.entity();
+    auto e_1 = ecs.entity().add(rel, obj_a);
+    auto e_2 = ecs.entity().add(rel, obj_a);
+    auto e_3 = ecs.entity().add(rel, obj_a).add(rel, obj_b);
+
+    ecs.remove_all(rel, obj_a);
+
+    test_assert(e_1.is_alive());
+    test_assert(e_2.is_alive());
+    test_assert(e_3.is_alive());
+
+    test_assert(!e_1.has(rel, obj_a));
+    test_assert(!e_2.has(rel, obj_a));
+    test_assert(!e_3.has(rel, obj_a));
+    
+    test_assert(e_3.has(rel, obj_b));
+}
+
+void World_remove_all_pair_type() {
+    flecs::world ecs;
+
+    struct Rel { };
+    struct ObjA { };
+    struct ObjB { };
+
+    auto e_1 = ecs.entity().add<Rel, ObjA>();
+    auto e_2 = ecs.entity().add<Rel, ObjA>();
+    auto e_3 = ecs.entity().add<Rel, ObjA>().add<Rel, ObjB>();
+
+    ecs.remove_all<Rel, ObjA>();
+
+    test_assert(e_1.is_alive());
+    test_assert(e_2.is_alive());
+    test_assert(e_3.is_alive());
+
+    test_assert((!e_1.has<Rel, ObjA>()));
+    test_assert((!e_2.has<Rel, ObjA>()));
+    test_assert((!e_3.has<Rel, ObjA>()));
+    
+    test_assert((!e_1.has<Rel, ObjB>()));
+    test_assert((!e_2.has<Rel, ObjB>()));
+    test_assert((e_3.has<Rel, ObjB>()));
+}

--- a/test/cpp_api/src/main.cpp
+++ b/test/cpp_api/src/main.cpp
@@ -680,6 +680,14 @@ void World_entity_as_component_2_worlds_implicit_namespaced(void);
 void World_type_as_component(void);
 void World_type_w_name_as_component(void);
 void World_component_as_component(void);
+void World_delete_with_id(void);
+void World_delete_with_type(void);
+void World_delete_with_pair(void);
+void World_delete_with_pair_type(void);
+void World_remove_all_id(void);
+void World_remove_all_type(void);
+void World_remove_all_pair(void);
+void World_remove_all_pair_type(void);
 
 // Testsuite 'Singleton'
 void Singleton_set_get_singleton(void);
@@ -3293,6 +3301,38 @@ bake_test_case World_testcases[] = {
     {
         "component_as_component",
         World_component_as_component
+    },
+    {
+        "delete_with_id",
+        World_delete_with_id
+    },
+    {
+        "delete_with_type",
+        World_delete_with_type
+    },
+    {
+        "delete_with_pair",
+        World_delete_with_pair
+    },
+    {
+        "delete_with_pair_type",
+        World_delete_with_pair_type
+    },
+    {
+        "remove_all_id",
+        World_remove_all_id
+    },
+    {
+        "remove_all_type",
+        World_remove_all_type
+    },
+    {
+        "remove_all_pair",
+        World_remove_all_pair
+    },
+    {
+        "remove_all_pair_type",
+        World_remove_all_pair_type
     }
 };
 
@@ -3512,7 +3552,7 @@ static bake_test_suite suites[] = {
         "World",
         NULL,
         NULL,
-        48,
+        56,
         World_testcases
     },
     {


### PR DESCRIPTION
This PR adds the `delete_with` (delete all entities with id) and `remove_all` (remove all instances of id) functions, in addition to a new deferred operation that enables the operations to be called from a stage.