### PR TITLE
Install *.inl files with headers.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,8 @@ install(DIRECTORY "${PROJECT_SOURCE_DIR}/include/"
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         FILES_MATCHING
         PATTERN "*.h"
-        PATTERN "*.hpp")
+        PATTERN "*.hpp"
+        PATTERN "*.inl")
 
 install(TARGETS ${FLECS_TARGETS}
         EXPORT flecs-export


### PR DESCRIPTION
Howdy!

I have been working with flecs via conan and so I've started using CMake again. After setting up a recipe for flecs v3 I noticed that *.inl files don't get installed.

