### PR TITLE
Improved relation search

### DIFF
--- a/flecs.h
+++ b/flecs.h
@@ -308,7 +308,7 @@ typedef int32_t ecs_size_t;
         ECS_ID_ON_DELETE_OBJECT_DELETE)
 
 #define ECS_ID_EXCLUSIVE                 (1u << 6)
-#define ECS_ID_PRIVATE                   (1u << 7)
+#define ECS_ID_DONT_INHERIT              (1u << 7)
 
 /* Utilities for converting from flags to delete policies and vice versa */
 #define ECS_ID_ON_DELETE(flags) \

--- a/flecs.h
+++ b/flecs.h
@@ -11297,6 +11297,7 @@ static const flecs::entity_t This = EcsThis;
 static const flecs::entity_t Transitive = EcsTransitive;
 static const flecs::entity_t Reflexive = EcsReflexive;
 static const flecs::entity_t Final = EcsFinal;
+static const flecs::entity_t DontInherit = EcsDontInherit;
 static const flecs::entity_t Tag = EcsTag;
 static const flecs::entity_t Exclusive = EcsExclusive;
 static const flecs::entity_t Acyclic = EcsAcyclic;

--- a/flecs.h
+++ b/flecs.h
@@ -308,6 +308,7 @@ typedef int32_t ecs_size_t;
         ECS_ID_ON_DELETE_OBJECT_DELETE)
 
 #define ECS_ID_EXCLUSIVE                 (1u << 6)
+#define ECS_ID_PRIVATE                   (1u << 7)
 
 /* Utilities for converting from flags to delete policies and vice versa */
 #define ECS_ID_ON_DELETE(flags) \
@@ -4077,15 +4078,21 @@ FLECS_API extern const ecs_entity_t EcsTransitive;
  */
 FLECS_API extern const ecs_entity_t EcsReflexive;
 
-/* Can be added to component/relation to indicate it is final. Final components/
- * relations cannot be derived from using an IsA relationship. Queries will not
- * attempt to substitute a component/relationship with IsA subsets if they are
- * final. 
+/** Ensures that entity/component cannot be used as object in IsA relation.
+ * Final can improve the performance of rule-based queries, as they will not 
+ * attempt to substitute a final component with its subsets.
  * 
  * Behavior: 
  *   if IsA(X, Y) and Final(Y) throw error
  */
 FLECS_API extern const ecs_entity_t EcsFinal;
+
+/** Ensures that component is never inherited from an IsA object.
+ * 
+ * Behavior:
+ *   if DontInherit(X) and X(B) and IsA(A, B) then X(A) is false.
+ */
+FLECS_API extern const ecs_entity_t EcsDontInherit;
 
 /* Marks relationship as commutative.
  * Behavior:

--- a/flecs.h
+++ b/flecs.h
@@ -836,6 +836,7 @@ int ecs_log_last_error(void);
 #define ECS_MISSING_OS_API (9)
 #define ECS_OPERATION_FAILED (10)
 #define ECS_INVALID_CONVERSION (11)
+#define ECS_ID_IN_USE (12)
 
 #define ECS_INCONSISTENT_NAME (20)
 #define ECS_NAME_IN_USE (21)

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -963,15 +963,21 @@ FLECS_API extern const ecs_entity_t EcsTransitive;
  */
 FLECS_API extern const ecs_entity_t EcsReflexive;
 
-/* Can be added to component/relation to indicate it is final. Final components/
- * relations cannot be derived from using an IsA relationship. Queries will not
- * attempt to substitute a component/relationship with IsA subsets if they are
- * final. 
+/** Ensures that entity/component cannot be used as object in IsA relation.
+ * Final can improve the performance of rule-based queries, as they will not 
+ * attempt to substitute a final component with its subsets.
  * 
  * Behavior: 
  *   if IsA(X, Y) and Final(Y) throw error
  */
 FLECS_API extern const ecs_entity_t EcsFinal;
+
+/** Ensures that component is never inherited from an IsA object.
+ * 
+ * Behavior:
+ *   if DontInherit(X) and X(B) and IsA(A, B) then X(A) is false.
+ */
+FLECS_API extern const ecs_entity_t EcsDontInherit;
 
 /* Marks relationship as commutative.
  * Behavior:

--- a/include/flecs/addons/cpp/c_types.hpp
+++ b/include/flecs/addons/cpp/c_types.hpp
@@ -97,6 +97,7 @@ static const flecs::entity_t This = EcsThis;
 static const flecs::entity_t Transitive = EcsTransitive;
 static const flecs::entity_t Reflexive = EcsReflexive;
 static const flecs::entity_t Final = EcsFinal;
+static const flecs::entity_t DontInherit = EcsDontInherit;
 static const flecs::entity_t Tag = EcsTag;
 static const flecs::entity_t Exclusive = EcsExclusive;
 static const flecs::entity_t Acyclic = EcsAcyclic;

--- a/include/flecs/addons/log.h
+++ b/include/flecs/addons/log.h
@@ -352,6 +352,7 @@ int ecs_log_last_error(void);
 #define ECS_MISSING_OS_API (9)
 #define ECS_OPERATION_FAILED (10)
 #define ECS_INVALID_CONVERSION (11)
+#define ECS_ID_IN_USE (12)
 
 #define ECS_INCONSISTENT_NAME (20)
 #define ECS_NAME_IN_USE (21)

--- a/include/flecs/private/api_defines.h
+++ b/include/flecs/private/api_defines.h
@@ -194,6 +194,7 @@ typedef int32_t ecs_size_t;
         ECS_ID_ON_DELETE_OBJECT_DELETE)
 
 #define ECS_ID_EXCLUSIVE                 (1u << 6)
+#define ECS_ID_PRIVATE                   (1u << 7)
 
 /* Utilities for converting from flags to delete policies and vice versa */
 #define ECS_ID_ON_DELETE(flags) \

--- a/include/flecs/private/api_defines.h
+++ b/include/flecs/private/api_defines.h
@@ -194,7 +194,7 @@ typedef int32_t ecs_size_t;
         ECS_ID_ON_DELETE_OBJECT_DELETE)
 
 #define ECS_ID_EXCLUSIVE                 (1u << 6)
-#define ECS_ID_PRIVATE                   (1u << 7)
+#define ECS_ID_DONT_INHERIT              (1u << 7)
 
 /* Utilities for converting from flags to delete policies and vice versa */
 #define ECS_ID_ON_DELETE(flags) \

--- a/src/addons/log.c
+++ b/src/addons/log.c
@@ -370,6 +370,7 @@ const char* ecs_strerror(
     ECS_ERR_STR(ECS_INVALID_OPERATION);
     ECS_ERR_STR(ECS_CONSTRAINT_VIOLATED);
     ECS_ERR_STR(ECS_LOCKED_STORAGE);
+    ECS_ERR_STR(ECS_ID_IN_USE);
     }
 
     return "unknown error code";

--- a/src/bootstrap.c
+++ b/src/bootstrap.c
@@ -434,6 +434,7 @@ void flecs_bootstrap(
     flecs_bootstrap_tag(world, EcsReflexive);
     flecs_bootstrap_tag(world, EcsSymmetric);
     flecs_bootstrap_tag(world, EcsFinal);
+    flecs_bootstrap_tag(world, EcsDontInherit);
     flecs_bootstrap_tag(world, EcsTag);
     flecs_bootstrap_tag(world, EcsExclusive);
     flecs_bootstrap_tag(world, EcsAcyclic);
@@ -488,6 +489,7 @@ void flecs_bootstrap(
     ecs_add_id(world, EcsReflexive, EcsFinal);
     ecs_add_id(world, EcsSymmetric, EcsFinal);
     ecs_add_id(world, EcsFinal, EcsFinal);
+    ecs_add_id(world, EcsDontInherit, EcsFinal);
     ecs_add_id(world, EcsTag, EcsFinal);
     ecs_add_id(world, EcsExclusive, EcsFinal);
     ecs_add_id(world, EcsAcyclic, EcsFinal);

--- a/src/bootstrap.c
+++ b/src/bootstrap.c
@@ -145,6 +145,18 @@ void register_exclusive(ecs_iter_t *it) {
 }
 
 static
+void register_dont_inherit(ecs_iter_t *it) {
+    ecs_world_t *world = it->world;
+    
+    int i, count = it->count;
+    for (i = 0; i < count; i ++) {
+        ecs_entity_t e = it->entities[i];
+        ecs_id_record_t *r = flecs_ensure_id_record(world, e);
+        r->flags |= ECS_ID_DONT_INHERIT;
+    } 
+}
+
+static
 void on_symmetric_add_remove(ecs_iter_t *it) {
     ecs_entity_t pair = ecs_term_id(it, 1);
 
@@ -515,7 +527,6 @@ void flecs_bootstrap(
     ecs_set(world, EcsOnAdd, EcsIterable, { .init = on_event_iterable_init });
     ecs_set(world, EcsOnSet, EcsIterable, { .init = on_event_iterable_init });
 
-    /* Define triggers for when relationship cleanup rules are assigned */
     ecs_trigger_init(world, &(ecs_trigger_desc_t){
         .term = {.id = ecs_pair(EcsOnDelete, EcsWildcard)},
         .callback = register_on_delete,
@@ -528,17 +539,21 @@ void flecs_bootstrap(
         .events = {EcsOnAdd}
     });
 
-    /* Define trigger for exclusive property */
     ecs_trigger_init(world, &(ecs_trigger_desc_t){
         .term = {.id = EcsExclusive },
         .callback = register_exclusive,
         .events = {EcsOnAdd}
     });
 
-    /* Define trigger for symmetric property */
     ecs_trigger_init(world, &(ecs_trigger_desc_t){
         .term = {.id = EcsSymmetric },
         .callback = register_symmetric,
+        .events = {EcsOnAdd}
+    });
+
+    ecs_trigger_init(world, &(ecs_trigger_desc_t){
+        .term = {.id = EcsDontInherit },
+        .callback = register_dont_inherit,
         .events = {EcsOnAdd}
     });
 

--- a/src/datastructures/map.c
+++ b/src/datastructures/map.c
@@ -43,22 +43,30 @@ int32_t get_bucket_index(
     return (int32_t)(hash & ((uint32_t)bucket_count - 1));
 }
 
-/* Get bucket for key */
+/* Get bucket for hash */
 static
-ecs_bucket_t* get_bucket(
+ecs_bucket_t* get_bucket_for_hash(
     const ecs_map_t *map,
-    ecs_map_key_t key)
+    int32_t hash)
 {
     int32_t bucket_count = map->bucket_count;
     if (!bucket_count) {
         return NULL;
     }
 
-    uint32_t hash = get_key_hash(key);
     int32_t bucket_id = get_bucket_index(bucket_count, hash);
     ecs_assert(bucket_id < bucket_count, ECS_INTERNAL_ERROR, NULL);
-
     return &map->buckets[bucket_id];
+}
+
+/* Get bucket for key */
+static
+ecs_bucket_t* get_bucket(
+    const ecs_map_t *map,
+    ecs_map_key_t key)
+{
+    uint32_t hash = get_key_hash(key);
+    return get_bucket_for_hash(map, hash);
 }
 
 /* Ensure that map has at least new_count buckets */

--- a/src/datastructures/map.c
+++ b/src/datastructures/map.c
@@ -47,7 +47,7 @@ int32_t get_bucket_index(
 static
 ecs_bucket_t* get_bucket_for_hash(
     const ecs_map_t *map,
-    int32_t hash)
+    uint32_t hash)
 {
     int32_t bucket_count = map->bucket_count;
     if (!bucket_count) {

--- a/src/entity.c
+++ b/src/entity.c
@@ -2409,13 +2409,12 @@ void on_delete_object_action(
             /* delete_object_action should be invoked for relations */
             ecs_assert(rel != 0, ECS_INTERNAL_ERROR,  NULL);
 
-            /* Get the record for the relation, to find the delete action */
-            ecs_id_record_t *idrr;
+            /* Find delete action for relation */
             if (!action) {
-                idrr = flecs_get_id_record(world, rel);
+                ecs_id_record_t *idrr = flecs_get_id_record(world, rel);
                 if (idrr) {
                     action = ECS_ID_ON_DELETE_OBJECT(idrr->flags);
-                } 
+                }
             }
 
             if (!action || action == EcsRemove) {

--- a/src/hierarchy.c
+++ b/src/hierarchy.c
@@ -302,7 +302,7 @@ ecs_hashmap_t _flecs_string_hashmap_new(ecs_size_t size) {
 
 void flecs_bootstrap_hierarchy(ecs_world_t *world) {
     ecs_trigger_init(world, &(ecs_trigger_desc_t){
-        .term = {.id = ecs_pair(ecs_id(EcsIdentifier), EcsSymbol)},
+        .term = {.id = ecs_pair(ecs_id(EcsIdentifier), EcsSymbol), .subj.set.mask = EcsSelf },
         .callback = on_set_symbol,
         .events = {EcsOnSet},
         .yield_existing = true

--- a/src/private_api.h
+++ b/src/private_api.h
@@ -13,10 +13,6 @@
 void flecs_bootstrap(
     ecs_world_t *world);
 
-ecs_type_t flecs_bootstrap_type(
-    ecs_world_t *world,
-    ecs_entity_t entity);
-
 #define flecs_bootstrap_component(world, id)\
     ecs_component_init(world, &(ecs_component_desc_t){\
         .entity = {\

--- a/src/private_api.h
+++ b/src/private_api.h
@@ -29,10 +29,11 @@ ecs_type_t flecs_bootstrap_type(
     });
 
 #define flecs_bootstrap_tag(world, name)\
-    ecs_set_name(world, name, (char*)&#name[ecs_os_strlen(world->name_prefix)]);\
-    ecs_set_symbol(world, name, #name);\
+    ecs_add_id(world, name, EcsFinal);\
     ecs_add_pair(world, name, EcsChildOf, ecs_get_scope(world));\
-    ecs_set(world, name, EcsComponent, {.size = 0})
+    ecs_set(world, name, EcsComponent, {.size = 0});\
+    ecs_set_name(world, name, (char*)&#name[ecs_os_strlen(world->name_prefix)]);\
+    ecs_set_symbol(world, name, #name)
 
 
 /* Bootstrap functions for other parts in the code */

--- a/src/private_types.h
+++ b/src/private_types.h
@@ -554,6 +554,9 @@ struct ecs_world_t {
     ecs_map_t *id_index;         /* map<id, ecs_id_record_t*> */
     ecs_sparse_t *type_info;     /* sparse<type_id, type_info_t> */
 
+    /* Cached handle to (IsA, *) */
+    ecs_id_record_t *idr_isa_wildcard;
+
     /* -- Mixins -- */
     ecs_world_t *self;
     ecs_observable_t observable;

--- a/src/search.c
+++ b/src/search.c
@@ -78,12 +78,10 @@ int32_t type_search_relation(
             if (!(flags & EcsTableHasIsA)) {
                 return -1;
             }
-            if (id == EcsPrefab || id == EcsDisabled ||
-                ECS_PAIR_RELATION(id) == ecs_id(EcsIdentifier) ||
-                ECS_PAIR_RELATION(id) == EcsChildOf)
-            {
+            if (idr->flags & ECS_ID_DONT_INHERIT) {
                 return -1;
             }
+            idr_r = world->idr_isa_wildcard;
         }
 
         if (!idr_r) {
@@ -116,9 +114,9 @@ int32_t type_search_relation(
                 }
 
                 if (!is_a) {
-                    r = type_search_relation(world, obj_table, id, 
-                        idr, ecs_pair(EcsIsA, EcsWildcard), NULL, 1, INT_MAX, subject_out, 
-                        id_out, tr_out);
+                    r = type_search_relation(world, obj_table, id, idr, 
+                        ecs_pair(EcsIsA, EcsWildcard), world->idr_isa_wildcard, 
+                            1, INT_MAX, subject_out, id_out, tr_out);
                     if (r != -1) {
                         if (subject_out && !subject_out[0]) {
                             subject_out[0] = ecs_get_alive(world, obj);

--- a/src/world.c
+++ b/src/world.c
@@ -56,10 +56,11 @@ const ecs_entity_t EcsTransitive =            ECS_HI_COMPONENT_ID + 13;
 const ecs_entity_t EcsReflexive =             ECS_HI_COMPONENT_ID + 14;
 const ecs_entity_t EcsSymmetric =             ECS_HI_COMPONENT_ID + 15;
 const ecs_entity_t EcsFinal =                 ECS_HI_COMPONENT_ID + 16;
-const ecs_entity_t EcsTag =                   ECS_HI_COMPONENT_ID + 17;
-const ecs_entity_t EcsExclusive =             ECS_HI_COMPONENT_ID + 18;
-const ecs_entity_t EcsAcyclic =               ECS_HI_COMPONENT_ID + 19;
-const ecs_entity_t EcsWith =                  ECS_HI_COMPONENT_ID + 20;
+const ecs_entity_t EcsDontInherit =           ECS_HI_COMPONENT_ID + 17;
+const ecs_entity_t EcsTag =                   ECS_HI_COMPONENT_ID + 18;
+const ecs_entity_t EcsExclusive =             ECS_HI_COMPONENT_ID + 19;
+const ecs_entity_t EcsAcyclic =               ECS_HI_COMPONENT_ID + 20;
+const ecs_entity_t EcsWith =                  ECS_HI_COMPONENT_ID + 21;
 
 /* Builtin relations */
 const ecs_entity_t EcsChildOf =               ECS_HI_COMPONENT_ID + 25;

--- a/src/world.c
+++ b/src/world.c
@@ -1742,13 +1742,22 @@ ecs_id_record_t* flecs_ensure_id_record(
     ecs_world_t *world,
     ecs_id_t id)
 {
-    ecs_id_record_t **idr_ptr = ecs_map_ensure(world->id_index, ecs_id_record_t*, 
-        ecs_strip_generation(id));
+    ecs_id_record_t **idr_ptr = ecs_map_ensure(world->id_index, 
+        ecs_id_record_t*, ecs_strip_generation(id));
     ecs_id_record_t *idr;
     if (!*idr_ptr) {
         idr = flecs_sparse_add(world->id_records, ecs_id_record_t);
         idr->id = flecs_sparse_last_id(world->id_records);
         *idr_ptr = idr;
+
+        /* If id is a pair, inherit flags from relation id record */
+        if (ECS_HAS_ROLE(id, PAIR)) {
+            ecs_id_record_t *idr_r = flecs_get_id_record(
+                world, ECS_PAIR_RELATION(id));
+            if (idr_r) {
+                idr->flags = idr_r->flags;
+            }
+        }
     } else {
         idr = *idr_ptr;
     }

--- a/test/api/project.json
+++ b/test/api/project.json
@@ -1428,7 +1428,8 @@
                 "remove_wildcard",
                 "remove_relation_wildcard",
                 "remove_wildcard_all",
-                "inherit_exclusive"
+                "inherit_exclusive",
+                "dont_inherit"
             ]
         }, {
             "id": "Rules",

--- a/test/api/src/Pairs.c
+++ b/test/api/src/Pairs.c
@@ -2624,3 +2624,23 @@ void Pairs_inherit_exclusive() {
 
     ecs_fini(world);
 }
+
+void Pairs_dont_inherit() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, TagA);
+    ecs_add_id(world, TagA, EcsDontInherit);
+    ECS_TAG(world, TagB);
+
+    ecs_entity_t base = ecs_new_w_id(world, TagA);
+    ecs_add(world, base, TagB);
+    ecs_entity_t inst = ecs_new_w_pair(world, EcsIsA, base);
+
+    test_assert( ecs_has(world, base, TagA));
+    test_assert( !ecs_has(world, inst, TagA));
+
+    test_assert( ecs_has(world, base, TagB));
+    test_assert( ecs_has(world, inst, TagB));
+
+    ecs_fini(world);
+}

--- a/test/api/src/main.c
+++ b/test/api/src/main.c
@@ -1363,6 +1363,7 @@ void Pairs_remove_wildcard(void);
 void Pairs_remove_relation_wildcard(void);
 void Pairs_remove_wildcard_all(void);
 void Pairs_inherit_exclusive(void);
+void Pairs_dont_inherit(void);
 
 // Testsuite 'Rules'
 void Rules_empty_rule(void);
@@ -7648,6 +7649,10 @@ bake_test_case Pairs_testcases[] = {
     {
         "inherit_exclusive",
         Pairs_inherit_exclusive
+    },
+    {
+        "dont_inherit",
+        Pairs_dont_inherit
     }
 };
 
@@ -11856,7 +11861,7 @@ static bake_test_suite suites[] = {
         "Pairs",
         NULL,
         NULL,
-        90,
+        91,
         Pairs_testcases
     },
     {


### PR DESCRIPTION
This PR improves the performance of searching for components by following a relationship. It also introduces a new `DontInherit` policy that prevents components from being inherited from base entities (`IsA` targets). This new property replaces the builtin behavior for the `Prefab`, `Disabled`, `Identifier` and `ChildOf` components.

This PR is part of implementing #632 