### PR TITLE
#124 implement chained page & worker iterators

### DIFF
--- a/flecs.h
+++ b/flecs.h
@@ -2778,16 +2778,18 @@ typedef struct ecs_ids_t {
     int32_t size;           /* The size of the array */
 } ecs_ids_t;
 
-typedef struct ecs_page_cursor_t {
-    int32_t first;
-    int32_t count;
-} ecs_page_cursor_t;
-
+/* Page-iterator specific data */
 typedef struct ecs_page_iter_t {
     int32_t offset;
     int32_t limit;
     int32_t remaining;
 } ecs_page_iter_t;
+
+/* Worker-iterator specific data */
+typedef struct ecs_worker_iter_t {
+    int32_t index;
+    int32_t count;
+} ecs_worker_iter_t;
 
 /** Term-iterator specific data */
 typedef struct ecs_term_iter_t {
@@ -2829,7 +2831,6 @@ typedef struct ecs_filter_iter_t {
 /** Query-iterator specific data */
 typedef struct ecs_query_iter_t {
     ecs_query_t *query;
-    ecs_page_iter_t page_iter;
     ecs_query_table_node_t *node;
     int32_t sparse_smallest;
     int32_t sparse_first;
@@ -2885,103 +2886,51 @@ typedef struct ecs_iter_cache_t {
     bool match_indices_alloc;
 } ecs_iter_cache_t;
 
+/* Private iterator data. Used by iterator implementations to keep track of
+ * progress & to provide builtin storage. */
+typedef struct ecs_iter_private_t {
+    union {
+        ecs_term_iter_t term;
+        ecs_filter_iter_t filter;
+        ecs_query_iter_t query;
+        ecs_rule_iter_t rule;
+        ecs_snapshot_iter_t snapshot;
+        ecs_page_iter_t page;
+        ecs_worker_iter_t worker;
+    } iter;                       /* Iterator specific data */
+
+    ecs_iter_cache_t cache;       /* Inline arrays to reduce allocations */
+} ecs_iter_private_t;
+
 /** Iterator.
- * Contains all data necessary to iterate entities and component data. Iterators
- * can be used without knowledge about the components being iterated. This makes 
- * it possible for code like serializers and language bindings to inspect them.
- *
- * Each iterable object in flecs has an "iter" and a "next" function that are 
- * used to obtain an iterator and iterate through the results. For example:
- *
- *   ecs_query_t *q = ...;
- *  
- *   // Create iterator
- *   ecs_iter_t it = ecs_query_iter(q);
- *  
- *   // Iterate results
- *   while (ecs_query_next(&it)) { }
- *
- * For each time the "next" function returns true, there are "count" entities to
- * iterate, with the entity ids stored in the "entities" array:
- *
- *   while (ecs_query_next(&it)) { 
- *     for (int i = 0; i < it.count; i ++) {
- *       printf("entity matched: %u\n", it.entities[i]);
- *     }
- *   }
- *
- *
- * It is guaranteed that each entity returned by a single "next" call has the
- * same components. The type of the current batch of entities is accessible
- * through the "type" member.
- *
- * Component data is accessible through the "ptrs" member which contains an
- * array where each element stores the component data for a query term. For
- * example, the following expression accesses a component value for the 2nd 
- * term, 10th entity of type "Position": ((Position*)it.ptrs[1])[9];
- *
- * For convenience and safety checking applications should use ecs_term():
- *
- *   Position *p = ecs_term(&it, Position, 2);
- * 
- * Note that terms start counting from 1.
- *
- * This shows a typical example of iterating two components:
- *
- *   while (ecs_query_next(&it)) { 
- *     Position *p = ecs_term(&it, Position, 1);
- *     Velocity *v = ecs_term(&it, Velocity, 2);
- *  
- *     for (int i = 0; i < it.count; i ++) {
- *       p[i].x += v[i].x;
- *       p[i].y += v[i].y;
- *     }
- *   }
- *
- * When an iterator has terms with a subject that is different from the entity
- * being matched, the component data is provided as a pointer (vs. an array). An
- * example of a query with such a term is the following:
- *
- *   Position, Velocity, MaxSpeed(Game)
- * 
- * Here the 3rd term is explicitly matched on the "Game" entity. As a result
- * MaxSpeed will be provided as a pointer to Game's component, as is shown here:
- *
- *   while (ecs_query_next(&it)) { 
- *     Position *p = ecs_term(&it, Position, 1);
- *     Velocity *v = ecs_term(&it, Velocity, 2);
- *     MaxSpeed *s = ecs_term(&it, MaxSpeed, 3);
- *  
- *     for (int i = 0; i < it.count; i ++) {
- *       p[i].x += max(v[i].x, s->value);
- *       p[i].y += max(v[i].y, s->value);
- *     }
- *   }
  */
 struct ecs_iter_t {
+    /* World */
     ecs_world_t *world;           /* The world */
-    ecs_world_t *real_world;      /* Actual world. This differs from world when using threads.  */
-    ecs_entity_t system;          /* The current system (if applicable) */
-    ecs_entity_t event;           /* The event (if applicable) */
-    ecs_id_t event_id;            /* The (component) id for the event */
-    ecs_entity_t self;            /* Self entity (if set) */
+    ecs_world_t *real_world;      /* Actual world. This differs from world when in staged mode */
 
+    /* Matched data */
+    ecs_entity_t *entities;       /* Entity identifiers */
+    void **ptrs;                  /* Pointers to components. Array if from this, pointer if not. */
+    ecs_size_t *sizes;            /* Component sizes */
     ecs_table_t *table;           /* Current table */
     ecs_type_t type;              /* Current type */
     ecs_table_t *other_table;     /* Prev or next table when adding/removing */
-
     ecs_id_t *ids;                /* (Component) ids */
+    ecs_entity_t *variables;      /* Values of variables (if any) */
     int32_t *columns;             /* Query term to table column mapping */
     ecs_entity_t *subjects;       /* Subject (source) entities */
-    ecs_size_t *sizes;            /* Component sizes */
-    void **ptrs;                  /* Pointers to components. Array if from this, pointer if not. */
-    char **variable_names;        /* Names of variables (if any) */
-    ecs_entity_t *variables;      /* Values of variables (if any) */
-
     int32_t *match_indices;       /* Indices of current match for term. Allows an iterator to iterate
                                    * all permutations of wildcards in query. */
-    ecs_ref_t *references;
+    ecs_ref_t *references;        /* Cached refs to components (if iterating a cache) */
 
+    /* Source information */
+    ecs_entity_t system;          /* The system (if applicable) */
+    ecs_entity_t event;           /* The event (if applicable) */
+    ecs_id_t event_id;            /* The (component) id for the event */
+    ecs_entity_t self;            /* Self entity (if set for system) */
+
+    /* Query information */
     ecs_term_t *terms;            /* Terms of query being evaluated */
     int32_t table_count;          /* Active table count for query */
     int32_t term_count;           /* Number of terms in query */
@@ -2989,41 +2938,36 @@ struct ecs_iter_t {
                                    * This field will be set to the 'index' field
                                    * of a trigger/observer term. */
     int32_t variable_count;       /* Number of variables for query */
-    
-    ecs_entity_t *entities;       /* Entity identifiers */
+    char **variable_names;        /* Names of variables (if any) */
 
+    /* Context */
     void *param;                  /* Param passed to ecs_run */
     void *ctx;                    /* System context */
     void *binding_ctx;            /* Binding context */
+
+    /* Time */
     FLECS_FLOAT delta_time;       /* Time elapsed since last frame */
     FLECS_FLOAT delta_system_time;/* Time elapsed since last system invocation */
 
+    /* Iterator counters */
     int32_t frame_offset;         /* Offset relative to start of iteration */
     int32_t offset;               /* Offset relative to current table */
     int32_t count;                /* Number of entities to iterate */
     int32_t instance_count;       /* Number of entities to iterate before next table */
-    int32_t total_count;          /* Number of entities in table */
 
+    /* Iterator flags */
     bool is_valid;                /* Set to true after first next() */
     bool is_filter;               /* When true, data fields are not set */
     bool is_instanced;            /* When true, owned terms are always returned as arrays */
     bool has_shared;              /* Iterator may set this when iterator has shared terms */
 
-    ecs_ids_t *triggered_by;      /* Component(s) that triggered the system */
     ecs_entity_t interrupted_by;  /* When set, system execution is interrupted */
 
+    ecs_iter_private_t priv;      /* Private data */
+
+    /* Chained iterators */
     ecs_iter_next_action_t next;  /* Next function to use for iterator */
     ecs_iter_t *chain_it;         /* Optional, allows for creating iterator chains */
-
-    union {
-        ecs_term_iter_t term;
-        ecs_filter_iter_t filter;
-        ecs_query_iter_t query;
-        ecs_rule_iter_t rule;
-        ecs_snapshot_iter_t snapshot;
-    } iter;                       /* Iterator specific data */
-
-    ecs_iter_cache_t cache;       /* Inline arrays to reduce allocations */
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -5801,23 +5745,6 @@ ecs_iter_t ecs_query_iter(
     const ecs_world_t *world,
     ecs_query_t *query);  
 
-/** Iterate over a query.
- * This operation is similar to ecs_query_iter, but starts iterating from a
- * specified offset, and will not iterate more than limit entities.
- *
- * @param world The world or stage, when iterating in readonly mode.
- * @param query The query to iterate.
- * @param offset The number of entities to skip.
- * @param limit The maximum number of entities to iterate.
- * @return The query iterator.
- */
-FLECS_API
-ecs_iter_t ecs_query_iter_page(
-    const ecs_world_t *world,
-    ecs_query_t *query,
-    int32_t offset,
-    int32_t limit);  
-
 /** Progress the query iterator.
  * This operation progresses the query iterator to the next table. The 
  * iterator must have been initialized with `ecs_query_iter`. This operation 
@@ -5837,27 +5764,6 @@ bool ecs_query_next(
 FLECS_API
 bool ecs_query_next_instanced(
     ecs_iter_t *iter);
-
-/** Progress the query iterator for a worker thread.
- * This operation is similar to ecs_query_next, but provides the ability to 
- * divide entities up across multiple worker threads. The operation accepts a
- * current thread id and a total thread id, which is used to determine which
- * subset of entities should be assigned to the current thread.
- *
- * Current should be less than total, and there should be as many as total
- * threads. If there are less entities in a table than there are threads, only
- * as many threads as there are entities will iterate that table.
- *
- * @param it The iterator.
- * @param stage_current Id of current stage.
- * @param stage_count Total number of stages.
- * @returns True if more data is available, false if not.
- */
-FLECS_API
-bool ecs_query_next_worker(
-    ecs_iter_t *it,
-    int32_t stage_current,
-    int32_t stage_count);
 
 /** Returns whether the query data changed since the last iteration.
  * This operation must be invoked before obtaining the iterator, as this will
@@ -6100,6 +6006,73 @@ bool ecs_iter_next(
  */
 FLECS_API
 bool ecs_iter_count(
+    ecs_iter_t *it);
+
+/** Create a paged iterator.
+ * Paged iterators limit the results to those starting from 'offset', and will
+ * return at most 'limit' results.
+ * 
+ * The iterator must be iterated with ecs_page_next.
+ * 
+ * A paged iterator acts as a passthrough for data exposed by the parent
+ * iterator, so that any data provided by the parent will also be provided by
+ * the paged iterator.
+ * 
+ * @param it The source iterator.
+ * @param offset The number of entities to skip.
+ * @param limit The maximum number of entities to iterate.
+ * @return A page iterator.
+ */
+FLECS_API
+ecs_iter_t ecs_page_iter(
+    ecs_iter_t *it,
+    int32_t offset,
+    int32_t limit);
+
+/** Progress a paged iterator.
+ * Progresses an iterator created by ecs_page_iter.
+ * 
+ * @param it The iterator.
+ * @return true if iterator has more results, false if not.
+ */
+FLECS_API
+bool ecs_page_next(
+    ecs_iter_t *it);
+
+/** Create a worker iterator.
+ * Worker iterators can be used to equally divide the number of matched entities 
+ * across N resources (usually threads). Each resource will process the total
+ * number of matched entities divided by 'count'.
+ * 
+ * Entities are distributed across resources such that the distribution is
+ * stable between queries. Two queries that match the same table are guaranteed
+ * to match the same entities in that table.
+ * 
+ * The iterator must be iterated with ecs_worker_next.
+ * 
+ * A worker iterator acts as a passthrough for data exposed by the parent
+ * iterator, so that any data provided by the parent will also be provided by
+ * the worker iterator.
+ * 
+ * @param it The source iterator.
+ * @param index The index of the current resource.
+ * @param count The total number of resources to divide entities to.
+ * @return A worker iterator.
+ */
+FLECS_API
+ecs_iter_t ecs_worker_iter(
+    ecs_iter_t *it,
+    int32_t index,
+    int32_t count);
+
+/** Progress a worker iterator.
+ * Progresses an iterator created by ecs_worker_iter.
+ * 
+ * @param it The iterator.
+ * @return true if iterator has more results, false if not.
+ */
+FLECS_API
+bool ecs_worker_next(
     ecs_iter_t *it);
 
 /** Obtain data for a query term.
@@ -16200,18 +16173,6 @@ flecs::entity component(
     return result;
 }
 
-/* Register component with existing entity id */
-template <typename T>
-void component_for_id(flecs::world_t *world, flecs::id_t id) {
-    flecs::entity result = component<T>(world, nullptr, true, id);
-
-    ecs_assert(result.id() == id, ECS_INTERNAL_ERROR, NULL);
-
-    if (_::cpp_type<T>::size()) {
-        _::register_lifecycle_actions<T>(world, result);
-    }
-}
-
 template <typename T>
 flecs::entity_t type_id() {
     return _::cpp_type<T>::id();
@@ -18014,23 +17975,11 @@ public:
     void each(Func&& func) const {
         iterate<_::each_invoker>(std::forward<Func>(func), 
             ecs_query_next_instanced);
-    } 
-
-    template <typename Func>
-    void each_worker(int32_t stage_current, int32_t stage_count, Func&& func) const {
-        iterate<_::each_invoker>(std::forward<Func>(func), 
-            ecs_query_next_worker, stage_current, stage_count);
     }
 
     template <typename Func>
     void iter(Func&& func) const { 
         iterate<_::iter_invoker>(std::forward<Func>(func), ecs_query_next);
-    }
-
-    template <typename Func>
-    void iter_worker(int32_t stage_current, int32_t stage_count, Func&& func) const {
-        iterate<_::iter_invoker>(std::forward<Func>(func), 
-            ecs_query_next_worker, stage_current, stage_count);
     }
 
 private:

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -2850,23 +2850,6 @@ ecs_iter_t ecs_query_iter(
     const ecs_world_t *world,
     ecs_query_t *query);  
 
-/** Iterate over a query.
- * This operation is similar to ecs_query_iter, but starts iterating from a
- * specified offset, and will not iterate more than limit entities.
- *
- * @param world The world or stage, when iterating in readonly mode.
- * @param query The query to iterate.
- * @param offset The number of entities to skip.
- * @param limit The maximum number of entities to iterate.
- * @return The query iterator.
- */
-FLECS_API
-ecs_iter_t ecs_query_iter_page(
-    const ecs_world_t *world,
-    ecs_query_t *query,
-    int32_t offset,
-    int32_t limit);  
-
 /** Progress the query iterator.
  * This operation progresses the query iterator to the next table. The 
  * iterator must have been initialized with `ecs_query_iter`. This operation 
@@ -2886,27 +2869,6 @@ bool ecs_query_next(
 FLECS_API
 bool ecs_query_next_instanced(
     ecs_iter_t *iter);
-
-/** Progress the query iterator for a worker thread.
- * This operation is similar to ecs_query_next, but provides the ability to 
- * divide entities up across multiple worker threads. The operation accepts a
- * current thread id and a total thread id, which is used to determine which
- * subset of entities should be assigned to the current thread.
- *
- * Current should be less than total, and there should be as many as total
- * threads. If there are less entities in a table than there are threads, only
- * as many threads as there are entities will iterate that table.
- *
- * @param it The iterator.
- * @param stage_current Id of current stage.
- * @param stage_count Total number of stages.
- * @returns True if more data is available, false if not.
- */
-FLECS_API
-bool ecs_query_next_worker(
-    ecs_iter_t *it,
-    int32_t stage_current,
-    int32_t stage_count);
 
 /** Returns whether the query data changed since the last iteration.
  * This operation must be invoked before obtaining the iterator, as this will
@@ -3149,6 +3111,73 @@ bool ecs_iter_next(
  */
 FLECS_API
 bool ecs_iter_count(
+    ecs_iter_t *it);
+
+/** Create a paged iterator.
+ * Paged iterators limit the results to those starting from 'offset', and will
+ * return at most 'limit' results.
+ * 
+ * The iterator must be iterated with ecs_page_next.
+ * 
+ * A paged iterator acts as a passthrough for data exposed by the parent
+ * iterator, so that any data provided by the parent will also be provided by
+ * the paged iterator.
+ * 
+ * @param it The source iterator.
+ * @param offset The number of entities to skip.
+ * @param limit The maximum number of entities to iterate.
+ * @return A page iterator.
+ */
+FLECS_API
+ecs_iter_t ecs_page_iter(
+    ecs_iter_t *it,
+    int32_t offset,
+    int32_t limit);
+
+/** Progress a paged iterator.
+ * Progresses an iterator created by ecs_page_iter.
+ * 
+ * @param it The iterator.
+ * @return true if iterator has more results, false if not.
+ */
+FLECS_API
+bool ecs_page_next(
+    ecs_iter_t *it);
+
+/** Create a worker iterator.
+ * Worker iterators can be used to equally divide the number of matched entities 
+ * across N resources (usually threads). Each resource will process the total
+ * number of matched entities divided by 'count'.
+ * 
+ * Entities are distributed across resources such that the distribution is
+ * stable between queries. Two queries that match the same table are guaranteed
+ * to match the same entities in that table.
+ * 
+ * The iterator must be iterated with ecs_worker_next.
+ * 
+ * A worker iterator acts as a passthrough for data exposed by the parent
+ * iterator, so that any data provided by the parent will also be provided by
+ * the worker iterator.
+ * 
+ * @param it The source iterator.
+ * @param index The index of the current resource.
+ * @param count The total number of resources to divide entities to.
+ * @return A worker iterator.
+ */
+FLECS_API
+ecs_iter_t ecs_worker_iter(
+    ecs_iter_t *it,
+    int32_t index,
+    int32_t count);
+
+/** Progress a worker iterator.
+ * Progresses an iterator created by ecs_worker_iter.
+ * 
+ * @param it The iterator.
+ * @return true if iterator has more results, false if not.
+ */
+FLECS_API
+bool ecs_worker_next(
     ecs_iter_t *it);
 
 /** Obtain data for a query term.

--- a/include/flecs/addons/cpp/component.hpp
+++ b/include/flecs/addons/cpp/component.hpp
@@ -616,18 +616,6 @@ flecs::entity component(
     return result;
 }
 
-/* Register component with existing entity id */
-template <typename T>
-void component_for_id(flecs::world_t *world, flecs::id_t id) {
-    flecs::entity result = component<T>(world, nullptr, true, id);
-
-    ecs_assert(result.id() == id, ECS_INTERNAL_ERROR, NULL);
-
-    if (_::cpp_type<T>::size()) {
-        _::register_lifecycle_actions<T>(world, result);
-    }
-}
-
 template <typename T>
 flecs::entity_t type_id() {
     return _::cpp_type<T>::id();

--- a/include/flecs/addons/cpp/mixins/query/impl.hpp
+++ b/include/flecs/addons/cpp/mixins/query/impl.hpp
@@ -128,23 +128,11 @@ public:
     void each(Func&& func) const {
         iterate<_::each_invoker>(std::forward<Func>(func), 
             ecs_query_next_instanced);
-    } 
-
-    template <typename Func>
-    void each_worker(int32_t stage_current, int32_t stage_count, Func&& func) const {
-        iterate<_::each_invoker>(std::forward<Func>(func), 
-            ecs_query_next_worker, stage_current, stage_count);
     }
 
     template <typename Func>
     void iter(Func&& func) const { 
         iterate<_::iter_invoker>(std::forward<Func>(func), ecs_query_next);
-    }
-
-    template <typename Func>
-    void iter_worker(int32_t stage_current, int32_t stage_count, Func&& func) const {
-        iterate<_::iter_invoker>(std::forward<Func>(func), 
-            ecs_query_next_worker, stage_current, stage_count);
     }
 
 private:

--- a/src/addons/rules.c
+++ b/src/addons/rules.c
@@ -2799,7 +2799,7 @@ ecs_entity_t ecs_rule_variable(
     ecs_iter_t *iter,
     int32_t var_id)
 {
-    ecs_rule_iter_t *it = &iter->iter.rule;
+    ecs_rule_iter_t *it = &iter->priv.iter.rule;
     const ecs_rule_t *rule = it->rule;
 
     /* We can only return entity variables */
@@ -2825,7 +2825,7 @@ ecs_iter_t ecs_rule_iter(
     result.world = (ecs_world_t*)world;
     result.real_world = (ecs_world_t*)ecs_get_world(rule->world);
 
-    ecs_rule_iter_t *it = &result.iter.rule;
+    ecs_rule_iter_t *it = &result.priv.iter.rule;
     it->rule = rule;
 
     if (rule->operation_count) {
@@ -2871,7 +2871,7 @@ ecs_iter_t ecs_rule_iter(
 void ecs_rule_iter_free(
     ecs_iter_t *iter)
 {
-    ecs_rule_iter_t *it = &iter->iter.rule;
+    ecs_rule_iter_t *it = &iter->priv.iter.rule;
     ecs_os_free(it->registers);
     ecs_os_free(it->columns);
     ecs_os_free(it->op_ctx);
@@ -3052,7 +3052,7 @@ void set_source(
 
     ecs_assert(op->term >= 0, ECS_INTERNAL_ERROR, NULL);
 
-    const ecs_rule_t *rule = it->iter.rule.rule;
+    const ecs_rule_t *rule = it->priv.iter.rule.rule;
     if ((r != UINT8_MAX) && rule->variables[r].kind == EcsRuleVarKindEntity) {
         it->subjects[op->term] = reg_get_entity(rule, op, regs, r);
     } else {
@@ -3092,7 +3092,7 @@ bool eval_superset(
     int32_t op_index,
     bool redo)
 {
-    ecs_rule_iter_t *iter = &it->iter.rule;
+    ecs_rule_iter_t *iter = &it->priv.iter.rule;
     const ecs_rule_t  *rule = iter->rule;
     ecs_world_t *world = rule->world;
     ecs_rule_superset_ctx_t *op_ctx = &iter->op_ctx[op_index].is.superset;
@@ -3198,7 +3198,7 @@ bool eval_subset(
     int32_t op_index,
     bool redo)
 {
-    ecs_rule_iter_t *iter = &it->iter.rule;
+    ecs_rule_iter_t *iter = &it->priv.iter.rule;
     const ecs_rule_t  *rule = iter->rule;
     ecs_world_t *world = rule->world;
     ecs_rule_subset_ctx_t *op_ctx = &iter->op_ctx[op_index].is.subset;
@@ -3338,7 +3338,7 @@ bool eval_select(
     int32_t op_index,
     bool redo)
 {
-    ecs_rule_iter_t *iter = &it->iter.rule;
+    ecs_rule_iter_t *iter = &it->priv.iter.rule;
     const ecs_rule_t  *rule = iter->rule;
     ecs_world_t *world = rule->world;
     ecs_rule_with_ctx_t *op_ctx = &iter->op_ctx[op_index].is.with;
@@ -3461,7 +3461,7 @@ bool eval_with(
     int32_t op_index,
     bool redo)
 {
-    ecs_rule_iter_t *iter = &it->iter.rule;
+    ecs_rule_iter_t *iter = &it->priv.iter.rule;
     const ecs_rule_t *rule = iter->rule;
     ecs_world_t *world = rule->world;
     ecs_rule_with_ctx_t *op_ctx = &iter->op_ctx[op_index].is.with;
@@ -3612,7 +3612,7 @@ bool eval_each(
     int32_t op_index,
     bool redo)
 {
-    ecs_rule_iter_t *iter = &it->iter.rule;
+    ecs_rule_iter_t *iter = &it->priv.iter.rule;
     ecs_rule_each_ctx_t *op_ctx = &iter->op_ctx[op_index].is.each;
     ecs_rule_reg_t *regs = get_registers(iter, op);
     int32_t r_in = op->r_in;
@@ -3697,7 +3697,7 @@ bool eval_store(
         return false;
     }
 
-    ecs_rule_iter_t *iter = &it->iter.rule;
+    ecs_rule_iter_t *iter = &it->priv.iter.rule;
     const ecs_rule_t *rule = iter->rule;
     ecs_rule_reg_t *regs = get_registers(iter, op);
     int32_t r_in = op->r_in;
@@ -3725,7 +3725,7 @@ bool eval_setjmp(
     int32_t op_index,
     bool redo)
 {
-    ecs_rule_iter_t *iter = &it->iter.rule;
+    ecs_rule_iter_t *iter = &it->priv.iter.rule;
     ecs_rule_setjmp_ctx_t *ctx = &iter->op_ctx[op_index].is.setjmp;
 
     if (!redo) {
@@ -3979,7 +3979,7 @@ bool ecs_rule_next(
     ecs_check(it != NULL, ECS_INVALID_PARAMETER, NULL);
     ecs_check(it->next == ecs_rule_next, ECS_INVALID_PARAMETER, NULL);
 
-    ecs_rule_iter_t *iter = &it->iter.rule;
+    ecs_rule_iter_t *iter = &it->priv.iter.rule;
     const ecs_rule_t *rule = iter->rule;
     bool redo = iter->redo;
     int32_t last_frame = -1;

--- a/src/addons/snapshot.c
+++ b/src/addons/snapshot.c
@@ -373,7 +373,7 @@ ecs_iter_t ecs_snapshot_iter(
     return (ecs_iter_t){
         .world = snapshot->world,
         .table_count = ecs_vector_count(snapshot->tables),
-        .iter.snapshot = iter,
+        .priv.iter.snapshot = iter,
         .next = ecs_snapshot_next
     };
 }
@@ -381,7 +381,7 @@ ecs_iter_t ecs_snapshot_iter(
 bool ecs_snapshot_next(
     ecs_iter_t *it)
 {
-    ecs_snapshot_iter_t *iter = &it->iter.snapshot;
+    ecs_snapshot_iter_t *iter = &it->priv.iter.snapshot;
     ecs_table_leaf_t *tables = ecs_vector_first(iter->tables, ecs_table_leaf_t);
     int32_t count = ecs_vector_count(iter->tables);
     int32_t i;

--- a/src/filter.c
+++ b/src/filter.c
@@ -1390,7 +1390,7 @@ ecs_iter_t ecs_term_iter(
         .next = ecs_term_next
     };
 
-    term_iter_init(world, term, &it.iter.term);
+    term_iter_init(world, term, &it.priv.iter.term);
 
     return it;
 error:
@@ -1412,15 +1412,15 @@ ecs_iter_t ecs_term_chain_iter(
     }
 
     ecs_iter_t it = {
-        .chain_it = (ecs_iter_t*)chain_it,
         .real_world = (ecs_world_t*)world,
         .world = chain_it->world,
         .terms = term,
         .term_count = 1,
+        .chain_it = (ecs_iter_t*)chain_it,
         .next = ecs_term_next
     };
 
-    term_iter_init(world, term, &it.iter.term);
+    term_iter_init(world, term, &it.priv.iter.term);
 
     return it;
 error:
@@ -1543,7 +1543,7 @@ bool ecs_term_next(
     ecs_check(it != NULL, ECS_INVALID_PARAMETER, NULL);
     ecs_check(it->next == ecs_term_next, ECS_INVALID_PARAMETER, NULL);
 
-    ecs_term_iter_t *iter = &it->iter.term;
+    ecs_term_iter_t *iter = &it->priv.iter.term;
     ecs_term_t *term = &iter->term;
     ecs_world_t *world = it->real_world;
     ecs_table_t *table;
@@ -1605,7 +1605,7 @@ const ecs_filter_t* init_filter_iter(
     ecs_iter_t *it,
     const ecs_filter_t *filter)
 {
-    ecs_filter_iter_t *iter = &it->iter.filter;
+    ecs_filter_iter_t *iter = &it->priv.iter.filter;
 
     if (filter) {
         iter->filter = *filter;
@@ -1647,7 +1647,7 @@ ecs_iter_t ecs_filter_iter(
         .is_instanced = filter ? filter->instanced : false
     };
 
-    ecs_filter_iter_t *iter = &it.iter.filter;
+    ecs_filter_iter_t *iter = &it.priv.iter.filter;
 
     filter = init_filter_iter(world, &it, filter);
 
@@ -1723,13 +1723,13 @@ ecs_iter_t ecs_filter_chain_iter(
     ecs_iter_t it = {
         .terms = filter->terms,
         .term_count = filter->term_count,
-        .chain_it = (ecs_iter_t*)chain_it,
-        .next = ecs_filter_next,
         .world = chain_it->world,
-        .real_world = chain_it->real_world
+        .real_world = chain_it->real_world,
+        .chain_it = (ecs_iter_t*)chain_it,
+        .next = ecs_filter_next
     };
 
-    ecs_filter_iter_t *iter = &it.iter.filter;
+    ecs_filter_iter_t *iter = &it.priv.iter.filter;
     init_filter_iter(it.world, &it, filter);
 
     iter->kind = EcsIterEvalChain;
@@ -1764,7 +1764,7 @@ bool ecs_filter_next_instanced(
     ecs_check(it->next == ecs_filter_next, ECS_INVALID_PARAMETER, NULL);
     ecs_check(it->chain_it != it, ECS_INVALID_PARAMETER, NULL);
 
-    ecs_filter_iter_t *iter = &it->iter.filter;
+    ecs_filter_iter_t *iter = &it->priv.iter.filter;
     ecs_filter_t *filter = &iter->filter;
     ecs_world_t *world = it->real_world;
     ecs_table_t *table = NULL;
@@ -1818,7 +1818,7 @@ bool ecs_filter_next_instanced(
                         goto done;
                     }
 
-                    table = it->table = term_iter->table;
+                    table = term_iter->table;
                     if (pivot_term != -1) {
                         it->ids[pivot_term] = term_iter->id;
                         it->subjects[pivot_term] = term_iter->subject;

--- a/test/api/include/api.h
+++ b/test/api/include/api.h
@@ -79,7 +79,7 @@ void install_test_abort();
 #define ITER_MAX_TERMS (16)
 #define ITER_MAX_VARIABLES (16)
 
-typedef struct ecs_iter_result_t {
+typedef struct test_iter_result_t {
     ecs_entity_t entities[ITER_MAX_ENTITIES];
     ecs_id_t term_ids[ITER_MAX_ENTITIES][ITER_MAX_TERMS];
     void *term_columns[ITER_MAX_TERMS];
@@ -96,13 +96,13 @@ typedef struct ecs_iter_result_t {
         ecs_entity_t entities[ITER_MAX_ENTITIES];
         char *entity_names[ITER_MAX_ENTITIES];
     } variables[ITER_MAX_VARIABLES];
-} ecs_iter_result_t;
+} test_iter_result_t;
 
 // Utility for doing order-independent validation of iterator output
 bool test_iter(
     ecs_iter_t *it, 
     ecs_iter_next_action_t next, 
-    ecs_iter_result_t *expect);
+    test_iter_result_t *expect);
 
 const ecs_entity_t* bulk_new_w_type(
     ecs_world_t *world, ecs_entity_t type_ent, int32_t count);

--- a/test/api/project.json
+++ b/test/api/project.json
@@ -1192,7 +1192,8 @@
                 "filter_no_this_component_2_ents",
                 "filter_no_this_tag_2_ents_1_not",
                 "filter_no_this_component_2_ents_1_not",
-                "filter_no_this_component_1_not"
+                "filter_no_this_component_1_not",
+                "filter_iter_frame_offset"
             ]
         }, {
             "id": "Query",
@@ -1250,7 +1251,28 @@
                 "2_terms_1_filter",
                 "3_terms_2_filter",
                 "no_instancing_w_singleton",
-                "no_instancing_w_shared"
+                "no_instancing_w_shared",
+                "query_iter_frame_offset"
+            ]
+        }, {
+            "id": "Iter",
+            "testcases": [
+                "page_iter_0_0",
+                "page_iter_1_0",
+                "page_iter_0_1",
+                "page_iter_n_0",
+                "page_iter_0_n",
+                "page_iter_m_n",
+                "page_iter_skip_1_table",
+                "page_iter_skip_2_tables",
+                "worker_iter_1",
+                "worker_iter_2",
+                "worker_iter_3",
+                "worker_iter_4",
+                "paged_iter_w_shared_comp",
+                "worker_iter_w_shared_comp",
+                "paged_iter_w_task_query",
+                "worker_iter_w_task_query"
             ]
         }, {
             "id": "Pairs",
@@ -1447,7 +1469,8 @@
                 "2_terms_1_filter",
                 "3_terms_2_filter",
                 "term_obj_w_this",
-                "term_subj_w_this"
+                "term_subj_w_this",
+                "rule_iter_frame_offset"
             ]
         }, {
             "id": "TransitiveRules",

--- a/test/api/src/Filter.c
+++ b/test/api/src/Filter.c
@@ -5189,3 +5189,57 @@ void Filter_filter_no_this_component_1_not() {
 
     ecs_fini(world);
 }
+
+void Filter_filter_iter_frame_offset() {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+    ECS_TAG(world, TagC);
+
+    ecs_filter_t f;
+    test_int(ecs_filter_init(world, &f, &(ecs_filter_desc_t) {
+        .terms = {
+            { .id = TagA, }
+        },
+    }), 0);
+
+    ecs_entity_t e1 = ecs_new(world, TagA);
+    ecs_entity_t e2 = ecs_new(world, TagA);
+    ecs_entity_t e3 = ecs_new(world, TagA);
+    ecs_entity_t e4 = ecs_new(world, TagA);
+    ecs_entity_t e5 = ecs_new(world, TagA);
+
+    ecs_add(world, e3, TagB);
+    ecs_add(world, e4, TagB);
+    ecs_add(world, e5, TagC);
+
+    ecs_iter_t it = ecs_filter_iter(world, &f);
+
+    test_bool(ecs_filter_next(&it), true);
+    test_int(it.count, 2);
+    test_int(it.frame_offset, 0);
+    test_assert(it.entities != NULL);
+    test_assert(it.entities[0] == e1);
+    test_assert(it.entities[1] == e2);
+    test_assert(it.ids[0] == TagA);
+
+    test_bool(ecs_filter_next(&it), true);
+    test_int(it.count, 2);
+    test_int(it.frame_offset, 2);
+    test_assert(it.entities != NULL);
+    test_assert(it.entities[0] == e3);
+    test_assert(it.entities[1] == e4);
+    test_assert(it.ids[0] == TagA);
+
+    test_bool(ecs_filter_next(&it), true);
+    test_int(it.count, 1);
+    test_int(it.frame_offset, 4);
+    test_assert(it.entities != NULL);
+    test_assert(it.entities[0] == e5);
+    test_assert(it.ids[0] == TagA);
+
+    test_bool(ecs_filter_next(&it), false);
+
+    ecs_fini(world);
+}

--- a/test/api/src/Iter.c
+++ b/test/api/src/Iter.c
@@ -1,0 +1,1140 @@
+#include <api.h>
+
+void Iter_page_iter_0_0() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_COMPONENT(world, Self);
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+
+    ecs_entity_t e1 = ecs_new_id(world); ecs_set(world, e1, Self, {e1});
+    ecs_entity_t e2 = ecs_new_id(world); ecs_set(world, e2, Self, {e2});
+    ecs_entity_t e3 = ecs_new_id(world); ecs_set(world, e3, Self, {e3});
+    ecs_entity_t e4 = ecs_new_id(world); ecs_set(world, e4, Self, {e4});
+    ecs_entity_t e5 = ecs_new_id(world); ecs_set(world, e5, Self, {e5});
+
+    ecs_add(world, e3, TagA);
+    ecs_add(world, e4, TagA);
+    ecs_add(world, e5, TagB);
+
+    ecs_filter_t f;
+    ecs_filter_init(world, &f, &(ecs_filter_desc_t) {
+        .terms = {{ ecs_id(Self) }}
+    });
+
+    ecs_iter_t it = ecs_filter_iter(world, &f);
+    ecs_iter_t pit = ecs_page_iter(&it, 0, 0);
+
+    {
+        test_bool(ecs_page_next(&pit), true);
+        test_int(pit.count, 2);
+        test_int(pit.frame_offset, 0);
+        test_int(pit.entities[0], e1);
+        test_int(pit.entities[1], e2);
+        test_int(pit.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e1);
+        test_int(ptr[1].value, e2);
+    }
+
+    {
+        test_bool(ecs_page_next(&pit), true);
+        test_int(pit.count, 2);
+        test_int(pit.frame_offset, 2);
+        test_int(pit.entities[0], e3);
+        test_int(pit.entities[1], e4);
+        test_int(pit.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e3);
+        test_int(ptr[1].value, e4);
+    }
+
+    {
+        test_bool(ecs_page_next(&pit), true);
+        test_int(pit.count, 1);
+        test_int(pit.frame_offset, 4);
+        test_int(pit.entities[0], e5);
+        test_int(pit.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e5);
+    }
+
+    test_bool(ecs_page_next(&pit), false);
+
+    ecs_fini(world);
+}
+
+void Iter_page_iter_1_0() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_COMPONENT(world, Self);
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+
+    ecs_entity_t e1 = ecs_new_id(world); ecs_set(world, e1, Self, {e1});
+    ecs_entity_t e2 = ecs_new_id(world); ecs_set(world, e2, Self, {e2});
+    ecs_entity_t e3 = ecs_new_id(world); ecs_set(world, e3, Self, {e3});
+    ecs_entity_t e4 = ecs_new_id(world); ecs_set(world, e4, Self, {e4});
+    ecs_entity_t e5 = ecs_new_id(world); ecs_set(world, e5, Self, {e5});
+
+    ecs_add(world, e3, TagA);
+    ecs_add(world, e4, TagA);
+    ecs_add(world, e5, TagB);
+
+    ecs_filter_t f;
+    ecs_filter_init(world, &f, &(ecs_filter_desc_t) {
+        .terms = {{ ecs_id(Self) }}
+    });
+
+    ecs_iter_t it = ecs_filter_iter(world, &f);
+    ecs_iter_t pit = ecs_page_iter(&it, 1, 0);
+
+    {
+        test_bool(ecs_page_next(&pit), true);
+        test_int(pit.count, 1);
+        test_int(pit.entities[0], e2);
+        test_int(pit.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e2);
+    }
+
+    {
+        test_bool(ecs_page_next(&pit), true);
+        test_int(pit.count, 2);
+        test_int(pit.entities[0], e3);
+        test_int(pit.entities[1], e4);
+        test_int(pit.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e3);
+        test_int(ptr[1].value, e4);
+    }
+
+    {
+        test_bool(ecs_page_next(&pit), true);
+        test_int(pit.count, 1);
+        test_int(pit.entities[0], e5);
+        test_int(pit.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e5);
+    }
+
+    test_bool(ecs_page_next(&pit), false);
+
+    ecs_fini(world);
+}
+
+void Iter_page_iter_0_1() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_COMPONENT(world, Self);
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+
+    ecs_entity_t e1 = ecs_new_id(world); ecs_set(world, e1, Self, {e1});
+    ecs_entity_t e2 = ecs_new_id(world); ecs_set(world, e2, Self, {e2});
+    ecs_entity_t e3 = ecs_new_id(world); ecs_set(world, e3, Self, {e3});
+    ecs_entity_t e4 = ecs_new_id(world); ecs_set(world, e4, Self, {e4});
+    ecs_entity_t e5 = ecs_new_id(world); ecs_set(world, e5, Self, {e5});
+
+    ecs_add(world, e3, TagA);
+    ecs_add(world, e4, TagA);
+    ecs_add(world, e5, TagB);
+
+    ecs_filter_t f;
+    ecs_filter_init(world, &f, &(ecs_filter_desc_t) {
+        .terms = {{ ecs_id(Self) }}
+    });
+
+    ecs_iter_t it = ecs_filter_iter(world, &f);
+    ecs_iter_t pit = ecs_page_iter(&it, 0, 1);
+
+    {
+        test_bool(ecs_page_next(&pit), true);
+        test_int(pit.count, 1);
+        test_int(pit.entities[0], e1);
+        test_int(pit.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e1);
+    }
+
+    test_bool(ecs_page_next(&pit), false);
+
+    ecs_fini(world);
+}
+
+void Iter_page_iter_n_0() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_COMPONENT(world, Self);
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+
+    ecs_entity_t e1 = ecs_new_id(world); ecs_set(world, e1, Self, {e1});
+    ecs_entity_t e2 = ecs_new_id(world); ecs_set(world, e2, Self, {e2});
+    ecs_entity_t e3 = ecs_new_id(world); ecs_set(world, e3, Self, {e3});
+    ecs_entity_t e4 = ecs_new_id(world); ecs_set(world, e4, Self, {e4});
+    ecs_entity_t e5 = ecs_new_id(world); ecs_set(world, e5, Self, {e5});
+
+    ecs_add(world, e4, TagA);
+    ecs_add(world, e5, TagB);
+
+    ecs_filter_t f;
+    ecs_filter_init(world, &f, &(ecs_filter_desc_t) {
+        .terms = {{ ecs_id(Self) }}
+    });
+
+    ecs_iter_t it = ecs_filter_iter(world, &f);
+    ecs_iter_t pit = ecs_page_iter(&it, 2, 0);
+
+    {
+        test_bool(ecs_page_next(&pit), true);
+        test_int(pit.count, 1);
+        test_int(pit.entities[0], e3);
+        test_int(pit.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e3);
+    }
+
+    {
+        test_bool(ecs_page_next(&pit), true);
+        test_int(pit.count, 1);
+        test_int(pit.entities[0], e4);
+        test_int(pit.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e4);
+    }
+
+    {
+        test_bool(ecs_page_next(&pit), true);
+        test_int(pit.count, 1);
+        test_int(pit.entities[0], e5);
+        test_int(pit.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e5);
+    }
+
+    test_bool(ecs_page_next(&pit), false);
+
+    ecs_fini(world);
+}
+
+void Iter_page_iter_0_n() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_COMPONENT(world, Self);
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+
+    ecs_entity_t e1 = ecs_new_id(world); ecs_set(world, e1, Self, {e1});
+    ecs_entity_t e2 = ecs_new_id(world); ecs_set(world, e2, Self, {e2});
+    ecs_entity_t e3 = ecs_new_id(world); ecs_set(world, e3, Self, {e3});
+    ecs_entity_t e4 = ecs_new_id(world); ecs_set(world, e4, Self, {e4});
+    ecs_entity_t e5 = ecs_new_id(world); ecs_set(world, e5, Self, {e5});
+
+    ecs_add(world, e4, TagA);
+    ecs_add(world, e5, TagB);
+
+    ecs_filter_t f;
+    ecs_filter_init(world, &f, &(ecs_filter_desc_t) {
+        .terms = {{ ecs_id(Self) }}
+    });
+
+    ecs_iter_t it = ecs_filter_iter(world, &f);
+    ecs_iter_t pit = ecs_page_iter(&it, 0, 2);
+
+    {
+        test_bool(ecs_page_next(&pit), true);
+        test_int(pit.count, 2);
+        test_int(pit.entities[0], e1);
+        test_int(pit.entities[1], e2);
+        test_int(pit.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e1);
+        test_int(ptr[1].value, e2);
+    }
+
+    test_bool(ecs_page_next(&pit), false);
+
+    ecs_fini(world);
+}
+
+void Iter_page_iter_m_n() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_COMPONENT(world, Self);
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+
+    ecs_entity_t e1 = ecs_new_id(world); ecs_set(world, e1, Self, {e1});
+    ecs_entity_t e2 = ecs_new_id(world); ecs_set(world, e2, Self, {e2});
+    ecs_entity_t e3 = ecs_new_id(world); ecs_set(world, e3, Self, {e3});
+    ecs_entity_t e4 = ecs_new_id(world); ecs_set(world, e4, Self, {e4});
+    ecs_entity_t e5 = ecs_new_id(world); ecs_set(world, e5, Self, {e5});
+    ecs_entity_t e6 = ecs_new_id(world); ecs_set(world, e6, Self, {e6});
+
+    ecs_add(world, e4, TagA);
+    ecs_add(world, e5, TagA);
+    ecs_add(world, e6, TagB);
+
+    ecs_filter_t f;
+    ecs_filter_init(world, &f, &(ecs_filter_desc_t) {
+        .terms = {{ ecs_id(Self) }}
+    });
+
+    ecs_iter_t it = ecs_filter_iter(world, &f);
+    ecs_iter_t pit = ecs_page_iter(&it, 2, 3);
+
+    {
+        test_bool(ecs_page_next(&pit), true);
+        test_int(pit.count, 1);
+        test_int(pit.entities[0], e3);
+        test_int(pit.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e3);
+    }
+    {
+        test_bool(ecs_page_next(&pit), true);
+        test_int(pit.count, 2);
+        test_int(pit.entities[0], e4);
+        test_int(pit.entities[1], e5);
+        test_int(pit.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e4);
+        test_int(ptr[1].value, e5);
+    }
+
+    test_bool(ecs_page_next(&pit), false);
+
+    ecs_fini(world);
+}
+
+void Iter_page_iter_skip_1_table() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_COMPONENT(world, Self);
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+
+    ecs_entity_t e1 = ecs_new_id(world); ecs_set(world, e1, Self, {e1});
+    ecs_entity_t e2 = ecs_new_id(world); ecs_set(world, e2, Self, {e2});
+    ecs_entity_t e3 = ecs_new_id(world); ecs_set(world, e3, Self, {e3});
+    ecs_entity_t e4 = ecs_new_id(world); ecs_set(world, e4, Self, {e4});
+    ecs_entity_t e5 = ecs_new_id(world); ecs_set(world, e5, Self, {e5});
+
+    ecs_add(world, e3, TagA);
+    ecs_add(world, e4, TagA);
+    ecs_add(world, e5, TagB);
+
+    ecs_filter_t f;
+    ecs_filter_init(world, &f, &(ecs_filter_desc_t) {
+        .terms = {{ ecs_id(Self) }}
+    });
+
+    ecs_iter_t it = ecs_filter_iter(world, &f);
+    ecs_iter_t pit = ecs_page_iter(&it, 2, 0);
+
+    {
+        test_bool(ecs_page_next(&pit), true);
+        test_int(pit.count, 2);
+        test_int(pit.entities[0], e3);
+        test_int(pit.entities[1], e4);
+        test_int(pit.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e3);
+        test_int(ptr[1].value, e4);
+    }
+
+    {
+        test_bool(ecs_page_next(&pit), true);
+        test_int(pit.count, 1);
+        test_int(pit.entities[0], e5);
+        test_int(pit.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e5);
+    }
+
+    test_bool(ecs_page_next(&pit), false);
+
+    ecs_fini(world);
+}
+
+void Iter_page_iter_skip_2_tables() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_COMPONENT(world, Self);
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+
+    ecs_entity_t e1 = ecs_new_id(world); ecs_set(world, e1, Self, {e1});
+    ecs_entity_t e2 = ecs_new_id(world); ecs_set(world, e2, Self, {e2});
+    ecs_entity_t e3 = ecs_new_id(world); ecs_set(world, e3, Self, {e3});
+    ecs_entity_t e4 = ecs_new_id(world); ecs_set(world, e4, Self, {e4});
+    ecs_entity_t e5 = ecs_new_id(world); ecs_set(world, e5, Self, {e5});
+
+    ecs_add(world, e3, TagA);
+    ecs_add(world, e4, TagB);
+    ecs_add(world, e5, TagB);
+
+    ecs_filter_t f;
+    ecs_filter_init(world, &f, &(ecs_filter_desc_t) {
+        .terms = {{ ecs_id(Self) }}
+    });
+
+    ecs_iter_t it = ecs_filter_iter(world, &f);
+    ecs_iter_t pit = ecs_page_iter(&it, 3, 0);
+
+    {
+        test_bool(ecs_page_next(&pit), true);
+        test_int(pit.count, 2);
+        test_int(pit.entities[0], e4);
+        test_int(pit.entities[1], e5);
+        test_int(pit.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e4);
+        test_int(ptr[1].value, e5);
+    }
+
+    test_bool(ecs_page_next(&pit), false);
+
+    ecs_fini(world);
+}
+
+void Iter_worker_iter_1() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_COMPONENT(world, Self);
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+
+    ecs_entity_t e1 = ecs_new_id(world); ecs_set(world, e1, Self, {e1});
+    ecs_entity_t e2 = ecs_new_id(world); ecs_set(world, e2, Self, {e2});
+    ecs_entity_t e3 = ecs_new_id(world); ecs_set(world, e3, Self, {e3});
+    ecs_entity_t e4 = ecs_new_id(world); ecs_set(world, e4, Self, {e4});
+    ecs_entity_t e5 = ecs_new_id(world); ecs_set(world, e5, Self, {e5});
+
+    ecs_add(world, e3, TagA);
+    ecs_add(world, e4, TagA);
+    ecs_add(world, e5, TagB);
+
+    ecs_filter_t f;
+    ecs_filter_init(world, &f, &(ecs_filter_desc_t) {
+        .terms = {{ ecs_id(Self) }}
+    });
+
+    ecs_iter_t it = ecs_filter_iter(world, &f);
+    ecs_iter_t pit = ecs_worker_iter(&it, 0, 1);
+
+    {
+        test_bool(ecs_worker_next(&pit), true);
+        test_int(pit.count, 2);
+        test_int(pit.entities[0], e1);
+        test_int(pit.entities[1], e2);
+        test_int(pit.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e1);
+        test_int(ptr[1].value, e2);
+    }
+
+    {
+        test_bool(ecs_worker_next(&pit), true);
+        test_int(pit.count, 2);
+        test_int(pit.entities[0], e3);
+        test_int(pit.entities[1], e4);
+        test_int(pit.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e3);
+        test_int(ptr[1].value, e4);
+    }
+
+    {
+        test_bool(ecs_worker_next(&pit), true);
+        test_int(pit.count, 1);
+        test_int(pit.entities[0], e5);
+        test_int(pit.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e5);
+    }
+
+    test_bool(ecs_worker_next(&pit), false);
+
+    ecs_fini(world);
+}
+
+void Iter_worker_iter_2() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_COMPONENT(world, Self);
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+
+    ecs_entity_t e1 = ecs_new_id(world); ecs_set(world, e1, Self, {e1});
+    ecs_entity_t e2 = ecs_new_id(world); ecs_set(world, e2, Self, {e2});
+    ecs_entity_t e3 = ecs_new_id(world); ecs_set(world, e3, Self, {e3});
+    ecs_entity_t e4 = ecs_new_id(world); ecs_set(world, e4, Self, {e4});
+    ecs_entity_t e5 = ecs_new_id(world); ecs_set(world, e5, Self, {e5});
+
+    ecs_add(world, e3, TagA);
+    ecs_add(world, e4, TagA);
+    ecs_add(world, e5, TagB);
+
+    ecs_filter_t f;
+    ecs_filter_init(world, &f, &(ecs_filter_desc_t) {
+        .terms = {{ ecs_id(Self) }}
+    });
+
+    ecs_iter_t it_1 = ecs_filter_iter(world, &f);
+    ecs_iter_t pit_1 = ecs_worker_iter(&it_1, 0, 2);
+    ecs_iter_t it_2 = ecs_filter_iter(world, &f);
+    ecs_iter_t pit_2 = ecs_worker_iter(&it_2, 1, 2);
+
+    /* Iter 1 */
+    {
+        test_bool(ecs_worker_next(&pit_1), true);
+        test_int(pit_1.count, 1);
+        test_int(pit_1.entities[0], e1);
+        test_int(pit_1.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit_1, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e1);
+    }
+
+    {
+        test_bool(ecs_worker_next(&pit_1), true);
+        test_int(pit_1.count, 1);
+        test_int(pit_1.entities[0], e3);
+        test_int(pit_1.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit_1, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e3);
+    }
+
+    {
+        test_bool(ecs_worker_next(&pit_1), true);
+        test_int(pit_1.count, 1);
+        test_int(pit_1.entities[0], e5);
+        test_int(pit_1.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit_1, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e5);
+    }
+
+    test_bool(ecs_worker_next(&pit_1), false);
+
+    /* Iter 2 */
+    {
+        test_bool(ecs_worker_next(&pit_2), true);
+        test_int(pit_2.count, 1);
+        test_int(pit_2.entities[0], e2);
+        test_int(pit_2.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit_2, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e2);
+    }
+
+    {
+        test_bool(ecs_worker_next(&pit_2), true);
+        test_int(pit_2.count, 1);
+        test_int(pit_2.entities[0], e4);
+        test_int(pit_2.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit_2, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e4);
+    }
+
+    test_bool(ecs_worker_next(&pit_2), false);
+
+    ecs_fini(world);
+}
+
+void Iter_worker_iter_3() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_COMPONENT(world, Self);
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+
+    ecs_entity_t e1 = ecs_new_id(world); ecs_set(world, e1, Self, {e1});
+    ecs_entity_t e2 = ecs_new_id(world); ecs_set(world, e2, Self, {e2});
+    ecs_entity_t e3 = ecs_new_id(world); ecs_set(world, e3, Self, {e3});
+    ecs_entity_t e4 = ecs_new_id(world); ecs_set(world, e4, Self, {e4});
+    ecs_entity_t e5 = ecs_new_id(world); ecs_set(world, e5, Self, {e5});
+    ecs_entity_t e6 = ecs_new_id(world); ecs_set(world, e6, Self, {e6});
+
+    ecs_add(world, e4, TagA);
+    ecs_add(world, e5, TagA);
+    ecs_add(world, e6, TagB);
+
+    ecs_filter_t f;
+    ecs_filter_init(world, &f, &(ecs_filter_desc_t) {
+        .terms = {{ ecs_id(Self) }}
+    });
+
+    ecs_iter_t it_1 = ecs_filter_iter(world, &f);
+    ecs_iter_t pit_1 = ecs_worker_iter(&it_1, 0, 3);
+    ecs_iter_t it_2 = ecs_filter_iter(world, &f);
+    ecs_iter_t pit_2 = ecs_worker_iter(&it_2, 1, 3);
+    ecs_iter_t it_3 = ecs_filter_iter(world, &f);
+    ecs_iter_t pit_3 = ecs_worker_iter(&it_3, 2, 3);
+
+    /* Iter 1 */
+    {
+        test_bool(ecs_worker_next(&pit_1), true);
+        test_int(pit_1.count, 1);
+        test_int(pit_1.entities[0], e1);
+        test_int(pit_1.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit_1, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e1);
+    }
+
+    {
+        test_bool(ecs_worker_next(&pit_1), true);
+        test_int(pit_1.count, 1);
+        test_int(pit_1.entities[0], e4);
+        test_int(pit_1.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit_1, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e4);
+    }
+
+    {
+        test_bool(ecs_worker_next(&pit_1), true);
+        test_int(pit_1.count, 1);
+        test_int(pit_1.entities[0], e6);
+        test_int(pit_1.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit_1, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e6);
+    }
+
+    test_bool(ecs_worker_next(&pit_1), false);
+
+    /* Iter 2 */
+    {
+        test_bool(ecs_worker_next(&pit_2), true);
+        test_int(pit_2.count, 1);
+        test_int(pit_2.entities[0], e2);
+        test_int(pit_2.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit_2, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e2);
+    }
+
+    {
+        test_bool(ecs_worker_next(&pit_2), true);
+        test_int(pit_2.count, 1);
+        test_int(pit_2.entities[0], e5);
+        test_int(pit_2.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit_2, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e5);
+    }
+
+    test_bool(ecs_worker_next(&pit_2), false);
+
+    /* Iter 3 */
+    {
+        test_bool(ecs_worker_next(&pit_3), true);
+        test_int(pit_3.count, 1);
+        test_int(pit_3.entities[0], e3);
+        test_int(pit_3.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit_3, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e3);
+    }
+
+    test_bool(ecs_worker_next(&pit_3), false);
+
+    ecs_fini(world);
+}
+
+void Iter_worker_iter_4() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_COMPONENT(world, Self);
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+
+    ecs_entity_t e1 = ecs_new_id(world); ecs_set(world, e1, Self, {e1});
+    ecs_entity_t e2 = ecs_new_id(world); ecs_set(world, e2, Self, {e2});
+    ecs_entity_t e3 = ecs_new_id(world); ecs_set(world, e3, Self, {e3});
+    ecs_entity_t e4 = ecs_new_id(world); ecs_set(world, e4, Self, {e4});
+    ecs_entity_t e5 = ecs_new_id(world); ecs_set(world, e5, Self, {e5});
+    ecs_entity_t e6 = ecs_new_id(world); ecs_set(world, e6, Self, {e6});
+    ecs_entity_t e7 = ecs_new_id(world); ecs_set(world, e7, Self, {e7});
+    ecs_entity_t e8 = ecs_new_id(world); ecs_set(world, e8, Self, {e8});
+    ecs_entity_t e9 = ecs_new_id(world); ecs_set(world, e9, Self, {e9});
+
+    ecs_add(world, e5, TagA);
+    ecs_add(world, e6, TagA);
+    ecs_add(world, e7, TagA);
+    ecs_add(world, e8, TagB);
+    ecs_add(world, e9, TagB);
+
+    ecs_filter_t f;
+    ecs_filter_init(world, &f, &(ecs_filter_desc_t) {
+        .terms = {{ ecs_id(Self) }}
+    });
+
+    ecs_iter_t it_1 = ecs_filter_iter(world, &f);
+    ecs_iter_t pit_1 = ecs_worker_iter(&it_1, 0, 4);
+    ecs_iter_t it_2 = ecs_filter_iter(world, &f);
+    ecs_iter_t pit_2 = ecs_worker_iter(&it_2, 1, 4);
+    ecs_iter_t it_3 = ecs_filter_iter(world, &f);
+    ecs_iter_t pit_3 = ecs_worker_iter(&it_3, 2, 4);
+    ecs_iter_t it_4 = ecs_filter_iter(world, &f);
+    ecs_iter_t pit_4 = ecs_worker_iter(&it_4, 3, 4);
+
+    /* Iter 1 */
+    {
+        test_bool(ecs_worker_next(&pit_1), true);
+        test_int(pit_1.count, 1);
+        test_int(pit_1.entities[0], e1);
+        test_int(pit_1.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit_1, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e1);
+    }
+
+    {
+        test_bool(ecs_worker_next(&pit_1), true);
+        test_int(pit_1.count, 1);
+        test_int(pit_1.entities[0], e5);
+        test_int(pit_1.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit_1, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e5);
+    }
+
+    {
+        test_bool(ecs_worker_next(&pit_1), true);
+        test_int(pit_1.count, 1);
+        test_int(pit_1.entities[0], e8);
+        test_int(pit_1.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit_1, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e8);
+    }
+
+    test_bool(ecs_worker_next(&pit_1), false);
+
+    /* Iter 2 */
+    {
+        test_bool(ecs_worker_next(&pit_2), true);
+        test_int(pit_2.count, 1);
+        test_int(pit_2.entities[0], e2);
+        test_int(pit_2.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit_2, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e2);
+    }
+
+    {
+        test_bool(ecs_worker_next(&pit_2), true);
+        test_int(pit_2.count, 1);
+        test_int(pit_2.entities[0], e6);
+        test_int(pit_2.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit_2, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e6);
+    }
+
+    {
+        test_bool(ecs_worker_next(&pit_2), true);
+        test_int(pit_2.count, 1);
+        test_int(pit_2.entities[0], e9);
+        test_int(pit_2.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit_2, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e9);
+    }
+
+    test_bool(ecs_worker_next(&pit_2), false);
+
+    /* Iter 3 */
+    {
+        test_bool(ecs_worker_next(&pit_3), true);
+        test_int(pit_3.count, 1);
+        test_int(pit_3.entities[0], e3);
+        test_int(pit_3.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit_3, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e3);
+    }
+
+    {
+        test_bool(ecs_worker_next(&pit_3), true);
+        test_int(pit_3.count, 1);
+        test_int(pit_3.entities[0], e7);
+        test_int(pit_3.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit_3, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e7);
+    }
+
+    test_bool(ecs_worker_next(&pit_3), false);
+
+    /* Iter 4 */
+    {
+        test_bool(ecs_worker_next(&pit_4), true);
+        test_int(pit_4.count, 1);
+        test_int(pit_4.entities[0], e4);
+        test_int(pit_4.ids[0], ecs_id(Self));
+
+        Self *ptr = ecs_term(&pit_4, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e4);
+    }
+
+    test_bool(ecs_worker_next(&pit_4), false);
+
+    ecs_fini(world);
+}
+
+void Iter_paged_iter_w_shared_comp() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_COMPONENT(world, Position);
+    ECS_COMPONENT(world, Self);
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+
+    ecs_entity_t foo = ecs_set(world, 0, Position, {10, 20});
+
+    ecs_entity_t e1 = ecs_new_id(world); ecs_set(world, e1, Self, {e1});
+    ecs_entity_t e2 = ecs_new_id(world); ecs_set(world, e2, Self, {e2});
+    ecs_entity_t e3 = ecs_new_id(world); ecs_set(world, e3, Self, {e3});
+    ecs_entity_t e4 = ecs_new_id(world); ecs_set(world, e4, Self, {e4});
+    ecs_entity_t e5 = ecs_new_id(world); ecs_set(world, e5, Self, {e5});
+
+    ecs_add(world, e3, TagA);
+    ecs_add(world, e4, TagA);
+    ecs_add(world, e5, TagB);
+
+    ecs_filter_t f;
+    ecs_filter_init(world, &f, &(ecs_filter_desc_t) {
+        .terms = {{ ecs_id(Self) }, { ecs_id(Position), .subj.entity = foo} },
+        .instanced = true
+    });
+
+    ecs_iter_t it = ecs_filter_iter(world, &f);
+    ecs_iter_t pit = ecs_page_iter(&it, 0, 0);
+
+    {
+        test_bool(ecs_page_next(&pit), true);
+        test_int(pit.count, 2);
+        test_int(pit.entities[0], e1);
+        test_int(pit.entities[1], e2);
+        test_int(pit.ids[0], ecs_id(Self));
+        test_int(pit.ids[1], ecs_id(Position));
+        test_int(pit.subjects[0], 0);
+        test_int(pit.subjects[1], foo);
+
+        Self *ptr = ecs_term(&pit, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e1);
+        test_int(ptr[1].value, e2);
+
+        Position *pptr = ecs_term(&pit, Position, 2);
+        test_int(pptr->x, 10);
+        test_int(pptr->y, 20);
+    }
+
+    {
+        test_bool(ecs_page_next(&pit), true);
+        test_int(pit.count, 2);
+        test_int(pit.entities[0], e3);
+        test_int(pit.entities[1], e4);
+        test_int(pit.ids[0], ecs_id(Self));
+        test_int(pit.ids[1], ecs_id(Position));
+        test_int(pit.subjects[0], 0);
+        test_int(pit.subjects[1], foo);
+
+        Self *ptr = ecs_term(&pit, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e3);
+        test_int(ptr[1].value, e4);
+
+        Position *pptr = ecs_term(&pit, Position, 2);
+        test_int(pptr->x, 10);
+        test_int(pptr->y, 20);
+    }
+
+    {
+        test_bool(ecs_page_next(&pit), true);
+        test_int(pit.count, 1);
+        test_int(pit.entities[0], e5);
+        test_int(pit.ids[0], ecs_id(Self));
+        test_int(pit.ids[1], ecs_id(Position));
+        test_int(pit.subjects[0], 0);
+        test_int(pit.subjects[1], foo);
+
+        Self *ptr = ecs_term(&pit, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e5);
+
+        Position *pptr = ecs_term(&pit, Position, 2);
+        test_int(pptr->x, 10);
+        test_int(pptr->y, 20);
+    }
+
+    test_bool(ecs_page_next(&pit), false);
+
+    ecs_fini(world);
+}
+
+void Iter_worker_iter_w_shared_comp() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_COMPONENT(world, Self);
+    ECS_COMPONENT(world, Position);
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+
+    ecs_entity_t foo = ecs_set(world, 0, Position, {10, 20});
+
+    ecs_entity_t e1 = ecs_new_id(world); ecs_set(world, e1, Self, {e1});
+    ecs_entity_t e2 = ecs_new_id(world); ecs_set(world, e2, Self, {e2});
+    ecs_entity_t e3 = ecs_new_id(world); ecs_set(world, e3, Self, {e3});
+    ecs_entity_t e4 = ecs_new_id(world); ecs_set(world, e4, Self, {e4});
+    ecs_entity_t e5 = ecs_new_id(world); ecs_set(world, e5, Self, {e5});
+
+    ecs_add(world, e3, TagA);
+    ecs_add(world, e4, TagA);
+    ecs_add(world, e5, TagB);
+
+    ecs_filter_t f;
+    ecs_filter_init(world, &f, &(ecs_filter_desc_t) {
+        .terms = {{ ecs_id(Self) }, { ecs_id(Position), .subj.entity = foo} },
+        .instanced = true
+    });
+
+    ecs_iter_t it_1 = ecs_filter_iter(world, &f);
+    ecs_iter_t pit_1 = ecs_worker_iter(&it_1, 0, 2);
+    ecs_iter_t it_2 = ecs_filter_iter(world, &f);
+    ecs_iter_t pit_2 = ecs_worker_iter(&it_2, 1, 2);
+
+    /* Iter 1 */
+    {
+        test_bool(ecs_worker_next(&pit_1), true);
+        test_int(pit_1.count, 1);
+        test_int(pit_1.entities[0], e1);
+        test_int(pit_1.ids[0], ecs_id(Self));
+        test_int(pit_1.ids[1], ecs_id(Position));
+        test_int(pit_1.subjects[0], 0);
+        test_int(pit_1.subjects[1], foo);
+
+        Self *ptr = ecs_term(&pit_1, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e1);
+
+        Position *pptr = ecs_term(&pit_1, Position, 2);
+        test_int(pptr->x, 10);
+        test_int(pptr->y, 20);
+    }
+
+    {
+        test_bool(ecs_worker_next(&pit_1), true);
+        test_int(pit_1.count, 1);
+        test_int(pit_1.entities[0], e3);
+        test_int(pit_1.ids[0], ecs_id(Self));
+        test_int(pit_1.ids[1], ecs_id(Position));
+        test_int(pit_1.subjects[0], 0);
+        test_int(pit_1.subjects[1], foo);
+
+        Self *ptr = ecs_term(&pit_1, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e3);
+
+        Position *pptr = ecs_term(&pit_1, Position, 2);
+        test_int(pptr->x, 10);
+        test_int(pptr->y, 20);
+    }
+
+    {
+        test_bool(ecs_worker_next(&pit_1), true);
+        test_int(pit_1.count, 1);
+        test_int(pit_1.entities[0], e5);
+        test_int(pit_1.ids[0], ecs_id(Self));
+        test_int(pit_1.ids[1], ecs_id(Position));
+        test_int(pit_1.subjects[0], 0);
+        test_int(pit_1.subjects[1], foo);
+
+        Self *ptr = ecs_term(&pit_1, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e5);
+
+        Position *pptr = ecs_term(&pit_1, Position, 2);
+        test_int(pptr->x, 10);
+        test_int(pptr->y, 20);
+    }
+
+    test_bool(ecs_worker_next(&pit_1), false);
+
+    /* Iter 2 */
+    {
+        test_bool(ecs_worker_next(&pit_2), true);
+        test_int(pit_2.count, 1);
+        test_int(pit_2.entities[0], e2);
+        test_int(pit_2.ids[0], ecs_id(Self));
+        test_int(pit_2.ids[1], ecs_id(Position));
+        test_int(pit_2.subjects[0], 0);
+        test_int(pit_2.subjects[1], foo);
+
+        Self *ptr = ecs_term(&pit_2, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e2);
+
+        Position *pptr = ecs_term(&pit_2, Position, 2);
+        test_int(pptr->x, 10);
+        test_int(pptr->y, 20);
+    }
+
+    {
+        test_bool(ecs_worker_next(&pit_2), true);
+        test_int(pit_2.count, 1);
+        test_int(pit_2.entities[0], e4);
+        test_int(pit_2.ids[0], ecs_id(Self));
+        test_int(pit_2.ids[1], ecs_id(Position));
+        test_int(pit_2.subjects[0], 0);
+        test_int(pit_2.subjects[1], foo);
+
+        Self *ptr = ecs_term(&pit_2, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, e4);
+
+        Position *pptr = ecs_term(&pit_2, Position, 2);
+        test_int(pptr->x, 10);
+        test_int(pptr->y, 20);
+    }
+
+    test_bool(ecs_worker_next(&pit_2), false);
+
+    ecs_fini(world);
+}
+
+void Iter_paged_iter_w_task_query() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_COMPONENT(world, Self);
+
+    ecs_entity_t foo = ecs_new_id(world); ecs_set(world, foo, Self, {foo});
+
+    ecs_filter_t f;
+    ecs_filter_init(world, &f, &(ecs_filter_desc_t) {
+        .terms = {{ ecs_id(Self), .subj.entity = foo }}
+    });
+
+    ecs_iter_t it = ecs_filter_iter(world, &f);
+    ecs_iter_t pit = ecs_page_iter(&it, 0, 0);
+
+    {
+        test_bool(ecs_page_next(&pit), true);
+        test_int(pit.count, 0);
+        test_int(pit.ids[0], ecs_id(Self));
+        test_int(pit.subjects[0], foo);
+
+        Self *ptr = ecs_term(&pit, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, foo);
+    }
+
+    test_bool(ecs_page_next(&pit), false);
+
+    ecs_fini(world);
+}
+
+void Iter_worker_iter_w_task_query() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_COMPONENT(world, Self);
+
+    ecs_entity_t foo = ecs_new_id(world); ecs_set(world, foo, Self, {foo});
+
+    ecs_filter_t f;
+    ecs_filter_init(world, &f, &(ecs_filter_desc_t) {
+        .terms = {{ ecs_id(Self), .subj.entity = foo }}
+    });
+
+    ecs_iter_t it_1 = ecs_filter_iter(world, &f);
+    ecs_iter_t pit_1 = ecs_worker_iter(&it_1, 0, 2);
+    ecs_iter_t it_2 = ecs_filter_iter(world, &f);
+    ecs_iter_t pit_2 = ecs_worker_iter(&it_2, 1, 2);
+
+    /* Iter 1 */
+    {
+        test_bool(ecs_worker_next(&pit_1), true);
+        test_int(pit_1.count, 0);
+        test_int(pit_1.ids[0], ecs_id(Self));
+        test_int(pit_1.subjects[0], foo);
+
+        Self *ptr = ecs_term(&pit_1, Self, 1);
+        test_assert(ptr != NULL);
+        test_int(ptr[0].value, foo);
+    }
+
+    test_bool(ecs_worker_next(&pit_1), false);
+
+    /* Iter 2 */
+
+    test_bool(ecs_worker_next(&pit_2), false);
+
+    ecs_fini(world);
+}

--- a/test/api/src/MultiThread.c
+++ b/test/api/src/MultiThread.c
@@ -733,7 +733,6 @@ void TestAll(ecs_iter_t *it) {
     }
 }
 
-
 static
 void test_combs_100_entity(int THREADS) {
     ecs_world_t *world = ecs_init();
@@ -777,7 +776,7 @@ void MultiThread_2_thread_test_combs_100_entity_w_next_worker() {
 
     ecs_query_t *q = ecs_query_new(world, "Position, TestSubset()");
 
-    int i, ENTITIES = 4;
+    int i, ENTITIES = 100;
 
     const ecs_entity_t *ids = ecs_bulk_new(world, Position, ENTITIES);
 
@@ -786,13 +785,15 @@ void MultiThread_2_thread_test_combs_100_entity_w_next_worker() {
     }
 
     ecs_iter_t it = ecs_query_iter(world, q);
-    while (ecs_query_next_worker(&it, 0, 2)) {
-        TestAll(&it);
+    ecs_iter_t wit = ecs_worker_iter(&it, 0, 2);
+    while (ecs_worker_next(&wit)) {
+        TestAll(&wit);
     }
 
     it = ecs_query_iter(world, q);
-    while (ecs_query_next_worker(&it, 1, 2)) {
-        TestAll(&it);
+    wit = ecs_worker_iter(&it, 1, 2);
+    while (ecs_worker_next(&wit)) {
+        TestAll(&wit);
     }
 
     for (i = 0; i < ENTITIES; i ++) {

--- a/test/api/src/Query.c
+++ b/test/api/src/Query.c
@@ -2398,3 +2398,56 @@ void Query_no_instancing_w_shared() {
 
     ecs_fini(world);
 }
+
+void Query_query_iter_frame_offset() {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+    ECS_TAG(world, TagC);
+
+    ecs_query_t *q = ecs_query_init(world, &(ecs_query_desc_t) {
+        .filter.terms = {
+            { .id = TagA, }
+        },
+    });
+
+    ecs_entity_t e1 = ecs_new(world, TagA);
+    ecs_entity_t e2 = ecs_new(world, TagA);
+    ecs_entity_t e3 = ecs_new(world, TagA);
+    ecs_entity_t e4 = ecs_new(world, TagA);
+    ecs_entity_t e5 = ecs_new(world, TagA);
+
+    ecs_add(world, e3, TagB);
+    ecs_add(world, e4, TagB);
+    ecs_add(world, e5, TagC);
+
+    ecs_iter_t it = ecs_query_iter(world, q);
+
+    test_bool(ecs_query_next(&it), true);
+    test_int(it.count, 2);
+    test_int(it.frame_offset, 0);
+    test_assert(it.entities != NULL);
+    test_assert(it.entities[0] == e1);
+    test_assert(it.entities[1] == e2);
+    test_assert(it.ids[0] == TagA);
+
+    test_bool(ecs_query_next(&it), true);
+    test_int(it.count, 2);
+    test_int(it.frame_offset, 2);
+    test_assert(it.entities != NULL);
+    test_assert(it.entities[0] == e3);
+    test_assert(it.entities[1] == e4);
+    test_assert(it.ids[0] == TagA);
+
+    test_bool(ecs_query_next(&it), true);
+    test_int(it.count, 1);
+    test_int(it.frame_offset, 4);
+    test_assert(it.entities != NULL);
+    test_assert(it.entities[0] == e5);
+    test_assert(it.ids[0] == TagA);
+
+    test_bool(ecs_query_next(&it), false);
+
+    ecs_fini(world);
+}

--- a/test/api/src/Rules.c
+++ b/test/api/src/Rules.c
@@ -438,7 +438,7 @@ void test_1_comp(const char *expr) {
 
     ecs_iter_t it = ecs_rule_iter(world, r);
 
-    test_true(test_iter(&it, ecs_rule_next, &(ecs_iter_result_t){
+    test_true(test_iter(&it, ecs_rule_next, &(test_iter_result_t){
         {e1, e2, e3, e4},
         {{ecs_id(Position)}},
         {
@@ -478,7 +478,7 @@ void test_2_comp(const char *expr) {
 
     ecs_iter_t it = ecs_rule_iter(world, r);
 
-    test_true(test_iter(&it, ecs_rule_next, &(ecs_iter_result_t){
+    test_true(test_iter(&it, ecs_rule_next, &(test_iter_result_t){
         {e1, e2, e3, e4},
         {{ecs_id(Position), ecs_id(Velocity)}},
         {
@@ -821,7 +821,7 @@ void Rules_find_1_pair() {
 
     ecs_iter_t it = ecs_rule_iter(world, r);
 
-    test_true(test_iter(&it, ecs_rule_next, &(ecs_iter_result_t){
+    test_true(test_iter(&it, ecs_rule_next, &(test_iter_result_t){
         .entity_names = {"BB8", "Luke", "Rey"},
         .term_ids_expr = {{"(HomePlanet,Tatooine)"}}
     }));
@@ -844,7 +844,7 @@ void Rules_find_2_pairs() {
 
     ecs_iter_t it = ecs_rule_iter(world, r);
 
-    test_true(test_iter(&it, ecs_rule_next, &(ecs_iter_result_t){
+    test_true(test_iter(&it, ecs_rule_next, &(test_iter_result_t){
         .entity_names = {"Luke", "Rey"},
         .term_ids_expr = {{"(HomePlanet,Tatooine)", "(Enemy,Palpatine)"}}
     }));
@@ -870,7 +870,7 @@ void Rules_find_w_pred_var() {
 
     ecs_iter_t it = ecs_rule_iter(world, r);
 
-    test_true(test_iter(&it, ecs_rule_next, &(ecs_iter_result_t){
+    test_true(test_iter(&it, ecs_rule_next, &(test_iter_result_t){
         .entity_names = {
             "Luke", "Luke",
             "Yoda", "Yoda",
@@ -914,7 +914,7 @@ void Rules_find_w_pred_var_explicit_subject() {
 
     ecs_iter_t it = ecs_rule_iter(world, r);
 
-    test_true(test_iter(&it, ecs_rule_next, &(ecs_iter_result_t){
+    test_true(test_iter(&it, ecs_rule_next, &(test_iter_result_t){
         .term_ids_expr = {
             {"Human"}, {"Jedi"}
         },
@@ -946,7 +946,7 @@ void Rules_find_1_pair_w_object_var() {
 
     ecs_iter_t it = ecs_rule_iter(world, r);
 
-    test_true(test_iter(&it, ecs_rule_next, &(ecs_iter_result_t){
+    test_true(test_iter(&it, ecs_rule_next, &(test_iter_result_t){
         .entity_names = {"BB8", "DarthVader", "Luke", "Yoda", "Rey"},
         .term_ids_expr = {
             {"(HomePlanet,Tatooine)"}, {"(HomePlanet,Mustafar)"}, 
@@ -983,7 +983,7 @@ void Rules_find_2_pairs_w_object_var() {
 
     ecs_iter_t it = ecs_rule_iter(world, r);
 
-    test_true(test_iter(&it, ecs_rule_next, &(ecs_iter_result_t){
+    test_true(test_iter(&it, ecs_rule_next, &(test_iter_result_t){
         .entity_names = {"Luke", "Luke", "Yoda", "Yoda", "Rey"},
         .term_ids_expr = {
             {"(HomePlanet,Tatooine)", "(Enemy,DarthVader)"}, 
@@ -1023,7 +1023,7 @@ void Rules_find_1_pair_w_pred_var() {
 
     ecs_iter_t it = ecs_rule_iter(world, r);
 
-    test_true(test_iter(&it, ecs_rule_next, &(ecs_iter_result_t){
+    test_true(test_iter(&it, ecs_rule_next, &(test_iter_result_t){
         .entity_names = {"BB8", "Luke", "Rey"},
         .term_ids_expr = {
             {"(HomePlanet,Tatooine)"},
@@ -1058,7 +1058,7 @@ void Rules_find_2_pairs_w_pred_var() {
 
     ecs_iter_t it = ecs_rule_iter(world, r);
 
-    test_true(test_iter(&it, ecs_rule_next, &(ecs_iter_result_t){
+    test_true(test_iter(&it, ecs_rule_next, &(test_iter_result_t){
         .entity_names = {"Luke", "Rey"},
         .term_ids_expr = {
             {"(HomePlanet,Tatooine)", "(Enemy,Palpatine)"}
@@ -1094,7 +1094,7 @@ void Rules_find_cyclic_pairs() {
 
     ecs_iter_t it = ecs_rule_iter(world, r);
 
-    test_true(test_iter(&it, ecs_rule_next, &(ecs_iter_result_t){
+    test_true(test_iter(&it, ecs_rule_next, &(test_iter_result_t){
         .entity_names = {"HanSolo", "Leia"},
         .term_ids_expr = {
             {"(Likes,Leia)", "(Likes,HanSolo)"},
@@ -1130,7 +1130,7 @@ void Rules_join_by_object() {
 
     ecs_iter_t it = ecs_rule_iter(world, r);
 
-    test_true(test_iter(&it, ecs_rule_next, &(ecs_iter_result_t){
+    test_true(test_iter(&it, ecs_rule_next, &(test_iter_result_t){
         .entity_names = {
             "BenSolo", "BenSolo",
             "Luke",    "Luke",
@@ -1178,7 +1178,7 @@ void Rules_join_by_predicate() {
 
     ecs_iter_t it = ecs_rule_iter(world, r);
 
-    test_true(test_iter(&it, ecs_rule_next, &(ecs_iter_result_t){
+    test_true(test_iter(&it, ecs_rule_next, &(test_iter_result_t){
         .entity_names = {
             "Luke", "Luke", "Luke", "Luke",
             "Yoda", "Yoda",
@@ -4268,6 +4268,59 @@ void Rules_term_subj_w_this() {
     test_assert(ecs_rule_next(&it) == false);
 
     ecs_rule_fini(r);
+
+    ecs_fini(world);
+}
+
+void Rules_rule_iter_frame_offset() {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+    ECS_TAG(world, TagC);
+
+    ecs_rule_t *q = ecs_rule_init(world, &(ecs_filter_desc_t) {
+        .terms = {
+            { .id = TagA, }
+        },
+    });
+
+    ecs_entity_t e1 = ecs_new(world, TagA);
+    ecs_entity_t e2 = ecs_new(world, TagA);
+    ecs_entity_t e3 = ecs_new(world, TagA);
+    ecs_entity_t e4 = ecs_new(world, TagA);
+    ecs_entity_t e5 = ecs_new(world, TagA);
+
+    ecs_add(world, e3, TagB);
+    ecs_add(world, e4, TagB);
+    ecs_add(world, e5, TagC);
+
+    ecs_iter_t it = ecs_rule_iter(world, q);
+
+    test_bool(ecs_rule_next(&it), true);
+    test_int(it.count, 2);
+    test_int(it.frame_offset, 0);
+    test_assert(it.entities != NULL);
+    test_assert(it.entities[0] == e1);
+    test_assert(it.entities[1] == e2);
+    test_assert(it.ids[0] == TagA);
+
+    test_bool(ecs_rule_next(&it), true);
+    test_int(it.count, 2);
+    test_int(it.frame_offset, 2);
+    test_assert(it.entities != NULL);
+    test_assert(it.entities[0] == e3);
+    test_assert(it.entities[1] == e4);
+    test_assert(it.ids[0] == TagA);
+
+    test_bool(ecs_rule_next(&it), true);
+    test_int(it.count, 1);
+    test_int(it.frame_offset, 4);
+    test_assert(it.entities != NULL);
+    test_assert(it.entities[0] == e5);
+    test_assert(it.ids[0] == TagA);
+
+    test_bool(ecs_rule_next(&it), false);
 
     ecs_fini(world);
 }

--- a/test/api/src/main.c
+++ b/test/api/src/main.c
@@ -1133,6 +1133,7 @@ void Filter_filter_no_this_component_2_ents(void);
 void Filter_filter_no_this_tag_2_ents_1_not(void);
 void Filter_filter_no_this_component_2_ents_1_not(void);
 void Filter_filter_no_this_component_1_not(void);
+void Filter_filter_iter_frame_offset(void);
 
 // Testsuite 'Query'
 void Query_query_changed_after_new(void);
@@ -1189,6 +1190,25 @@ void Query_2_terms_1_filter(void);
 void Query_3_terms_2_filter(void);
 void Query_no_instancing_w_singleton(void);
 void Query_no_instancing_w_shared(void);
+void Query_query_iter_frame_offset(void);
+
+// Testsuite 'Iter'
+void Iter_page_iter_0_0(void);
+void Iter_page_iter_1_0(void);
+void Iter_page_iter_0_1(void);
+void Iter_page_iter_n_0(void);
+void Iter_page_iter_0_n(void);
+void Iter_page_iter_m_n(void);
+void Iter_page_iter_skip_1_table(void);
+void Iter_page_iter_skip_2_tables(void);
+void Iter_worker_iter_1(void);
+void Iter_worker_iter_2(void);
+void Iter_worker_iter_3(void);
+void Iter_worker_iter_4(void);
+void Iter_paged_iter_w_shared_comp(void);
+void Iter_worker_iter_w_shared_comp(void);
+void Iter_paged_iter_w_task_query(void);
+void Iter_worker_iter_w_task_query(void);
 
 // Testsuite 'Pairs'
 void Pairs_type_w_one_pair(void);
@@ -1382,6 +1402,7 @@ void Rules_2_terms_1_filter(void);
 void Rules_3_terms_2_filter(void);
 void Rules_term_obj_w_this(void);
 void Rules_term_subj_w_this(void);
+void Rules_rule_iter_frame_offset(void);
 
 // Testsuite 'TransitiveRules'
 void TransitiveRules_trans_X_X(void);
@@ -6608,6 +6629,10 @@ bake_test_case Filter_testcases[] = {
     {
         "filter_no_this_component_1_not",
         Filter_filter_no_this_component_1_not
+    },
+    {
+        "filter_iter_frame_offset",
+        Filter_filter_iter_frame_offset
     }
 };
 
@@ -6827,6 +6852,77 @@ bake_test_case Query_testcases[] = {
     {
         "no_instancing_w_shared",
         Query_no_instancing_w_shared
+    },
+    {
+        "query_iter_frame_offset",
+        Query_query_iter_frame_offset
+    }
+};
+
+bake_test_case Iter_testcases[] = {
+    {
+        "page_iter_0_0",
+        Iter_page_iter_0_0
+    },
+    {
+        "page_iter_1_0",
+        Iter_page_iter_1_0
+    },
+    {
+        "page_iter_0_1",
+        Iter_page_iter_0_1
+    },
+    {
+        "page_iter_n_0",
+        Iter_page_iter_n_0
+    },
+    {
+        "page_iter_0_n",
+        Iter_page_iter_0_n
+    },
+    {
+        "page_iter_m_n",
+        Iter_page_iter_m_n
+    },
+    {
+        "page_iter_skip_1_table",
+        Iter_page_iter_skip_1_table
+    },
+    {
+        "page_iter_skip_2_tables",
+        Iter_page_iter_skip_2_tables
+    },
+    {
+        "worker_iter_1",
+        Iter_worker_iter_1
+    },
+    {
+        "worker_iter_2",
+        Iter_worker_iter_2
+    },
+    {
+        "worker_iter_3",
+        Iter_worker_iter_3
+    },
+    {
+        "worker_iter_4",
+        Iter_worker_iter_4
+    },
+    {
+        "paged_iter_w_shared_comp",
+        Iter_paged_iter_w_shared_comp
+    },
+    {
+        "worker_iter_w_shared_comp",
+        Iter_worker_iter_w_shared_comp
+    },
+    {
+        "paged_iter_w_task_query",
+        Iter_paged_iter_w_task_query
+    },
+    {
+        "worker_iter_w_task_query",
+        Iter_worker_iter_w_task_query
     }
 };
 
@@ -7589,6 +7685,10 @@ bake_test_case Rules_testcases[] = {
     {
         "term_subj_w_this",
         Rules_term_subj_w_this
+    },
+    {
+        "rule_iter_frame_offset",
+        Rules_rule_iter_frame_offset
     }
 };
 
@@ -11165,15 +11265,22 @@ static bake_test_suite suites[] = {
         "Filter",
         NULL,
         NULL,
-        111,
+        112,
         Filter_testcases
     },
     {
         "Query",
         NULL,
         NULL,
-        54,
+        55,
         Query_testcases
+    },
+    {
+        "Iter",
+        NULL,
+        NULL,
+        16,
+        Iter_testcases
     },
     {
         "Pairs",
@@ -11186,7 +11293,7 @@ static bake_test_suite suites[] = {
         "Rules",
         NULL,
         NULL,
-        115,
+        116,
         Rules_testcases
     },
     {
@@ -11424,5 +11531,5 @@ static bake_test_suite suites[] = {
 
 int main(int argc, char *argv[]) {
     ut_init(argv[0]);
-    return bake_test_run("api", argc, argv, suites, 64);
+    return bake_test_run("api", argc, argv, suites, 65);
 }

--- a/test/api/src/util.c
+++ b/test/api/src/util.c
@@ -92,7 +92,7 @@ const ecs_entity_t* bulk_new_w_type(
 
 int32_t find_entity(
     ecs_world_t *world,
-    ecs_iter_result_t *expect, 
+    test_iter_result_t *expect, 
     ecs_entity_t e)
 {
     int i;
@@ -142,7 +142,7 @@ int32_t find_entity(
 bool test_iter(
     ecs_iter_t *it, 
     ecs_iter_next_action_t next, 
-    ecs_iter_result_t *expect) 
+    test_iter_result_t *expect) 
 {
     int32_t entity_index = -1;
 


### PR DESCRIPTION
This adds the ability to create paged / worker iterators from any source. Previous to this change only query iterators could be paged (using offset/limit) and used on multiple threads (using `ecs_query_next_worker`).

See here for more details: https://github.com/SanderMertens/flecs/discussions/466#discussioncomment-1775633