### PR TITLE
Delayed table events

### DIFF
--- a/flecs.h
+++ b/flecs.h
@@ -2168,6 +2168,9 @@ void ecs_os_set_api_defaults(void);
 #define ecs_os_memdup_t(ptr, T) ecs_os_memdup(ptr, ECS_SIZEOF(T))
 #define ecs_os_memdup_n(ptr, T, count) ecs_os_memdup(ptr, ECS_SIZEOF(T) * count)
 
+#define ecs_offset(ptr, T, index)\
+    ECS_CAST(T*, ECS_OFFSET(ptr, ECS_SIZEOF(T) * index))
+
 #if defined(ECS_TARGET_MSVC)
 #define ecs_os_strcat(str1, str2) strcat_s(str1, INT_MAX, str2)
 #define ecs_os_sprintf(ptr, ...) sprintf_s(ptr, INT_MAX, __VA_ARGS__)
@@ -4577,6 +4580,20 @@ void ecs_set_target_fps(
 /** Get current number of threads. */
 FLECS_API
 int32_t ecs_get_threads(
+    ecs_world_t *world);
+
+/** Force aperiodic actions.
+ * The world may delay certain operations until they are necessary for the
+ * application to function correctly. This may cause observable side effects
+ * such as delayed triggering of events, which can be inconvenient when for
+ * example running a test suite.
+ * 
+ * This operation forces runs all aperiodic actions to run.
+ * 
+ * @param world The world.
+ */
+FLECS_API
+void ecs_force_aperiodic(
     ecs_world_t *world);
 
 /** @} */

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -1463,6 +1463,20 @@ FLECS_API
 int32_t ecs_get_threads(
     ecs_world_t *world);
 
+/** Force aperiodic actions.
+ * The world may delay certain operations until they are necessary for the
+ * application to function correctly. This may cause observable side effects
+ * such as delayed triggering of events, which can be inconvenient when for
+ * example running a test suite.
+ * 
+ * This operation forces runs all aperiodic actions to run.
+ * 
+ * @param world The world.
+ */
+FLECS_API
+void ecs_force_aperiodic(
+    ecs_world_t *world);
+
 /** @} */
 
 /**

--- a/include/flecs/os_api.h
+++ b/include/flecs/os_api.h
@@ -344,6 +344,9 @@ void ecs_os_set_api_defaults(void);
 #define ecs_os_memdup_t(ptr, T) ecs_os_memdup(ptr, ECS_SIZEOF(T))
 #define ecs_os_memdup_n(ptr, T, count) ecs_os_memdup(ptr, ECS_SIZEOF(T) * count)
 
+#define ecs_offset(ptr, T, index)\
+    ECS_CAST(T*, ECS_OFFSET(ptr, ECS_SIZEOF(T) * index))
+
 #if defined(ECS_TARGET_MSVC)
 #define ecs_os_strcat(str1, str2) strcat_s(str1, INT_MAX, str2)
 #define ecs_os_sprintf(ptr, ...) sprintf_s(ptr, INT_MAX, __VA_ARGS__)

--- a/src/addons/rules.c
+++ b/src/addons/rules.c
@@ -3010,6 +3010,8 @@ ecs_iter_t ecs_rule_iter(
     result.world = (ecs_world_t*)world;
     result.real_world = (ecs_world_t*)ecs_get_world(rule->world);
 
+    flecs_process_pending_tables(result.real_world);
+
     ecs_rule_iter_t *it = &result.priv.iter.rule;
     it->rule = rule;
 

--- a/src/datastructures/sparse.c
+++ b/src/datastructures/sparse.c
@@ -529,6 +529,7 @@ void* _flecs_sparse_remove_get(
         dense_array[dense] = index | inc_gen(cur_gen);
         
         int32_t count = sparse->count;
+        
         if (dense == (count - 1)) {
             /* If dense is the last used element, simply decrease count */
             sparse->count --;

--- a/src/entity.c
+++ b/src/entity.c
@@ -2358,12 +2358,12 @@ void delete_objects(
     if (data) {
         ecs_entity_t *entities = ecs_vector_first(
             data->entities, ecs_entity_t);
+        ecs_record_t **records = ecs_vector_first(
+            data->record_ptrs, ecs_record_t*);
 
         int32_t i, count = ecs_vector_count(data->entities);
         for (i = 0; i < count; i ++) {
-            ecs_entity_t e = entities[i];
-            ecs_record_t *r = flecs_sparse_get(
-                world->store.entity_index, ecs_record_t, e);
+            ecs_record_t *r = records[i];
             
             /* If entity is flagged, it could have delete actions. */
             uint32_t flags;

--- a/src/filter.c
+++ b/src/filter.c
@@ -1559,6 +1559,8 @@ ecs_iter_t ecs_term_iter(
 
     const ecs_world_t *world = ecs_get_world(stage);
 
+    flecs_process_pending_tables(world);
+
     if (ecs_term_finalize(world, NULL, term)) {
         ecs_throw(ECS_INVALID_PARAMETER, NULL);
     }
@@ -1879,6 +1881,8 @@ ecs_iter_t ecs_filter_iter(
     ecs_check(stage != NULL, ECS_INVALID_PARAMETER, NULL);
 
     const ecs_world_t *world = ecs_get_world(stage);
+    
+    flecs_process_pending_tables(world);
 
     ecs_iter_t it = {
         .real_world = (ecs_world_t*)world,

--- a/src/observable.c
+++ b/src/observable.c
@@ -39,18 +39,14 @@ void notify_subset(
     ecs_ids_t *ids)
 {
     ecs_id_t pair = ecs_pair(EcsWildcard, entity);
-    ecs_id_record_t *idr = flecs_get_id_record(world, pair);
-
+    ecs_table_iter_t idt;
+    ecs_id_record_t *idr = flecs_table_iter(world, pair, &idt);
     if (!idr) {
         return;
     }
 
-    ecs_table_record_t *trs = ecs_table_cache_tables(
-        &idr->cache, ecs_table_record_t);
-    int32_t i, count = ecs_table_cache_count(&idr->cache);
-
-    for (i = 0; i < count; i ++) {
-        ecs_table_record_t *tr = &trs[i];
+    for (; idt.cur < idt.end; ++ idt.cur) {
+        const ecs_table_record_t *tr = idt.cur;
         ecs_table_t *table = tr->table;
         ecs_id_t id = ecs_vector_get(table->type, ecs_id_t, tr->column)[0];
         ecs_entity_t rel = ECS_PAIR_RELATION(id);

--- a/src/private_api.h
+++ b/src/private_api.h
@@ -136,6 +136,9 @@ const ecs_table_record_t* flecs_id_record_table(
     ecs_id_record_t *idr,
     ecs_table_t *table);
 
+void flecs_process_pending_tables(
+    const ecs_world_t *world);
+
 ecs_id_record_t* flecs_table_iter(
     ecs_world_t *world,
     ecs_id_t id,

--- a/src/private_api.h
+++ b/src/private_api.h
@@ -136,17 +136,23 @@ const ecs_table_record_t* flecs_id_record_table(
     ecs_id_record_t *idr,
     ecs_table_t *table);
 
-const ecs_table_record_t* flecs_id_record_tables(
-    const ecs_id_record_t *idr);
+ecs_id_record_t* flecs_table_iter(
+    ecs_world_t *world,
+    ecs_id_t id,
+    ecs_table_iter_t *out);
 
-const ecs_table_record_t* flecs_id_record_empty_tables(
-    const ecs_id_record_t *idr);
+ecs_id_record_t* flecs_empty_table_iter(
+    ecs_world_t *world,
+    ecs_id_t id,
+    ecs_table_iter_t *out);
 
-int32_t flecs_id_record_count(
-    const ecs_id_record_t *idr);
+bool flecs_idr_iter(
+    ecs_id_record_t *idr,
+    ecs_table_iter_t *out);
 
-int32_t flecs_id_record_empty_count(
-    const ecs_id_record_t *idr);
+bool flecs_idr_empty_iter(
+    ecs_id_record_t *idr,
+    ecs_table_iter_t *out);
 
 void flecs_register_add_ref(
     ecs_world_t *world,

--- a/src/private_types.h
+++ b/src/private_types.h
@@ -584,11 +584,16 @@ struct ecs_world_t {
 
     /* --  Storages for API objects -- */
 
-    ecs_sparse_t *queries;       /* sparse<query_id, ecs_query_t> */
-    ecs_sparse_t *triggers;      /* sparse<query_id, ecs_trigger_t> */
-    ecs_sparse_t *observers;     /* sparse<query_id, ecs_observer_t> */
-    ecs_sparse_t *id_records;    /* sparse<idr_id, ecs_id_record_t> */
-    ecs_sparse_t *empty_tables;  /* sparse<table_id, ecs_table_t*> */
+    ecs_sparse_t *queries;         /* sparse<query_id, ecs_query_t> */
+    ecs_sparse_t *triggers;        /* sparse<query_id, ecs_trigger_t> */
+    ecs_sparse_t *observers;       /* sparse<query_id, ecs_observer_t> */
+    ecs_sparse_t *id_records;      /* sparse<idr_id, ecs_id_record_t> */
+
+
+    /* --  Pending table event buffers -- */
+
+    ecs_sparse_t *pending_buffer;  /* sparse<table_id, ecs_table_t*> */
+    ecs_sparse_t *pending_tables;  /* sparse<table_id, ecs_table_t*> */
     
 
     /* Keep track of components that were added/removed to/from monitored

--- a/src/private_types.h
+++ b/src/private_types.h
@@ -506,6 +506,13 @@ struct ecs_id_record_t {
     uint64_t id; /* Id to element in storage */
 };
 
+/* Convenience struct to iterate table array for id */
+typedef struct ecs_table_iter_t {
+    const ecs_table_record_t *begin;
+    const ecs_table_record_t *end;
+    const ecs_table_record_t *cur;
+} ecs_table_iter_t;
+
 typedef struct ecs_store_t {
     /* Entity lookup */
     ecs_sparse_t *entity_index; /* sparse<entity, ecs_record_t> */
@@ -581,6 +588,7 @@ struct ecs_world_t {
     ecs_sparse_t *triggers;      /* sparse<query_id, ecs_trigger_t> */
     ecs_sparse_t *observers;     /* sparse<query_id, ecs_observer_t> */
     ecs_sparse_t *id_records;    /* sparse<idr_id, ecs_id_record_t> */
+    ecs_sparse_t *empty_tables;  /* sparse<table_id, ecs_table_t*> */
     
 
     /* Keep track of components that were added/removed to/from monitored

--- a/src/stage.c
+++ b/src/stage.c
@@ -502,6 +502,8 @@ bool ecs_staging_begin(
 {
     ecs_poly_assert(world, ecs_world_t);
 
+    flecs_process_pending_tables(world);
+
     int32_t i, count = ecs_get_stage_count(world);
     for (i = 0; i < count; i ++) {
         ecs_defer_begin(ecs_get_stage(world, i));

--- a/src/table.c
+++ b/src/table.c
@@ -488,8 +488,8 @@ void dtor_all_components(
                         ECS_INTERNAL_ERROR, NULL);
                 } else {
                     // If this is not a delete, clear the entity index record
-                    ecs_record_t r = {NULL, 0};
-                    ecs_eis_set(world, e, &r);                
+                    records[i]->table = NULL;
+                    records[i]->row = 0;
                 }
             } else {
                 /* This should only happen in rare cases, such as when the data
@@ -522,9 +522,10 @@ void dtor_all_components(
                 ecs_assert(!e || records[i] == ecs_eis_get(world, e), 
                     ECS_INTERNAL_ERROR, NULL);
                 ecs_assert(!e || records[i]->table == table, 
-                    ECS_INTERNAL_ERROR, NULL);                
-                ecs_record_t r = {NULL, 0};
-                ecs_eis_set(world, e, &r);
+                    ECS_INTERNAL_ERROR, NULL);
+                records[i]->table = NULL;
+                records[i]->row = 0;
+                (void)e;
             }
         }      
     }
@@ -546,7 +547,9 @@ void fini_data(
         return;
     }
 
-    if (do_on_remove) {
+    ecs_flags32_t flags = table->flags;
+
+    if (do_on_remove && (flags & EcsTableHasOnRemove)) {
         run_on_remove(world, table, data);        
     }
 

--- a/src/table_cache.c
+++ b/src/table_cache.c
@@ -255,7 +255,7 @@ void* _ecs_table_cache_get(
     return result;
 }
 
-void ecs_table_cache_set_empty(
+bool ecs_table_cache_set_empty(
     ecs_table_cache_t *cache,
     const ecs_table_t *table,
     bool empty)
@@ -265,14 +265,14 @@ void ecs_table_cache_set_empty(
 
     int32_t *index = ecs_map_get(cache->index, int32_t, table->id);
     if (!index) {
-        return;
+        return false;
     }
 
     /* If table is already in the correct array nothing needs to be done */
     if (empty && index[0] < 0) {
-        return;
+        return false;
     } else if (!empty && index[0] >= 0) {
-        return;
+        return false;
     }
 
     if (index[0] < 0) {
@@ -282,6 +282,8 @@ void ecs_table_cache_set_empty(
         index[0] = move_table(
             cache, table, index[0], &cache->empty_tables, cache->tables, empty);
     }
+
+    return true;
 }
 
 void* _ecs_table_cache_tables(

--- a/src/table_cache.h
+++ b/src/table_cache.h
@@ -49,7 +49,7 @@ void* _ecs_table_cache_get(
 #define ecs_table_cache_get(cache, T, table)\
     ECS_CAST(T*, _ecs_table_cache_get(cache, ECS_SIZEOF(T), table))
 
-void ecs_table_cache_set_empty(
+bool ecs_table_cache_set_empty(
     ecs_table_cache_t *cache,
     const ecs_table_t *table,
     bool empty);

--- a/test/api/include/api/bake_config.h
+++ b/test/api/include/api/bake_config.h
@@ -19,6 +19,9 @@
 
 /* Headers of public dependencies */
 #include <flecs.h>
+#ifdef __BAKE__
+#include <bake_util.h>
+#endif
 #include <bake_test.h>
 
 #endif

--- a/test/api/src/Filter.c
+++ b/test/api/src/Filter.c
@@ -2266,13 +2266,13 @@ void Filter_term_iter_w_superset_pair_obj_wildcard() {
 
     test_assert(ecs_term_next(&it));
     test_int(it.count, 1);
-    test_int(it.entities[0], e_3);
+    test_int(it.entities[0], e_4);
     test_int(ecs_term_id(&it, 1), ecs_pair(Rel, Obj_2));
     test_int(ecs_term_source(&it, 1), base_2);
 
     test_assert(ecs_term_next(&it));
     test_int(it.count, 1);
-    test_int(it.entities[0], e_4);
+    test_int(it.entities[0], e_3);
     test_int(ecs_term_id(&it, 1), ecs_pair(Rel, Obj_2));
     test_int(ecs_term_source(&it, 1), base_2);
 
@@ -2509,18 +2509,18 @@ void Filter_filter_iter_3_tags_2_or() {
     ecs_iter_t it = ecs_filter_iter(world, &f);
 
     test_assert(ecs_filter_next(&it));
-    test_int(it.count, 1);
-    test_int(it.entities[0], e_3);
-    test_int(ecs_term_id(&it, 1), TagA);
-    test_int(ecs_term_id(&it, 2), TagC);
-    test_int(ecs_term_source(&it, 1), 0);
-
-    test_assert(ecs_filter_next(&it));
     test_int(it.count, 2);
     test_int(it.entities[0], e_1);
     test_int(it.entities[1], e_2);
     test_int(ecs_term_id(&it, 1), TagA);
     test_int(ecs_term_id(&it, 2), TagB);
+    test_int(ecs_term_source(&it, 1), 0);
+
+    test_assert(ecs_filter_next(&it));
+    test_int(it.count, 1);
+    test_int(it.entities[0], e_3);
+    test_int(ecs_term_id(&it, 1), TagA);
+    test_int(ecs_term_id(&it, 2), TagC);
     test_int(ecs_term_source(&it, 1), 0);
 
     test_assert(!ecs_filter_next(&it));
@@ -4687,12 +4687,12 @@ void Filter_term_iter_w_filter_term() {
 
     ECS_COMPONENT(world, Position);
 
+    ecs_entity_t e = ecs_set(world, 0, Position, {10, 20});
+
     ecs_iter_t it = ecs_term_iter(world, &(ecs_term_t) { 
         .id = ecs_id(Position),
         .inout = EcsInOutFilter
     });
-
-    ecs_entity_t e = ecs_set(world, 0, Position, {10, 20});
 
     test_bool(ecs_term_next(&it), true);
     test_assert(it.ids != NULL);
@@ -5792,13 +5792,13 @@ void Filter_match_empty_tables() {
 
     test_bool( ecs_filter_next(&it), true);
     test_int(it.count, 1);
-    test_int(it.entities[0], e4);
-    test_assert(it.table == t4);
+    test_int(it.entities[0], e3);
+    test_assert(it.table == t3);
 
     test_bool( ecs_filter_next(&it), true);
     test_int(it.count, 1);
-    test_int(it.entities[0], e3);
-    test_assert(it.table == t3);
+    test_int(it.entities[0], e4);
+    test_assert(it.table == t4);
 
     test_bool( ecs_filter_next(&it), false);
 

--- a/test/api/src/Observer.c
+++ b/test/api/src/Observer.c
@@ -2290,11 +2290,11 @@ static void TriggerTwice(ecs_iter_t *it) {
         test_assert(it->entities[0] == base_ent);
         invoke_count ++;
     } else if (invoke_count == 1) {
-        test_assert(it->entities[0] == inst_ent_a);
+        test_assert(it->entities[0] == inst_ent_b);
         invoke_count ++;
     } else {
         test_int(invoke_count, 2);
-        test_assert(it->entities[0] == inst_ent_b);
+        test_assert(it->entities[0] == inst_ent_a);
         invoke_count ++;
     }
 }

--- a/test/api/src/Pipeline.c
+++ b/test/api/src/Pipeline.c
@@ -199,7 +199,6 @@ void Pipeline_system_order_same_phase_after_activate() {
     
     test_assert( ecs_has_id(world, SysB, EcsInactive));
     ecs_add(world, E, Velocity);
-    test_assert( !ecs_has_id(world, SysB, EcsInactive));
 
     ecs_progress(world, 1);
 
@@ -210,6 +209,8 @@ void Pipeline_system_order_same_phase_after_activate() {
     test_int(sys_a_invoked, 1);
     test_int(sys_b_invoked, 1);
     test_int(sys_c_invoked, 1);
+
+    test_assert( !ecs_has_id(world, SysB, EcsInactive));
 
     ecs_progress(world, 1);
     test_int(stats->pipeline_build_count_total, 1);
@@ -233,9 +234,10 @@ void Pipeline_system_order_different_phase_after_activate() {
     
     test_assert( ecs_has_id(world, SysB, EcsInactive));
     ecs_add(world, E, Velocity);
-    test_assert( !ecs_has_id(world, SysB, EcsInactive));
 
     ecs_progress(world, 1);
+
+    test_assert( !ecs_has_id(world, SysB, EcsInactive));
 
     test_int(stats->systems_ran_frame, 3);
     test_int(stats->merge_count_total, 1);

--- a/test/api/src/Switch.c
+++ b/test/api/src/Switch.c
@@ -1197,10 +1197,23 @@ void Switch_switch_w_bitset_query() {
     ecs_add_id(world, e3, ECS_CASE | Walking);
     ecs_set(world, e3, Position, {13, 23});
 
+    test_bool(ecs_is_component_enabled(world, e1, Position), true);
+    test_bool(ecs_is_component_enabled(world, e2, Position), false);
+
     Position *p;
     ecs_entity_t *c;
 
     ecs_iter_t it = ecs_query_iter(world, q);
+    test_assert(ecs_query_next(&it));
+    test_int(it.count, 1);
+    test_int(it.entities[0], e3);
+    p = ecs_term(&it, Position, 1);
+    test_assert(p != NULL);
+    test_int(p->x, 13);
+    test_int(p->y, 23);
+    c = ecs_term(&it, ecs_entity_t, 2);
+    test_assert(c != NULL);
+    test_assert(c[0] == Walking);
 
     test_assert(ecs_query_next(&it));
     test_int(it.count, 1);
@@ -1209,17 +1222,6 @@ void Switch_switch_w_bitset_query() {
     test_assert(p != NULL);
     test_int(p->x, 10);
     test_int(p->y, 20);
-    c = ecs_term(&it, ecs_entity_t, 2);
-    test_assert(c != NULL);
-    test_assert(c[0] == Walking);
-
-    test_assert(ecs_query_next(&it));
-    test_int(it.count, 1);
-    test_int(it.entities[0], e3);
-    p = ecs_term(&it, Position, 1);
-    test_assert(p != NULL);
-    test_int(p->x, 13);
-    test_int(p->y, 23);
     c = ecs_term(&it, ecs_entity_t, 2);
     test_assert(c != NULL);
     test_assert(c[0] == Walking);
@@ -1261,22 +1263,22 @@ void Switch_switch_w_bitset_query_inv() {
     ecs_iter_t it = ecs_query_iter(world, q);
     test_assert(ecs_query_next(&it));
     test_int(it.count, 1);
-    test_int(it.entities[0], e1);
+    test_int(it.entities[0], e3);
     p = ecs_term(&it, Position, 1);
     test_assert(p != NULL);
-    test_int(p->x, 10);
-    test_int(p->y, 20);
+    test_int(p->x, 13);
+    test_int(p->y, 23);
     c = ecs_term(&it, ecs_entity_t, 2);
     test_assert(c != NULL);
     test_assert(c[0] == Walking);
 
     test_assert(ecs_query_next(&it));
     test_int(it.count, 1);
-    test_int(it.entities[0], e3);
+    test_int(it.entities[0], e1);
     p = ecs_term(&it, Position, 1);
     test_assert(p != NULL);
-    test_int(p->x, 13);
-    test_int(p->y, 23);
+    test_int(p->x, 10);
+    test_int(p->y, 20);
     c = ecs_term(&it, ecs_entity_t, 2);
     test_assert(c != NULL);
     test_assert(c[0] == Walking);
@@ -1324,6 +1326,17 @@ void Switch_switch_w_bitset_query_2_elems() {
 
     test_assert(ecs_query_next(&it));
     test_int(it.count, 1);
+    test_int(it.entities[0], e3);
+    p = ecs_term(&it, Position, 1);
+    test_assert(p != NULL);
+    test_int(p->x, 13);
+    test_int(p->y, 23);
+    c = ecs_term(&it, ecs_entity_t, 2);
+    test_assert(c != NULL);
+    test_assert(c[0] == Walking);
+
+    test_assert(ecs_query_next(&it));
+    test_int(it.count, 1);
     test_int(it.entities[0], e1);
     p = ecs_term(&it, Position, 1);
     test_assert(p != NULL);
@@ -1340,17 +1353,6 @@ void Switch_switch_w_bitset_query_2_elems() {
     test_assert(p != NULL);
     test_int(p->x, 11);
     test_int(p->y, 22);
-    c = ecs_term(&it, ecs_entity_t, 2);
-    test_assert(c != NULL);
-    test_assert(c[0] == Walking);
-
-    test_assert(ecs_query_next(&it));
-    test_int(it.count, 1);
-    test_int(it.entities[0], e3);
-    p = ecs_term(&it, Position, 1);
-    test_assert(p != NULL);
-    test_int(p->x, 13);
-    test_int(p->y, 23);
     c = ecs_term(&it, ecs_entity_t, 2);
     test_assert(c != NULL);
     test_assert(c[0] == Walking);
@@ -1398,6 +1400,17 @@ void Switch_switch_w_bitset_query_2_elems_skip() {
 
     test_assert(ecs_query_next(&it));
     test_int(it.count, 1);
+    test_int(it.entities[0], e3);
+    p = ecs_term(&it, Position, 1);
+    test_assert(p != NULL);
+    test_int(p->x, 13);
+    test_int(p->y, 23);
+    c = ecs_term(&it, ecs_entity_t, 2);
+    test_assert(c != NULL);
+    test_assert(c[0] == Walking);
+
+    test_assert(ecs_query_next(&it));
+    test_int(it.count, 1);
     test_int(it.entities[0], e1);
     p = ecs_term(&it, Position, 1);
     test_assert(p != NULL);
@@ -1414,17 +1427,6 @@ void Switch_switch_w_bitset_query_2_elems_skip() {
     test_assert(p != NULL);
     test_int(p->x, 11);
     test_int(p->y, 22);
-    c = ecs_term(&it, ecs_entity_t, 2);
-    test_assert(c != NULL);
-    test_assert(c[0] == Walking);
-
-    test_assert(ecs_query_next(&it));
-    test_int(it.count, 1);
-    test_int(it.entities[0], e3);
-    p = ecs_term(&it, Position, 1);
-    test_assert(p != NULL);
-    test_int(p->x, 13);
-    test_int(p->y, 23);
     c = ecs_term(&it, ecs_entity_t, 2);
     test_assert(c != NULL);
     test_assert(c[0] == Walking);

--- a/test/api/src/SystemManual.c
+++ b/test/api/src/SystemManual.c
@@ -138,7 +138,8 @@ void SystemManual_activate_status() {
     test_int(normal_count, 0);
 
     reset_status();
-    ecs_new(world, Position);    
+    ecs_new(world, Position);
+    ecs_force_aperiodic(world);
 
     test_bool(system_status_action_invoked, true);
     test_assert(enable_status == EcsSystemStatusNone);

--- a/test/api/src/SystemMisc.c
+++ b/test/api/src/SystemMisc.c
@@ -613,6 +613,8 @@ void SystemMisc_status_activate_after_new() {
     /* Add entity with Position. Should activate system. */
     reset_status();
     ecs_new(world, Position);
+    ecs_force_aperiodic(world);
+
     test_assert(system_status_action_invoked == true);
     test_assert(enable_status == EcsSystemStatusNone);
     test_assert(active_status == EcsSystemActivated);
@@ -644,6 +646,8 @@ void SystemMisc_status_deactivate_after_delete() {
 
     ecs_entity_t e = ecs_new(world, Position);
 
+    ecs_force_aperiodic(world);
+
     /* Setting the status action should have triggered the enabled status since
      * the system is already enabled. The system should be active since it has
      * been matched with an entity. */
@@ -654,6 +658,8 @@ void SystemMisc_status_deactivate_after_delete() {
     /* Delete the entity. Should trigger the Deactivated status */
     reset_status();
     ecs_delete(world, e);
+    ecs_force_aperiodic(world);
+
     test_assert(system_status_action_invoked == true);
     test_assert(enable_status == EcsSystemStatusNone);
     test_assert(active_status == EcsSystemDeactivated);
@@ -890,11 +896,13 @@ void SystemMisc_system_readeactivate() {
     test_assert( ecs_has_id(world, Dummy, EcsInactive));
 
     ecs_entity_t e = ecs_new(world, Position);
+    ecs_force_aperiodic(world);
 
     /* System should be active, one entity is matched */
     test_assert( !ecs_has_id(world, Dummy, EcsInactive));
 
     ecs_delete(world, e);
+    ecs_force_aperiodic(world);
 
     /* System is not automatically deactivated */
     test_assert( !ecs_has_id(world, Dummy, EcsInactive));
@@ -929,12 +937,14 @@ void SystemMisc_system_readeactivate_w_2_systems() {
 
     ecs_entity_t e1 = ecs_new(world, Position);
     ecs_new(world, Mass);
+    ecs_force_aperiodic(world);
 
     /* Systems should be active, one entity is matched */
     test_assert( !ecs_has_id(world, Dummy1, EcsInactive));
     test_assert( !ecs_has_id(world, Dummy2, EcsInactive));
 
     ecs_delete(world, e1);
+    ecs_force_aperiodic(world);
 
     /* System is not automatically deactivated */
     test_assert( !ecs_has_id(world, Dummy1, EcsInactive));
@@ -1721,6 +1731,8 @@ void SystemMisc_deactivate_after_disable() {
     ECS_SYSTEM(world, Dummy, EcsOnUpdate, Tag);
 
     ecs_entity_t e = ecs_new_w_id(world, Tag);
+    ecs_force_aperiodic(world);
+    
     test_assert(!ecs_has_id(world, Dummy, EcsInactive));
 
     ecs_enable(world, Dummy, false);
@@ -1728,6 +1740,7 @@ void SystemMisc_deactivate_after_disable() {
     test_assert(ecs_has_id(world, Dummy, EcsDisabled));
 
     ecs_delete(world, e);
+    ecs_force_aperiodic(world);
 
     test_assert(!ecs_has_id(world, Dummy, EcsInactive));
     test_assert(ecs_has_id(world, Dummy, EcsDisabled));

--- a/test/api/src/Trigger.c
+++ b/test/api/src/Trigger.c
@@ -3807,11 +3807,11 @@ static void TriggerTwice(ecs_iter_t *it) {
         test_assert(it->entities[0] == base_ent);
         invoke_count ++;
     } else if (invoke_count == 1) {
-        test_assert(it->entities[0] == inst_ent_a);
+        test_assert(it->entities[0] == inst_ent_b);
         invoke_count ++;
     } else {
         test_int(invoke_count, 2);
-        test_assert(it->entities[0] == inst_ent_b);
+        test_assert(it->entities[0] == inst_ent_a);
         invoke_count ++;
     }
 }


### PR DESCRIPTION
This PR implements a change that delays emitting table empty events until the administration is required to be consistent (for example, when evaluating a query). In practice this reduces the number of emitted events as well as the frequency with which tables are removed between empty and non-empty lists, which can significantly improve performance of `add` operations.

For reference, this is a simple add benchmark before the change (lower is better):
```md
## Add 16 tags (entities = 1000000, low id = 1)
new w/tag:          37.08ns
add 16 tags:        472.88ns (avg)
delete_with:        9.04ns (per entity)
```
The same benchmark after the change:
```md
## Add 16 tags (entities = 1000000, low id = 1)
new w/tag:          37.48ns
add 16 tags:        33.19ns (avg)
delete_with:        9.62ns (per entity)
```

In the first benchmark, the events generated by each table empty/non-empty transition increases time spent on an `add` linearly with the number of components, whereas after the change the time remains constant.