### PR TITLE
#673 Prevent rare deadlock on the last worker thread

### DIFF
--- a/src/addons/pipeline/worker.c
+++ b/src/addons/pipeline/worker.c
@@ -91,9 +91,12 @@ void sync_worker(
         /* Only signal main thread when all threads are waiting */
         ecs_os_cond_signal(world->sync_cond);
     }
+    
+    if (!world->quit_workers) {
+        /* Wait until main thread signals that thread can continue */
+        ecs_os_cond_wait(world->worker_cond, world->sync_mutex);
+    }
 
-    /* Wait until main thread signals that thread can continue */
-    ecs_os_cond_wait(world->worker_cond, world->sync_mutex);
     ecs_os_mutex_unlock(world->sync_mutex);
 }
 


### PR DESCRIPTION
Sometimes last worker just deadlocks on the worker_cond, it seems that this change fixes #673 .

I am on Linux Mint 20.2 Cinnamon Intel© Xeon© CPU E3-1231 v3 @ 3.40GHz × 4