### PR TITLE
Added ecs_set_entity_generation

### DIFF
--- a/include/flecs.h
+++ b/include/flecs.h
@@ -1229,6 +1229,17 @@ void ecs_set_entity_range(
     ecs_entity_t id_start,
     ecs_entity_t id_end);
 
+/** Sets the entity's generation in the world's sparse set.
+ * Used for managing manual id pools.
+ *
+ * @param world The world.
+ * @param entity_with_generation Entity for which to set the generation with the new generation to set.
+ */
+FLECS_API
+void ecs_set_entity_generation(
+    ecs_world_t *world,
+    ecs_entity_t entity_with_generation);
+
 /** Enable/disable range limits.
  * When an application is both a receiver of range-limited entities and a
  * producer of range-limited entities, range checking needs to be temporarily

--- a/include/flecs/private/sparse.h
+++ b/include/flecs/private/sparse.h
@@ -110,12 +110,6 @@ void* _flecs_sparse_remove_get(
 #define flecs_sparse_remove_get(sparse, type, index)\
     ((type*)_flecs_sparse_remove_get(sparse, sizeof(type), index))
 
-/** Override the generation count for a specific id */
-FLECS_DBG_API
-void flecs_sparse_set_generation(
-    ecs_sparse_t *sparse,
-    uint64_t id);    
-
 /** Check whether an id has ever been issued. */
 FLECS_DBG_API
 bool flecs_sparse_exists(
@@ -271,6 +265,12 @@ uint64_t ecs_sparse_last_id(
 FLECS_API
 int32_t ecs_sparse_count(
     const ecs_sparse_t *sparse);
+
+/** Override the generation count for a specific id */
+FLECS_API
+void flecs_sparse_set_generation(
+    ecs_sparse_t *sparse,
+    uint64_t id);
 
 FLECS_API
 void* _ecs_sparse_get_dense(

--- a/src/world.c
+++ b/src/world.c
@@ -1221,6 +1221,13 @@ bool ecs_enable_range_check(
     return old_value;
 }
 
+void ecs_set_entity_generation(
+    ecs_world_t *world,
+    ecs_entity_t entity_with_generation)
+{
+    flecs_sparse_set_generation(world->store.entity_index, entity_with_generation);
+}
+
 int32_t ecs_get_threads(
     ecs_world_t *world)
 {


### PR DESCRIPTION
implements #587

Use case example (sorry for custom syntax):
```c
entity CreateEntity(ecs &ECS, FStringView Name, EEntityKind Kind) {
    // We do not recycle ids because it allows us to preserve creation order during serialization even in single-threaded mode (unlike flecs).
    // For temporary entities we travel between N ranges of entities to avoid locks yet reuse ids.
    uint64 Id;
    if(Kind == EEntityKind::Persistent) {
        Id = Impl::PersistentEntityIdCounter.fetch_add(1, std::memory_order_relaxed);
    } else {
        Check(Kind == EEntityKind::Temporary);
        Id = Impl::TemporaryEntityIdCounter.fetch_add(1, std::memory_order_relaxed);
        Checkf(Id < Impl::TemporaryEntityIdCurrentFrameEnd, "Temporary entity overflow");
        auto OldId = Id | ((Impl::TemporaryEntityIdLoopCounter - 1) << Impl::EntityIdGenerationBitsOffset);
        auto OldEntity = ECS.entity(OldId);
        bool NeedsDestruction = ecs_is_alive(ECS.c_ptr(), OldEntity.id()) && OldEntity.type().vector().size() > 0;
        if(NeedsDestruction) {
            // Always destruct, because we need to free spaces anyway if we don't want to overflow eventually.
            Destruct(OldEntity);
            if (IsDeferredContext(ECS)) {
                // Destruction is going to be deferred, but we need new entity now, so ignore this one.
                return CreateEntity(ECS, Name, Kind);
            }
            // Destruction is immediate, so we can proceed by overriding the generation safely.
        }
        Id |= Impl::TemporaryEntityIdLoopCounter << Impl::EntityIdGenerationBitsOffset;
        ecs_set_entity_generation(ECS.c_ptr(), Id);
    }
    auto Entity = ECS.entity(Id);
    Checkf(Entity.type().vector().size() == 0, "Entity was already in use");
    if (auto Scope = ECS.entity(ECS.get_scope())) {
        Entity.child_of(Scope);
    }
    if(Name) {
        Entity.set<CName>({Name});
    }
    return Entity;
}
```