### PR TITLE
Improve compile times

### DIFF
--- a/examples/c/entities/basics/src/main.c
+++ b/examples/c/entities/basics/src/main.c
@@ -1,4 +1,5 @@
 #include <basics.h>
+#include <stdio.h>
 
 typedef struct {
     double x, y;

--- a/examples/c/entities/hierarchy/src/main.c
+++ b/examples/c/entities/hierarchy/src/main.c
@@ -1,4 +1,5 @@
 #include <hierarchy.h>
+#include <stdio.h>
 
 typedef struct {
     double x, y;

--- a/examples/c/entities/iterate_components/src/main.c
+++ b/examples/c/entities/iterate_components/src/main.c
@@ -1,4 +1,5 @@
 #include <iterate_components.h>
+#include <stdio.h>
 
 typedef struct {
     double x, y;

--- a/examples/c/entities/prefab/src/main.c
+++ b/examples/c/entities/prefab/src/main.c
@@ -1,4 +1,5 @@
 #include <prefab.h>
+#include <stdio.h>
 
 typedef struct { double value; } Attack;
 typedef struct { double value; } Defense;

--- a/examples/c/entities/relations/.gitignore
+++ b/examples/c/entities/relations/.gitignore
@@ -1,5 +1,0 @@
-.bake_cache
-.DS_Store
-.vscode
-gcov
-bin

--- a/examples/c/entities/relations/src/main.c
+++ b/examples/c/entities/relations/src/main.c
@@ -1,4 +1,5 @@
 #include <relations.h>
+#include <stdio.h>
 
 int main(int argc, char *argv[]) {
     ecs_world_t *ecs = ecs_init_w_args(argc, argv);

--- a/examples/c/hello_world/src/main.c
+++ b/examples/c/hello_world/src/main.c
@@ -1,4 +1,5 @@
 #include <hello_world.h>
+#include <stdio.h>
 
 typedef struct {
     double x;

--- a/examples/c/queries/basics/src/main.c
+++ b/examples/c/queries/basics/src/main.c
@@ -1,4 +1,5 @@
 #include <basics.h>
+#include <stdio.h>
 
 typedef struct {
     double x;

--- a/examples/c/queries/hierarchies/src/main.c
+++ b/examples/c/queries/hierarchies/src/main.c
@@ -1,4 +1,5 @@
 #include <hierarchies.h>
+#include <stdio.h>
 
 typedef struct {
     double x;

--- a/examples/c/reflection/auto_define_enum/src/main.c
+++ b/examples/c/reflection/auto_define_enum/src/main.c
@@ -1,4 +1,5 @@
 #include <auto_define_enum.h>
+#include <stdio.h>
 
 // Color is used by Car, so it must also be captured
 ECS_ENUM(Color, {

--- a/examples/c/reflection/auto_define_nested_struct/src/main.c
+++ b/examples/c/reflection/auto_define_nested_struct/src/main.c
@@ -1,4 +1,5 @@
 #include <auto_define_nested_struct.h>
+#include <stdio.h>
 
 // Point is used by Line, so it must also be captured
 ECS_STRUCT(Point, {

--- a/examples/c/reflection/auto_define_struct/src/main.c
+++ b/examples/c/reflection/auto_define_struct/src/main.c
@@ -1,4 +1,5 @@
 #include <auto_define_struct.h>
+#include <stdio.h>
 
 // This type captured is used later to inject reflection data for Position
 ECS_STRUCT(Position, {

--- a/examples/c/reflection/basics/src/main.c
+++ b/examples/c/reflection/basics/src/main.c
@@ -1,4 +1,5 @@
 #include <basics.h>
+#include <stdio.h>
 
 typedef struct {
     float x, y;

--- a/examples/c/reflection/basics_deserialize/src/main.c
+++ b/examples/c/reflection/basics_deserialize/src/main.c
@@ -1,4 +1,5 @@
 #include <basics_deserialize.h>
+#include <stdio.h>
 
 typedef struct {
     float x, y;

--- a/examples/c/reflection/basics_json/src/main.c
+++ b/examples/c/reflection/basics_json/src/main.c
@@ -1,4 +1,5 @@
 #include <basics_json.h>
+#include <stdio.h>
 
 typedef struct {
     float x, y;

--- a/examples/c/reflection/nested_struct/src/main.c
+++ b/examples/c/reflection/nested_struct/src/main.c
@@ -1,4 +1,5 @@
 #include <nested_struct.h>
+#include <stdio.h>
 
 typedef struct {
     float x, y;

--- a/examples/c/reflection/runtime_component/src/main.c
+++ b/examples/c/reflection/runtime_component/src/main.c
@@ -1,4 +1,5 @@
 #include <runtime_component.h>
+#include <stdio.h>
 
 int main(int argc, char *argv[]) {
     ecs_world_t *ecs = ecs_init_w_args(argc, argv);

--- a/examples/c/systems/basics/src/main.c
+++ b/examples/c/systems/basics/src/main.c
@@ -1,4 +1,5 @@
 #include <basics.h>
+#include <stdio.h>
 
 typedef struct {
     double x, y;

--- a/examples/c/systems/delta_time/src/main.c
+++ b/examples/c/systems/delta_time/src/main.c
@@ -1,4 +1,5 @@
 #include <delta_time.h>
+#include <stdio.h>
 
 void PrintDeltaTime(ecs_iter_t *it) {
     // Print delta_time. The same value is passed to all systems.

--- a/examples/c/systems/pipeline/src/main.c
+++ b/examples/c/systems/pipeline/src/main.c
@@ -1,4 +1,5 @@
 #include <pipeline.h>
+#include <stdio.h>
 
 typedef struct {
     double x, y;

--- a/examples/c/systems/target_fps/src/main.c
+++ b/examples/c/systems/target_fps/src/main.c
@@ -1,4 +1,5 @@
 #include <target_fps.h>
+#include <stdio.h>
 
 void PrintDeltaTime(ecs_iter_t *it) {
     // Print delta_time. The same value is passed to all systems.

--- a/flecs.h
+++ b/flecs.h
@@ -86,13 +86,8 @@
 #define FLECS_API_DEFINES_H
 
 /* Standard library dependencies */
-#include <time.h>
-#include <stdlib.h>
 #include <assert.h>
 #include <stdarg.h>
-#include <string.h>
-#include <stdio.h>
-#include <limits.h>
 #include <string.h>
 
 /* Non-standard but required. If not provided by platform, add manually. */
@@ -163,6 +158,10 @@ extern "C" {
 
 #ifndef FLECS_LEGACY
 #include <stdbool.h>
+#endif
+
+#ifndef NULL
+#define NULL ((void*)0)
 #endif
 
 /* The API uses the native bool type in C++, or a custom one in C */
@@ -1231,8 +1230,6 @@ ecs_vector_t* _ecs_vector_copy(
 #ifdef __cplusplus
 #ifndef FLECS_NO_CPP
 
-#include <initializer_list>
-
 namespace flecs {
 
 template <typename T>
@@ -1275,17 +1272,6 @@ public:
     vector(size_t count = 0) : m_vector( nullptr ) { 
         if (count) {
             init(count);
-        }
-    }
-
-    vector(std::initializer_list<T> elems) : m_vector( nullptr) {
-        init(elems.size());
-        *this = elems;
-    }
-
-    void operator=(std::initializer_list<T> elems) {
-        for (auto elem : elems) {
-            this->add(elem);
         }
     }
 

--- a/include/flecs/addons/cpp/entity_view.hpp
+++ b/include/flecs/addons/cpp/entity_view.hpp
@@ -152,7 +152,7 @@ struct entity_view : public id {
 
         ecs_iter_t it = ecs_filter_iter(m_world, &f);
         while (ecs_filter_next(&it)) {
-            _::each_invoker<Func>(std::move(func)).invoke(&it);
+            _::each_invoker<Func>(FLECS_MOV(func)).invoke(&it);
         }
     }
 

--- a/include/flecs/addons/cpp/flecs.hpp
+++ b/include/flecs/addons/cpp/flecs.hpp
@@ -2,7 +2,7 @@
  * @file flecs.hpp
  * @brief Flecs C++ API.
  *
- * Modern, type safe C++11 API
+ * Modern C++11 API
  */
 
 #pragma once

--- a/include/flecs/addons/cpp/impl/world.hpp
+++ b/include/flecs/addons/cpp/impl/world.hpp
@@ -8,7 +8,7 @@ template <typename T, typename ... Args, if_t<
     std::is_constructible<actual_type_t<T>, flecs::entity, Args...>::value >>
 inline void emplace(world_t *world, id_t entity, Args&&... args) {
     flecs::entity self(world, entity);
-    emplace<T>(world, entity, self, std::forward<Args>(args)...);
+    emplace<T>(world, entity, self, FLECS_FWD(args)...);
 }
 
 inline void world::init_builtin_components() {

--- a/include/flecs/addons/cpp/invoker.hpp
+++ b/include/flecs/addons/cpp/invoker.hpp
@@ -164,7 +164,7 @@ struct each_invoker : public invoker {
 
     template < if_not_t< is_same< void(Func), void(Func)& >::value > = 0>
     explicit each_invoker(Func&& func) noexcept 
-        : m_func(std::move(func)) { }
+        : m_func(FLECS_MOV(func)) { }
 
     explicit each_invoker(const Func& func) noexcept 
         : m_func(func) { }
@@ -289,7 +289,7 @@ private:
 public:
     template < if_not_t< is_same< void(Func), void(Func)& >::value > = 0>
     explicit iter_invoker(Func&& func) noexcept 
-        : m_func(std::move(func)) { }
+        : m_func(FLECS_MOV(func)) { }
 
     explicit iter_invoker(const Func& func) noexcept 
         : m_func(func) { }

--- a/include/flecs/addons/cpp/lifecycle_traits.hpp
+++ b/include/flecs/addons/cpp/lifecycle_traits.hpp
@@ -123,7 +123,7 @@ void move_impl(
     T *dst_arr = static_cast<T*>(dst_ptr);
     T *src_arr = static_cast<T*>(src_ptr);
     for (int i = 0; i < count; i ++) {
-        dst_arr[i] = std::move(src_arr[i]);
+        dst_arr[i] = FLECS_MOV(src_arr[i]);
     }
 }
 
@@ -153,7 +153,7 @@ void move_ctor_impl(
     T *dst_arr = static_cast<T*>(dst_ptr);
     T *src_arr = static_cast<T*>(src_ptr);
     for (int i = 0; i < count; i ++) {
-        FLECS_PLACEMENT_NEW(&dst_arr[i], T(std::move(src_arr[i])));
+        FLECS_PLACEMENT_NEW(&dst_arr[i], T(FLECS_MOV(src_arr[i])));
     }
 }
 
@@ -169,7 +169,7 @@ void ctor_move_dtor_impl(
     T *dst_arr = static_cast<T*>(dst_ptr);
     T *src_arr = static_cast<T*>(src_ptr);
     for (int i = 0; i < count; i ++) {
-        FLECS_PLACEMENT_NEW(&dst_arr[i], T(std::move(src_arr[i])));
+        FLECS_PLACEMENT_NEW(&dst_arr[i], T(FLECS_MOV(src_arr[i])));
         src_arr[i].~T();
     }
 }
@@ -188,7 +188,7 @@ void move_dtor_impl(
     T *src_arr = static_cast<T*>(src_ptr);
     for (int i = 0; i < count; i ++) {
         // Move assignment should free dst & assign dst to src
-        dst_arr[i] = std::move(src_arr[i]);
+        dst_arr[i] = FLECS_MOV(src_arr[i]);
         // Destruct src. Move should have left object in a state where it no
         // longer holds resources, but it still needs to be destructed.
         src_arr[i].~T();
@@ -211,7 +211,7 @@ void move_dtor_impl(
         // Cleanup resources of dst
         dst_arr[i].~T();
         // Copy src to dst
-        dst_arr[i] = std::move(src_arr[i]);
+        dst_arr[i] = FLECS_MOV(src_arr[i]);
         // No need to destruct src. Since this is a trivial move the code
         // should be agnostic to the address of the component which means we
         // can pretend nothing got destructed.

--- a/include/flecs/addons/cpp/mixins/component/impl.hpp
+++ b/include/flecs/addons/cpp/mixins/component/impl.hpp
@@ -5,7 +5,7 @@ namespace flecs {
 // Component mixin implementation
 template <typename T, typename... Args>
 inline flecs::entity world::component(Args &&... args) const {
-    return flecs::component<T>(m_world, std::forward<Args>(args)...);
+    return flecs::component<T>(m_world, FLECS_FWD(args)...);
 }
 
 } // namespace flecs

--- a/include/flecs/addons/cpp/mixins/entity/builder.hpp
+++ b/include/flecs/addons/cpp/mixins/entity/builder.hpp
@@ -203,7 +203,7 @@ struct entity_builder : entity_view {
     template <typename T>
     Self& set_override(T&& val) {
         this->override<T>();
-        this->set<T>(std::forward<T>(val));
+        this->set<T>(FLECS_FWD(val));
         return to_base();  
     }    
 
@@ -385,7 +385,7 @@ struct entity_builder : entity_view {
     template<typename T, if_t< 
         !is_callable<T>::value && is_actual<T>::value> = 0 >
     Self& set(T&& value) {
-        flecs::set<T>(this->m_world, this->m_id, std::forward<T&&>(value));
+        flecs::set<T>(this->m_world, this->m_id, FLECS_FWD(value));
         return to_base();
     }
 
@@ -399,7 +399,7 @@ struct entity_builder : entity_view {
     template<typename T, typename A = actual_type_t<T>, if_not_t< 
         is_callable<T>::value || is_actual<T>::value > = 0>
     Self& set(A&& value) {
-        flecs::set<T>(this->m_world, this->m_id, std::forward<A&&>(value));
+        flecs::set<T>(this->m_world, this->m_id, FLECS_FWD(value));
         return to_base();
     }
 
@@ -502,7 +502,7 @@ struct entity_builder : entity_view {
     template <typename T, typename ... Args>
     Self& emplace(Args&&... args) {
         flecs::emplace<T>(this->m_world, this->m_id, 
-            std::forward<Args>(args)...);
+            FLECS_FWD(args)...);
         return to_base();
     }
 

--- a/include/flecs/addons/cpp/mixins/entity/impl.hpp
+++ b/include/flecs/addons/cpp/mixins/entity/impl.hpp
@@ -174,7 +174,7 @@ inline flecs::entity entity_view::lookup(const char *path) const {
 // Entity mixin implementation
 template <typename... Args>
 inline flecs::entity world::entity(Args &&... args) const {
-    return flecs::entity(m_world, std::forward<Args>(args)...);
+    return flecs::entity(m_world, FLECS_FWD(args)...);
 }
 
 template <typename T>
@@ -184,7 +184,7 @@ inline flecs::entity world::entity(const char *name) const {
 
 template <typename... Args>
 inline flecs::entity world::prefab(Args &&... args) const {
-    flecs::entity result = flecs::entity(m_world, std::forward<Args>(args)...);
+    flecs::entity result = flecs::entity(m_world, FLECS_FWD(args)...);
     result.add(flecs::Prefab);
     return result;
 }

--- a/include/flecs/addons/cpp/mixins/filter/impl.hpp
+++ b/include/flecs/addons/cpp/mixins/filter/impl.hpp
@@ -137,10 +137,10 @@ public:
         return *this;
     }
 
-    filter(filter&& obj) : filter_base(std::move(obj)) { }
+    filter(filter&& obj) : filter_base(FLECS_MOV(obj)) { }
 
     filter& operator=(filter&& obj) {
-        filter_base(std::move(obj));
+        filter_base(FLECS_MOV(obj));
         return *this;
     }
 
@@ -161,13 +161,13 @@ private:
 // World mixin implementation
 template <typename... Comps, typename... Args>
 inline flecs::filter<Comps...> world::filter(Args &&... args) const {
-    return flecs::filter_builder<Comps...>(m_world, std::forward<Args>(args)...)
+    return flecs::filter_builder<Comps...>(m_world, FLECS_FWD(args)...)
         .build();
 }
 
 template <typename... Comps, typename... Args>
 inline flecs::filter_builder<Comps...> world::filter_builder(Args &&... args) const {
-    return flecs::filter_builder<Comps...>(m_world, std::forward<Args>(args)...);
+    return flecs::filter_builder<Comps...>(m_world, FLECS_FWD(args)...);
 }
 
 // world::each
@@ -182,7 +182,7 @@ struct filter_invoker_w_ent<Func, arg_list<E, Args ...> >
 {
     filter_invoker_w_ent(const flecs::world& world, Func&& func) {
         auto f = world.filter<Args ...>();
-        f.each(std::move(func));
+        f.each(FLECS_MOV(func));
     }
 };
 
@@ -195,7 +195,7 @@ struct filter_invoker_no_ent<Func, arg_list<Args ...> >
 {
     filter_invoker_no_ent(const flecs::world& world, Func&& func) {
         auto f = world.filter<Args ...>();
-        f.each(std::move(func));
+        f.each(FLECS_MOV(func));
     }
 };
 
@@ -206,14 +206,14 @@ struct filter_invoker;
 template <typename Func>
 struct filter_invoker<Func, if_t<is_same<first_arg_t<Func>, flecs::entity>::value> > {
     filter_invoker(const flecs::world& world, Func&& func) {
-        filter_invoker_w_ent<Func, arg_list_t<Func>>(world, std::move(func));
+        filter_invoker_w_ent<Func, arg_list_t<Func>>(world, FLECS_MOV(func));
     }
 };
 
 template <typename Func>
 struct filter_invoker<Func, if_not_t<is_same<first_arg_t<Func>, flecs::entity>::value> > {
     filter_invoker(const flecs::world& world, Func&& func) {
-        filter_invoker_no_ent<Func, arg_list_t<Func>>(world, std::move(func));
+        filter_invoker_no_ent<Func, arg_list_t<Func>>(world, FLECS_MOV(func));
     }
 };
 
@@ -221,7 +221,7 @@ struct filter_invoker<Func, if_not_t<is_same<first_arg_t<Func>, flecs::entity>::
 
 template <typename Func>
 inline void world::each(Func&& func) const {
-    _::filter_invoker<Func> f_invoker(*this, std::move(func));
+    _::filter_invoker<Func> f_invoker(*this, FLECS_MOV(func));
 }
 
 template <typename T, typename Func>

--- a/include/flecs/addons/cpp/mixins/id/impl.hpp
+++ b/include/flecs/addons/cpp/mixins/id/impl.hpp
@@ -63,7 +63,7 @@ inline flecs::id world::id() const {
 
 template <typename ... Args>
 inline flecs::id world::id(Args&&... args) const {
-    return flecs::id(m_world, std::forward<Args>(args)...);
+    return flecs::id(m_world, FLECS_FWD(args)...);
 }
 
 template <typename R, typename O>

--- a/include/flecs/addons/cpp/mixins/observer/impl.hpp
+++ b/include/flecs/addons/cpp/mixins/observer/impl.hpp
@@ -33,7 +33,7 @@ struct observer final : entity
 
 template <typename... Comps, typename... Args>
 inline observer_builder<Comps...> world::observer(Args &&... args) const {
-    return flecs::observer_builder<Comps...>(m_world, std::forward<Args>(args)...);
+    return flecs::observer_builder<Comps...>(m_world, FLECS_FWD(args)...);
 }
 
 } // namespace flecs

--- a/include/flecs/addons/cpp/mixins/pipeline/impl.hpp
+++ b/include/flecs/addons/cpp/mixins/pipeline/impl.hpp
@@ -16,7 +16,7 @@ struct pipeline : type_base<pipeline> {
 
 template <typename... Args>
 inline flecs::pipeline world::pipeline(Args &&... args) const {
-    return flecs::pipeline(m_world, std::forward<Args>(args)...);
+    return flecs::pipeline(m_world, FLECS_FWD(args)...);
 }
 
 inline void world::set_pipeline(const flecs::pipeline& pip) const {

--- a/include/flecs/addons/cpp/mixins/query/impl.hpp
+++ b/include/flecs/addons/cpp/mixins/query/impl.hpp
@@ -130,13 +130,13 @@ public:
 // Mixin implementation
 template <typename... Comps, typename... Args>
 inline flecs::query<Comps...> world::query(Args &&... args) const {
-    return flecs::query_builder<Comps...>(m_world, std::forward<Args>(args)...)
+    return flecs::query_builder<Comps...>(m_world, FLECS_FWD(args)...)
         .build();
 }
 
 template <typename... Comps, typename... Args>
 inline flecs::query_builder<Comps...> world::query_builder(Args &&... args) const {
-    return flecs::query_builder<Comps...>(m_world, std::forward<Args>(args)...);
+    return flecs::query_builder<Comps...>(m_world, FLECS_FWD(args)...);
 }
 
 // Builder implementation

--- a/include/flecs/addons/cpp/mixins/snapshot/impl.hpp
+++ b/include/flecs/addons/cpp/mixins/snapshot/impl.hpp
@@ -79,7 +79,7 @@ private:
 // Snapshot mixin implementation
 template <typename... Args>
 inline flecs::snapshot world::snapshot(Args &&... args) const {
-    return flecs::snapshot(*this, std::forward<Args>(args)...);
+    return flecs::snapshot(*this, FLECS_FWD(args)...);
 }
 
 }

--- a/include/flecs/addons/cpp/mixins/system/impl.hpp
+++ b/include/flecs/addons/cpp/mixins/system/impl.hpp
@@ -118,7 +118,7 @@ inline system world::system(flecs::entity e) const {
 
 template <typename... Comps, typename... Args>
 inline system_builder<Comps...> world::system(Args &&... args) const {
-    return flecs::system_builder<Comps...>(m_world, std::forward<Args>(args)...);
+    return flecs::system_builder<Comps...>(m_world, FLECS_FWD(args)...);
 }
 
 } // namespace flecs

--- a/include/flecs/addons/cpp/mixins/term/impl.hpp
+++ b/include/flecs/addons/cpp/mixins/term/impl.hpp
@@ -127,17 +127,17 @@ private:
 // Term mixin implementation
 template <typename... Args>
 inline flecs::term world::term(Args &&... args) const {
-    return flecs::term(m_world, std::forward<Args>(args)...);
+    return flecs::term(m_world, FLECS_FWD(args)...);
 }
 
 template <typename T, typename... Args>
 inline flecs::term world::term(Args &&... args) const {
-    return flecs::term(m_world, std::forward<Args>(args)...).id<T>();
+    return flecs::term(m_world, FLECS_FWD(args)...).id<T>();
 }
 
 template <typename R, typename O, typename... Args>
 inline flecs::term world::term(Args &&... args) const {
-    return flecs::term(m_world, std::forward<Args>(args)...).id<R, O>();
+    return flecs::term(m_world, FLECS_FWD(args)...).id<R, O>();
 }
 
 // Builder implementation

--- a/include/flecs/addons/cpp/mixins/timer/impl.hpp
+++ b/include/flecs/addons/cpp/mixins/timer/impl.hpp
@@ -5,7 +5,7 @@ namespace flecs {
 // Timer class
 struct timer final : entity {
     template <typename ... Args>
-    timer(Args&&... args) : entity(std::forward<Args>(args)...) { }
+    timer(Args&&... args) : entity(FLECS_FWD(args)...) { }
 };
 
 inline void system::interval(FLECS_FLOAT interval) {

--- a/include/flecs/addons/cpp/mixins/trigger/impl.hpp
+++ b/include/flecs/addons/cpp/mixins/trigger/impl.hpp
@@ -31,7 +31,7 @@ struct trigger final : entity
 
 template <typename... Comps, typename... Args>
 inline trigger_builder<Comps...> world::trigger(Args &&... args) const {
-    return flecs::trigger_builder<Comps...>(m_world, std::forward<Args>(args)...);
+    return flecs::trigger_builder<Comps...>(m_world, FLECS_FWD(args)...);
 }
 
 } // namespace flecs

--- a/include/flecs/addons/cpp/mixins/type/impl.hpp
+++ b/include/flecs/addons/cpp/mixins/type/impl.hpp
@@ -5,7 +5,7 @@ namespace flecs {
 // Type mixin implementation
 template <typename... Args>
 inline flecs::type world::type(Args &&... args) const {
-    return flecs::type(m_world, std::forward<Args>(args)...);
+    return flecs::type(m_world, FLECS_FWD(args)...);
 }
 
 template <typename T>

--- a/include/flecs/addons/cpp/utils/array.hpp
+++ b/include/flecs/addons/cpp/utils/array.hpp
@@ -74,7 +74,7 @@ template <typename T, size_t Size>
 struct array<T, Size, enable_if_t<Size == 0>> final {
     array() {};
     array(const T* (&elems)) { (void)elems; }
-    T operator[](size_t index) { abort(); (void)index; return T(); }
+    T operator[](size_t index) { ecs_os_abort(); (void)index; return T(); }
     array_iterator<T> begin() { return array_iterator<T>(nullptr, 0); }
     array_iterator<T> end() { return array_iterator<T>(nullptr, 0); }
 

--- a/include/flecs/addons/cpp/utils/iterable.hpp
+++ b/include/flecs/addons/cpp/utils/iterable.hpp
@@ -20,7 +20,7 @@ struct iterable {
      */
     template <typename Func>
     void each(Func&& func) const {
-        iterate<_::each_invoker>(std::forward<Func>(func), 
+        iterate<_::each_invoker>(FLECS_FWD(func), 
             this->next_each_action());
     }
 
@@ -37,7 +37,7 @@ struct iterable {
      */
     template <typename Func>
     void iter(Func&& func) const { 
-        iterate<_::iter_invoker>(std::forward<Func>(func), this->next_action());
+        iterate<_::iter_invoker>(FLECS_FWD(func), this->next_action());
     }
 
     /** Page iterator.
@@ -73,7 +73,7 @@ protected:
         ecs_iter_t it = this->get_iter();
         it.is_instanced |= Invoker<Func, Components...>::instanced();
 
-        while (next(&it, std::forward<Args>(args)...)) {
+        while (next(&it, FLECS_FWD(args)...)) {
             Invoker<Func, Components...>(func).invoke(&it);
         }
     }

--- a/include/flecs/addons/cpp/utils/node_builder.hpp
+++ b/include/flecs/addons/cpp/utils/node_builder.hpp
@@ -29,7 +29,7 @@ public:
     T iter(Func&& func) {
         using Invoker = typename _::iter_invoker<
             typename std::decay<Func>::type, Components...>;
-        return build<Invoker>(std::forward<Func>(func));
+        return build<Invoker>(FLECS_FWD(func));
     }
 
     /* Each is similar to action, but accepts a function that operates on a
@@ -39,7 +39,7 @@ public:
         using Invoker = typename _::each_invoker<
             typename std::decay<Func>::type, Components...>;
         m_instanced = true;
-        return build<Invoker>(std::forward<Func>(func));
+        return build<Invoker>(FLECS_FWD(func));
     }
 
 protected:
@@ -51,7 +51,7 @@ protected:
 private:
     template <typename Invoker, typename Func>
     T build(Func&& func) {
-        auto ctx = FLECS_NEW(Invoker)(std::forward<Func>(func));
+        auto ctx = FLECS_NEW(Invoker)(FLECS_FWD(func));
 
         m_desc.callback = Invoker::run;
         m_desc.binding_ctx = ctx;

--- a/include/flecs/addons/cpp/utils/utils.hpp
+++ b/include/flecs/addons/cpp/utils/utils.hpp
@@ -130,6 +130,7 @@ struct always_false {
 
 } // namespace flecs
 
+#include <stdlib.h>
 #include "array.hpp"
 #include "string.hpp"
 #include "stringstream.hpp"

--- a/include/flecs/addons/cpp/utils/utils.hpp
+++ b/include/flecs/addons/cpp/utils/utils.hpp
@@ -23,6 +23,16 @@
     }                               \
   } while (false)
 
+/* Faster (compile time) alternatives to std::move / std::forward. From:
+ *   https://www.foonathan.net/2020/09/move-forward/
+ */
+
+#define FLECS_MOV(...) \
+  static_cast<flecs::remove_reference_t<decltype(__VA_ARGS__)>&&>(__VA_ARGS__)
+
+#define FLECS_FWD(...) \
+  static_cast<decltype(__VA_ARGS__)&&>(__VA_ARGS__)
+
 namespace flecs 
 {
 

--- a/include/flecs/addons/cpp/world.hpp
+++ b/include/flecs/addons/cpp/world.hpp
@@ -10,7 +10,7 @@ inline void set(world_t *world, entity_t entity, T&& value, ecs_id_t id) {
     ecs_assert(_::cpp_type<T>::size() != 0, ECS_INVALID_PARAMETER, NULL);
 
     T& dst = *static_cast<T*>(ecs_get_mut_id(world, entity, id, NULL));
-    dst = std::move(value);
+    dst = FLECS_MOV(value);
 
     ecs_modified_id(world, entity, id);
 }
@@ -37,7 +37,7 @@ inline void set(world_t *world, entity_t entity, T&& value, ecs_id_t id) {
     /* If type is not constructible get_mut should assert on new values */
     ecs_assert(!is_new, ECS_INTERNAL_ERROR, NULL);
 
-    dst = std::move(value);
+    dst = FLECS_MOV(value);
 
     ecs_modified_id(world, entity, id);
 }
@@ -67,7 +67,7 @@ inline void emplace(world_t *world, id_t entity, Args&&... args) {
     ecs_assert(_::cpp_type<T>::size() != 0, ECS_INVALID_PARAMETER, NULL);
     T& dst = *static_cast<T*>(ecs_emplace_id(world, entity, id));
     
-    FLECS_PLACEMENT_NEW(&dst, T{std::forward<Args>(args)...});
+    FLECS_PLACEMENT_NEW(&dst, T{FLECS_FWD(args)...});
 
     ecs_modified_id(world, entity, id);    
 }
@@ -81,7 +81,7 @@ inline void emplace(world_t *world, id_t entity, Args&&... args);
 template <typename T, typename A>
 inline void set(world_t *world, entity_t entity, A&& value) {
     id_t id = _::cpp_type<T>::id(world);
-    flecs::set(world, entity, std::forward<A&&>(value), id);
+    flecs::set(world, entity, FLECS_FWD(value), id);
 }
 
 // set(const T&)
@@ -483,7 +483,7 @@ struct world final {
     template <typename T, if_t< !is_callable<T>::value > = 0>
     void set(T&& value) const {
         flecs::set<T>(m_world, _::cpp_type<T>::id(m_world), 
-            std::forward<T&&>(value));
+            FLECS_FWD(value));
     }
     
     /** Set singleton component inside a callback.
@@ -494,7 +494,7 @@ struct world final {
     template <typename T, typename ... Args>
     void emplace(Args&&... args) const {
         flecs::emplace<T>(m_world, _::cpp_type<T>::id(m_world), 
-            std::forward<Args>(args)...);
+            FLECS_FWD(args)...);
     }        
 
     /** Get mut singleton component.

--- a/include/flecs/private/api_defines.h
+++ b/include/flecs/private/api_defines.h
@@ -11,13 +11,8 @@
 #define FLECS_API_DEFINES_H
 
 /* Standard library dependencies */
-#include <time.h>
-#include <stdlib.h>
 #include <assert.h>
 #include <stdarg.h>
-#include <string.h>
-#include <stdio.h>
-#include <limits.h>
 #include <string.h>
 
 /* Non-standard but required. If not provided by platform, add manually. */
@@ -49,6 +44,10 @@ extern "C" {
 
 #ifndef FLECS_LEGACY
 #include <stdbool.h>
+#endif
+
+#ifndef NULL
+#define NULL ((void*)0)
 #endif
 
 /* The API uses the native bool type in C++, or a custom one in C */

--- a/include/flecs/private/map.h
+++ b/include/flecs/private/map.h
@@ -191,71 +191,9 @@ void ecs_map_memory(
         }\
     }
 #endif
+
 #ifdef __cplusplus
 }
-#endif
-
-/** C++ wrapper for map. */
-#ifdef __cplusplus
-#ifndef FLECS_NO_CPP
-
-#include <initializer_list>
-#include <utility>
-
-namespace flecs {
-
-/* C++ class mainly used as wrapper around internal ecs_map_t. Do not use
- * this class as a replacement for STL datastructures! */
-template <typename K, typename T>
-class map {
-public:
-    map(size_t count = 0) {
-        init(count);
-    }
-
-    map(std::initializer_list<std::pair<K, T>> elems) {
-        init(elems.size());
-        *this = elems;
-    }
-
-    void operator=(std::initializer_list<std::pair<K, T>> elems) {
-        for (auto elem : elems) {
-            this->set(elem.first, elem.second);
-        }
-    }
-
-    void clear() {
-        ecs_map_clear(m_map);
-    }
-
-    int32_t count() {
-        return ecs_map_count(m_map);
-    }
-
-    void set(K& key, T& value) {
-        _ecs_map_set(m_map, sizeof(T), reinterpret_cast<ecs_map_key_t>(key), &value);
-    }
-
-    T& get(K& key) {
-        static_cast<T*>(_ecs_map_get(m_map, sizeof(T),
-            reinterpret_cast<ecs_map_key_t>(key)));
-    }
-
-    void destruct() {
-        ecs_map_free(m_map);
-    }
-
-private:
-    void init(size_t count) {
-        m_map = ecs_map_new(T, static_cast<ecs_size_t>(count));
-    }
-
-    ecs_map_t *m_map;
-};
-
-}
-
-#endif
 #endif
 
 #endif

--- a/include/flecs/private/vector.h
+++ b/include/flecs/private/vector.h
@@ -407,8 +407,6 @@ ecs_vector_t* _ecs_vector_copy(
 #ifdef __cplusplus
 #ifndef FLECS_NO_CPP
 
-#include <initializer_list>
-
 namespace flecs {
 
 template <typename T>
@@ -451,17 +449,6 @@ public:
     vector(size_t count = 0) : m_vector( nullptr ) { 
         if (count) {
             init(count);
-        }
-    }
-
-    vector(std::initializer_list<T> elems) : m_vector( nullptr) {
-        init(elems.size());
-        *this = elems;
-    }
-
-    void operator=(std::initializer_list<T> elems) {
-        for (auto elem : elems) {
-            this->add(elem);
         }
     }
 

--- a/test/api/src/main.c
+++ b/test/api/src/main.c
@@ -11755,6 +11755,5 @@ static bake_test_suite suites[] = {
 };
 
 int main(int argc, char *argv[]) {
-    ut_init(argv[0]);
     return bake_test_run("api", argc, argv, suites, 65);
 }

--- a/test/collections/src/main.c
+++ b/test/collections/src/main.c
@@ -524,6 +524,5 @@ static bake_test_suite suites[] = {
 };
 
 int main(int argc, char *argv[]) {
-    ut_init(argv[0]);
     return bake_test_run("collections", argc, argv, suites, 4);
 }

--- a/test/cpp_api/include/cpp_api.h
+++ b/test/cpp_api/include/cpp_api.h
@@ -51,7 +51,7 @@ public:
 
     Pod(Pod&& obj) {
         move_ctor_invoked ++;
-        *this = std::move(obj);
+        *this = FLECS_MOV(obj);
     }
 
     Pod& operator=(const Pod& obj) {

--- a/test/cpp_api/include/cpp_api/bake_config.h
+++ b/test/cpp_api/include/cpp_api/bake_config.h
@@ -19,9 +19,6 @@
 
 /* Headers of public dependencies */
 #include <flecs.h>
-#ifdef __BAKE__
-#include <bake_util.h>
-#endif
 #include <bake_test.h>
 
 #endif

--- a/test/cpp_api/src/main.cpp
+++ b/test/cpp_api/src/main.cpp
@@ -3921,6 +3921,5 @@ static bake_test_suite suites[] = {
 };
 
 int main(int argc, char *argv[]) {
-    ut_init(argv[0]);
     return bake_test_run("cpp_api", argc, argv, suites, 24);
 }

--- a/test/meta/src/main.c
+++ b/test/meta/src/main.c
@@ -2442,6 +2442,5 @@ static bake_test_suite suites[] = {
 };
 
 int main(int argc, char *argv[]) {
-    ut_init(argv[0]);
     return bake_test_run("meta", argc, argv, suites, 15);
 }


### PR DESCRIPTION
This PR has a number of changes that improve compile times for C/C++:
- include fewer headers from C standard library
- remove <initializer_list> dependency
- replace std::move / std::forward with FLECS_MOV, FLECS_FWD
- remove dependency on bake.util for tests (change in bake, only improves test build times)