### PR TITLE
Added const variants for flecs::ref methods

### DIFF
--- a/flecs.c
+++ b/flecs.c
@@ -8045,6 +8045,41 @@ const void* ecs_get_ref_w_id(
     return ref->ptr;
 }
 
+const void* ecs_get_const_ref_w_id(
+    const ecs_world_t * world,
+    const ecs_ref_t * ref,
+    ecs_entity_t entity,
+    ecs_id_t id)
+{
+    ecs_assert(world != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_assert(ref != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_assert(!entity || !ref->entity || entity == ref->entity, ECS_INVALID_PARAMETER, NULL);
+    ecs_assert(!id || !ref->component || id == ref->component, ECS_INVALID_PARAMETER, NULL);
+    ecs_record_t *record = ref->record;
+    /* Make sure we're not working with a stage */
+    world = ecs_get_world(world);
+    entity |= ref->entity;
+    if (!record) {
+        record = ecs_eis_get(world, entity);
+    }
+    if (!record || !record->table) {
+        return NULL;
+    }
+    ecs_table_t *table = record->table;
+    if (ref->record == record &&
+        ref->table == table &&
+        ref->row == record->row &&
+        ref->alloc_count == table->alloc_count)
+    {
+        return ref->ptr;
+    }
+    id |= ref->component;
+    int32_t row = record->row;
+    bool is_monitored;
+    row = flecs_record_to_row(row, &is_monitored);
+    return get_component(world, table, row, id);
+}
+
 void* ecs_get_mut_id(
     ecs_world_t *world,
     ecs_entity_t entity,

--- a/flecs.h
+++ b/flecs.h
@@ -5112,6 +5112,23 @@ const void* ecs_get_ref_w_id(
     ecs_ref_t *ref,
     ecs_entity_t entity,
     ecs_id_t id);
+    
+/** Get an immutable reference to a component.
+ * Same as ecs_get_ref_w_id, but with const ref and thus 
+ * won't update the ref if stale.
+ *
+ * @param world The world.
+ * @param ref Pointer to a ecs_ref_t value. Must be initialized.
+ * @param entity The entity.
+ * @param component The entity id of the component to obtain.
+ * @return The component pointer, NULL if the entity does not have the component.
+ */
+FLECS_API
+const void* ecs_get_const_ref_w_id (
+    const ecs_world_t *world,
+    const ecs_ref_t *ref,
+    ecs_entity_t entity,
+    ecs_id_t id);
 
 /** Get an immutable reference to a component.
  * Same as ecs_get_ref_w_id, but accepts the typename of a component.
@@ -13650,6 +13667,15 @@ public:
         return result;
     }
 
+    const T* operator->() const {
+        const T* result = static_cast<const T*>(ecs_get_const_ref_w_id(
+            m_world, &m_ref, m_entity, _::cpp_type<T>::id(m_world)));
+
+        ecs_assert(result != NULL, ECS_INVALID_PARAMETER, NULL);
+
+        return result;
+    }
+
     const T* get() {
         if (m_entity) {
             ecs_get_ref_w_id(
@@ -13657,6 +13683,14 @@ public:
         }
 
         return static_cast<T*>(m_ref.ptr);
+    }    
+    
+    const T* get() const{
+        if (m_entity) {
+            return static_cast<const T*>(ecs_get_const_ref_w_id(
+                m_world, &m_ref, m_entity, _::cpp_type<T>::id(m_world)));    
+        }
+        return NULL;
     }
 
     flecs::entity entity() const;

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -1980,6 +1980,23 @@ const void* ecs_get_ref_w_id(
     ecs_ref_t *ref,
     ecs_entity_t entity,
     ecs_id_t id);
+    
+/** Get an immutable reference to a component.
+ * Same as ecs_get_ref_w_id, but with const ref and thus 
+ * won't update the ref if stale.
+ *
+ * @param world The world.
+ * @param ref Pointer to a ecs_ref_t value. Must be initialized.
+ * @param entity The entity.
+ * @param component The entity id of the component to obtain.
+ * @return The component pointer, NULL if the entity does not have the component.
+ */
+FLECS_API
+const void* ecs_get_const_ref_w_id (
+    const ecs_world_t *world,
+    const ecs_ref_t *ref,
+    ecs_entity_t entity,
+    ecs_id_t id);
 
 /** Get an immutable reference to a component.
  * Same as ecs_get_ref_w_id, but accepts the typename of a component.

--- a/include/flecs/cpp/entity.hpp
+++ b/include/flecs/cpp/entity.hpp
@@ -1208,6 +1208,15 @@ public:
         return result;
     }
 
+    const T* operator->() const {
+        const T* result = static_cast<const T*>(ecs_get_const_ref_w_id(
+            m_world, &m_ref, m_entity, _::cpp_type<T>::id(m_world)));
+
+        ecs_assert(result != NULL, ECS_INVALID_PARAMETER, NULL);
+
+        return result;
+    }
+
     const T* get() {
         if (m_entity) {
             ecs_get_ref_w_id(
@@ -1215,6 +1224,14 @@ public:
         }
 
         return static_cast<T*>(m_ref.ptr);
+    }    
+    
+    const T* get() const{
+        if (m_entity) {
+            return static_cast<const T*>(ecs_get_const_ref_w_id(
+                m_world, &m_ref, m_entity, _::cpp_type<T>::id(m_world)));    
+        }
+        return NULL;
     }
 
     flecs::entity entity() const;


### PR DESCRIPTION
Adding const versions of the getter methods on flecs::ref to enable refs to be used as components. 