### PR TITLE
Correct documentation for ecs_set_symbol

### DIFF
--- a/include/flecs.h
+++ b/include/flecs.h
@@ -1914,7 +1914,7 @@ ecs_entity_t ecs_set_name(
  * This will set or overwrite the symbol of an entity. If no entity is provided,
  * a new entity will be created.
  *
- * The symbol will be stored in the EcsName component.
+ * The symbol will be stored in the EcsSymbol component.
  *
  * @param world The world.
  * @param entity The entity.


### PR DESCRIPTION
The prior doc comment says that it sets the given string as the `EcsName` component, but in reality, it uses the `EcsSymbol` component.

This PR fixes the doc comment to match that reality.