### PR TITLE
#476 Implement soft asserts

### DIFF
--- a/include/flecs.h
+++ b/include/flecs.h
@@ -29,10 +29,13 @@
 #define FLECS_SANITIZE
 #endif
 
-/* FLECS_CUSTOM_BUILD should be defined when manually selecting features */
+/* FLECS_SOFT_ASSERT disables aborting for recoverable errors */
+// #define FLECS_SOFT_ASSERT
+
+/* FLECS_CUSTOM_BUILD should be defined when manually selecting addons */
 // #define FLECS_CUSTOM_BUILD
 
-/* If this is a regular, non-custom build, build all addons. */
+/* If this is a regular, non-custom build, include all addons. */
 #ifndef FLECS_CUSTOM_BUILD
 // #define FLECS_C          /* C API convenience macro's, always enabled */
 #define FLECS_CPP           /* C++ API */

--- a/include/flecs/addons/log.h
+++ b/include/flecs/addons/log.h
@@ -28,23 +28,16 @@
 #ifndef FLECS_LOG_H
 #define FLECS_LOG_H
 
-#ifdef FLECS_LOG
-
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#ifdef FLECS_LOG
 
 ////////////////////////////////////////////////////////////////////////////////
 //// Tracing
 ////////////////////////////////////////////////////////////////////////////////
 
-FLECS_API
-void _ecs_log(
-    int32_t level,
-    const char *file,
-    int32_t line,
-    const char *fmt,
-    ...);
 
 FLECS_API
 void _ecs_deprecated(
@@ -68,64 +61,11 @@ FLECS_API
 const char* ecs_strerror(
     int32_t error_code);
 
-/** Abort */
-FLECS_API
-void _ecs_abort(
-    int32_t error_code,
-    const char *file,
-    int32_t line,
-    const char *fmt,
-    ...);
-
-/** Assert */
-FLECS_API
-void _ecs_assert(
-    bool condition,
-    int32_t error_code,
-    const char *condition_str,
-    const char *file,
-    int32_t line,
-    const char *fmt,
-    ...);
-
-/** Parser error.
- * This function is used by parsers, and includes additional information such
- * as the failed expression, position in the expression and the name of the
- * expression/script being parsed. */
-FLECS_API
-void _ecs_parser_error(
-    const char *name,
-    const char *expr, 
-    int64_t column,
-    const char *fmt,
-    ...);
-
-FLECS_API
-void _ecs_parser_errorv(
-    const char *name,
-    const char *expr, 
-    int64_t column,
-    const char *fmt,
-    va_list args);
-
-#ifdef __cplusplus
-}
-#endif
-
 #else // FLECS_LOG
 
-
 ////////////////////////////////////////////////////////////////////////////////
-//// Functions/macro's that do nothing when logging is disabled
+//// Dummy macro's for when logging is disabled
 ////////////////////////////////////////////////////////////////////////////////
-
-FLECS_API
-void _ecs_log(
-    int32_t level,
-    const char *file,
-    int32_t line,
-    const char *fmt,
-    ...);
 
 #define _ecs_deprecated(file, line, msg)\
     (void)file;\
@@ -138,6 +78,21 @@ void _ecs_log(
 #define ecs_strerror(error_code)\
     (void)error_code
 
+#endif // FLECS_LOG
+
+
+////////////////////////////////////////////////////////////////////////////////
+//// Logging functions (do nothing when logging is enabled)
+////////////////////////////////////////////////////////////////////////////////
+
+FLECS_API
+void _ecs_log(
+    int32_t level,
+    const char *file,
+    int32_t line,
+    const char *fmt,
+    ...);
+
 FLECS_API
 void _ecs_abort(
     int32_t error_code,
@@ -147,7 +102,7 @@ void _ecs_abort(
     ...);
 
 FLECS_API
-void _ecs_assert(
+bool _ecs_assert(
     bool condition,
     int32_t error_code,
     const char *condition_str,
@@ -171,8 +126,6 @@ void _ecs_parser_errorv(
     int64_t column,
     const char *fmt,
     va_list args);
-
-#endif // FLECS_LOG
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -253,17 +206,61 @@ void _ecs_parser_errorv(
 
 #define ecs_dbg ecs_dbg_1 /* Default debug tracing is at level 1 */
 
+/** Abort 
+ * Unconditionally aborts process. */
+#define ecs_abort(error_code, ...)\
+    _ecs_abort(error_code, __FILE__, __LINE__, __VA_ARGS__);\
+    ecs_os_abort(); abort(); /* satisfy compiler/static analyzers */
+
+/** Assert 
+ * Aborts if condition is false, disabled in debug mode. */
 #ifdef NDEBUG
 #define ecs_assert(condition, error_code, ...)
 #else
 #define ecs_assert(condition, error_code, ...)\
-    _ecs_assert(condition, error_code, #condition, __FILE__, __LINE__, __VA_ARGS__);\
-    assert(condition)
+    if (!_ecs_assert(condition, error_code, #condition, __FILE__, __LINE__, __VA_ARGS__)) {\
+        ecs_os_abort();\
+    }\
+    assert(condition) /* satisfy compiler/static analyzers */
 #endif // NDEBUG
 
-#define ecs_abort(error_code, ...)\
-    _ecs_abort(error_code, __FILE__, __LINE__, __VA_ARGS__); abort()
+/** Check
+ * goto error if condition is false. */
+#ifdef NDEBUG
+#define ecs_check(condition, error_code, ...)\
+    if ((false)) {\
+        goto error;\
+    } // Silence dead code/unused label warnings
+#else
+#ifdef FLECS_SOFT_ASSERT
+#define ecs_check(condition, error_code, ...)\
+    if (!_ecs_assert(condition, error_code, #condition, __FILE__, __LINE__, __VA_ARGS__)) {\
+        goto error;\
+    }
+#else // FLECS_SOFT_ASSERT
+#define ecs_check(condition, error_code, ...)\
+    ecs_assert(condition, error_code, __VA_ARGS__);\
+    if ((false)) {\
+        goto error;\
+    } // Silence dead code/unused label warnings
+#endif
+#endif // NDEBUG
 
+/** Throw
+ * goto error when FLECS_SOFT_ASSERT is defined, otherwise abort */
+#ifdef FLECS_SOFT_ASSERT
+#define ecs_throw(error_code, ...)\
+    _ecs_abort(error_code, __FILE__, __LINE__, __VA_ARGS__);\
+    goto error;
+#else
+#define ecs_throw(error_code, ...)\
+    ecs_abort(error_code, __VA_ARGS__);\
+    if ((false)) {\
+        goto error;\
+    } // Silence dead code/unused label warnings
+#endif
+
+/** Parser error */
 #define ecs_parser_error(name, expr, column, ...)\
     _ecs_parser_error(name, expr, column, __VA_ARGS__)
 
@@ -276,10 +273,6 @@ void _ecs_parser_errorv(
 ////////////////////////////////////////////////////////////////////////////////
 //// Functions that are always available
 ////////////////////////////////////////////////////////////////////////////////
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 /** Enable or disable tracing.
  * This will enable builtin tracing. For tracing to work, it will have to be
@@ -313,10 +306,6 @@ FLECS_API
 bool ecs_log_enable_colors(
     bool enabled);
 
-#ifdef __cplusplus
-}
-#endif
-
 ////////////////////////////////////////////////////////////////////////////////
 //// Used when logging with colors is enabled
 ////////////////////////////////////////////////////////////////////////////////
@@ -332,5 +321,9 @@ bool ecs_log_enable_colors(
 #define ECS_GREY    "\033[0;37m"
 #define ECS_NORMAL  "\033[0;49m"
 #define ECS_BOLD    "\033[1;49m"
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // FLECS_LOG_H

--- a/include/flecs/os_api.h
+++ b/include/flecs/os_api.h
@@ -1,6 +1,6 @@
 /**
  * @file os_api.h
- * @brief Operationg system abstractions.
+ * @brief Operating system abstraction API.
  *
  * This file contains the operating system abstraction API. The flecs core 
  * library avoids OS/runtime specific API calls as much as possible. Instead it

--- a/include/flecs/private/vector.h
+++ b/include/flecs/private/vector.h
@@ -499,7 +499,6 @@ public:
     }
 
     T& get(int32_t index) {
-        ecs_assert(index < ecs_vector_count(m_vector), ECS_OUT_OF_RANGE, NULL);
         return *static_cast<T*>(_ecs_vector_get(m_vector, ECS_VECTOR_T(T), index));
     }
 

--- a/src/addons/expr/serialize.c
+++ b/src/addons/expr/serialize.c
@@ -146,7 +146,7 @@ int expr_ser_enum(
     ecs_strbuf_t *str) 
 {
     const EcsEnum *enum_type = ecs_get(world, op->type, EcsEnum);
-    ecs_assert(enum_type != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(enum_type != NULL, ECS_INVALID_PARAMETER, NULL);
 
     int32_t value = *(int32_t*)base;
     
@@ -158,12 +158,14 @@ int expr_ser_enum(
         char *path = ecs_get_fullpath(world, op->type);
         ecs_err("value %d is not valid for enum type '%s'", value, path);
         ecs_os_free(path);
-        return -1;
+        goto error;
     }
 
     ecs_strbuf_appendstr(str, ecs_get_name(world, constant->constant));
 
     return 0;
+error:
+    return -1;
 }
 
 /* Serialize bitmask */
@@ -175,7 +177,7 @@ int expr_ser_bitmask(
     ecs_strbuf_t *str) 
 {
     const EcsBitmask *bitmask_type = ecs_get(world, op->type, EcsBitmask);
-    ecs_assert(bitmask_type != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(bitmask_type != NULL, ECS_INVALID_PARAMETER, NULL);
 
     uint32_t value = *(uint32_t*)ptr;
     ecs_map_key_t key;
@@ -322,7 +324,7 @@ int expr_ser_type_op(
     case EcsOpPush:
     case EcsOpPop:
         /* Should not be parsed as single op */
-        ecs_abort(ECS_INVALID_PARAMETER, NULL);
+        ecs_throw(ECS_INVALID_PARAMETER, NULL);
         break;
     case EcsOpEnum:
         if (expr_ser_enum(world, op, ECS_OFFSET(ptr, op->offset), str)) {

--- a/src/addons/expr/strutil.c
+++ b/src/addons/expr/strutil.c
@@ -130,9 +130,11 @@ ecs_size_t ecs_stresc(
     char ch, *bptr = out, buff[3];
     ecs_size_t written = 0;
     while ((ch = *ptr++)) {
-        if ((written += (ecs_size_t)(ecs_chresc(buff, ch, delimiter) - buff)) <= n) {
+        if ((written += (ecs_size_t)(ecs_chresc(
+            buff, ch, delimiter) - buff)) <= n) 
+        {
             /* If size != 0, an out buffer must be provided. */
-            ecs_assert(out != NULL, ECS_INVALID_PARAMETER, NULL);
+            ecs_check(out != NULL, ECS_INVALID_PARAMETER, NULL);
             *bptr++ = buff[0];
             if ((ch = buff[1])) {
                 *bptr = ch;
@@ -149,6 +151,8 @@ ecs_size_t ecs_stresc(
         }
     }
     return written;
+error:
+    return 0;
 }
 
 char* ecs_astresc(

--- a/src/addons/http.c
+++ b/src/addons/http.c
@@ -861,27 +861,29 @@ void ecs_http_server_fini(
 int ecs_http_server_start(
     ecs_http_server_t *srv)
 {
-    ecs_assert(srv != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(srv->initialized, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(!srv->should_run, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(!srv->thread, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(srv != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(srv->initialized, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(!srv->should_run, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(!srv->thread, ECS_INVALID_PARAMETER, NULL);
 
     srv->should_run = true;
 
     srv->thread = ecs_os_thread_new(http_server_thread, srv);
     if (!srv->thread) {
-        return -1;
+        goto error;
     }
 
     return 0;
+error:
+    return -1;
 }
 
 void ecs_http_server_stop(
     ecs_http_server_t* srv) 
 {
-    ecs_assert(srv != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(srv->initialized, ECS_INVALID_OPERATION, NULL);
-    ecs_assert(srv->should_run, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(srv != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(srv->initialized, ECS_INVALID_OPERATION, NULL);
+    ecs_check(srv->should_run, ECS_INVALID_PARAMETER, NULL);
 
     /* Stop server thread */
     ecs_trace("http: shutting down server thread");
@@ -912,15 +914,19 @@ void ecs_http_server_stop(
         ECS_INTERNAL_ERROR, NULL);
 
     srv->thread = 0;
+error:
+    return;
 }
 
 void ecs_http_server_dequeue(
     ecs_http_server_t* srv)
 {
-    ecs_assert(srv != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(srv->initialized, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(srv->should_run, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(srv != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(srv->initialized, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(srv->should_run, ECS_INVALID_PARAMETER, NULL);
     dequeue_requests(srv);
+error:
+    return;
 }
 
 #endif

--- a/src/addons/log.c
+++ b/src/addons/log.c
@@ -293,11 +293,9 @@ void _ecs_abort(
     } else {
         _ecs_fatal(file, line, "%s", ecs_strerror(err));
     }
-
-    ecs_os_abort();
 }
 
-void _ecs_assert(
+bool _ecs_assert(
     bool condition,
     int32_t err,
     const char *cond_str,
@@ -319,9 +317,9 @@ void _ecs_assert(
             _ecs_fatal(file, line, "assert(%s) %s", 
                 cond_str, ecs_strerror(err));
         }
-
-        ecs_os_abort();
     }
+
+    return condition;
 }
 
 void _ecs_deprecated(
@@ -438,7 +436,7 @@ void _ecs_abort(
 }
 
 FLECS_API
-void _ecs_assert(
+bool _ecs_assert(
     bool condition,
     int32_t error_code,
     const char *condition_str,
@@ -453,6 +451,7 @@ void _ecs_assert(
     (void)file;
     (void)line;
     (void)fmt;
+    return true;
 }
 
 #endif

--- a/src/addons/meta_c.c
+++ b/src/addons/meta_c.c
@@ -461,7 +461,7 @@ ecs_entity_t meta_lookup_array(
         e = ecs_set(world, 0, EcsMetaType, { EcsArrayType });
     }
 
-    ecs_assert(params.count <= INT32_MAX, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(params.count <= INT32_MAX, ECS_INVALID_PARAMETER, NULL);
 
     return ecs_set(world, e, EcsArray, { element_type, (int32_t)params.count });
 error:
@@ -536,13 +536,13 @@ ecs_entity_t meta_lookup_bitmask(
 
     ecs_entity_t bitmask_type = meta_lookup(
         world, &params.type, params_decl, 1, &param_ctx);
-    ecs_assert(bitmask_type != 0, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(bitmask_type != 0, ECS_INVALID_PARAMETER, NULL);
 
 #ifndef NDEBUG
     /* Make sure this is a bitmask type */
     const EcsMetaType *type_ptr = ecs_get(world, bitmask_type, EcsMetaType);
-    ecs_assert(type_ptr != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(type_ptr->kind == EcsBitmaskType, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(type_ptr != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(type_ptr->kind == EcsBitmaskType, ECS_INVALID_PARAMETER, NULL);
 #endif
 
     return bitmask_type;
@@ -638,7 +638,7 @@ ecs_entity_t meta_lookup(
     }
 
     if (count != 1) {
-        ecs_assert(count <= INT32_MAX, ECS_INVALID_PARAMETER, NULL);
+        ecs_check(count <= INT32_MAX, ECS_INVALID_PARAMETER, NULL);
 
         type = ecs_set(world, ecs_set(world, 0,
             EcsMetaType, {EcsArrayType}),

--- a/src/addons/module.c
+++ b/src/addons/module.c
@@ -30,7 +30,7 @@ ecs_entity_t ecs_import(
     ecs_module_action_t init_action,
     const char *module_name)
 {
-    ecs_assert(!world->is_readonly, ECS_INVALID_WHILE_ITERATING, NULL);
+    ecs_check(!world->is_readonly, ECS_INVALID_WHILE_ITERATING, NULL);
 
     ecs_entity_t old_scope = ecs_set_scope(world, 0);
     const char *old_name_prefix = world->name_prefix;
@@ -48,7 +48,7 @@ ecs_entity_t ecs_import(
 
         /* Lookup module entity (must be registered by module) */
         e = ecs_lookup_fullpath(world, module_name);
-        ecs_assert(e != 0, ECS_MODULE_UNDEFINED, module_name);
+        ecs_check(e != 0, ECS_MODULE_UNDEFINED, module_name);
 
         ecs_log_pop();
     }
@@ -58,6 +58,8 @@ ecs_entity_t ecs_import(
     world->name_prefix = old_name_prefix;
 
     return e;
+error:
+    return 0;
 }
 
 ecs_entity_t ecs_import_from_library(
@@ -65,7 +67,7 @@ ecs_entity_t ecs_import_from_library(
     const char *library_name,
     const char *module_name)
 {
-    ecs_assert(library_name != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(library_name != NULL, ECS_INVALID_PARAMETER, NULL);
 
     char *import_func = (char*)module_name; /* safe */
     char *module = (char*)module_name;
@@ -165,13 +167,15 @@ ecs_entity_t ecs_import_from_library(
     ecs_os_free(library_filename);
 
     return result;
+error:
+    return 0;
 }
 
 ecs_entity_t ecs_module_init(
     ecs_world_t *world,
     const ecs_component_desc_t *desc)
 {
-    ecs_assert(desc != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(desc != NULL, ECS_INVALID_PARAMETER, NULL);
     ecs_poly_assert(world, ecs_world_t);
 
     const char *name = desc->entity.name;
@@ -198,6 +202,8 @@ ecs_entity_t ecs_module_init(
     }
 
     return e;
+error:
+    return 0;
 }
 
 #endif

--- a/src/addons/parser.c
+++ b/src/addons/parser.c
@@ -944,9 +944,9 @@ char* ecs_parse_term(
     const char *ptr,
     ecs_term_t *term)
 {
-    ecs_assert(world != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(ptr != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(term != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(world != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(ptr != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(term != NULL, ECS_INVALID_PARAMETER, NULL);
 
     ecs_term_id_t *subj = &term->subj;
 
@@ -1077,7 +1077,9 @@ char* ecs_parse_term(
 
     return (char*)ptr;
 error:
-    ecs_term_fini(term);
+    if (term) {
+        ecs_term_fini(term);
+    }
     return NULL;
 }
 

--- a/src/addons/pipeline/pipeline.c
+++ b/src/addons/pipeline/pipeline.c
@@ -658,18 +658,22 @@ void ecs_set_pipeline(
     ecs_entity_t pipeline)
 {
     ecs_poly_assert(world, ecs_world_t);
-    ecs_assert( ecs_get(world, pipeline, EcsPipelineQuery) != NULL, 
+    ecs_check( ecs_get(world, pipeline, EcsPipelineQuery) != NULL, 
         ECS_INVALID_PARAMETER, NULL);
 
     world->pipeline = pipeline;
+error:
+    return;
 }
 
 ecs_entity_t ecs_get_pipeline(
     const ecs_world_t *world)
 {
-    ecs_assert(world != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(world != NULL, ECS_INVALID_PARAMETER, NULL);
     world = ecs_get_world(world);
     return world->pipeline;
+error:
+    return 0;
 }
 
 /* -- Module implementation -- */

--- a/src/addons/stats.c
+++ b/src/addons/stats.c
@@ -89,8 +89,8 @@ void ecs_gauge_reduce(
     ecs_gauge_t *src,
     int32_t t_src)
 {
-    ecs_assert(dst != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(src != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(dst != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(src != NULL, ECS_INVALID_PARAMETER, NULL);
 
     bool min_set = false;
     dst->min[t_dst] = 0;
@@ -109,14 +109,16 @@ void ecs_gauge_reduce(
             dst->max[t_dst] = src->max[t];
         }
     }
+error:
+    return;
 }
 
 void ecs_get_world_stats(
     const ecs_world_t *world,
     ecs_world_stats_t *s)
 {
-    ecs_assert(world != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(s != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(world != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(s != NULL, ECS_INVALID_PARAMETER, NULL);
 
     world = ecs_get_world(world);
 
@@ -194,6 +196,9 @@ void ecs_get_world_stats(
     record_gauge(&s->table_count, t, count);
     record_gauge(&s->empty_table_count, t, empty_table_count);
     record_gauge(&s->singleton_table_count, t, singleton_table_count);
+
+error:
+    return;
 }
 
 void ecs_get_query_stats(
@@ -201,9 +206,9 @@ void ecs_get_query_stats(
     const ecs_query_t *query,
     ecs_query_stats_t *s)
 {
-    ecs_assert(world != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(query != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(s != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(world != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(query != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(s != NULL, ECS_INVALID_PARAMETER, NULL);
     (void)world;
 
     int32_t t = s->t = t_next(s->t);
@@ -213,6 +218,8 @@ void ecs_get_query_stats(
     record_gauge(&s->matched_table_count, t, ecs_query_table_count(query));
     record_gauge(&s->matched_empty_table_count, t, 
         ecs_query_empty_table_count(query));
+error:
+    return;
 }
 
 #ifdef FLECS_SYSTEM
@@ -221,9 +228,9 @@ bool ecs_get_system_stats(
     ecs_entity_t system,
     ecs_system_stats_t *s)
 {
-    ecs_assert(world != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(s != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(system != 0, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(world != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(s != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(system != 0, ECS_INVALID_PARAMETER, NULL);
 
     world = ecs_get_world(world);
 
@@ -241,18 +248,21 @@ bool ecs_get_system_stats(
     record_gauge(&s->enabled, t, !ecs_has_id(world, system, EcsDisabled));
 
     return true;
+error:
+    return false;
 }
 #endif
 
 
 #ifdef FLECS_PIPELINE
 
-static ecs_system_stats_t* get_system_stats(
+static 
+ecs_system_stats_t* get_system_stats(
     ecs_map_t *systems,
     ecs_entity_t system)
 {
-    ecs_assert(systems != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(system != 0, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(systems != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(system != 0, ECS_INVALID_PARAMETER, NULL);
 
     ecs_system_stats_t *s = ecs_map_get(systems, ecs_system_stats_t, system);
     if (!s) {
@@ -260,6 +270,8 @@ static ecs_system_stats_t* get_system_stats(
     }
 
     return s;
+error:
+    return NULL;
 }
 
 bool ecs_get_pipeline_stats(
@@ -267,9 +279,9 @@ bool ecs_get_pipeline_stats(
     ecs_entity_t pipeline,
     ecs_pipeline_stats_t *s)
 {
-    ecs_assert(stage != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(s != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(pipeline != 0, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(stage != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(s != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(pipeline != 0, ECS_INVALID_PARAMETER, NULL);
 
     const ecs_world_t *world = ecs_get_world(stage);
 
@@ -354,6 +366,8 @@ bool ecs_get_pipeline_stats(
     }
 
     return true;
+error:
+    return false;
 }
 
 void ecs_pipeline_stats_fini(
@@ -371,8 +385,8 @@ void ecs_dump_world_stats(
 {
     int32_t t = s->t;
 
-    ecs_assert(world != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(s != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(world != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(s != NULL, ECS_INVALID_PARAMETER, NULL);
 
     world = ecs_get_world(world);    
     
@@ -407,6 +421,9 @@ void ecs_dump_world_stats(
     print_counter("deferred set operations", t, &s->set_count);
     print_counter("discarded operations", t, &s->discard_count);
     printf("\n");
+    
+error:
+    return;
 }
 
 #endif

--- a/src/addons/system/system.c
+++ b/src/addons/system/system.c
@@ -387,7 +387,7 @@ ecs_entity_t ecs_system_init(
     const ecs_system_desc_t *desc)
 {
     ecs_poly_assert(world, ecs_world_t);
-    ecs_assert(!world->is_readonly, ECS_INVALID_WHILE_ITERATING, NULL);
+    ecs_check(!world->is_readonly, ECS_INVALID_WHILE_ITERATING, NULL);
 
     ecs_entity_t existing = desc->entity.entity;
     ecs_entity_t result = ecs_entity_init(world, &desc->entity);
@@ -398,7 +398,7 @@ ecs_entity_t ecs_system_init(
     bool added = false;
     EcsSystem *system = ecs_get_mut(world, result, EcsSystem, &added);
     if (added) {
-        ecs_assert(desc->callback != NULL, ECS_INVALID_PARAMETER, NULL);
+        ecs_check(desc->callback != NULL, ECS_INVALID_PARAMETER, NULL);
 
         memset(system, 0, sizeof(EcsSystem));
 
@@ -528,6 +528,8 @@ ecs_entity_t ecs_system_init(
     }
 
     return result;
+error:
+    return 0;
 }
 
 void FlecsSystemImport(

--- a/src/addons/timer.c
+++ b/src/addons/timer.c
@@ -106,7 +106,7 @@ ecs_entity_t ecs_set_timeout(
     ecs_entity_t timer,
     FLECS_FLOAT timeout)
 {
-    ecs_assert(world != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(world != NULL, ECS_INVALID_PARAMETER, NULL);
 
     timer = ecs_set(world, timer, EcsTimer, {
         .timeout = timeout,
@@ -119,6 +119,7 @@ ecs_entity_t ecs_set_timeout(
         system_data->tick_source = timer;
     }
 
+error:
     return timer;
 }
 
@@ -126,15 +127,15 @@ FLECS_FLOAT ecs_get_timeout(
     const ecs_world_t *world,
     ecs_entity_t timer)
 {
-    ecs_assert(world != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(timer != 0, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(world != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(timer != 0, ECS_INVALID_PARAMETER, NULL);
 
     const EcsTimer *value = ecs_get(world, timer, EcsTimer);
     if (value) {
         return value->timeout;
-    } else {
-        return 0;
     }
+error:
+    return 0;
 }
 
 ecs_entity_t ecs_set_interval(
@@ -142,7 +143,7 @@ ecs_entity_t ecs_set_interval(
     ecs_entity_t timer,
     FLECS_FLOAT interval)
 {
-    ecs_assert(world != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(world != NULL, ECS_INVALID_PARAMETER, NULL);
 
     timer = ecs_set(world, timer, EcsTimer, {
         .timeout = interval,
@@ -152,8 +153,8 @@ ecs_entity_t ecs_set_interval(
     EcsSystem *system_data = ecs_get_mut(world, timer, EcsSystem, NULL);
     if (system_data) {
         system_data->tick_source = timer;
-    }  
-
+    }
+error:
     return timer;  
 }
 
@@ -161,7 +162,7 @@ FLECS_FLOAT ecs_get_interval(
     const ecs_world_t *world,
     ecs_entity_t timer)
 {
-    ecs_assert(world != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(world != NULL, ECS_INVALID_PARAMETER, NULL);
 
     if (!timer) {
         return 0;
@@ -170,9 +171,9 @@ FLECS_FLOAT ecs_get_interval(
     const EcsTimer *value = ecs_get(world, timer, EcsTimer);
     if (value) {
         return value->timeout;
-    } else {
-        return 0;
     }
+error:
+    return 0;
 }
 
 void ecs_start_timer(
@@ -180,10 +181,11 @@ void ecs_start_timer(
     ecs_entity_t timer)
 {
     EcsTimer *ptr = ecs_get_mut(world, timer, EcsTimer, NULL);
-    ecs_assert(ptr != NULL, ECS_INVALID_PARAMETER, NULL);
-
+    ecs_check(ptr != NULL, ECS_INVALID_PARAMETER, NULL);
     ptr->active = true;
     ptr->time = 0;
+error:
+    return;
 }
 
 void ecs_stop_timer(
@@ -191,9 +193,10 @@ void ecs_stop_timer(
     ecs_entity_t timer)
 {
     EcsTimer *ptr = ecs_get_mut(world, timer, EcsTimer, NULL);
-    ecs_assert(ptr != NULL, ECS_INVALID_PARAMETER, NULL);
-
+    ecs_check(ptr != NULL, ECS_INVALID_PARAMETER, NULL);
     ptr->active = false;
+error:
+    return;
 }
 
 ecs_entity_t ecs_set_rate(
@@ -202,7 +205,7 @@ ecs_entity_t ecs_set_rate(
     int32_t rate,
     ecs_entity_t source)
 {
-    ecs_assert(world != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(world != NULL, ECS_INVALID_PARAMETER, NULL);
 
     filter = ecs_set(world, filter, EcsRateFilter, {
         .rate = rate,
@@ -214,6 +217,7 @@ ecs_entity_t ecs_set_rate(
         system_data->tick_source = filter;
     }  
 
+error:
     return filter;     
 }
 
@@ -222,14 +226,16 @@ void ecs_set_tick_source(
     ecs_entity_t system,
     ecs_entity_t tick_source)
 {
-    ecs_assert(world != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(system != 0, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(tick_source != 0, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(world != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(system != 0, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(tick_source != 0, ECS_INVALID_PARAMETER, NULL);
 
     EcsSystem *system_data = ecs_get_mut(world, system, EcsSystem, NULL);
-    ecs_assert(system_data != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(system_data != NULL, ECS_INVALID_PARAMETER, NULL);
 
     system_data->tick_source = tick_source;
+error:
+    return;
 }
 
 void FlecsTimerImport(
@@ -245,16 +251,20 @@ void FlecsTimerImport(
     flecs_bootstrap_component(world, EcsRateFilter);
 
     /* Add EcsTickSource to timers and rate filters */
-    ECS_SYSTEM(world, AddTickSource, EcsPreFrame, [in] Timer || RateFilter, [out] !flecs.system.TickSource);
+    ECS_SYSTEM(world, AddTickSource, EcsPreFrame, 
+        [in] Timer || RateFilter, [out] !flecs.system.TickSource);
 
     /* Timer handling */
-    ECS_SYSTEM(world, ProgressTimers, EcsPreFrame, Timer, flecs.system.TickSource);
+    ECS_SYSTEM(world, ProgressTimers, EcsPreFrame, 
+        Timer, flecs.system.TickSource);
 
     /* Rate filter handling */
-    ECS_SYSTEM(world, ProgressRateFilters, EcsPreFrame, [in] RateFilter, [out] flecs.system.TickSource);
+    ECS_SYSTEM(world, ProgressRateFilters, EcsPreFrame, 
+        [in] RateFilter, [out] flecs.system.TickSource);
 
     /* TickSource without a timer or rate filter just increases each frame */
-    ECS_SYSTEM(world, ProgressTickSource, EcsPreFrame, [out] flecs.system.TickSource, !RateFilter, !Timer);
+    ECS_SYSTEM(world, ProgressTickSource, EcsPreFrame, 
+        [out] flecs.system.TickSource, !RateFilter, !Timer);
 }
 
 #endif

--- a/src/datastructures/bitset.c
+++ b/src/datastructures/bitset.c
@@ -56,19 +56,23 @@ void flecs_bitset_set(
     int32_t elem,
     bool value)
 {
-    ecs_assert(elem < bs->count, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(elem < bs->count, ECS_INVALID_PARAMETER, NULL);
     int32_t hi = elem >> 6;
     int32_t lo = elem & 0x3F;
     uint64_t v = bs->data[hi];
     bs->data[hi] = (v & ~((uint64_t)1 << lo)) | ((uint64_t)value << lo);
+error:
+    return;
 }
 
 bool flecs_bitset_get(
     const ecs_bitset_t *bs,
     int32_t elem)
 {
-    ecs_assert(elem < bs->count, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(elem < bs->count, ECS_INVALID_PARAMETER, NULL);
     return !!(bs->data[elem >> 6] & ((uint64_t)1 << ((uint64_t)elem & 0x3F)));
+error:
+    return false;
 }
 
 int32_t flecs_bitset_count(
@@ -81,11 +85,13 @@ void flecs_bitset_remove(
     ecs_bitset_t *bs,
     int32_t elem)
 {
-    ecs_assert(elem < bs->count, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(elem < bs->count, ECS_INVALID_PARAMETER, NULL);
     int32_t last = bs->count - 1;
     bool last_value = flecs_bitset_get(bs, last);
     flecs_bitset_set(bs, elem, last_value);
     bs->count --;
+error:
+    return;
 }
 
 void flecs_bitset_swap(
@@ -93,11 +99,13 @@ void flecs_bitset_swap(
     int32_t elem_a,
     int32_t elem_b)
 {
-    ecs_assert(elem_a < bs->count, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(elem_b < bs->count, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(elem_a < bs->count, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(elem_b < bs->count, ECS_INVALID_PARAMETER, NULL);
 
     bool a = flecs_bitset_get(bs, elem_a);
     bool b = flecs_bitset_get(bs, elem_b);
     flecs_bitset_set(bs, elem_a, b);
     flecs_bitset_set(bs, elem_b, a);
+error:
+    return;
 }

--- a/src/datastructures/sparse.c
+++ b/src/datastructures/sparse.c
@@ -83,6 +83,13 @@ chunk_t* get_chunk(
     const ecs_sparse_t *sparse,
     int32_t chunk_index)
 {
+    if (!sparse->chunks) {
+        return NULL;
+    }
+    if (chunk_index >= ecs_vector_count(sparse->chunks)) {
+        return NULL;
+    }
+
     /* If chunk_index is below zero, application used an invalid entity id */
     ecs_assert(chunk_index >= 0, ECS_INVALID_PARAMETER, NULL);
     chunk_t *result = ecs_vector_get(sparse->chunks, chunk_t, chunk_index);

--- a/src/datastructures/vector.c
+++ b/src/datastructures/vector.c
@@ -363,18 +363,10 @@ void* _ecs_vector_get(
     int16_t offset,
     int32_t index)
 {
-    if (!vector) {
-        return NULL;
-    }
-    
+    ecs_assert(vector != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(vector->elem_size == elem_size, ECS_INTERNAL_ERROR, NULL);    
     ecs_assert(index >= 0, ECS_INTERNAL_ERROR, NULL);
-
-    int32_t count = vector->count;
-
-    if (index >= count) {
-        return NULL;
-    }
+    ecs_assert(index < vector->count, ECS_INTERNAL_ERROR, NULL);
 
     return ECS_OFFSET(vector, offset + elem_size * index);
 }

--- a/src/iter.c
+++ b/src/iter.c
@@ -34,7 +34,7 @@ void flecs_iter_init(
 void flecs_iter_fini(
     ecs_iter_t *it)
 {
-    ecs_assert(it->is_valid == true, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(it->is_valid == true, ECS_INVALID_PARAMETER, NULL);
     it->is_valid = false;
 
     FINI_CACHE(it, ids);
@@ -43,6 +43,8 @@ void flecs_iter_fini(
     FINI_CACHE(it, sizes);
     FINI_CACHE(it, ptrs);
     FINI_CACHE(it, match_indices);
+error:
+    return;
 }
 
 static
@@ -190,8 +192,8 @@ void* ecs_term_w_size(
     size_t size,
     int32_t term)
 {
-    ecs_assert(it->is_valid, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(!size || ecs_term_size(it, term) == size, 
+    ecs_check(it->is_valid, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(!size || ecs_term_size(it, term) == size, 
         ECS_INVALID_PARAMETER, NULL);
 
     (void)size;
@@ -205,17 +207,19 @@ void* ecs_term_w_size(
     }
 
     return it->ptrs[term - 1];
+error:
+    return NULL;
 }
 
 bool ecs_term_is_readonly(
     const ecs_iter_t *it,
     int32_t term_index)
 {
-    ecs_assert(it->is_valid, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(term_index > 0, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(it->is_valid, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(term_index > 0, ECS_INVALID_PARAMETER, NULL);
 
     ecs_term_t *term = &it->terms[term_index - 1];
-    ecs_assert(term != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(term != NULL, ECS_INVALID_PARAMETER, NULL);
     
     if (term->inout == EcsIn) {
         return true;
@@ -235,6 +239,7 @@ bool ecs_term_is_readonly(
         }
     }
 
+error:
     return false;
 }
 
@@ -242,16 +247,18 @@ int32_t ecs_iter_find_column(
     const ecs_iter_t *it,
     ecs_entity_t component)
 {
-    ecs_assert(it->is_valid, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(it->table != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(it->is_valid, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(it->table != NULL, ECS_INVALID_PARAMETER, NULL);
     return ecs_type_index_of(it->table->type, 0, component);
+error:
+    return -1;
 }
 
 bool ecs_term_is_set(
     const ecs_iter_t *it,
     int32_t index)
 {
-    ecs_assert(it->is_valid, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(it->is_valid, ECS_INVALID_PARAMETER, NULL);
 
     int32_t column = it->columns[index - 1];
     if (!column) {
@@ -267,6 +274,8 @@ bool ecs_term_is_set(
     }
 
     return true;
+error:
+    return false;
 }
 
 void* ecs_iter_column_w_size(
@@ -274,8 +283,8 @@ void* ecs_iter_column_w_size(
     size_t size,
     int32_t index)
 {
-    ecs_assert(it->is_valid, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(it->table != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(it->is_valid, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(it->table != NULL, ECS_INVALID_PARAMETER, NULL);
     (void)size;
     
     ecs_table_t *table = it->table;
@@ -286,21 +295,23 @@ void* ecs_iter_column_w_size(
 
     ecs_column_t *columns = table->storage.columns;
     ecs_column_t *column = &columns[storage_index];
-    ecs_assert(!size || (ecs_size_t)size == column->size, 
+    ecs_check(!size || (ecs_size_t)size == column->size, 
         ECS_INVALID_PARAMETER, NULL);
 
     void *ptr = ecs_vector_first_t(
         column->data, column->size, column->alignment);
 
     return ECS_OFFSET(ptr, column->size * it->offset);
+error:
+    return NULL;
 }
 
 size_t ecs_iter_column_size(
     const ecs_iter_t *it,
     int32_t index)
 {
-    ecs_assert(it->is_valid, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(it->table != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(it->is_valid, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(it->table != NULL, ECS_INVALID_PARAMETER, NULL);
     
     ecs_table_t *table = it->table;
     int32_t storage_index = ecs_table_type_to_storage_index(table, index);
@@ -312,6 +323,8 @@ size_t ecs_iter_column_size(
     ecs_column_t *column = &columns[storage_index];
     
     return flecs_to_size_t(column->size);
+error:
+    return 0;
 }
 
 char* ecs_iter_str(
@@ -399,17 +412,22 @@ void ecs_iter_poly(
 bool ecs_iter_next(
     ecs_iter_t *iter)
 {
-    ecs_assert(iter != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(iter->next != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(iter != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(iter->next != NULL, ECS_INVALID_PARAMETER, NULL);
     return iter->next(iter);
+error:
+    return false;
 }
 
 bool ecs_iter_count(
     ecs_iter_t *it)
 {
+    ecs_check(it != NULL, ECS_INVALID_PARAMETER, NULL);
     int32_t count = 0;
     while (ecs_iter_next(it)) {
         count += it->count;
     }
     return count;
+error:
+    return 0;
 }

--- a/src/observable.c
+++ b/src/observable.c
@@ -34,9 +34,9 @@ void ecs_emit(
     ecs_event_desc_t *desc)
 {
     ecs_poly_assert(world, ecs_world_t);
-    ecs_assert(desc != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(desc->event != 0, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(desc->event != EcsWildcard, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(desc != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(desc->event != 0, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(desc->event != EcsWildcard, ECS_INVALID_PARAMETER, NULL);
 
     ecs_ids_t ids_storage, *ids = desc->ids;
     ecs_table_t *table = NULL, *other_table = NULL;
@@ -81,4 +81,6 @@ void ecs_emit(
 
     flecs_triggers_notify(world, desc->observable, ids, event, 
         entity, table, other_table, row, count, desc->param);
+error:
+    return;
 }

--- a/src/observer.c
+++ b/src/observer.c
@@ -94,9 +94,9 @@ ecs_entity_t ecs_observer_init(
     ecs_world_t *world,
     const ecs_observer_desc_t *desc)
 {
-    ecs_assert(world != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(desc != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(!world->is_fini, ECS_INVALID_OPERATION, NULL);
+    ecs_check(world != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(desc != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(!world->is_fini, ECS_INVALID_OPERATION, NULL);
 
     /* If entity is provided, create it */
     ecs_entity_t existing = desc->entity.entity;
@@ -133,7 +133,7 @@ ecs_entity_t ecs_observer_init(
 
             if (event == EcsMonitor) {
                 /* Monitor event must be first and last event */
-                ecs_assert(i == 0, ECS_INVALID_PARAMETER, NULL);
+                ecs_check(i == 0, ECS_INVALID_PARAMETER, NULL);
 
                 observer->events[0] = EcsOnAdd;
                 observer->events[1] = EcsOnRemove;
@@ -147,7 +147,7 @@ ecs_entity_t ecs_observer_init(
         }
 
         /* Observer must have at least one event */
-        ecs_assert(observer->event_count != 0, ECS_INVALID_PARAMETER, NULL);
+        ecs_check(observer->event_count != 0, ECS_INVALID_PARAMETER, NULL);
 
         /* Create a trigger for each term in the filter */
         observer->triggers = ecs_os_malloc_n(ecs_entity_t, 
@@ -210,6 +210,11 @@ ecs_entity_t ecs_observer_init(
     }
 
     return entity; 
+error:
+    if (entity) {
+        ecs_delete(world, entity);
+    }
+    return 0;
 }
 
 void flecs_observer_fini(

--- a/src/table.c
+++ b/src/table.c
@@ -2080,37 +2080,41 @@ int32_t ecs_table_type_to_storage_index(
     const ecs_table_t *table,
     int32_t index)
 {
-    ecs_assert(index < ecs_vector_count(table->type), 
+    ecs_check(index < ecs_vector_count(table->type), 
         ECS_INVALID_PARAMETER, NULL);
     int32_t *storage_map = table->storage_map;
     if (storage_map) {
         return storage_map[index];
-    } else {
-        return -1;
     }
+error:
+    return -1;
 }
 
 int32_t ecs_table_storage_to_type_index(
     const ecs_table_t *table,
     int32_t index)
 {
-    ecs_assert(index < ecs_vector_count(table->storage_type), 
+    ecs_check(index < ecs_vector_count(table->storage_type), 
         ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(table->storage_map != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(table->storage_map != NULL, ECS_INVALID_PARAMETER, NULL);
     int32_t offset = ecs_vector_count(table->type);
     return table->storage_map[offset + index];
+error:
+    return -1;
 }
 
 ecs_record_t* ecs_record_find(
     ecs_world_t *world,
     ecs_entity_t entity)
 {
+    ecs_poly_assert(world, ecs_world_t);
+    ecs_check(entity != 0, ECS_INVALID_PARAMETER, NULL);
     ecs_record_t *r = ecs_eis_get(world, entity);
     if (r) {
         return r;
-    } else {
-        return NULL;
     }
+error:
+    return NULL;
 }
 
 void* ecs_record_get_column(
@@ -2121,14 +2125,14 @@ void* ecs_record_get_column(
     (void)c_size;
     ecs_table_t *table = r->table;
 
-    ecs_assert(column < ecs_vector_count(table->storage_type), 
+    ecs_check(column < ecs_vector_count(table->storage_type), 
         ECS_INVALID_PARAMETER, NULL);
 
     ecs_column_t *c = &table->storage.columns[column];
     ecs_assert(c != NULL, ECS_INTERNAL_ERROR, NULL);
 
     int16_t size = c->size;
-    ecs_assert(!flecs_from_size_t(c_size) || 
+    ecs_check(!flecs_from_size_t(c_size) || 
         flecs_from_size_t(c_size) == c->size, 
         ECS_INVALID_PARAMETER, NULL);
 
@@ -2137,4 +2141,6 @@ void* ecs_record_get_column(
     int32_t row = flecs_record_to_row(r->row, &is_watched);
 
     return ECS_OFFSET(array, size * row);
+error:
+    return NULL;
 }

--- a/src/table_graph.c
+++ b/src/table_graph.c
@@ -840,8 +840,8 @@ ecs_table_t* flecs_table_traverse_remove(
     node = node ? node : &world->store.root;
 
     /* Removing 0 from an entity is not valid */
-    ecs_assert(id_ptr != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(id_ptr[0] != 0, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(id_ptr != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(id_ptr[0] != 0, ECS_INVALID_PARAMETER, NULL);
 
     ecs_id_t id = id_ptr[0];
     ecs_edge_t *edge = ensure_edge(&node->node.remove, id);
@@ -856,6 +856,8 @@ ecs_table_t* flecs_table_traverse_remove(
     populate_diff(node, edge, NULL, id_ptr, diff);
 
     return next;
+error:
+    return NULL;
 }
 
 ecs_table_t* flecs_table_traverse_add(
@@ -869,8 +871,8 @@ ecs_table_t* flecs_table_traverse_add(
     node = node ? node : &world->store.root;
 
     /* Adding 0 to an entity is not valid */
-    ecs_assert(id_ptr != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(id_ptr[0] != 0, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(id_ptr != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(id_ptr[0] != 0, ECS_INVALID_PARAMETER, NULL);
 
     ecs_id_t id = id_ptr[0];
     ecs_edge_t *edge = ensure_edge(&node->node.add, id);
@@ -885,6 +887,8 @@ ecs_table_t* flecs_table_traverse_add(
     populate_diff(node, edge, id_ptr, NULL, diff);
 
     return next;
+error:
+    return NULL;
 }
 
 static

--- a/src/trigger.c
+++ b/src/trigger.c
@@ -180,7 +180,7 @@ ecs_map_t* get_triggers_for_event(
 
     /* Get triggers for event */
     ecs_observable_t *observable = ecs_get_observable(object);
-    ecs_assert(observable != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(observable != NULL, ECS_INVALID_PARAMETER, NULL);
 
     ecs_sparse_t *triggers = observable->triggers;
     ecs_assert(triggers != NULL, ECS_INTERNAL_ERROR, NULL);
@@ -192,6 +192,7 @@ ecs_map_t* get_triggers_for_event(
         return evt->triggers;
     }
 
+error:
     return NULL;
 }
 
@@ -522,9 +523,9 @@ ecs_entity_t ecs_trigger_init(
     const ecs_trigger_desc_t *desc)
 {
     ecs_poly_assert(world, ecs_world_t);
-    ecs_assert(!world->is_readonly, ECS_INVALID_OPERATION, NULL);
-    ecs_assert(desc != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(!world->is_fini, ECS_INVALID_OPERATION, NULL);
+    ecs_check(!world->is_readonly, ECS_INVALID_OPERATION, NULL);
+    ecs_check(desc != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(!world->is_fini, ECS_INVALID_OPERATION, NULL);
 
     char *name = NULL;
     const char *expr = desc->expr;
@@ -541,10 +542,10 @@ ecs_entity_t ecs_trigger_init(
     bool added = false;
     EcsTrigger *comp = ecs_get_mut(world, entity, EcsTrigger, &added);
     if (added) {
-        ecs_assert(desc->callback != NULL, ECS_INVALID_PARAMETER, NULL);
+        ecs_check(desc->callback != NULL, ECS_INVALID_PARAMETER, NULL);
         
         /* Something went wrong with the construction of the entity */
-        ecs_assert(entity != 0, ECS_INVALID_PARAMETER, NULL);
+        ecs_check(entity != 0, ECS_INVALID_PARAMETER, NULL);
         name = ecs_get_fullpath(world, entity);
 
         ecs_term_t term;
@@ -578,7 +579,7 @@ ecs_entity_t ecs_trigger_init(
         }
 
         /* Currently triggers are not supported for specific entities */
-        ecs_assert(term.subj.entity == EcsThis, ECS_UNSUPPORTED, NULL);
+        ecs_check(term.subj.entity == EcsThis, ECS_UNSUPPORTED, NULL);
 
         ecs_trigger_t *trigger = flecs_sparse_add(world->triggers, ecs_trigger_t);
         trigger->id = flecs_sparse_last_id(world->triggers);
@@ -600,7 +601,7 @@ ecs_entity_t ecs_trigger_init(
         comp->trigger = trigger;
 
         /* Trigger must have at least one event */
-        ecs_assert(trigger->event_count != 0, ECS_INVALID_PARAMETER, NULL);
+        ecs_check(trigger->event_count != 0, ECS_INVALID_PARAMETER, NULL);
 
         register_trigger(world, observable, trigger);
 
@@ -665,9 +666,7 @@ void* ecs_get_trigger_binding_ctx(
 void flecs_trigger_fini(
     ecs_world_t *world,
     ecs_trigger_t *trigger)
-{
-    ecs_assert(trigger != NULL, ECS_INVALID_PARAMETER, NULL);
-    
+{    
     unregister_trigger(trigger->observable, trigger);
     ecs_term_fini(&trigger->term);
 

--- a/test/api/project.json
+++ b/test/api/project.json
@@ -536,7 +536,7 @@
                 "get_parent",
                 "get_parent_from_nested",
                 "get_parent_from_nested_2",
-                "get_parent_from_root",
+                "get_object_from_0",
                 "tree_iter_empty",
                 "tree_iter_1_table",
                 "tree_iter_2_tables",

--- a/test/api/src/Error.c
+++ b/test/api/src/Error.c
@@ -30,8 +30,8 @@ void Error_override_abort() {
      * because abort always exits before it gets there. */
 
     /* hack, because the setup already set the OS API */
-    ((ecs_os_api_t*)&ecs_os_api)->abort_ = my_abort;
-    _ecs_abort(ECS_INTERNAL_ERROR, __FILE__, __LINE__, NULL);
+    ecs_os_api.abort_ = my_abort;
+    ecs_os_abort();
     test_assert(my_abort_called == true);
 }
 

--- a/test/api/src/Get_component.c
+++ b/test/api/src/Get_component.c
@@ -10,7 +10,7 @@ void Get_component_get_empty() {
     ecs_entity_t e = ecs_new(world, 0);
     test_assert(e != 0);
 
-    test_assert(ecs_vector_get(ecs_get_type(world, e), ecs_entity_t, 0) == 0);
+    test_assert(ecs_get_type(world, e) == NULL);
     
     ecs_fini(world);
 }
@@ -190,7 +190,7 @@ void Get_component_get_both_from_2_add_remove_in_progress() {
     test_assert( ecs_has(world, e, Velocity));
 
     test_assert(*ecs_vector_get(ecs_get_type(world, e), ecs_entity_t, 0) == ecs_id(Velocity));
-    test_assert(ecs_vector_get(ecs_get_type(world, e), ecs_entity_t, 1) == 0);
+    test_assert(ecs_vector_count(ecs_get_type(world, e)) == 1);
 
     ecs_fini(world);
 }

--- a/test/api/src/Hierarchies.c
+++ b/test/api/src/Hierarchies.c
@@ -48,16 +48,12 @@ void Hierarchies_get_parent_from_nested_2() {
     ecs_fini(world);
 }
 
-void Hierarchies_get_parent_from_root() {
+void Hierarchies_get_object_from_0() {
+    install_test_abort();
     ecs_world_t *world = ecs_init();
 
-    ECS_ENTITY(world, Scope, 0);
-    ECS_ENTITY(world, Child, (ChildOf, Scope));
-
-    ecs_entity_t e = ecs_get_object(world, 0, EcsChildOf, 0);
-    test_assert(e == 0);
-
-    ecs_fini(world);
+    test_expect_abort();
+    ecs_get_object(world, 0, EcsChildOf, 0);
 }
 
 void Hierarchies_delete_children() {

--- a/test/api/src/main.c
+++ b/test/api/src/main.c
@@ -506,7 +506,7 @@ void Hierarchies_empty_scope(void);
 void Hierarchies_get_parent(void);
 void Hierarchies_get_parent_from_nested(void);
 void Hierarchies_get_parent_from_nested_2(void);
-void Hierarchies_get_parent_from_root(void);
+void Hierarchies_get_object_from_0(void);
 void Hierarchies_tree_iter_empty(void);
 void Hierarchies_tree_iter_1_table(void);
 void Hierarchies_tree_iter_2_tables(void);
@@ -4139,8 +4139,8 @@ bake_test_case Hierarchies_testcases[] = {
         Hierarchies_get_parent_from_nested_2
     },
     {
-        "get_parent_from_root",
-        Hierarchies_get_parent_from_root
+        "get_object_from_0",
+        Hierarchies_get_object_from_0
     },
     {
         "tree_iter_empty",

--- a/test/collections/src/Vector.c
+++ b/test/collections/src/Vector.c
@@ -96,18 +96,18 @@ void Vector_get_last_from_null() {
 }
 
 void Vector_get_empty() {
+    install_test_abort();
     ecs_vector_t *array = ecs_vector_new(int, 4);
-    int *elem = ecs_vector_get(array, int, 1);
-    test_assert(elem == NULL);
-    ecs_vector_free(array);
+    test_expect_abort();
+    ecs_vector_get(array, int, 1);
 }
 
 void Vector_get_out_of_bound() {
+    install_test_abort();
     ecs_vector_t *array = ecs_vector_new(int, 4);
     array = fill_array(array);
-    int *elem = ecs_vector_get(array, int, 4);
-    test_assert(elem == NULL);
-    ecs_vector_free(array);
+    test_expect_abort();
+    ecs_vector_get(array, int, 4);
 }
 
 void Vector_add_empty() {
@@ -133,7 +133,7 @@ void Vector_add_resize() {
     test_int(*(int*)ecs_vector_get(array, int, 2), 2);
     test_int(*(int*)ecs_vector_get(array, int, 3), 3);
     test_int(*(int*)ecs_vector_get(array, int, 4), 4);
-    test_assert(ecs_vector_get(array, int, 5) == NULL);
+    test_assert(ecs_vector_count(array) == 5);
     ecs_vector_free(array);
 }
 


### PR DESCRIPTION
This PR adds a new macro `FLECS_SOFT_ASSERT`, which turns recoverable asserts into non-aborting errors.

Closes #476 