### PR TITLE
#585 Added ecs_ensure_entity_w_generation for the needs of manual id …

### DIFF
--- a/include/flecs.h
+++ b/include/flecs.h
@@ -1229,6 +1229,17 @@ void ecs_set_entity_range(
     ecs_entity_t id_start,
     ecs_entity_t id_end);
 
+/** Makes sure entity exists in the sparse set and sets the entity's generation in the world's sparse set.
+ * Used for managing & recycling manual ids.
+ *
+ * @param world The world.
+ * @param entity_with_generation Entity for which to set the generation with the new generation to set.
+ */
+FLECS_API
+void ecs_ensure_entity_w_generation(
+    ecs_world_t *world,
+    ecs_entity_t entity_with_generation);
+
 /** Enable/disable range limits.
  * When an application is both a receiver of range-limited entities and a
  * producer of range-limited entities, range checking needs to be temporarily

--- a/include/flecs/private/sparse.h
+++ b/include/flecs/private/sparse.h
@@ -176,16 +176,6 @@ void* _flecs_sparse_get_any(
 #define flecs_sparse_get_any(sparse, type, index)\
     ((type*)_flecs_sparse_get_any(sparse, sizeof(type), index))
 
-/** Get or create element by (sparse) id. */
-FLECS_DBG_API
-void* _flecs_sparse_ensure(
-    ecs_sparse_t *sparse,
-    ecs_size_t elem_size,
-    uint64_t id);
-
-#define flecs_sparse_ensure(sparse, type, index)\
-    ((type*)_flecs_sparse_ensure(sparse, sizeof(type), index))
-
 /** Set value. */
 FLECS_DBG_API
 void* _flecs_sparse_set(
@@ -271,6 +261,16 @@ uint64_t ecs_sparse_last_id(
 FLECS_API
 int32_t ecs_sparse_count(
     const ecs_sparse_t *sparse);
+
+/** Get or create element by (sparse) id. */
+FLECS_API
+void* _flecs_sparse_ensure(
+    ecs_sparse_t *sparse,
+    ecs_size_t elem_size,
+    uint64_t id);
+
+#define flecs_sparse_ensure(sparse, type, index)\
+    ((type*)_flecs_sparse_ensure(sparse, sizeof(type), index))
 
 FLECS_API
 void* _ecs_sparse_get_dense(

--- a/src/world.c
+++ b/src/world.c
@@ -1211,6 +1211,18 @@ error:
     return;
 }
 
+void ecs_ensure_entity_w_generation(
+    ecs_world_t *world,
+    ecs_entity_t entity_with_generation) {
+    if (ecs_is_alive(world, entity_with_generation)) {
+        return;
+    }
+    // Manual id could be abscent in the sparse set after delete.
+    flecs_sparse_ensure(world->store.entity_index, ecs_record_t, ecs_strip_generation(entity_with_generation));
+    // Override generation of the entity with the manually managed one.
+    flecs_sparse_set_generation(world->store.entity_index, entity_with_generation);
+}
+
 bool ecs_enable_range_check(
     ecs_world_t *world,
     bool enable)


### PR DESCRIPTION
implements #585

Upd.
this won't work, see #585 

Used like this (sorry for custom syntax), and it works:
```c
entity CreateEntity(ecs &ECS, FStringView Name, EEntityKind Kind) {
    // We do not recycle ids because it allows us to preserve creation order during serialization even in single-threaded mode (unlike flecs).
    // For temporary entities we travel between N ranges of entities to avoid locks yet reuse ids.
    uint64 Id;
    if(Kind == EEntityKind::Persistent) {
         Id = Impl::PersistentEntityIdCounter.fetch_add(1, std::memory_order_relaxed);
    } else {
        Check(Kind == EEntityKind::Temporary);
        Id = Impl::TemporaryEntityIdCounter.fetch_add(1, std::memory_order_relaxed);
        Checkf(Id < Impl::TemporaryEntityIdCurrentFrameEnd, "Temporary entity overflow");
        auto OldId = Id | ((Impl::TemporaryEntityIdLoopCounter - 1) << Impl::EntityIdGenerationBitsOffset);
        auto OldEntity = ECS.entity(OldId);
        bool NeedsDestruction = ecs_is_alive(ECS.c_ptr(), OldEntity.id()) && OldEntity.type().vector().size() > 0;
        if(NeedsDestruction) {
            Destruct(OldEntity);
            if (IsDeferredContext(ECS)) {
                // Destruction is going to be deferred, but we need new entity now.
                return CreateEntity(ECS, Name, Kind);
            }
        }
        Id |= Impl::TemporaryEntityIdLoopCounter << Impl::EntityIdGenerationBitsOffset;
        ecs_ensure_entity_w_generation(ECS.c_ptr(), Id);
    }
    auto Entity = ECS.entity(Id);
    Checkf(Entity.type().vector().size() == 0, "Entity was already in use");
    if (auto Scope = ECS.entity(ECS.get_scope())) {
        Entity.child_of(Scope);
    }
    if(Name) {
        Entity.set<CName>({Name});
    }
    return Entity;
}
```