### PR TITLE
Pipeline improvements

### DIFF
--- a/flecs.h
+++ b/flecs.h
@@ -18348,6 +18348,24 @@ public:
         return *this;
     }
 
+    /** Specify whether system can run on multiple threads.
+     *
+     * @param value If false system will always run on a single thread.
+     */
+    Base& multi_threaded(bool value = true) {
+        m_desc->multi_threaded = value;
+        return *this;
+    }
+
+    /** Specify whether system should be ran in staged context.
+     *
+     * @param value If false system will always run staged.
+     */
+    Base& no_staging(bool value = true) {
+        m_desc->no_staging = value;
+        return *this;
+    }
+
     /** Set system interval.
      * This operation will cause the system to be ran at the specified interval.
      *

--- a/include/flecs/addons/app.h
+++ b/include/flecs/addons/app.h
@@ -21,17 +21,40 @@
 extern "C" {
 #endif
 
+/** Callback type for init action. */
+typedef int(*ecs_app_init_action_t)(
+    ecs_world_t *world);
+
 /** Used with ecs_app_run. */
 typedef struct ecs_app_desc_t {
     FLECS_FLOAT target_fps;   /* Target FPS. */
     FLECS_FLOAT delta_time;   /* Frame time increment (0 for measured values) */
     int32_t threads;          /* Number of threads. */
     bool enable_rest;         /* Allows HTTP clients to access ECS data */
+
+    ecs_app_init_action_t init; /* If set, function is ran before starting the
+                                 * main loop. */
+
+    void *ctx;                /* Reserved for custom run/frame actions */
 } ecs_app_desc_t;
+
+/** Callback type for run action. */
+typedef int(*ecs_app_run_action_t)(
+    ecs_world_t *world, 
+    ecs_app_desc_t *desc);
+
+/** Callback type for frame action. */
+typedef int(*ecs_app_frame_action_t)(
+    ecs_world_t *world, 
+    const ecs_app_desc_t *desc);
 
 /** Run application.
  * This will run the application with the parameters specified in desc. After
  * the application quits (ecs_quit is called) the world will be cleaned up.
+ * 
+ * If a custom run action is set, it will be invoked by this operation. The
+ * default run action calls the frame action in a loop until it returns a
+ * non-zero value.
  * 
  * @param world The world.
  * @param desc Application parameters.
@@ -39,29 +62,11 @@ typedef struct ecs_app_desc_t {
 FLECS_API
 int ecs_app_run(
     ecs_world_t *world,
-    const ecs_app_desc_t *desc);
-
-/** Callback type for frame action. */
-typedef int(*ecs_frame_action_t)(
-    ecs_world_t *world, 
-    const ecs_app_desc_t *desc);
+    ecs_app_desc_t *desc);
 
 /** Default frame callback.
- * This function will call ecs_progress until it returns a non-zero value (the
- * application called ecs_quit). It is the default frame callback that will be
- * used by ecs_app_run, unless it is overridden.
- * 
- * Applications, though typically modules, can override the frame callback by
- * using the ecs_app_set_frame_action function. This enables a module to take
- * control of the main loop when necessary.
- * 
- * All worlds share the same frame accallbacktion. When a module attempts to 
- * overwrite a frame callback (except the default one), an error will be thrown. 
- * This prevents applications from importing modules with conflicting 
- * requirements (e.g. two modules that * both need control over the main loop).
- * 
- * A custom frame callback may call this function once after or before it has 
- * ran its own logic.
+ * This operation will run a single frame. By default this operation will invoke
+ * ecs_progress directly, unless a custom frame action is set.
  * 
  * @param world The world.
  * @param desc The desc struct passed to ecs_app_run.
@@ -72,6 +77,15 @@ int ecs_app_run_frame(
     ecs_world_t *world,
     const ecs_app_desc_t *desc);
 
+/** Set custom run action.
+ * See ecs_app_run.
+ * 
+ * @param callback The run action.
+ */
+FLECS_API
+int ecs_app_set_run_action(
+    ecs_app_run_action_t callback);
+
 /** Set custom frame action.
  * See ecs_app_run_frame.
  * 
@@ -79,7 +93,7 @@ int ecs_app_run_frame(
  */
 FLECS_API
 int ecs_app_set_frame_action(
-    ecs_frame_action_t callback);
+    ecs_app_frame_action_t callback);
 
 #ifdef __cplusplus
 }

--- a/include/flecs/addons/cpp/mixins/system/builder_i.hpp
+++ b/include/flecs/addons/cpp/mixins/system/builder_i.hpp
@@ -37,6 +37,24 @@ public:
         return *this;
     }
 
+    /** Specify whether system can run on multiple threads.
+     *
+     * @param value If false system will always run on a single thread.
+     */
+    Base& multi_threaded(bool value = true) {
+        m_desc->multi_threaded = value;
+        return *this;
+    }
+
+    /** Specify whether system should be ran in staged context.
+     *
+     * @param value If false system will always run staged.
+     */
+    Base& no_staging(bool value = true) {
+        m_desc->no_staging = value;
+        return *this;
+    }
+
     /** Set system interval.
      * This operation will cause the system to be ran at the specified interval.
      *

--- a/include/flecs/addons/system.h
+++ b/include/flecs/addons/system.h
@@ -109,7 +109,14 @@ typedef struct ecs_system_desc_t {
     int32_t rate;
 
     /* External tick soutce that determines when system ticks */
-    ecs_entity_t tick_source;     
+    ecs_entity_t tick_source;
+
+    /* If true, system will be ran on multiple threads */
+    bool multi_threaded;
+
+    /* If true, system will have access to actuall world. Cannot be true at the
+     * same time as multi_threaded. */
+    bool no_staging;
 } ecs_system_desc_t;
 
 /* Create a system */

--- a/src/addons/app.c
+++ b/src/addons/app.c
@@ -2,20 +2,43 @@
 
 #ifdef FLECS_APP
 
-static ecs_frame_action_t frame_action;
+static
+int default_run_action(
+    ecs_world_t *world,
+    ecs_app_desc_t *desc)
+{
+    if (desc->init) {
+        desc->init(world);
+    }
 
-int ecs_app_run(
+    int result;
+    while ((result = ecs_app_run_frame(world, desc)) == 0) { }
+    return result;
+}
+
+static
+int default_frame_action(
     ecs_world_t *world,
     const ecs_app_desc_t *desc)
 {
-    ecs_set_target_fps(world, desc->target_fps);
-    ecs_set_threads(world, desc->threads);
+    return !ecs_progress(world, desc->delta_time);
+}
 
-    ecs_frame_action_t callback = frame_action;
-    if (!callback) {
-        callback = ecs_app_run_frame;
+static ecs_app_run_action_t run_action = default_run_action;
+static ecs_app_frame_action_t frame_action = default_frame_action;
+
+int ecs_app_run(
+    ecs_world_t *world,
+    ecs_app_desc_t *desc)
+{
+    /* Don't set FPS & threads if custom run action is set, as the platform on
+     * which the app is running may not support it. */
+    if (!run_action) {
+        ecs_set_target_fps(world, desc->target_fps);
+        ecs_set_threads(world, desc->threads);
     }
 
+    /* REST server enables connecting to app with explorer */
     if (desc->enable_rest) {
 #ifdef FLECS_REST
         ecs_set(world, EcsWorld, EcsRest, {.port = 0});
@@ -24,23 +47,33 @@ int ecs_app_run(
 #endif
     }
 
-    int result;
-    while ((result = callback(world, desc)) == 0) { }
-
-    return result;
+    return run_action(world, desc);
 }
 
 int ecs_app_run_frame(
     ecs_world_t *world,
     const ecs_app_desc_t *desc)
 {
-    return !ecs_progress(world, desc->delta_time);
+    return frame_action(world, desc);
+}
+
+int ecs_app_set_run_action(
+    ecs_app_run_action_t callback)
+{
+    if (run_action != default_run_action) {
+        ecs_err("run action already set");
+        return -1;
+    }
+
+    run_action = callback;
+
+    return 0;
 }
 
 int ecs_app_set_frame_action(
-    ecs_frame_action_t callback)
+    ecs_app_frame_action_t callback)
 {
-    if (frame_action) {
+    if (frame_action != default_frame_action) {
         ecs_err("frame action already set");
         return -1;
     }

--- a/src/addons/http.c
+++ b/src/addons/http.c
@@ -157,13 +157,6 @@ ecs_size_t http_send(
 #endif
 }
 
-uint64_t _flecs_ito(
-    size_t dst_size,
-    bool dst_signed,
-    bool lt_zero,
-    uint64_t value,
-    const char *err);
-
 static
 ecs_size_t http_recv(
     ecs_http_socket_t sock,

--- a/src/addons/pipeline/pipeline.h
+++ b/src/addons/pipeline/pipeline.h
@@ -8,6 +8,7 @@
  * information about the set of systems that need to be ran before a merge. */
 typedef struct ecs_pipeline_op_t {
     int32_t count;              /* Number of systems to run before merge */
+    bool multi_threaded;        /* Whether systems can be ran multi threaded */
 } ecs_pipeline_op_t;
 
 typedef struct EcsPipelineQuery {

--- a/src/addons/pipeline/pipeline.h
+++ b/src/addons/pipeline/pipeline.h
@@ -19,6 +19,7 @@ typedef struct EcsPipelineQuery {
     int32_t match_count;
     int32_t rebuild_count;
     ecs_entity_t last_system;
+    bool no_staging;
 } EcsPipelineQuery;
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/addons/pipeline/pipeline.h
+++ b/src/addons/pipeline/pipeline.h
@@ -9,6 +9,7 @@
 typedef struct ecs_pipeline_op_t {
     int32_t count;              /* Number of systems to run before merge */
     bool multi_threaded;        /* Whether systems can be ran multi threaded */
+    bool no_staging;            /* Whether systems are staged or not */
 } ecs_pipeline_op_t;
 
 typedef struct EcsPipelineQuery {
@@ -17,6 +18,7 @@ typedef struct EcsPipelineQuery {
     ecs_vector_t *ops;
     int32_t match_count;
     int32_t rebuild_count;
+    ecs_entity_t last_system;
 } EcsPipelineQuery;
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -45,6 +47,13 @@ int32_t ecs_pipeline_update(
     ecs_world_t *world,
     ecs_entity_t pipeline,
     bool start_of_frame); 
+
+int32_t ecs_pipeline_reset_iter(
+    ecs_world_t *world,
+    const EcsPipelineQuery *pq,
+    ecs_iter_t *iter_out,
+    ecs_pipeline_op_t **op_out,
+    ecs_pipeline_op_t **last_op_out);
 
 ////////////////////////////////////////////////////////////////////////////////
 //// Worker API

--- a/src/addons/rest.c
+++ b/src/addons/rest.c
@@ -190,7 +190,7 @@ void on_set_rest(
 }
 
 static
-void dequeue_rest(ecs_iter_t *it) {
+void DequeueRest(ecs_iter_t *it) {
     EcsRest *rest = ecs_term(it, EcsRest, 1);
 
     if (it->delta_system_time > (FLECS_FLOAT)1.0) {
@@ -225,7 +225,7 @@ void FlecsRestImport(
         .on_set = on_set_rest
     });
 
-    ECS_SYSTEM(world, dequeue_rest, EcsPostFrame, EcsRest);
+    ECS_SYSTEM(world, DequeueRest, EcsPostFrame, EcsRest);
 }
 
 #endif

--- a/src/addons/system/system.c
+++ b/src/addons/system/system.c
@@ -141,11 +141,16 @@ ecs_entity_t ecs_run_intern(
         ecs_os_get_time(&time_start);
     }
 
-    ecs_defer_begin(stage->thread_ctx);
+    ecs_world_t *thread_ctx = world;
+    if (stage) {
+        thread_ctx = stage->thread_ctx;
+    }
+
+    ecs_defer_begin(thread_ctx);
 
     /* Prepare the query iterator */
     ecs_iter_t it = ecs_query_iter_page(
-        stage->thread_ctx, system_data->query, offset, limit);
+        thread_ctx, system_data->query, offset, limit);
 
     it.system = system;
     it.self = system_data->self;
@@ -169,13 +174,13 @@ ecs_entity_t ecs_run_intern(
         }
     }
 
-    ecs_defer_end(stage->thread_ctx);
-
     if (measure_time) {
         system_data->time_spent += (FLECS_FLOAT)ecs_time_measure(&time_start);
     }
 
     system_data->invoke_count ++;
+
+    ecs_defer_end(thread_ctx);
 
     return it.interrupted_by;
 }

--- a/src/addons/system/system.h
+++ b/src/addons/system/system.h
@@ -13,6 +13,10 @@ typedef struct EcsSystem {
     ecs_system_status_action_t status_action; /* Status action */   
     ecs_entity_t tick_source;       /* Tick source associated with system */
     
+    /* Schedule parameters */
+    bool multi_threaded;
+    bool no_staging;
+
     int32_t invoke_count;           /* Number of times system is invoked */
     FLECS_FLOAT time_spent;         /* Time spent on running system */
     FLECS_FLOAT time_passed;        /* Time passed since last invocation */

--- a/src/addons/system/system.h
+++ b/src/addons/system/system.h
@@ -20,6 +20,7 @@ typedef struct EcsSystem {
     int32_t invoke_count;           /* Number of times system is invoked */
     FLECS_FLOAT time_spent;         /* Time spent on running system */
     FLECS_FLOAT time_passed;        /* Time passed since last invocation */
+    int32_t last_frame;             /* Last frame for which the system was considered */
 
     ecs_entity_t self;              /* Entity associated with system */
 

--- a/src/entity.c
+++ b/src/entity.c
@@ -3507,6 +3507,26 @@ error:
     return 0;
 }
 
+void ecs_enable(
+    ecs_world_t *world,
+    ecs_entity_t entity,
+    bool enabled)
+{
+    const EcsType *type_ptr = ecs_get(world, entity, EcsType);
+    if (type_ptr) {
+        /* If entity is a type, disable all entities in the type */
+        ecs_vector_each(type_ptr->normalized, ecs_entity_t, e, {
+            ecs_enable(world, *e, enabled);
+        });
+    } else {
+        if (enabled) {
+            ecs_remove_id(world, entity, EcsDisabled);
+        } else {
+            ecs_add_id(world, entity, EcsDisabled);
+        }
+    }
+}
+
 bool ecs_defer_begin(
     ecs_world_t *world)
 {

--- a/test/api/project.json
+++ b/test/api/project.json
@@ -963,7 +963,11 @@
                 "random_read_after_random_write_w_wildcard",
                 "random_in_after_random_inout_after_random_out",
                 "stage_write_before_read",
-                "mixed_multithreaded"
+                "mixed_multithreaded",
+                "mixed_staging",
+                "single_threaded_pipeline_change",
+                "multi_threaded_pipeline_change",
+                "activate_after_add"
             ]
         }, {
             "id": "SystemMisc",

--- a/test/api/project.json
+++ b/test/api/project.json
@@ -965,6 +965,7 @@
                 "stage_write_before_read",
                 "mixed_multithreaded",
                 "mixed_staging",
+                "no_staging_system_create_query",
                 "single_threaded_pipeline_change",
                 "multi_threaded_pipeline_change",
                 "activate_after_add"

--- a/test/api/project.json
+++ b/test/api/project.json
@@ -962,7 +962,8 @@
                 "random_read_after_random_write_w_not_read",
                 "random_read_after_random_write_w_wildcard",
                 "random_in_after_random_inout_after_random_out",
-                "stage_write_before_read"
+                "stage_write_before_read",
+                "mixed_multithreaded"
             ]
         }, {
             "id": "SystemMisc",

--- a/test/api/src/MultiThread.c
+++ b/test/api/src/MultiThread.c
@@ -1,5 +1,7 @@
 #include <api.h>
 
+ECS_COMPONENT_DECLARE(Position);
+
 void MultiThread_setup() {
     ecs_log_set_level(-3);
 }
@@ -13,10 +15,23 @@ void Progress(ecs_iter_t *it) {
     }
 }
 
-void MultiThread_2_thread_10_entity() {
+static
+ecs_world_t* init_world(void) {
     ecs_world_t *world = ecs_init();
-    ECS_COMPONENT(world, Position);
+    ECS_COMPONENT_DEFINE(world, Position);
+
     ECS_SYSTEM(world, Progress, EcsOnUpdate, Position);
+
+    ecs_system_init(world, &(ecs_system_desc_t) {
+        .entity.entity = Progress,
+        .multi_threaded = true
+    });
+
+    return world;
+}
+
+void MultiThread_2_thread_10_entity() {
+    ecs_world_t *world = init_world();
 
     int i, ENTITIES = 10, THREADS = 2;
     ecs_entity_t *handles = ecs_os_alloca(sizeof(ecs_entity_t) * ENTITIES);
@@ -44,9 +59,7 @@ void MultiThread_2_thread_10_entity() {
 
 
 void MultiThread_2_thread_1_entity() {
-    ecs_world_t *world = ecs_init();
-    ECS_COMPONENT(world, Position);
-    ECS_SYSTEM(world, Progress, EcsOnUpdate, Position);
+    ecs_world_t *world = init_world();
 
     int i, ENTITIES = 1, THREADS = 2;
     ecs_entity_t *handles = ecs_os_alloca(sizeof(ecs_entity_t) * ENTITIES);
@@ -73,9 +86,7 @@ void MultiThread_2_thread_1_entity() {
 }
 
 void MultiThread_2_thread_2_entity() {
-    ecs_world_t *world = ecs_init();
-    ECS_COMPONENT(world, Position);
-    ECS_SYSTEM(world, Progress, EcsOnUpdate, Position);
+    ecs_world_t *world = init_world();
 
     int i, ENTITIES = 2, THREADS = 2;
     ecs_entity_t *handles = ecs_os_alloca(sizeof(ecs_entity_t) * ENTITIES);
@@ -102,9 +113,7 @@ void MultiThread_2_thread_2_entity() {
 }
 
 void MultiThread_2_thread_5_entity() {
-    ecs_world_t *world = ecs_init();
-    ECS_COMPONENT(world, Position);
-    ECS_SYSTEM(world, Progress, EcsOnUpdate, Position);
+    ecs_world_t *world = init_world();
 
     int i, ENTITIES = 5, THREADS = 2;
     ecs_entity_t *handles = ecs_os_alloca(sizeof(ecs_entity_t) * ENTITIES);
@@ -132,9 +141,7 @@ void MultiThread_2_thread_5_entity() {
 
 
 void MultiThread_3_thread_10_entity() {
-    ecs_world_t *world = ecs_init();
-    ECS_COMPONENT(world, Position);
-    ECS_SYSTEM(world, Progress, EcsOnUpdate, Position);
+    ecs_world_t *world = init_world();
 
     int i, ENTITIES = 10, THREADS = 3;
     ecs_entity_t *handles = ecs_os_alloca(sizeof(ecs_entity_t) * ENTITIES);
@@ -162,9 +169,7 @@ void MultiThread_3_thread_10_entity() {
 
 
 void MultiThread_3_thread_1_entity() {
-    ecs_world_t *world = ecs_init();
-    ECS_COMPONENT(world, Position);
-    ECS_SYSTEM(world, Progress, EcsOnUpdate, Position);
+    ecs_world_t *world = init_world();
 
     int i, ENTITIES = 1, THREADS = 3;
     ecs_entity_t *handles = ecs_os_alloca(sizeof(ecs_entity_t) * ENTITIES);
@@ -192,9 +197,7 @@ void MultiThread_3_thread_1_entity() {
 
 
 void MultiThread_3_thread_2_entity() {
-    ecs_world_t *world = ecs_init();
-    ECS_COMPONENT(world, Position);
-    ECS_SYSTEM(world, Progress, EcsOnUpdate, Position);
+    ecs_world_t *world = init_world();
 
     int i, ENTITIES = 2, THREADS = 3;
     ecs_entity_t *handles = ecs_os_alloca(sizeof(ecs_entity_t) * ENTITIES);
@@ -222,9 +225,7 @@ void MultiThread_3_thread_2_entity() {
 
 
 void MultiThread_3_thread_5_entity() {
-    ecs_world_t *world = ecs_init();
-    ECS_COMPONENT(world, Position);
-    ECS_SYSTEM(world, Progress, EcsOnUpdate, Position);
+    ecs_world_t *world = init_world();
 
     int i, ENTITIES = 5, THREADS = 3;
     ecs_entity_t *handles = ecs_os_alloca(sizeof(ecs_entity_t) * ENTITIES);
@@ -252,9 +253,7 @@ void MultiThread_3_thread_5_entity() {
 
 
 void MultiThread_4_thread_10_entity() {
-    ecs_world_t *world = ecs_init();
-    ECS_COMPONENT(world, Position);
-    ECS_SYSTEM(world, Progress, EcsOnUpdate, Position);
+    ecs_world_t *world = init_world();
 
     int i, ENTITIES = 10, THREADS = 4;
     ecs_entity_t *handles = ecs_os_alloca(sizeof(ecs_entity_t) * ENTITIES);
@@ -282,9 +281,7 @@ void MultiThread_4_thread_10_entity() {
 
 
 void MultiThread_4_thread_1_entity() {
-    ecs_world_t *world = ecs_init();
-    ECS_COMPONENT(world, Position);
-    ECS_SYSTEM(world, Progress, EcsOnUpdate, Position);
+    ecs_world_t *world = init_world();
 
     int i, ENTITIES = 1, THREADS = 4;
     ecs_entity_t *handles = ecs_os_alloca(sizeof(ecs_entity_t) * ENTITIES);
@@ -312,9 +309,7 @@ void MultiThread_4_thread_1_entity() {
 
 
 void MultiThread_4_thread_2_entity() {
-    ecs_world_t *world = ecs_init();
-    ECS_COMPONENT(world, Position);
-    ECS_SYSTEM(world, Progress, EcsOnUpdate, Position);
+    ecs_world_t *world = init_world();
 
     int i, ENTITIES = 2, THREADS = 4;
     ecs_entity_t *handles = ecs_os_alloca(sizeof(ecs_entity_t) * ENTITIES);
@@ -342,9 +337,7 @@ void MultiThread_4_thread_2_entity() {
 
 
 void MultiThread_4_thread_5_entity() {
-    ecs_world_t *world = ecs_init();
-    ECS_COMPONENT(world, Position);
-    ECS_SYSTEM(world, Progress, EcsOnUpdate, Position);
+    ecs_world_t *world = init_world();
 
     int i, ENTITIES = 5, THREADS = 4;
     ecs_entity_t *handles = ecs_os_alloca(sizeof(ecs_entity_t) * ENTITIES);
@@ -372,9 +365,7 @@ void MultiThread_4_thread_5_entity() {
 
 
 void MultiThread_5_thread_10_entity() {
-    ecs_world_t *world = ecs_init();
-    ECS_COMPONENT(world, Position);
-    ECS_SYSTEM(world, Progress, EcsOnUpdate, Position);
+    ecs_world_t *world = init_world();
 
     int i, ENTITIES = 10, THREADS = 5;
     ecs_entity_t *handles = ecs_os_alloca(sizeof(ecs_entity_t) * ENTITIES);
@@ -402,9 +393,7 @@ void MultiThread_5_thread_10_entity() {
 
 
 void MultiThread_5_thread_1_entity() {
-    ecs_world_t *world = ecs_init();
-    ECS_COMPONENT(world, Position);
-    ECS_SYSTEM(world, Progress, EcsOnUpdate, Position);
+    ecs_world_t *world = init_world();
 
     int i, ENTITIES = 1, THREADS = 5;
     ecs_entity_t *handles = ecs_os_alloca(sizeof(ecs_entity_t) * ENTITIES);
@@ -432,9 +421,7 @@ void MultiThread_5_thread_1_entity() {
 
 
 void MultiThread_5_thread_2_entity() {
-    ecs_world_t *world = ecs_init();
-    ECS_COMPONENT(world, Position);
-    ECS_SYSTEM(world, Progress, EcsOnUpdate, Position);
+    ecs_world_t *world = init_world();
 
     int i, ENTITIES = 2, THREADS = 5;
     ecs_entity_t *handles = ecs_os_alloca(sizeof(ecs_entity_t) * ENTITIES);
@@ -462,9 +449,7 @@ void MultiThread_5_thread_2_entity() {
 
 
 void MultiThread_5_thread_5_entity() {
-    ecs_world_t *world = ecs_init();
-    ECS_COMPONENT(world, Position);
-    ECS_SYSTEM(world, Progress, EcsOnUpdate, Position);
+    ecs_world_t *world = init_world();
 
     int i, ENTITIES = 5, THREADS = 5;
     ecs_entity_t *handles = ecs_os_alloca(sizeof(ecs_entity_t) * ENTITIES);
@@ -492,9 +477,7 @@ void MultiThread_5_thread_5_entity() {
 
 
 void MultiThread_6_thread_10_entity() {
-    ecs_world_t *world = ecs_init();
-    ECS_COMPONENT(world, Position);
-    ECS_SYSTEM(world, Progress, EcsOnUpdate, Position);
+    ecs_world_t *world = init_world();
 
     int i, ENTITIES = 10, THREADS = 6;
     ecs_entity_t *handles = ecs_os_alloca(sizeof(ecs_entity_t) * ENTITIES);
@@ -522,9 +505,7 @@ void MultiThread_6_thread_10_entity() {
 
 
 void MultiThread_6_thread_1_entity() {
-    ecs_world_t *world = ecs_init();
-    ECS_COMPONENT(world, Position);
-    ECS_SYSTEM(world, Progress, EcsOnUpdate, Position);
+    ecs_world_t *world = init_world();
 
     int i, ENTITIES = 1, THREADS = 6;
     ecs_entity_t *handles = ecs_os_alloca(sizeof(ecs_entity_t) * ENTITIES);
@@ -552,9 +533,7 @@ void MultiThread_6_thread_1_entity() {
 
 
 void MultiThread_6_thread_2_entity() {
-    ecs_world_t *world = ecs_init();
-    ECS_COMPONENT(world, Position);
-    ECS_SYSTEM(world, Progress, EcsOnUpdate, Position);
+    ecs_world_t *world = init_world();
 
     int i, ENTITIES = 2, THREADS = 6;
     ecs_entity_t *handles = ecs_os_alloca(sizeof(ecs_entity_t) * ENTITIES);
@@ -581,9 +560,7 @@ void MultiThread_6_thread_2_entity() {
 }
 
 void MultiThread_6_thread_5_entity() {
-    ecs_world_t *world = ecs_init();
-    ECS_COMPONENT(world, Position);
-    ECS_SYSTEM(world, Progress, EcsOnUpdate, Position);
+    ecs_world_t *world = init_world();
 
     int i, ENTITIES = 5, THREADS = 6;
     ecs_entity_t *handles = ecs_os_alloca(sizeof(ecs_entity_t) * ENTITIES);
@@ -611,7 +588,7 @@ void MultiThread_6_thread_5_entity() {
 
 void MultiThread_2_thread_1_entity_instanced() {
     ecs_world_t *world = ecs_init();
-    ECS_COMPONENT(world, Position);
+    ECS_COMPONENT_DEFINE(world, Position);
 
     ecs_entity_t s = ecs_system_init(world, &(ecs_system_desc_t) {
         .entity.add = {EcsOnUpdate},
@@ -619,7 +596,8 @@ void MultiThread_2_thread_1_entity_instanced() {
         .query.filter = {
             .expr = "Position",
             .instanced = true
-        }
+        },
+        .multi_threaded = true
     });
     test_assert(s != 0);
 
@@ -649,7 +627,7 @@ void MultiThread_2_thread_1_entity_instanced() {
 
 void MultiThread_2_thread_5_entity_instanced() {
     ecs_world_t *world = ecs_init();
-    ECS_COMPONENT(world, Position);
+    ECS_COMPONENT_DEFINE(world, Position);
 
     ecs_entity_t s = ecs_system_init(world, &(ecs_system_desc_t) {
         .entity.add = {EcsOnUpdate},
@@ -657,7 +635,8 @@ void MultiThread_2_thread_5_entity_instanced() {
         .query.filter = {
             .expr = "Position",
             .instanced = true
-        }
+        },
+        .multi_threaded = true
     });
     test_assert(s != 0);
 
@@ -687,7 +666,7 @@ void MultiThread_2_thread_5_entity_instanced() {
 
 void MultiThread_2_thread_10_entity_instanced() {
     ecs_world_t *world = ecs_init();
-    ECS_COMPONENT(world, Position);
+    ECS_COMPONENT_DEFINE(world, Position);
 
     ecs_entity_t s = ecs_system_init(world, &(ecs_system_desc_t) {
         .entity.add = {EcsOnUpdate},
@@ -695,7 +674,8 @@ void MultiThread_2_thread_10_entity_instanced() {
         .query.filter = {
             .expr = "Position",
             .instanced = true
-        }
+        },
+        .multi_threaded = true
     });
     test_assert(s != 0);
 
@@ -753,14 +733,20 @@ void TestAll(ecs_iter_t *it) {
     }
 }
 
+
 static
 void test_combs_100_entity(int THREADS) {
     ecs_world_t *world = ecs_init();
 
-    ECS_COMPONENT(world, Position);
+    ECS_COMPONENT_DEFINE(world, Position);
 
     ECS_SYSTEM(world, TestSubset, 0, Position);
     ECS_SYSTEM(world, TestAll, EcsOnUpdate, Position, TestSubset());
+
+    ecs_system_init(world, &(ecs_system_desc_t) {
+        .entity.entity = TestAll,
+        .multi_threaded = true
+    });
 
     int i, ENTITIES = 100;
 
@@ -785,7 +771,7 @@ void test_combs_100_entity(int THREADS) {
 void MultiThread_2_thread_test_combs_100_entity_w_next_worker() {
     ecs_world_t *world = ecs_init();
 
-    ECS_COMPONENT(world, Position);
+    ECS_COMPONENT_DEFINE(world, Position);
 
     ECS_SYSTEM(world, TestSubset, 0, Position);
 
@@ -841,12 +827,17 @@ static
 void test_combs_100_entity_2_types(int THREADS) {
     ecs_world_t *world = ecs_init();
 
-    ECS_COMPONENT(world, Position);
+    ECS_COMPONENT_DEFINE(world, Position);
     ECS_COMPONENT(world, Velocity);
     ECS_TYPE(world, Type, Position, Velocity);
 
     ECS_SYSTEM(world, TestSubset, 0, Position);
     ECS_SYSTEM(world, TestAll, EcsOnUpdate, Position, TestSubset());
+
+    ecs_system_init(world, &(ecs_system_desc_t) {
+        .entity.entity = TestAll,
+        .multi_threaded = true
+    });
 
     int i, ENTITIES = 100;
 
@@ -898,12 +889,17 @@ void MultiThread_6_thread_test_combs_100_entity_2_types() {
 void MultiThread_change_thread_count() {
     ecs_world_t *world = ecs_init();
 
-    ECS_COMPONENT(world, Position);
+    ECS_COMPONENT_DEFINE(world, Position);
     ECS_COMPONENT(world, Velocity);
     ECS_TYPE(world, Type, Position, Velocity);
 
     ECS_SYSTEM(world, TestSubset, 0, Position);
     ECS_SYSTEM(world, TestAll, EcsOnUpdate, Position, TestSubset());
+
+    ecs_system_init(world, &(ecs_system_desc_t) {
+        .entity.entity = TestAll,
+        .multi_threaded = true
+    });
 
     int i, ENTITIES = 100;
 
@@ -954,9 +950,14 @@ void QuitSystem(ecs_iter_t *it) {
 void MultiThread_multithread_quit() {
     ecs_world_t *world = ecs_init();
 
-    ECS_COMPONENT(world, Position);
+    ECS_COMPONENT_DEFINE(world, Position);
 
     ECS_SYSTEM(world, QuitSystem, EcsOnUpdate, Position);
+
+    ecs_system_init(world, &(ecs_system_desc_t) {
+        .entity.entity = QuitSystem,
+        .multi_threaded = true
+    });
 
     ecs_bulk_new(world, Position, 100);
 
@@ -978,6 +979,11 @@ void MultiThread_schedule_w_tasks() {
     ecs_world_t *world = ecs_init();
 
     ECS_SYSTEM(world, MtTask, EcsOnUpdate, 0);
+
+    ecs_system_init(world, &(ecs_system_desc_t) {
+        .entity.entity = MtTask,
+        .multi_threaded = true
+    });
 
     ecs_set_threads(world, 2);
 
@@ -1006,9 +1012,14 @@ void PeriodicDummySystem(ecs_iter_t * it) {
 void MultiThread_reactive_system() {    
     ecs_world_t * world = ecs_init();
 
-    ECS_COMPONENT(world, Position);        
+    ECS_COMPONENT_DEFINE(world, Position);        
     ECS_SYSTEM(world, PeriodicDummySystem, EcsOnUpdate, Position);
     ECS_TRIGGER(world, ReactiveDummySystem, EcsOnSet, Position);
+
+    ecs_system_init(world, &(ecs_system_desc_t) {
+        .entity.entity = PeriodicDummySystem,
+        .multi_threaded = true
+    });
 
     ecs_bulk_new(world, Position, 2);
     ecs_set_threads(world, 2);

--- a/test/api/src/MultiThreadStaging.c
+++ b/test/api/src/MultiThreadStaging.c
@@ -32,6 +32,11 @@ void MultiThreadStaging_2_threads_add_to_current() {
 
     ECS_SYSTEM(world, Add_to_current, EcsOnUpdate, Position);
 
+    ecs_system_init(world, &(ecs_system_desc_t) {
+        .entity.entity = Add_to_current,
+        .multi_threaded = true
+    });
+
     IterData ctx = {.component = ecs_id(Rotation)};
     ecs_set_context(world, &ctx);
 
@@ -70,6 +75,11 @@ void MultiThreadStaging_3_threads_add_to_current() {
     ECS_TYPE(world, Type, Position, Velocity);
 
     ECS_SYSTEM(world, Add_to_current, EcsOnUpdate, Position);
+
+    ecs_system_init(world, &(ecs_system_desc_t) {
+        .entity.entity = Add_to_current,
+        .multi_threaded = true
+    });
 
     IterData ctx = {.component = ecs_id(Rotation)};
     ecs_set_context(world, &ctx);
@@ -110,6 +120,11 @@ void MultiThreadStaging_4_threads_add_to_current() {
 
     ECS_SYSTEM(world, Add_to_current, EcsOnUpdate, Position);
 
+    ecs_system_init(world, &(ecs_system_desc_t) {
+        .entity.entity = Add_to_current,
+        .multi_threaded = true
+    });
+
     IterData ctx = {.component = ecs_id(Rotation)};
     ecs_set_context(world, &ctx);
 
@@ -149,6 +164,11 @@ void MultiThreadStaging_5_threads_add_to_current() {
 
     ECS_SYSTEM(world, Add_to_current, EcsOnUpdate, Position);
 
+    ecs_system_init(world, &(ecs_system_desc_t) {
+        .entity.entity = Add_to_current,
+        .multi_threaded = true
+    });
+
     IterData ctx = {.component = ecs_id(Rotation)};
     ecs_set_context(world, &ctx);
 
@@ -187,6 +207,11 @@ void MultiThreadStaging_6_threads_add_to_current() {
     ECS_TYPE(world, Type, Position, Velocity);
 
     ECS_SYSTEM(world, Add_to_current, EcsOnUpdate, Position);
+
+    ecs_system_init(world, &(ecs_system_desc_t) {
+        .entity.entity = Add_to_current,
+        .multi_threaded = true
+    });
 
     IterData ctx = {.component = ecs_id(Rotation)};
     ecs_set_context(world, &ctx);
@@ -247,6 +272,11 @@ void MultiThreadStaging_2_threads_on_add() {
     ECS_TRIGGER(world, InitVelocity, EcsOnAdd, Velocity);
     ECS_SYSTEM(world, AddVelocity, EcsOnUpdate, Position, Velocity());
 
+    ecs_system_init(world, &(ecs_system_desc_t) {
+        .entity.entity = AddVelocity,
+        .multi_threaded = true
+    });
+
     Probe ctx = {0};
     ecs_set_context(world, &ctx);
 
@@ -283,6 +313,11 @@ void MultiThreadStaging_new_w_count() {
     ECS_COMPONENT(world, Position);
 
     ECS_SYSTEM(world, New_w_count, EcsOnUpdate, Position());
+
+    ecs_system_init(world, &(ecs_system_desc_t) {
+        .entity.entity = New_w_count,
+        .multi_threaded = true
+    });
 
     ecs_set_threads(world, 2);
 

--- a/test/api/src/Stresstests.c
+++ b/test/api/src/Stresstests.c
@@ -101,6 +101,16 @@ void create_delete_entity_random_components_staged(
     ECS_SYSTEM(world, Add_random, EcsOnUpdate, Position);
     ECS_SYSTEM(world, Delete_above_1000, EcsPostUpdate, Position);
 
+    ecs_system_init(world, &(ecs_system_desc_t){
+        .entity.entity = Add_random,
+        .multi_threaded = true
+    });
+
+    ecs_system_init(world, &(ecs_system_desc_t){
+        .entity.entity = Delete_above_1000,
+        .multi_threaded = true
+    });
+
     IterData ctx = {.component = ecs_id(Position), .component_2 = ecs_id(Velocity), .component_3 = ecs_id(Rotation)};
     ecs_set_context(world, &ctx);
 
@@ -135,6 +145,16 @@ void set_entity_random_components(
     ECS_SYSTEM(world, Set_random, EcsOnUpdate, Position);
     ECS_SYSTEM(world, Set_velocity_callback, EcsOnSet, Velocity);
     ECS_SYSTEM(world, Delete_above_1000, EcsPostUpdate, Position);
+
+    ecs_system_init(world, &(ecs_system_desc_t){
+        .entity.entity = Set_random,
+        .multi_threaded = true
+    });
+
+    ecs_system_init(world, &(ecs_system_desc_t){
+        .entity.entity = Delete_above_1000,
+        .multi_threaded = true
+    });
 
     IterData ctx = {.component = ecs_id(Position), .component_2 = ecs_id(Velocity), .component_3 = ecs_id(Rotation)};
     ecs_set_context(world, &ctx);

--- a/test/api/src/main.c
+++ b/test/api/src/main.c
@@ -909,6 +909,7 @@ void Pipeline_random_read_after_random_write_w_not_read(void);
 void Pipeline_random_read_after_random_write_w_wildcard(void);
 void Pipeline_random_in_after_random_inout_after_random_out(void);
 void Pipeline_stage_write_before_read(void);
+void Pipeline_mixed_multithreaded(void);
 
 // Testsuite 'SystemMisc'
 void SystemMisc_setup(void);
@@ -5715,6 +5716,10 @@ bake_test_case Pipeline_testcases[] = {
     {
         "stage_write_before_read",
         Pipeline_stage_write_before_read
+    },
+    {
+        "mixed_multithreaded",
+        Pipeline_mixed_multithreaded
     }
 };
 
@@ -11064,7 +11069,7 @@ static bake_test_suite suites[] = {
         "Pipeline",
         Pipeline_setup,
         NULL,
-        30,
+        31,
         Pipeline_testcases
     },
     {

--- a/test/api/src/main.c
+++ b/test/api/src/main.c
@@ -911,6 +911,7 @@ void Pipeline_random_in_after_random_inout_after_random_out(void);
 void Pipeline_stage_write_before_read(void);
 void Pipeline_mixed_multithreaded(void);
 void Pipeline_mixed_staging(void);
+void Pipeline_no_staging_system_create_query(void);
 void Pipeline_single_threaded_pipeline_change(void);
 void Pipeline_multi_threaded_pipeline_change(void);
 void Pipeline_activate_after_add(void);
@@ -5728,6 +5729,10 @@ bake_test_case Pipeline_testcases[] = {
     {
         "mixed_staging",
         Pipeline_mixed_staging
+    },
+    {
+        "no_staging_system_create_query",
+        Pipeline_no_staging_system_create_query
     },
     {
         "single_threaded_pipeline_change",
@@ -11089,7 +11094,7 @@ static bake_test_suite suites[] = {
         "Pipeline",
         Pipeline_setup,
         NULL,
-        35,
+        36,
         Pipeline_testcases
     },
     {

--- a/test/api/src/main.c
+++ b/test/api/src/main.c
@@ -910,6 +910,10 @@ void Pipeline_random_read_after_random_write_w_wildcard(void);
 void Pipeline_random_in_after_random_inout_after_random_out(void);
 void Pipeline_stage_write_before_read(void);
 void Pipeline_mixed_multithreaded(void);
+void Pipeline_mixed_staging(void);
+void Pipeline_single_threaded_pipeline_change(void);
+void Pipeline_multi_threaded_pipeline_change(void);
+void Pipeline_activate_after_add(void);
 
 // Testsuite 'SystemMisc'
 void SystemMisc_setup(void);
@@ -5720,6 +5724,22 @@ bake_test_case Pipeline_testcases[] = {
     {
         "mixed_multithreaded",
         Pipeline_mixed_multithreaded
+    },
+    {
+        "mixed_staging",
+        Pipeline_mixed_staging
+    },
+    {
+        "single_threaded_pipeline_change",
+        Pipeline_single_threaded_pipeline_change
+    },
+    {
+        "multi_threaded_pipeline_change",
+        Pipeline_multi_threaded_pipeline_change
+    },
+    {
+        "activate_after_add",
+        Pipeline_activate_after_add
     }
 };
 
@@ -11069,7 +11089,7 @@ static bake_test_suite suites[] = {
         "Pipeline",
         Pipeline_setup,
         NULL,
-        31,
+        35,
         Pipeline_testcases
     },
     {


### PR DESCRIPTION
This PR introduces 2 new features:
- Single threaded systems (now the default). Systems can be made multithreaded by explicitly setting the `multi_threaded` parameter to `true`
- Unstaged systems. Systems can be made unstaged by explicitly setting the `no_staging` parameter to `true`.

The PR also fixes an issue where the pipeline schedule would get confused in multithreaded mode when systems would be added/removed while progressing a frame.

Fixes #389 
Fixes #543 