### PR TITLE
Add support for setting table variables on rule iterators

### DIFF
--- a/flecs.c
+++ b/flecs.c
@@ -33610,6 +33610,22 @@ error:
     return;
 }
 
+static
+void ecs_rule_iter_free(
+    ecs_iter_t *iter)
+{
+    ecs_rule_iter_t *it = &iter->priv.iter.rule;
+    ecs_os_free(it->registers);
+    ecs_os_free(it->columns);
+    ecs_os_free(it->op_ctx);
+    ecs_os_free(it->variables);
+    iter->columns = NULL;
+    it->registers = NULL;
+    it->columns = NULL;
+    it->op_ctx = NULL;
+    ecs_iter_fini(iter);
+}
+
 /* Create rule iterator */
 ecs_iter_t ecs_rule_iter(
     const ecs_world_t *world,
@@ -33662,25 +33678,11 @@ ecs_iter_t ecs_rule_iter(
     result.term_count = rule->filter.term_count;
     result.terms = rule->filter.terms;
     result.next = ecs_rule_next;
+    result.fini = ecs_rule_iter_free;
     result.is_filter = rule->filter.filter;
     result.columns = it->columns; /* prevent alloc */
 
     return result;
-}
-
-void ecs_rule_iter_free(
-    ecs_iter_t *iter)
-{
-    ecs_rule_iter_t *it = &iter->priv.iter.rule;
-    ecs_os_free(it->registers);
-    ecs_os_free(it->columns);
-    ecs_os_free(it->op_ctx);
-    ecs_os_free(it->variables);
-    iter->columns = NULL;
-    it->registers = NULL;
-    it->columns = NULL;
-    it->op_ctx = NULL;
-    ecs_iter_fini(iter);
 }
 
 /* Edge case: if the filter has the same variable for both predicate and

--- a/flecs.h
+++ b/flecs.h
@@ -16058,6 +16058,7 @@ struct iter_iterable final : iterable<Components...> {
         m_next_each = it->next_action();
     }
 
+#ifdef FLECS_RULES
     iter_iterable<Components...>& set_var(int var_id, flecs::entity_t value) {
         ecs_assert(m_it.next == ecs_rule_next, ECS_INVALID_OPERATION, NULL);
         ecs_assert(var_id != -1, ECS_INVALID_PARAMETER, 0);
@@ -16073,6 +16074,7 @@ struct iter_iterable final : iterable<Components...> {
         ecs_rule_set_var(&m_it, var_id, value);
         return *this;
     }
+#endif
 
 protected:
     ecs_iter_t get_iter() const {

--- a/flecs.h
+++ b/flecs.h
@@ -9490,69 +9490,224 @@ int ecs_plecs_from_file(
 extern "C" {
 #endif
 
+/** Create a rule.
+ * A rule accepts the same descriptor as a filter, but has the additional
+ * ability to use query variables.
+ * 
+ * Query variables can be used to constrain wildcards across multiple terms to
+ * the same entity. Regular ECS queries do this in a limited form, as querying
+ * for Position, Velocity only returns entities that have both components.
+ * 
+ * Query variables expand this to constrain entities that are resolved while the
+ * query is being matched. Consider a query for all entities and the mission
+ * they are on:
+ *   (Mission, *)
+ * 
+ * If an entity is on multiple missions, the wildcard will match it multiple
+ * times. Now say we want to only list combat missions. Naively we could try:
+ *   (Mission, *), CombatMission(*)
+ * 
+ * But this doesn't work, as term 1 returns entities with missions, and term 2
+ * returns all combat missions for all entities. Query variables make it 
+ * possible to apply CombatMission to the found mission:
+ *   (Mission, _M), CombatMission(_M)
+ * 
+ * By using the same variable ('M') we ensure that CombatMission is applied to
+ * the mission found in the current result.
+ * 
+ * Variables can be used in each part of the term (predicate, subject, object).
+ * This is a valid query:
+ *   Likes(_X, _Y), Likes(_Y, _X)
+ * 
+ * This is also a valid query:
+ *   _Component, Serializable(_Component)
+ * 
+ * In the query expression syntax, variables are prefixed with a _. When using
+ * the descriptor, do this:
+ *   desc.terms[0].obj.name = "_X";
+ * 
+ * or
+ * 
+ *   desc.terms[0].obj.name = "X";
+ *   desc.terms[0].obj.var = EcsVarIsVariable;
+ * 
+ * Different terms with the same variable name are automatically correlated by
+ * the query engine.
+ * 
+ * A rule needs to be explicitly deleted with ecs_rule_fini.
+ * 
+ * @param world The world.
+ * @param desc The descriptor (see ecs_filter_desc_t)
+ * @return The rule.
+ */
 FLECS_API
 ecs_rule_t* ecs_rule_init(
     ecs_world_t *world,
     const ecs_filter_desc_t *desc);
 
+/** Delete a rule. 
+ * 
+ * @param rule The rule.
+ */
 FLECS_API
 void ecs_rule_fini(
     ecs_rule_t *rule);
 
+/** Obtain filter from rule.
+ * This operation returns the filter with which the rule was created.
+ * 
+ * @param rule The rule.
+ * @return The filter.
+ */
 FLECS_API
 const ecs_filter_t* ecs_rule_get_filter(
     const ecs_rule_t *rule);
 
+/** Return number of variables in rule.
+ * 
+ * @param rule The rule.
+ * @return The number of variables/
+ */
 FLECS_API
 int32_t ecs_rule_var_count(
     const ecs_rule_t *rule);
 
+/** Find variable index.
+ * This operation looks up the index of a variable in the rule. This index can
+ * be used in operations like ecs_rule_set_var and ecs_rule_get_var.
+ * 
+ * @param rule The rule.
+ * @param name The variable name.
+ * @return The variable index.
+ */
 FLECS_API
 int32_t ecs_rule_find_var(
     const ecs_rule_t *rule,
     const char *name);    
 
+/** Get variable name.
+ * This operation returns the variable name for an index.
+ * 
+ * @param rule The rule.
+ * @param var_id The variable index.
+ */
 FLECS_API
 const char* ecs_rule_var_name(
     const ecs_rule_t *rule,
     int32_t var_id);
 
+/** Set variable to a value.
+ * This operation initializes the variable to the specified entity. By default
+ * variables are initialized with a wildcard. By setting the variable it is
+ * possible to reuse a single rule for different data sets. For example:
+ * 
+ * // Rule that matches (Eats, *)
+ * ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t) {
+ *   .terms = {
+ *     { .pred.entity = Eats, .obj.name = "_Food" }
+ *   }
+ * });
+ * 
+ * int food_var = ecs_rule_find_var(r, "Food");
+ * 
+ * // Set Food to Apples, so we're only matching (Eats, Apples)
+ * ecs_iter_t it = ecs_rule_iter(world, r);
+ * ecs_rule_set_var(&it, food_var, Apples);
+ * 
+ * while (ecs_rule_next(&it)) {
+ *   for (int i = 0; i < it.count; i ++) {
+ *     // iterate as usual
+ *   }
+ * }
+ * 
+ * That the variable must be initialized after calling ecs_rule_iter and before
+ * calling ecs_rule_next.
+ * 
+ * @param it The iterator.
+ * @param var_id The variable index.
+ * @param value The entity to initialize the variable with.
+ */
 FLECS_API
 void ecs_rule_set_var(
     ecs_iter_t *it,
     int32_t var_id,
     ecs_entity_t value);
 
+/** Get value of variable for current result.
+ * This operation should be called after ecs_rule_next has returned true.
+ * 
+ * If a variable has not been initialized with a value (for example, if it 
+ * occurs in a term with an optional operator) this operation will return
+ * EcsWildcard.
+ * 
+ * @param it The iterator.
+ * @param var_id The variable index.
+ * @return The value of the variable.
+ */
 FLECS_API
 ecs_entity_t ecs_rule_get_var(
     const ecs_iter_t *it,
     int32_t var_id);
 
+/** Test if variable is an entity.
+ * Internally the rule engine has entity variables and table variables. When
+ * iterating through rule variables (by using ecs_rule_variable_count) only
+ * the values for entity variables are accessible. This operation enables an
+ * appliction to check if a variable is an entity variable.
+ * 
+ * @param rule The rule.
+ * @param var_id The variable id.
+ */
 FLECS_API
 bool ecs_rule_var_is_entity(
     const ecs_rule_t *rule,
     int32_t var_id);  
 
+/** Iterate a rule.
+ * Note that rule iterators may allocate memory, and that unless the iterator
+ * is iterated until completion, it may still hold resources. When stopping
+ * iteration before ecs_rule_next has returned false, use ecs_iter_fini to
+ * cleanup any remaining resources.
+ * 
+ * @param world The world.
+ * @param rule The rule.
+ * @return An iterator.
+ */
 FLECS_API
 ecs_iter_t ecs_rule_iter(
     const ecs_world_t *world,
     const ecs_rule_t *rule);
 
-FLECS_API
-void ecs_rule_iter_free(
-    ecs_iter_t *iter);
-
+/** Progress rule iterator.
+ * 
+ * @param it The iterator.
+ */
 FLECS_API
 bool ecs_rule_next(
     ecs_iter_t *it);
 
+/** Progress instanced iterator.
+ * Should not be called unless you know what you're doing :-)
+ * 
+ * @param it The iterator.
+ */
 FLECS_API
 bool ecs_rule_next_instanced(
     ecs_iter_t *it);
 
+/** Convert rule to a string.
+ * This will convert the rule program to a string which can aid in debugging
+ * the behavior of a rule.
+ * 
+ * The returned string must be freed with ecs_os_free.
+ * 
+ * @param rule The rule.
+ * @return The string
+ */
 FLECS_API
 char* ecs_rule_str(
     ecs_rule_t *rule);
+
 
 #ifdef __cplusplus
 }

--- a/src/addons/rules.c
+++ b/src/addons/rules.c
@@ -2879,6 +2879,23 @@ error:
     return;
 }
 
+static
+void ecs_rule_iter_free(
+    ecs_iter_t *iter)
+{
+    ecs_rule_iter_t *it = &iter->priv.iter.rule;
+    ecs_os_free(it->registers);
+    ecs_os_free(it->columns);
+    ecs_os_free(it->op_ctx);
+    ecs_os_free(it->variables);
+    iter->columns = NULL;
+    it->registers = NULL;
+    it->columns = NULL;
+    it->op_ctx = NULL;
+    iter->fini = NULL;
+    ecs_iter_fini(iter);
+}
+
 /* Create rule iterator */
 ecs_iter_t ecs_rule_iter(
     const ecs_world_t *world,
@@ -2931,25 +2948,11 @@ ecs_iter_t ecs_rule_iter(
     result.term_count = rule->filter.term_count;
     result.terms = rule->filter.terms;
     result.next = ecs_rule_next;
+    result.fini = ecs_rule_iter_free;
     result.is_filter = rule->filter.filter;
     result.columns = it->columns; /* prevent alloc */
 
     return result;
-}
-
-void ecs_rule_iter_free(
-    ecs_iter_t *iter)
-{
-    ecs_rule_iter_t *it = &iter->priv.iter.rule;
-    ecs_os_free(it->registers);
-    ecs_os_free(it->columns);
-    ecs_os_free(it->op_ctx);
-    ecs_os_free(it->variables);
-    iter->columns = NULL;
-    it->registers = NULL;
-    it->columns = NULL;
-    it->op_ctx = NULL;
-    ecs_iter_fini(iter);
 }
 
 /* Edge case: if the filter has the same variable for both predicate and

--- a/src/addons/rules.c
+++ b/src/addons/rules.c
@@ -319,6 +319,7 @@ typedef struct ecs_rule_var_t {
     ecs_rule_var_kind_t kind;
     char *name;       /* Variable name */
     int32_t id;       /* Unique variable id */
+    int32_t other;    /* Id to table variable (-1 if none exists) */
     int32_t occurs;   /* Number of occurrences (used for operation ordering) */
     int32_t depth;  /* Depth in dependency tree (used for operation ordering) */
     bool marked;      /* Used for cycle detection */
@@ -2500,6 +2501,35 @@ void create_variable_name_array(
     }
 }
 
+static
+void create_variable_cross_references(
+    ecs_rule_t *rule)
+{
+    if (rule->variable_count) {
+        int i;
+        for (i = 0; i < rule->variable_count; i ++) {
+            ecs_rule_var_t *var = &rule->variables[i];
+            if (var->kind == EcsRuleVarKindEntity) {
+                ecs_rule_var_t *tvar = find_variable(
+                    rule, EcsRuleVarKindTable, var->name);
+                if (tvar) {
+                    var->other = tvar->id;
+                } else {
+                    var->other = -1;
+                }
+            } else {
+                ecs_rule_var_t *evar = find_variable(
+                    rule, EcsRuleVarKindEntity, var->name);
+                if (evar) {
+                    var->other = evar->id;
+                } else {
+                    var->other = -1;
+                }
+            }
+        }
+    }
+}
+
 /* Implementation for iterable mixin */
 static
 void rule_iter_init(
@@ -2564,6 +2594,10 @@ ecs_rule_t* ecs_rule_init(
     /* Create array with variable names so this can be easily accessed by 
      * iterators without requiring access to the ecs_rule_t */
     create_variable_name_array(result);
+
+    /* Create cross-references between variables so it's easy to go from entity
+     * to table variable and vice versa */
+    create_variable_cross_references(result);
 
     /* Create lookup array for subject variables */
     result->subject_variables = ecs_os_malloc_n(int32_t, term_count);
@@ -2831,6 +2865,16 @@ void ecs_rule_set_var(
     ecs_check(var_id < r->variable_count, ECS_INVALID_PARAMETER, NULL);
 
     entity_reg_set(r, iter->registers, var_id, value);
+
+    /* Also set table variable if it exists */
+    ecs_rule_var_t *var = &r->variables[var_id];
+    if (var->other != -1) {
+        ecs_rule_var_t *tvar = &r->variables[var->other];
+        ecs_assert(tvar->kind == EcsRuleVarKindTable, 
+            ECS_INTERNAL_ERROR, NULL);
+        (void)tvar;
+        reg_set_entity(r, iter->registers, var->other, value);
+    }
 error:
     return;
 }
@@ -3414,25 +3458,49 @@ bool eval_select(
         return false;
     }
 
-    /* If this is not a redo, start at the beginning */
-    if (!redo) {
-        op_ctx->table_index = 0;
+    /* If the input register is not NULL, this is a variable that's been set by
+     * the application. */
+    table = iter->registers[r].table;
+    bool output_is_input = table != NULL;
 
-        /* Return the first table_record in the table set. */
-        table_record = find_next_table(&filter, op_ctx);
-    
-        /* If no table record was found, there are no results. */
-        if (!table_record.table) {
+    if (output_is_input && !redo) {
+        ecs_assert(regs[r].table == iter->registers[r].table, 
+            ECS_INTERNAL_ERROR, NULL);
+
+        table = iter->registers[r].table;
+
+        /* Check if table can be found in the id record. If not, the provided 
+        * table does not match with the query. */
+        ecs_table_record_t *tr = ecs_table_cache_get(&idr->cache, 
+            ecs_table_record_t, table);
+        if (!tr) {
             return false;
         }
 
-        table = table_record.table;
+        column = columns[op->term] = tr->column;
+    }
 
-        /* Set current column to first occurrence of queried for entity */
-        column = columns[op->term] = table_record.column;
+    /* If this is not a redo, start at the beginning */
+    if (!redo) {
+        if (!table) {
+            op_ctx->table_index = 0;
 
-        /* Store table in register */
-        table_reg_set(rule, regs, r, table);
+            /* Return the first table_record in the table set. */
+            table_record = find_next_table(&filter, op_ctx);
+        
+            /* If no table record was found, there are no results. */
+            if (!table_record.table) {
+                return false;
+            }
+
+            table = table_record.table;
+
+            /* Set current column to first occurrence of queried for entity */
+            column = columns[op->term] = table_record.column;
+
+            /* Store table in register */
+            table_reg_set(rule, regs, r, table);
+        }
     
     /* If this is a redo, progress to the next match */
     } else {
@@ -3442,6 +3510,7 @@ bool eval_select(
             table = table_reg_get(rule, regs, r);
             ecs_assert(table != NULL, ECS_INTERNAL_ERROR, NULL);
 
+
             column = columns[op->term];
             column = find_next_column(world, table, column, &filter);
             columns[op->term] = column;
@@ -3449,6 +3518,10 @@ bool eval_select(
 
         /* If no next match was found for this table, move to next table */
         if (column == -1) {
+            if (output_is_input) {
+                return false;
+            }
+
             table_record = find_next_table(&filter, op_ctx);
             if (!table_record.table) {
                 return false;

--- a/test/api/project.json
+++ b/test/api/project.json
@@ -1513,7 +1513,9 @@
                 "rule_iter_set_var",
                 "rule_iter_set_2_vars",
                 "rule_iter_set_pred_var",
-                "rule_iter_set_var_for_2_terms"
+                "rule_iter_set_var_for_2_terms",
+                "rule_iter_set_cyclic_variable",
+                "rule_iter_set_cyclic_variable_w_this"
             ]
         }, {
             "id": "TransitiveRules",

--- a/test/api/src/main.c
+++ b/test/api/src/main.c
@@ -1446,6 +1446,8 @@ void Rules_rule_iter_set_var(void);
 void Rules_rule_iter_set_2_vars(void);
 void Rules_rule_iter_set_pred_var(void);
 void Rules_rule_iter_set_var_for_2_terms(void);
+void Rules_rule_iter_set_cyclic_variable(void);
+void Rules_rule_iter_set_cyclic_variable_w_this(void);
 
 // Testsuite 'TransitiveRules'
 void TransitiveRules_trans_X_X(void);
@@ -7910,6 +7912,14 @@ bake_test_case Rules_testcases[] = {
     {
         "rule_iter_set_var_for_2_terms",
         Rules_rule_iter_set_var_for_2_terms
+    },
+    {
+        "rule_iter_set_cyclic_variable",
+        Rules_rule_iter_set_cyclic_variable
+    },
+    {
+        "rule_iter_set_cyclic_variable_w_this",
+        Rules_rule_iter_set_cyclic_variable_w_this
     }
 };
 
@@ -11538,7 +11548,7 @@ static bake_test_suite suites[] = {
         "Rules",
         NULL,
         NULL,
-        120,
+        122,
         Rules_testcases
     },
     {
@@ -11775,6 +11785,5 @@ static bake_test_suite suites[] = {
 };
 
 int main(int argc, char *argv[]) {
-    ut_init(argv[0]);
     return bake_test_run("api", argc, argv, suites, 65);
 }


### PR DESCRIPTION
This PR introduces a change that makes it possible to set variables that are resolved as table by the rule engine.