### PR TITLE
Verify omitted members break reflection

### DIFF
--- a/test/meta/project.json
+++ b/test/meta/project.json
@@ -100,7 +100,8 @@
                 "i32_bool_bool_bool",
                 "i32_i64",
                 "i32_i64_i32",
-                "incomplete_member"
+                "incomplete_member",
+                "omitted_member"
             ]
         }, {
             "id": "NestedStructTypes",

--- a/test/meta/src/StructTypes.c
+++ b/test/meta/src/StructTypes.c
@@ -395,3 +395,39 @@ void StructTypes_incomplete_member() {
 
     ecs_fini(world);
 }
+
+void StructTypes_omitted_member() {
+    typedef struct {
+        ecs_i32_t x;
+        ecs_i32_t y;
+        ecs_i32_t z;
+    } T;
+
+    ecs_world_t *world = ecs_init();
+    
+    ECS_COMPONENT(world, T);
+
+    ecs_entity_t ref_id = ecs_struct_init(world, &(ecs_struct_desc_t) {
+        .entity.entity = ecs_id(T),
+        .members = {
+            {"x", ecs_id(ecs_i32_t), 0, 0},
+            {"z", ecs_id(ecs_i32_t), 0, 8}
+        }
+    });
+    ecs_entity_t e = ecs_new_id(world);
+    ecs_set(world, e, T, {10, 20, 30});
+    const T *val = ecs_get(world, e, T);
+    
+    meta_test_struct(world, ref_id, T);
+
+    test_assert(val->x == 10);
+    test_assert(val->y == 20);
+    test_assert(val->z == 30);
+
+    char *expr = ecs_ptr_to_expr(world,  ecs_id(T), val);
+    test_assert(expr != NULL);
+    test_str(expr, "{x: 10, z: 30}");
+    ecs_os_free(expr);
+
+    ecs_fini(world);
+}

--- a/test/meta/src/main.c
+++ b/test/meta/src/main.c
@@ -90,6 +90,7 @@ void StructTypes_i32_bool_bool_bool(void);
 void StructTypes_i32_i64(void);
 void StructTypes_i32_i64_i32(void);
 void StructTypes_incomplete_member(void);
+void StructTypes_omitted_member(void);
 
 // Testsuite 'NestedStructTypes'
 void NestedStructTypes_1_bool(void);
@@ -808,6 +809,10 @@ bake_test_case StructTypes_testcases[] = {
     {
         "incomplete_member",
         StructTypes_incomplete_member
+    },
+    {
+        "omitted_member",
+        StructTypes_omitted_member
     }
 };
 
@@ -2414,7 +2419,7 @@ static bake_test_suite suites[] = {
         "StructTypes",
         NULL,
         NULL,
-        12,
+        13,
         StructTypes_testcases
     },
     {


### PR DESCRIPTION
Added test checking if omitting a member from a registered component breaks things