### PR TITLE
Fix typo in "relations" docs

### DIFF
--- a/docs/Relations.md
+++ b/docs/Relations.md
@@ -253,7 +253,7 @@ auto q = world.query_builder()
   .term(Likes, flecs::Wildcard)
   .build();
 
-q.iter([]flecs::iter& it) {
+q.iter([](flecs::iter& it) {
   auto id = it.term_id(1);
 
   for (auto i : it) {


### PR DESCRIPTION
A lambda callback was missing its open parentheses.