### PR TITLE
Add C++ rules API

### DIFF
--- a/flecs.c
+++ b/flecs.c
@@ -22003,9 +22003,12 @@ ecs_term_t ecs_term_move(
         src->pred.name = NULL;
         src->subj.name = NULL;
         src->obj.name = NULL;
+        dst.move = false;
         return dst;
     } else {
-        return ecs_term_copy(src);
+        ecs_term_t dst = ecs_term_copy(src);
+        dst.move = false;
+        return dst;
     }
 }
 
@@ -31342,7 +31345,7 @@ int32_t push_frame(
  * register will store a wildcard. */
 static
 ecs_rule_reg_t* get_register_frame(
-    ecs_rule_iter_t *it,
+    const ecs_rule_iter_t *it,
     int32_t frame)    
 {
     if (it->registers) {
@@ -31358,7 +31361,7 @@ ecs_rule_reg_t* get_register_frame(
  * register will store a wildcard. */
 static
 ecs_rule_reg_t* get_registers(
-    ecs_rule_iter_t *it,
+    const ecs_rule_iter_t *it,
     ecs_rule_op_t *op)    
 {
     return get_register_frame(it, op->frame);
@@ -33337,7 +33340,7 @@ void ecs_rule_fini(
     ecs_os_free(rule);
 }
 
-const ecs_filter_t* ecs_rule_filter(
+const ecs_filter_t* ecs_rule_get_filter(
     const ecs_rule_t *rule)
 {
     return &rule->filter; 
@@ -33526,10 +33529,10 @@ bool ecs_rule_var_is_entity(
 
 /* Public function to get the value of a variable. */
 ecs_entity_t ecs_rule_get_var(
-    ecs_iter_t *iter,
+    const ecs_iter_t *iter,
     int32_t var_id)
 {
-    ecs_rule_iter_t *it = &iter->priv.iter.rule;
+    const ecs_rule_iter_t *it = &iter->priv.iter.rule;
     const ecs_rule_t *rule = it->rule;
 
     /* We can only return entity variables */
@@ -34723,11 +34726,26 @@ bool is_control_flow(
     }
 }
 
+bool ecs_rule_next(
+    ecs_iter_t *it)
+{
+    ecs_check(it != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(it->next == ecs_rule_next, ECS_INVALID_PARAMETER, NULL);
+
+    if (flecs_iter_next_row(it)) {
+        return true;
+    }
+
+    return flecs_iter_next_instanced(it, ecs_rule_next_instanced(it));
+error:
+    return false;
+}
+
 /* Iterator next function. This evaluates the program until it reaches a Yield
  * operation, and returns the intermediate result(s) to the application. An
  * iterator can, depending on the program, either return a table, entity, or
  * just true/false, in case a rule doesn't contain the this variable. */
-bool ecs_rule_next(
+bool ecs_rule_next_instanced(
     ecs_iter_t *it)
 {
     ecs_check(it != NULL, ECS_INVALID_PARAMETER, NULL);

--- a/include/flecs/addons/cpp/c_types.hpp
+++ b/include/flecs/addons/cpp/c_types.hpp
@@ -12,6 +12,7 @@ using type_t = ecs_type_t;
 using table_t = ecs_table_t;
 using filter_t = ecs_filter_t;
 using query_t = ecs_query_t;
+using rule_t = ecs_rule_t;
 using ref_t = ecs_ref_t;
 using iter_t = ecs_iter_t;
 using ComponentLifecycle = EcsComponentLifecycle;

--- a/include/flecs/addons/cpp/flecs.hpp
+++ b/include/flecs/addons/cpp/flecs.hpp
@@ -59,6 +59,9 @@ struct each_invoker;
 #ifdef FLECS_REST
 #include "mixins/rest/decl.hpp"
 #endif
+#ifdef FLECS_RULES
+#include "mixins/rule/decl.hpp"
+#endif
 
 #include "log.hpp"
 #include "pair.hpp"
@@ -101,5 +104,12 @@ struct each_invoker;
 #ifdef FLECS_DOC
 #include "mixins/doc/impl.hpp"
 #endif
+#ifdef FLECS_DOC
+#include "mixins/doc/impl.hpp"
+#endif
+#ifdef FLECS_RULES
+#include "mixins/rule/impl.hpp"
+#endif
+
 
 #include "impl.hpp"

--- a/include/flecs/addons/cpp/impl/iter.hpp
+++ b/include/flecs/addons/cpp/impl/iter.hpp
@@ -45,4 +45,24 @@ inline flecs::type iter::type() const {
     return flecs::type(m_iter->world, m_iter->table);
 }
 
+#ifdef FLECS_RULES
+inline flecs::entity iter::get_var(int var_id) const {
+    ecs_assert(m_iter->next == ecs_rule_next, ECS_INVALID_OPERATION, NULL);
+    ecs_assert(var_id != -1, ECS_INVALID_PARAMETER, 0);
+    return flecs::entity(m_iter->world, ecs_rule_get_var(m_iter, var_id));
+}
+
+/** Get value of variable by name.
+ * Get value of a query variable for current result.
+ */
+inline flecs::entity iter::get_var(const char *name) const {
+    ecs_assert(m_iter->next == ecs_rule_next, ECS_INVALID_OPERATION, NULL);
+    ecs_rule_iter_t *rit = &m_iter->priv.iter.rule;
+    const flecs::rule_t *r = rit->rule;
+    int var_id = ecs_rule_find_var(r, name);
+    ecs_assert(var_id != -1, ECS_INVALID_PARAMETER, name);
+    return flecs::entity(m_iter->world, ecs_rule_get_var(m_iter, var_id));
+}
+#endif
+
 } // namespace flecs

--- a/include/flecs/addons/cpp/iter.hpp
+++ b/include/flecs/addons/cpp/iter.hpp
@@ -417,6 +417,18 @@ public:
         ecs_query_skip(m_iter);
     }
 
+#ifdef FLECS_RULES
+    /** Get value of variable by id.
+     * Get value of a query variable for current result.
+     */
+    flecs::entity get_var(int var_id) const;
+
+    /** Get value of variable by name.
+     * Get value of a query variable for current result.
+     */
+    flecs::entity get_var(const char *name) const;
+#endif
+
 private:
     /* Get term, check if correct type is used */
     template <typename T, typename A = actual_type_t<T>>

--- a/include/flecs/addons/cpp/mixins/filter/builder_i.hpp
+++ b/include/flecs/addons/cpp/mixins/filter/builder_i.hpp
@@ -106,6 +106,7 @@ struct filter_builder_i : term_builder_i<Base> {
     Base& term(const char *expr) {
         this->term();
         *this->m_term = flecs::term(this->world_v()).expr(expr).move();
+        this->m_term->move = true;
         return *this;
     }
 

--- a/include/flecs/addons/cpp/mixins/rule/builder.hpp
+++ b/include/flecs/addons/cpp/mixins/rule/builder.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "../filter/builder_i.hpp"
+
+namespace flecs {
+namespace _ {
+    template <typename ... Components>
+    using rule_builder_base = builder<
+        rule, ecs_filter_desc_t, rule_builder<Components...>, 
+        filter_builder_i, Components ...>;
+}
+
+template <typename ... Components>
+struct rule_builder final : _::rule_builder_base<Components...> {
+    rule_builder(flecs::world_t* world)
+        : _::rule_builder_base<Components...>(world)
+    {
+        _::sig<Components...>(world).populate(this);
+    }
+};
+
+}

--- a/include/flecs/addons/cpp/mixins/rule/decl.hpp
+++ b/include/flecs/addons/cpp/mixins/rule/decl.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace flecs {
+
+struct rule_base;
+
+template<typename ... Components>
+struct rule;
+
+template<typename ... Components>
+struct rule_builder;
+
+}

--- a/include/flecs/addons/cpp/mixins/rule/impl.hpp
+++ b/include/flecs/addons/cpp/mixins/rule/impl.hpp
@@ -1,0 +1,101 @@
+#pragma once
+
+#include "builder.hpp"
+
+namespace flecs {
+
+////////////////////////////////////////////////////////////////////////////////
+//// Persistent queries
+////////////////////////////////////////////////////////////////////////////////
+
+struct rule_base {
+    rule_base()
+        : m_world(nullptr)
+        , m_rule(nullptr) { }    
+    
+    rule_base(world_t *world, rule_t *rule = nullptr)
+        : m_world(world)
+        , m_rule(rule) { }
+
+    rule_base(world_t *world, ecs_filter_desc_t *desc) 
+        : m_world(world)
+    {
+        m_rule = ecs_rule_init(world, desc);
+
+        if (!m_rule) {
+            ecs_abort(ECS_INVALID_PARAMETER, NULL);
+        }
+
+        if (desc->terms_buffer) {
+            ecs_os_free(desc->terms_buffer);
+        }
+    }
+
+    operator rule_t*() const {
+        return m_rule;
+    }
+
+    /** Free the rule.
+     */
+    void destruct() {
+        ecs_rule_fini(m_rule);
+        m_world = nullptr;
+        m_rule = nullptr;
+    }
+
+    flecs::string str() {
+        const ecs_filter_t *f = ecs_rule_get_filter(m_rule);
+        char *result = ecs_filter_str(m_world, f);
+        return flecs::string(result);
+    }
+
+    operator rule<>() const;
+
+protected:
+    world_t *m_world;
+    rule_t *m_rule;
+};
+
+template<typename ... Components>
+struct rule final : rule_base, iterable<Components...> {
+private:
+    using Terms = typename _::term_ptrs<Components...>::array;
+
+    ecs_iter_t get_iter() const override {
+        return ecs_rule_iter(m_world, m_rule);
+    }
+
+    ecs_iter_next_action_t next_action() const override {
+        return ecs_rule_next;
+    }
+
+    ecs_iter_next_action_t next_each_action() const override {
+        return ecs_rule_next_instanced;
+    }
+
+public:
+    using rule_base::rule_base;
+
+    int32_t find_var(const char *name) {
+        return ecs_rule_find_var(m_rule, name);
+    }
+};
+
+// Mixin implementation
+template <typename... Comps, typename... Args>
+inline flecs::rule<Comps...> world::rule(Args &&... args) const {
+    return flecs::rule_builder<Comps...>(m_world, FLECS_FWD(args)...)
+        .build();
+}
+
+template <typename... Comps, typename... Args>
+inline flecs::rule_builder<Comps...> world::rule_builder(Args &&... args) const {
+    return flecs::rule_builder<Comps...>(m_world, FLECS_FWD(args)...);
+}
+
+// rule_base implementation
+inline rule_base::operator rule<>() const {
+    return flecs::rule<>(m_world, m_rule);
+}
+
+} // namespace flecs

--- a/include/flecs/addons/cpp/mixins/rule/mixin.inl
+++ b/include/flecs/addons/cpp/mixins/rule/mixin.inl
@@ -1,0 +1,18 @@
+
+/** Create a rule.
+ * @see ecs_rule_init
+ */
+template <typename... Comps, typename... Args>
+flecs::rule<Comps...> rule(Args &&... args) const;
+
+/** Create a subrule.
+ * @see ecs_rule_init
+ */
+template <typename... Comps, typename... Args>
+flecs::rule<Comps...> rule(flecs::rule_base& parent, Args &&... args) const;
+
+/** Create a rule builder.
+ * @see ecs_rule_init
+ */
+template <typename... Comps, typename... Args>
+flecs::rule_builder<Comps...> rule_builder(Args &&... args) const;

--- a/include/flecs/addons/cpp/mixins/term/builder_i.hpp
+++ b/include/flecs/addons/cpp/mixins/term/builder_i.hpp
@@ -46,7 +46,7 @@ struct term_id_builder_i {
      */
     Base& name(const char *name) {
         ecs_assert(m_term_id != NULL, ECS_INVALID_PARAMETER, NULL);
-        m_term_id->name = ecs_os_strdup(name);
+        m_term_id->name = const_cast<char*>(name);
         return *this;
     }
 
@@ -196,6 +196,8 @@ struct term_builder_i : term_id_builder_i<Base> {
             ecs_abort(ECS_INVALID_PARAMETER, NULL);
         }
 
+        m_term->move = true;
+
         // Should not have more than one term
         ecs_assert(ptr[0] == 0, ECS_INVALID_PARAMETER, NULL);
         return *this;
@@ -240,7 +242,28 @@ struct term_builder_i : term_id_builder_i<Base> {
         this->m_term_id->entity = entity;
         return *this;
     }
-    
+
+    /** Select predicate of term, initialize it with specified name. */
+    Base& pred(const char *n) {
+        this->pred();
+        this->m_term_id->name = const_cast<char*>(n);
+        return *this;
+    }
+
+    /** Select subject of term, initialize it with specified name. */
+    Base& subj(const char *n) {
+        this->subj();
+        this->m_term_id->name = const_cast<char*>(n);
+        return *this;
+    }
+
+    /** Select object of term, initialize it with specified name. */
+    Base& obj(const char *n) {
+        this->obj();
+        this->m_term_id->name = const_cast<char*>(n);
+        return *this;
+    }
+
     /** Select subject of term, initialize it with id from specified type. */
     template<typename T>
     Base& subj() {

--- a/include/flecs/addons/cpp/mixins/term/impl.hpp
+++ b/include/flecs/addons/cpp/mixins/term/impl.hpp
@@ -34,7 +34,7 @@ struct term final : term_builder_i<term> {
             value = t;
             value.move = false;
             this->set_term(&value);
-        }        
+        }
 
     term(flecs::world_t *world_ptr, id_t r, id_t o) 
         : term_builder_i<term>(&value)

--- a/include/flecs/addons/cpp/world.hpp
+++ b/include/flecs/addons/cpp/world.hpp
@@ -720,6 +720,9 @@ struct world final {
 #   ifdef FLECS_SYSTEM
 #   include "mixins/system/mixin.inl"
 #   endif
+#   ifdef FLECS_RULES
+#   include "mixins/rule/mixin.inl"
+#   endif
 
 public:
     void init_builtin_components();

--- a/include/flecs/addons/rules.h
+++ b/include/flecs/addons/rules.h
@@ -31,7 +31,7 @@ void ecs_rule_fini(
     ecs_rule_t *rule);
 
 FLECS_API
-const ecs_filter_t* ecs_rule_filter(
+const ecs_filter_t* ecs_rule_get_filter(
     const ecs_rule_t *rule);
 
 FLECS_API
@@ -56,7 +56,7 @@ void ecs_rule_set_var(
 
 FLECS_API
 ecs_entity_t ecs_rule_get_var(
-    ecs_iter_t *it,
+    const ecs_iter_t *it,
     int32_t var_id);
 
 FLECS_API
@@ -75,6 +75,10 @@ void ecs_rule_iter_free(
 
 FLECS_API
 bool ecs_rule_next(
+    ecs_iter_t *it);
+
+FLECS_API
+bool ecs_rule_next_instanced(
     ecs_iter_t *it);
 
 FLECS_API

--- a/src/addons/rules.c
+++ b/src/addons/rules.c
@@ -614,7 +614,7 @@ int32_t push_frame(
  * register will store a wildcard. */
 static
 ecs_rule_reg_t* get_register_frame(
-    ecs_rule_iter_t *it,
+    const ecs_rule_iter_t *it,
     int32_t frame)    
 {
     if (it->registers) {
@@ -630,7 +630,7 @@ ecs_rule_reg_t* get_register_frame(
  * register will store a wildcard. */
 static
 ecs_rule_reg_t* get_registers(
-    ecs_rule_iter_t *it,
+    const ecs_rule_iter_t *it,
     ecs_rule_op_t *op)    
 {
     return get_register_frame(it, op->frame);
@@ -2609,7 +2609,7 @@ void ecs_rule_fini(
     ecs_os_free(rule);
 }
 
-const ecs_filter_t* ecs_rule_filter(
+const ecs_filter_t* ecs_rule_get_filter(
     const ecs_rule_t *rule)
 {
     return &rule->filter; 
@@ -2798,10 +2798,10 @@ bool ecs_rule_var_is_entity(
 
 /* Public function to get the value of a variable. */
 ecs_entity_t ecs_rule_get_var(
-    ecs_iter_t *iter,
+    const ecs_iter_t *iter,
     int32_t var_id)
 {
-    ecs_rule_iter_t *it = &iter->priv.iter.rule;
+    const ecs_rule_iter_t *it = &iter->priv.iter.rule;
     const ecs_rule_t *rule = it->rule;
 
     /* We can only return entity variables */
@@ -3995,11 +3995,26 @@ bool is_control_flow(
     }
 }
 
+bool ecs_rule_next(
+    ecs_iter_t *it)
+{
+    ecs_check(it != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(it->next == ecs_rule_next, ECS_INVALID_PARAMETER, NULL);
+
+    if (flecs_iter_next_row(it)) {
+        return true;
+    }
+
+    return flecs_iter_next_instanced(it, ecs_rule_next_instanced(it));
+error:
+    return false;
+}
+
 /* Iterator next function. This evaluates the program until it reaches a Yield
  * operation, and returns the intermediate result(s) to the application. An
  * iterator can, depending on the program, either return a table, entity, or
  * just true/false, in case a rule doesn't contain the this variable. */
-bool ecs_rule_next(
+bool ecs_rule_next_instanced(
     ecs_iter_t *it)
 {
     ecs_check(it != NULL, ECS_INVALID_PARAMETER, NULL);

--- a/src/filter.c
+++ b/src/filter.c
@@ -691,9 +691,12 @@ ecs_term_t ecs_term_move(
         src->pred.name = NULL;
         src->subj.name = NULL;
         src->obj.name = NULL;
+        dst.move = false;
         return dst;
     } else {
-        return ecs_term_copy(src);
+        ecs_term_t dst = ecs_term_copy(src);
+        dst.move = false;
+        return dst;
     }
 }
 

--- a/test/api/include/api/bake_config.h
+++ b/test/api/include/api/bake_config.h
@@ -19,9 +19,6 @@
 
 /* Headers of public dependencies */
 #include <flecs.h>
-#ifdef __BAKE__
-#include <bake_util.h>
-#endif
 #include <bake_test.h>
 
 #endif

--- a/test/cpp_api/project.json
+++ b/test/cpp_api/project.json
@@ -576,6 +576,23 @@
                 "create_w_no_template_args"
             ]
         }, {
+            "id": "RuleBuilder",
+            "testcases": [
+                "1_type",
+                "2_types",
+                "id_term",
+                "type_term",
+                "id_pair_term",
+                "id_pair_wildcard_term",
+                "type_pair_term",
+                "pair_term_w_var",
+                "2_pair_terms_w_var",
+                "set_var",
+                "set_2_vars",
+                "set_var_by_name",
+                "set_2_vars_by_name"
+            ]
+        }, {
             "id": "SystemBuilder",
             "testcases": [
                 "builder_assign_same_type",

--- a/test/cpp_api/src/RuleBuilder.cpp
+++ b/test/cpp_api/src/RuleBuilder.cpp
@@ -1,0 +1,438 @@
+#include <cpp_api.h>
+
+void RuleBuilder_1_type() {
+    flecs::world ecs;
+
+    auto e1 = ecs.entity()
+        .set<Position>({10, 20});
+
+    ecs.entity().set<Velocity>({10, 20});
+
+    auto r = ecs.rule<Position>();
+
+    int count = 0;
+    r.each([&](flecs::entity e, Position& p) {
+        count ++;
+        test_assert(e == e1);
+        test_int(p.x, 10);
+        test_int(p.y, 20);
+    });
+
+    test_int(count, 1);
+
+    r.destruct();
+}
+
+void RuleBuilder_2_types() {
+    flecs::world ecs;
+
+    auto e1 = ecs.entity()
+        .set<Position>({10, 20})
+        .set<Velocity>({1, 2});
+
+    ecs.entity().set<Velocity>({10, 20});
+
+    auto r = ecs.rule<Position, const Velocity>();
+
+    int count = 0;
+    r.each([&](flecs::entity e, Position& p, const Velocity& v) {
+        count ++;
+        test_assert(e == e1);
+        test_int(p.x, 10);
+        test_int(p.y, 20);
+
+        test_int(v.x, 1);
+        test_int(v.y, 2);
+    });
+
+    test_int(count, 1);
+
+    r.destruct();
+}
+
+void RuleBuilder_id_term() {
+    flecs::world ecs;
+
+    auto Tag = ecs.entity();
+
+    auto e1 = ecs.entity()
+        .add(Tag);
+
+    ecs.entity().set<Velocity>({10, 20});
+
+    auto r = ecs.rule_builder()
+        .term(Tag)
+        .build();
+
+    int count = 0;
+    r.each([&](flecs::entity e) {
+        count ++;
+        test_assert(e == e1);
+    });
+
+    test_int(count, 1);
+
+    r.destruct();
+}
+
+void RuleBuilder_type_term() {
+    flecs::world ecs;
+
+    auto e1 = ecs.entity()
+        .set<Position>({10, 20});
+
+    ecs.entity().set<Velocity>({10, 20});
+
+    auto r = ecs.rule_builder()
+        .term<Position>()
+        .build();
+
+    int count = 0;
+    r.each([&](flecs::entity e) {
+        count ++;
+        test_assert(e == e1);
+    });
+
+    test_int(count, 1);
+
+    r.destruct();
+}
+
+void RuleBuilder_id_pair_term() {
+    flecs::world ecs;
+
+    auto Likes = ecs.entity();
+    auto Apples = ecs.entity();
+    auto Pears = ecs.entity();
+
+    auto e1 = ecs.entity()
+        .add(Likes, Apples);
+
+    ecs.entity()
+        .add(Likes, Pears);
+
+    auto r = ecs.rule_builder()
+        .term(Likes, Apples)
+        .build();
+
+    int count = 0;
+    r.each([&](flecs::entity e) {
+        count ++;
+        test_assert(e == e1);
+    });
+
+    test_int(count, 1);
+
+    r.destruct();
+}
+
+void RuleBuilder_id_pair_wildcard_term() {
+    flecs::world ecs;
+
+    auto Likes = ecs.entity();
+    auto Apples = ecs.entity();
+    auto Pears = ecs.entity();
+
+    auto e1 = ecs.entity()
+        .add(Likes, Apples);
+
+    auto e2 = ecs.entity()
+        .add(Likes, Pears);
+
+    auto r = ecs.rule_builder()
+        .term(Likes, flecs::Wildcard)
+        .build();
+
+    int count = 0;
+    r.each([&](flecs::iter& it, size_t index) {
+        if (it.entity(index) == e1) {
+            test_assert(it.id(1) == ecs.pair(Likes, Apples));
+            count ++;
+        }
+        if (it.entity(index) == e2) {
+            test_assert(it.id(1) == ecs.pair(Likes, Pears));
+            count ++;
+        }
+    });
+    test_int(count, 2);
+
+    r.destruct();
+}
+
+void RuleBuilder_type_pair_term() {
+    flecs::world ecs;
+
+    struct Likes { };
+    struct Apples { };
+    struct Pears { };
+
+    auto e1 = ecs.entity()
+        .add<Likes, Apples>();
+
+    auto e2 = ecs.entity()
+        .add<Likes, Pears>();
+
+    auto r = ecs.rule_builder()
+        .term<Likes>(flecs::Wildcard)
+        .build();
+
+    int count = 0;
+    r.each([&](flecs::iter& it, size_t index) {
+        if (it.entity(index) == e1) {
+            test_assert((it.id(1) == ecs.pair<Likes, Apples>()));
+            count ++;
+        }
+        if (it.entity(index) == e2) {
+            test_assert((it.id(1) == ecs.pair<Likes, Pears>()));
+            count ++;
+        }
+    });
+    test_int(count, 2);
+
+    r.destruct();
+}
+
+void RuleBuilder_pair_term_w_var() {
+    flecs::world ecs;
+
+    struct Likes { };
+    struct Apples { };
+    struct Pears { };
+
+    auto e1 = ecs.entity()
+        .add<Likes, Apples>();
+
+    auto e2 = ecs.entity()
+        .add<Likes, Pears>();
+
+    auto r = ecs.rule_builder()
+        .term<Likes>().obj("_Food")
+        .build();
+
+    int food_var = r.find_var("Food");
+
+    int count = 0;
+    r.each([&](flecs::iter& it, size_t index) {
+        if (it.entity(index) == e1) {
+            test_assert((it.id(1) == ecs.pair<Likes, Apples>()));
+            test_assert(it.get_var("Food") == ecs.id<Apples>());
+            test_assert(it.get_var(food_var) == ecs.id<Apples>());
+            count ++;
+        }
+        if (it.entity(index) == e2) {
+            test_assert((it.id(1) == ecs.pair<Likes, Pears>()));
+            test_assert(it.get_var("Food") == ecs.id<Pears>());
+            test_assert(it.get_var(food_var) == ecs.id<Pears>());
+            count ++;
+        }
+    });
+    test_int(count, 2);
+
+    r.destruct();
+}
+
+void RuleBuilder_2_pair_terms_w_var() {
+    flecs::world ecs;
+
+    struct Likes { };
+    struct Eats { };
+    struct Apples { };
+    struct Pears { };
+
+    auto Bob = ecs.entity()
+        .add<Eats, Apples>();
+
+    auto Alice = ecs.entity()
+        .add<Eats, Pears>()
+        .add<Likes>(Bob);
+
+    Bob.add<Likes>(Alice);
+
+    auto r = ecs.rule_builder()
+        .term<Eats>().obj("_Food")
+        .term<Likes>().obj("_Person")
+        .build();
+
+    int food_var = r.find_var("Food");
+    int person_var = r.find_var("Person");
+
+    int count = 0;
+    r.each([&](flecs::iter& it, size_t index) {
+        if (it.entity(index) == Bob) {
+            test_assert((it.id(1) == ecs.pair<Eats, Apples>()));
+            test_assert(it.get_var("Food") == ecs.id<Apples>());
+            test_assert(it.get_var(food_var) == ecs.id<Apples>());
+
+            test_assert((it.id(2) == ecs.pair<Likes>(Alice)));
+            test_assert(it.get_var("Person") == Alice);
+            test_assert(it.get_var(person_var) == Alice);
+            count ++;
+        }
+        if (it.entity(index) == Alice) {
+            test_assert((it.id(1) == ecs.pair<Eats, Pears>()));
+            test_assert(it.get_var("Food") == ecs.id<Pears>());
+            test_assert(it.get_var(food_var) == ecs.id<Pears>());
+
+            test_assert((it.id(2) == ecs.pair<Likes>(Bob)));
+            test_assert(it.get_var("Person") == Bob);
+            test_assert(it.get_var(person_var) == Bob);
+            count ++;
+        }
+    });
+    test_int(count, 2);
+
+    r.destruct();
+}
+
+void RuleBuilder_set_var() {
+    flecs::world ecs;
+
+    struct Likes { };
+    auto Apples = ecs.entity();
+    auto Pears = ecs.entity();
+
+    ecs.entity()
+        .add<Likes>(Apples);
+
+    auto e2 = ecs.entity()
+        .add<Likes>(Pears);
+
+    auto r = ecs.rule_builder()
+        .term<Likes>().obj("_Food")
+        .build();
+
+    int food_var = r.find_var("Food");
+
+    int count = 0;
+    r.iter()
+        .set_var(food_var, Pears)
+        .each([&](flecs::iter& it, size_t index) {
+            test_assert(it.entity(index) == e2);
+            test_assert((it.id(1) == ecs.pair<Likes>(Pears)));
+            test_assert(it.get_var("Food") == Pears);
+            test_assert(it.get_var(food_var) == Pears);
+            count ++;
+        });
+
+    test_int(count, 1);
+
+    r.destruct();
+}
+
+void RuleBuilder_set_2_vars() {
+    flecs::world ecs;
+
+    struct Likes { };
+    struct Eats { };
+    auto Apples = ecs.entity();
+    auto Pears = ecs.entity();
+
+    auto Bob = ecs.entity()
+        .add<Eats>(Apples);
+
+    auto Alice = ecs.entity()
+        .add<Eats>(Pears)
+        .add<Likes>(Bob);
+
+    Bob.add<Likes>(Alice);
+
+    auto r = ecs.rule_builder()
+        .term<Eats>().obj("_Food")
+        .term<Likes>().obj("_Person")
+        .build();
+
+    int food_var = r.find_var("Food");
+    int person_var = r.find_var("Person");
+
+    int count = 0;
+    r.iter()
+        .set_var(food_var, Pears)
+        .set_var(person_var, Bob)
+        .each([&](flecs::iter& it, size_t index) {
+            test_assert(it.entity(index) == Alice);
+            test_assert((it.id(1) == ecs.pair<Eats>(Pears)));
+            test_assert((it.id(2) == ecs.pair<Likes>(Bob)));
+            test_assert(it.get_var("Food") == Pears);
+            test_assert(it.get_var(food_var) == Pears);
+            test_assert(it.get_var("Person") == Bob);
+            test_assert(it.get_var(person_var) == Bob);
+            count ++;
+        });
+    test_int(count, 1);
+
+    r.destruct();
+}
+
+void RuleBuilder_set_var_by_name() {
+    flecs::world ecs;
+
+    struct Likes { };
+    auto Apples = ecs.entity();
+    auto Pears = ecs.entity();
+
+    ecs.entity()
+        .add<Likes>(Apples);
+
+    auto e2 = ecs.entity()
+        .add<Likes>(Pears);
+
+    auto r = ecs.rule_builder()
+        .term<Likes>().obj("_Food")
+        .build();
+
+    int count = 0;
+    r.iter()
+        .set_var("Food", Pears)
+        .each([&](flecs::iter& it, size_t index) {
+            test_assert(it.entity(index) == e2);
+            test_assert((it.id(1) == ecs.pair<Likes>(Pears)));
+            count ++;
+        });
+    test_int(count, 1);
+
+    r.destruct();
+}
+
+void RuleBuilder_set_2_vars_by_name() {
+    flecs::world ecs;
+
+    struct Likes { };
+    struct Eats { };
+    auto Apples = ecs.entity();
+    auto Pears = ecs.entity();
+
+    auto Bob = ecs.entity()
+        .add<Eats>(Apples);
+
+    auto Alice = ecs.entity()
+        .add<Eats>(Pears)
+        .add<Likes>(Bob);
+
+    Bob.add<Likes>(Alice);
+
+    auto r = ecs.rule_builder()
+        .term<Eats>().obj("_Food")
+        .term<Likes>().obj("_Person")
+        .build();
+
+    int food_var = r.find_var("Food");
+    int person_var = r.find_var("Person");
+
+    int count = 0;
+    r.iter()
+        .set_var("Food", Pears)
+        .set_var("Person", Bob)
+        .each([&](flecs::iter& it, size_t index) {
+            test_assert(it.entity(index) == Alice);
+            test_assert((it.id(1) == ecs.pair<Eats>(Pears)));
+            test_assert((it.id(2) == ecs.pair<Likes>(Bob)));
+            test_assert(it.get_var("Food") == Pears);
+            test_assert(it.get_var(food_var) == Pears);
+            test_assert(it.get_var("Person") == Bob);
+            test_assert(it.get_var(person_var) == Bob);
+            count ++;
+        });
+    test_int(count, 1);
+
+    r.destruct();
+}

--- a/test/cpp_api/src/main.cpp
+++ b/test/cpp_api/src/main.cpp
@@ -547,6 +547,21 @@ void FilterBuilder_name_arg(void);
 void FilterBuilder_const_in_term(void);
 void FilterBuilder_create_w_no_template_args(void);
 
+// Testsuite 'RuleBuilder'
+void RuleBuilder_1_type(void);
+void RuleBuilder_2_types(void);
+void RuleBuilder_id_term(void);
+void RuleBuilder_type_term(void);
+void RuleBuilder_id_pair_term(void);
+void RuleBuilder_id_pair_wildcard_term(void);
+void RuleBuilder_type_pair_term(void);
+void RuleBuilder_pair_term_w_var(void);
+void RuleBuilder_2_pair_terms_w_var(void);
+void RuleBuilder_set_var(void);
+void RuleBuilder_set_2_vars(void);
+void RuleBuilder_set_var_by_name(void);
+void RuleBuilder_set_2_vars_by_name(void);
+
 // Testsuite 'SystemBuilder'
 void SystemBuilder_builder_assign_same_type(void);
 void SystemBuilder_builder_build_to_auto(void);
@@ -2877,6 +2892,61 @@ bake_test_case FilterBuilder_testcases[] = {
     }
 };
 
+bake_test_case RuleBuilder_testcases[] = {
+    {
+        "1_type",
+        RuleBuilder_1_type
+    },
+    {
+        "2_types",
+        RuleBuilder_2_types
+    },
+    {
+        "id_term",
+        RuleBuilder_id_term
+    },
+    {
+        "type_term",
+        RuleBuilder_type_term
+    },
+    {
+        "id_pair_term",
+        RuleBuilder_id_pair_term
+    },
+    {
+        "id_pair_wildcard_term",
+        RuleBuilder_id_pair_wildcard_term
+    },
+    {
+        "type_pair_term",
+        RuleBuilder_type_pair_term
+    },
+    {
+        "pair_term_w_var",
+        RuleBuilder_pair_term_w_var
+    },
+    {
+        "2_pair_terms_w_var",
+        RuleBuilder_2_pair_terms_w_var
+    },
+    {
+        "set_var",
+        RuleBuilder_set_var
+    },
+    {
+        "set_2_vars",
+        RuleBuilder_set_2_vars
+    },
+    {
+        "set_var_by_name",
+        RuleBuilder_set_var_by_name
+    },
+    {
+        "set_2_vars_by_name",
+        RuleBuilder_set_2_vars_by_name
+    }
+};
+
 bake_test_case SystemBuilder_testcases[] = {
     {
         "builder_assign_same_type",
@@ -3835,6 +3905,13 @@ static bake_test_suite suites[] = {
         FilterBuilder_testcases
     },
     {
+        "RuleBuilder",
+        NULL,
+        NULL,
+        13,
+        RuleBuilder_testcases
+    },
+    {
         "SystemBuilder",
         NULL,
         NULL,
@@ -3921,6 +3998,5 @@ static bake_test_suite suites[] = {
 };
 
 int main(int argc, char *argv[]) {
-    ut_init(argv[0]);
-    return bake_test_run("cpp_api", argc, argv, suites, 24);
+    return bake_test_run("cpp_api", argc, argv, suites, 25);
 }


### PR DESCRIPTION
This PR adds support for the rules addon to the C++ API. The API reuses the same builder/iteration functions as filters & queries, but with the additional ability to use query variables:

```c
// Create query for (Eats, *)
auto r = world.rule_builder()
  .term(Eats).obj("_Food"); // _ means "Food" is a query variable
  .build();

// Anyone who eats anything
r.each([](flecs::iter& it, int index) {
  cout << "Entity " << it.entity(index).name()
       << "Eats " << it.get_var("Food").name() << "\n";
});

// Anyone who eats apples
r.iter()
 .set_var("Food", Apples)
 .each([](flecs::iter& it, int index) { /* .. */ });

// Anyone who eats pears
r.iter()
 .set_var("Food", Pears)
 .each([](flecs::iter& it, int index) { /* .. */ });
```

