### PR TITLE
Fixing C4706 MSVC warning: assignment within conditional expression

### DIFF
--- a/include/flecs/addons/cpp/component.hpp
+++ b/include/flecs/addons/cpp/component.hpp
@@ -63,7 +63,7 @@ struct name_util {
          * if this is a template type on msvc. */
         if (len > struct_len) {
             char *ptr = typeName;
-            while ((ptr = strstr(ptr + 1, "struct "))) {
+            while ((ptr = strstr(ptr + 1, "struct ")) != 0) {
                 // Make sure we're not matched with part of a longer identifier
                 // that contains 'struct'
                 if (ptr[-1] == '<' || ptr[-1] == ',' || isspace(ptr[-1])) {


### PR DESCRIPTION
When compiling with MSVC in Visual Studio or Rider for Unreal it complains about 'assignment within conditional expression' (C4706 warning):
`while ((ptr = strstr(ptr + 1, "struct "))) { }`

To fix this issue we need to explicitly test the result of the assignment:
`while ((ptr = strstr(ptr + 1, "struct ")) != 0) { }`


