### PR TITLE
Fixed compile errors due to referring to Unix sockets instead of Winsock on Windows with mingw and GCC

### DIFF
--- a/flecs.c
+++ b/flecs.c
@@ -26731,7 +26731,7 @@ void FlecsCoreDocImport(
 
 #ifdef FLECS_HTTP
 
-#ifdef _MSC_VER
+#if defined _MSC_VER || defined _WIN32
 #pragma comment(lib, "Ws2_32.lib")
 #include <WinSock2.h>
 #include <Ws2tcpip.h>
@@ -26909,7 +26909,7 @@ static
 void http_close(
     ecs_http_socket_t sock)
 {
-#ifdef _MSC_VER
+#if defined _MSC_VER || defined _WIN32
     closesocket(sock);
 #else
     shutdown(sock, SHUT_RDWR);
@@ -27564,7 +27564,7 @@ ecs_http_server_t* ecs_http_server_init(
     srv->connections = flecs_sparse_new(ecs_http_connection_impl_t);
     srv->requests = flecs_sparse_new(ecs_http_request_impl_t);
 
-#ifndef _MSC_VER
+#if !defined _MSC_VER && !defined _WIN32
     /* Ignore pipe signal. SIGPIPE can occur when a message is sent to a client
      * but te client already disconnected. */
     signal(SIGPIPE, SIG_IGN);
@@ -34544,7 +34544,7 @@ void ecs_os_fini(void) {
     }
 }
 
-#if !defined(_MSC_VER) && !defined(__EMSCRIPTEN__) && !defined(__ANDROID__)
+#if !defined(_MSC_VER) && !defined(__EMSCRIPTEN__) && !defined(__ANDROID__) && !defined(_WIN32)
 #include <execinfo.h>
 #define ECS_BT_BUF_SIZE 100
 static

--- a/src/addons/http.c
+++ b/src/addons/http.c
@@ -34,7 +34,7 @@
 
 #ifdef FLECS_HTTP
 
-#ifdef _MSC_VER
+#if defined _MSC_VER || defined _WIN32
 #pragma comment(lib, "Ws2_32.lib")
 #include <WinSock2.h>
 #include <Ws2tcpip.h>
@@ -212,7 +212,7 @@ static
 void http_close(
     ecs_http_socket_t sock)
 {
-#ifdef _MSC_VER
+#if defined _MSC_VER || defined _WIN32
     closesocket(sock);
 #else
     shutdown(sock, SHUT_RDWR);
@@ -867,7 +867,7 @@ ecs_http_server_t* ecs_http_server_init(
     srv->connections = flecs_sparse_new(ecs_http_connection_impl_t);
     srv->requests = flecs_sparse_new(ecs_http_request_impl_t);
 
-#ifndef _MSC_VER
+#if !defined _MSC_VER && !defined _WIN32
     /* Ignore pipe signal. SIGPIPE can occur when a message is sent to a client
      * but te client already disconnected. */
     signal(SIGPIPE, SIG_IGN);

--- a/src/os_api.c
+++ b/src/os_api.c
@@ -52,7 +52,7 @@ void ecs_os_fini(void) {
     }
 }
 
-#if !defined(_MSC_VER) && !defined(__EMSCRIPTEN__) && !defined(__ANDROID__)
+#if !defined(_MSC_VER) && !defined(__EMSCRIPTEN__) && !defined(__ANDROID__) && !defined(_WIN32)
 #include <execinfo.h>
 #define ECS_BT_BUF_SIZE 100
 static


### PR DESCRIPTION
Currently flecs is not compiled correctly on Windows if we aren't using MSVC compiler. This pull request adds appropriate #if defined _WIN32 and !defined where needed to support correct socket headers on mingw + GCC 