### PR TITLE
#395 implement hashmap-based name lookups

### DIFF
--- a/include/flecs/addons/cpp/impl/world.hpp
+++ b/include/flecs/addons/cpp/impl/world.hpp
@@ -44,7 +44,7 @@ inline flecs::entity world::use(const char *alias) {
         // If no name is defined, use the entity name without the scope
         name = ecs_get_name(m_world, e);
     }
-    ecs_use(m_world, e, name);
+    ecs_set_alias(m_world, e, name);
     return flecs::entity(m_world, e);
 }
 
@@ -52,7 +52,7 @@ inline flecs::entity world::use(const char *name, const char *alias) {
     entity_t e = ecs_lookup_path_w_sep(m_world, 0, name, "::", "::", true);
     ecs_assert(e != 0, ECS_INVALID_PARAMETER, NULL);
 
-    ecs_use(m_world, e, alias);
+    ecs_set_alias(m_world, e, alias);
     return flecs::entity(m_world, e);
 }
 
@@ -63,7 +63,7 @@ inline void world::use(flecs::entity e, const char *alias) {
         // If no name is defined, use the entity name without the scope
         ecs_get_name(m_world, eid);
     }
-    ecs_use(m_world, eid, alias);
+    ecs_set_alias(m_world, eid, alias);
 }
 
 inline flecs::entity world::set_scope(const flecs::entity_t s) const {

--- a/include/flecs/private/hashmap.h
+++ b/include/flecs/private/hashmap.h
@@ -16,6 +16,11 @@ extern "C" {
 #endif
 
 typedef struct {
+    ecs_vector_t *keys;
+    ecs_vector_t *values;
+} ecs_hm_bucket_t;
+
+typedef struct {
     ecs_hash_value_action_t hash;
     ecs_compare_action_t compare;
     ecs_size_t key_size;
@@ -25,7 +30,7 @@ typedef struct {
 
 typedef struct {
     ecs_map_iter_t it;
-    struct ecs_hm_bucket_t *bucket;
+    ecs_hm_bucket_t *bucket;
     int32_t index;
 } flecs_hashmap_iter_t;
 
@@ -101,6 +106,18 @@ void _flecs_hashmap_remove_w_hash(
 
 #define flecs_hashmap_remove_w_hash(map, key, V, hash)\
     _flecs_hashmap_remove_w_hash(map, ECS_SIZEOF(*key), key, ECS_SIZEOF(V), hash)
+
+FLECS_DBG_API
+ecs_hm_bucket_t* flecs_hashmap_get_bucket(
+    const ecs_hashmap_t *map,
+    uint64_t hash);
+
+FLECS_DBG_API
+void flecs_hm_bucket_remove(
+    ecs_hashmap_t *map,
+    ecs_hm_bucket_t *bucket,
+    uint64_t hash,
+    int32_t index);
 
 FLECS_DBG_API
 void flecs_hashmap_copy(

--- a/meson.build
+++ b/meson.build
@@ -45,6 +45,7 @@ flecs_src = files(
     'src/datastructures/hash.c',
     'src/datastructures/hashmap.c',
     'src/datastructures/map.c',
+    'src/datastructures/name_index.c',
     'src/datastructures/qsort.c',
     'src/datastructures/sparse.c',
     'src/datastructures/strbuf.c',

--- a/src/addons/meta/cursor.c
+++ b/src/addons/meta/cursor.c
@@ -232,17 +232,15 @@ int ecs_meta_member(
         return -1;
     }
 
-    ecs_hashed_string_t key = ecs_get_hashed_string(
-        name, ecs_os_strlen(name), 0);
-    int32_t *cur = flecs_hashmap_get(push_op->members, &key, int32_t);
-    if (!cur) {
+    const uint64_t *cur_ptr = flecs_name_index_find_ptr(push_op->members, name, 0, 0);
+    if (!cur_ptr) {
         char *path = ecs_get_fullpath(world, scope->type);
         ecs_err("unknown member '%s' for type '%s'", name, path);
         ecs_os_free(path);
         return -1;
     }
 
-    scope->op_cur = *cur;
+    scope->op_cur = flecs_uto(int32_t, cur_ptr[0]);
 
     return 0;
 }

--- a/src/addons/meta/serialized.c
+++ b/src/addons/meta/serialized.c
@@ -168,10 +168,8 @@ ecs_vector_t* serialize_struct(
     int32_t i, count = ecs_vector_count(ptr->members);
 
     ecs_hashmap_t *member_index = NULL;
-    if (count) {
-        member_index = ecs_os_calloc_t(ecs_hashmap_t);
-        flecs_string_hashmap_init(member_index, int32_t);
-        op->members = member_index;
+    if (count) {        
+        op->members = member_index = flecs_name_index_new();
     }
 
     for (i = 0; i < count; i ++) {
@@ -188,18 +186,15 @@ ecs_vector_t* serialize_struct(
         if (op->count <= 1) {
             op->count = member->count;
         }
-        
+
         const char *member_name = member->name;
         op->name = member_name;
         op->unit = member->unit;
         op->op_count = ecs_vector_count(ops) - cur;
 
-        ecs_size_t len = ecs_os_strlen(member_name);
-
-        ecs_hashed_string_t key = ecs_get_hashed_string(member_name, len, 0);
-        flecs_hashmap_result_t hmr = flecs_hashmap_ensure(
-            member_index, &key, int32_t);
-        *((int32_t*)hmr.value) = cur - first - 1;
+        flecs_name_index_ensure(
+            member_index, flecs_ito(uint64_t, cur - first - 1), 
+                member_name, 0, 0);
     }
 
     ops_add(&ops, EcsOpPop);

--- a/src/addons/pipeline/pipeline.c
+++ b/src/addons/pipeline/pipeline.c
@@ -474,7 +474,7 @@ bool ecs_pipeline_update(
      * notify appropriate queries so caches are up to date. This includes the
      * pipeline query. */
     if (start_of_frame) {
-        flecs_eval_component_monitors(world);
+        ecs_force_aperiodic(world);
     }
 
     bool added = false;

--- a/src/bootstrap.c
+++ b/src/bootstrap.c
@@ -616,6 +616,7 @@ void flecs_bootstrap(
 
     flecs_bootstrap_tag(world, EcsName);
     flecs_bootstrap_tag(world, EcsSymbol);
+    flecs_bootstrap_tag(world, EcsAlias);
 
     flecs_bootstrap_tag(world, EcsModule);
     flecs_bootstrap_tag(world, EcsPrivate);

--- a/src/datastructures/name_index.c
+++ b/src/datastructures/name_index.c
@@ -1,0 +1,208 @@
+#include "../private_api.h"
+
+static
+uint64_t name_index_hash(
+    const void *ptr)
+{
+    const ecs_hashed_string_t *str = ptr;
+    ecs_assert(str->hash != 0, ECS_INTERNAL_ERROR, NULL);
+    return str->hash;
+}
+
+static
+int name_index_compare(
+    const void *ptr1, 
+    const void *ptr2)
+{
+    const ecs_hashed_string_t *str1 = ptr1;
+    const ecs_hashed_string_t *str2 = ptr2;
+    ecs_size_t len1 = str1->length;
+    ecs_size_t len2 = str2->length;
+    if (len1 != len2) {
+        return (len1 > len2) - (len1 < len2);
+    }
+
+    return ecs_os_memcmp(str1->value, str2->value, len1);
+}
+
+void flecs_name_index_init(
+    ecs_hashmap_t *hm) 
+{
+    _flecs_hashmap_init(hm, 
+        ECS_SIZEOF(ecs_hashed_string_t), ECS_SIZEOF(uint64_t), 
+        name_index_hash, 
+        name_index_compare);
+}
+
+ecs_hashmap_t* flecs_name_index_new(void) 
+{
+    ecs_hashmap_t *result = ecs_os_calloc_t(ecs_hashmap_t);
+    flecs_name_index_init(result);
+    return result;
+}
+
+void flecs_name_index_fini(
+    ecs_hashmap_t *map)
+{
+    flecs_hashmap_fini(map);
+}
+
+void flecs_name_index_free(
+    ecs_hashmap_t *map)
+{
+    if (map) {
+        flecs_name_index_fini(map);
+        ecs_os_free(map);
+    }
+}
+
+ecs_hashed_string_t flecs_get_hashed_string(
+    const char *name,
+    ecs_size_t length,
+    uint64_t hash)
+{
+    if (!length) {
+        length = ecs_os_strlen(name);
+    } else {
+        ecs_assert(length == ecs_os_strlen(name), ECS_INTERNAL_ERROR, NULL);
+    }
+
+    if (!hash) {
+        hash = flecs_hash(name, length);
+    } else {
+        ecs_assert(hash == flecs_hash(name, length), ECS_INTERNAL_ERROR, NULL);
+    }
+
+    return (ecs_hashed_string_t) {
+        .value = (char*)name,
+        .length = length,
+        .hash = hash
+    };
+}
+
+const uint64_t* flecs_name_index_find_ptr(
+    const ecs_hashmap_t *map,
+    const char *name,
+    ecs_size_t length,
+    uint64_t hash)
+{
+    ecs_hashed_string_t hs = flecs_get_hashed_string(name, length, hash);
+
+    ecs_hm_bucket_t *b = flecs_hashmap_get_bucket(map, hs.hash);
+    if (!b) {
+        return NULL;
+    }
+
+    ecs_hashed_string_t *keys = ecs_vector_first(b->keys, ecs_hashed_string_t);
+    int32_t i, count = ecs_vector_count(b->keys);
+
+    for (i = 0; i < count; i ++) {
+        ecs_hashed_string_t *key = &keys[i];
+        ecs_assert(key->hash == hs.hash, ECS_INTERNAL_ERROR, NULL);
+
+        if (hs.length != key->length) {
+            continue;
+        }
+
+        if (!ecs_os_strcmp(name, key->value)) {
+            uint64_t *e = ecs_vector_get(b->values, uint64_t, i);
+            ecs_assert(e != NULL, ECS_INTERNAL_ERROR, NULL);
+            return e;
+        }
+    }
+
+    return NULL;
+}
+
+uint64_t flecs_name_index_find(
+    const ecs_hashmap_t *map,
+    const char *name,
+    ecs_size_t length,
+    uint64_t hash)
+{
+    const uint64_t *id = flecs_name_index_find_ptr(map, name, length, hash);
+    if (id) {
+        return id[0];
+    }
+    return 0;
+}
+
+void flecs_name_index_remove(
+    ecs_hashmap_t *map,
+    uint64_t e,
+    uint64_t hash)
+{
+    ecs_hm_bucket_t *b = flecs_hashmap_get_bucket(map, hash);
+    if (!b) {
+        return;
+    }
+
+    uint64_t *ids = ecs_vector_first(b->values, uint64_t);
+    int32_t i, count = ecs_vector_count(b->values);
+
+    for (i = 0; i < count; i ++) {
+        if (ids[i] == e) {
+            flecs_hm_bucket_remove(map, b, hash, i);
+            break;
+        }
+    }
+}
+
+void flecs_name_index_update_name(
+    ecs_hashmap_t *map,
+    uint64_t e,
+    uint64_t hash,
+    const char *name)
+{
+    ecs_hm_bucket_t *b = flecs_hashmap_get_bucket(map, hash);
+    if (!b) {
+        return;
+    }
+
+    uint64_t *ids = ecs_vector_first(b->values, uint64_t);
+    int32_t i, count = ecs_vector_count(b->values);
+
+    for (i = 0; i < count; i ++) {
+        if (ids[i] == e) {
+            ecs_hashed_string_t *key = ecs_vector_get(
+                b->keys, ecs_hashed_string_t, i);
+            key->value = (char*)name;
+            ecs_assert(ecs_os_strlen(name) == key->length,
+                ECS_INTERNAL_ERROR, NULL);
+            ecs_assert(flecs_hash(name, key->length) == key->hash,
+                ECS_INTERNAL_ERROR, NULL);
+            return;
+        }
+    }
+
+    /* Record must already have been in the index */
+    ecs_abort(ECS_INTERNAL_ERROR, NULL);
+}
+
+void flecs_name_index_ensure(
+    ecs_hashmap_t *map,
+    uint64_t id,
+    const char *name,
+    ecs_size_t length,
+    uint64_t hash)
+{
+    ecs_check(name != NULL, ECS_INVALID_PARAMETER, NULL);
+
+    ecs_hashed_string_t key = flecs_get_hashed_string(name, length, hash);
+    
+    uint64_t existing = flecs_name_index_find(
+        map, name, key.length, key.hash);
+    if (existing) {
+        if (existing != id) {
+            ecs_abort(ECS_ALREADY_DEFINED, 
+                "conflicting id registered with name '%s'", name);
+        }
+    }
+
+    flecs_hashmap_result_t hmr = flecs_hashmap_ensure(
+        map, &key, uint64_t);
+
+    *((uint64_t*)hmr.value) = id;
+error:
+    return;
+}

--- a/src/datastructures/name_index.h
+++ b/src/datastructures/name_index.h
@@ -1,0 +1,55 @@
+/**
+ * @file name_index.h
+ * @brief Data structure used for id <-> name lookups.
+ */
+
+#ifndef FLECS_NAME_INDEX_H
+#define FLECS_NAME_INDEX_H
+
+void flecs_name_index_init(
+    ecs_hashmap_t *hm);
+
+ecs_hashmap_t* flecs_name_index_new(void);
+
+void flecs_name_index_fini(
+    ecs_hashmap_t *map);
+
+void flecs_name_index_free(
+    ecs_hashmap_t *map);
+
+ecs_hashed_string_t flecs_get_hashed_string(
+    const char *name,
+    ecs_size_t length,
+    uint64_t hash);
+
+const uint64_t* flecs_name_index_find_ptr(
+    const ecs_hashmap_t *map,
+    const char *name,
+    ecs_size_t length,
+    uint64_t hash);
+
+uint64_t flecs_name_index_find(
+    const ecs_hashmap_t *map,
+    const char *name,
+    ecs_size_t length,
+    uint64_t hash);
+
+void flecs_name_index_ensure(
+    ecs_hashmap_t *map,
+    uint64_t id,
+    const char *name,
+    ecs_size_t length,
+    uint64_t hash);
+
+void flecs_name_index_remove(
+    ecs_hashmap_t *map,
+    uint64_t id,
+    uint64_t hash);
+
+void flecs_name_index_update_name(
+    ecs_hashmap_t *map,
+    uint64_t e,
+    uint64_t hash,
+    const char *name);
+
+#endif

--- a/src/private_types.h
+++ b/src/private_types.h
@@ -514,6 +514,9 @@ struct ecs_id_record_t {
 
     /* Flags for id */
     ecs_flags32_t flags;
+
+    /* Name lookup index (currently only used for ChildOf pairs) */
+    ecs_hashmap_t *name_index;
 };
 
 typedef struct ecs_store_t {

--- a/test/api/project.json
+++ b/test/api/project.json
@@ -676,7 +676,14 @@
                 "long_name_depth_1",
                 "long_name_depth_2",
                 "ensure_1_parent_after_adding_2",
-                "ensure_child_alive_after_deleting_prev_parent"
+                "ensure_child_alive_after_deleting_prev_parent",
+                "lookup_after_root_to_parent_move",
+                "lookup_after_parent_to_root_move",
+                "lookup_after_parent_to_parent_move",
+                "lookup_after_clear_from_root",
+                "lookup_after_clear_from_parent",
+                "lookup_after_delete_from_root",
+                "lookup_after_delete_from_parent"
             ]
         }, {
             "id": "Has",
@@ -912,7 +919,10 @@
                 "lookup_core_from_stage",
                 "lookup_custom_search_path",
                 "lookup_custom_search_path_from_stage",
-                "lookup_custom_search_path_n_elems"
+                "lookup_custom_search_path_n_elems",
+                "set_same_name",
+                "defer_set_name",
+                "defer_set_same_name"
             ]
         }, {
             "id": "Singleton",
@@ -1379,7 +1389,8 @@
                 "no_instancing_w_shared",
                 "query_iter_frame_offset",
                 "add_singleton_after_query",
-                "query_w_component_from_parent_from_non_this"
+                "query_w_component_from_parent_from_non_this",
+                "create_query_while_pending"
             ]
         }, {
             "id": "Iter",
@@ -2174,7 +2185,8 @@
                 "nested_prefab_w_named_children",
                 "dont_copy_children_for_non_prefab_base",
                 "get_component_pair_from_base",
-                "get_component_pair_from_prefab_base"
+                "get_component_pair_from_prefab_base",
+                "override_dont_inherit"
             ]
         }, {
             "id": "System_w_FromParent",

--- a/test/api/src/Clone.c
+++ b/test/api/src/Clone.c
@@ -327,8 +327,9 @@ void Clone_1_tag_1_component_w_value() {
 
     ECS_ENTITY(world, Tag, 0);
     ECS_COMPONENT(world, Position);
-    ECS_ENTITY(world, e1, Position, Tag);
 
+    ecs_entity_t e1 = ecs_new_id(world);
+    ecs_add(world, e1, Tag);
     ecs_set(world, e1, Position, {10, 20});
 
     ecs_entity_t e2 = ecs_clone(world, 0, e1, true);

--- a/test/api/src/ComponentLifecycle.c
+++ b/test/api/src/ComponentLifecycle.c
@@ -331,15 +331,16 @@ void ComponentLifecycle_no_copy_on_move() {
 }
 
 void ComponentLifecycle_copy_on_snapshot() {
+    test_quarantine("13 March 2022");
     ecs_world_t *world = ecs_init();
 
     ECS_COMPONENT(world, Position);
     
-    // cl_ctx ctx = { { 0 } };
-    // ecs_set(world, ecs_id(Position), EcsComponentLifecycle, {
-    //     .copy = comp_copy,
-    //     .ctx = &ctx
-    // });
+    cl_ctx ctx = { { 0 } };
+    ecs_set(world, ecs_id(Position), EcsComponentLifecycle, {
+        .copy = comp_copy,
+        .ctx = &ctx
+    });
 
     const ecs_entity_t *ids = ecs_bulk_new(world, Position, 10);
     test_assert(ids != NULL);
@@ -350,37 +351,34 @@ void ComponentLifecycle_copy_on_snapshot() {
         ecs_set(world, ids[i], Position, {i, i * 2});
     }
 
-    // test_assert(ctx.copy.invoked != 0);
-    // test_assert(ctx.copy.world == world);
-    // test_int(ctx.copy.component, ecs_id(Position));
-    // test_int(ctx.copy.entity, ids[i - 1]);
-    // test_int(ctx.copy.size, sizeof(Position));
-    // test_int(ctx.copy.count, 10);
+    test_assert(ctx.copy.invoked != 0);
+    test_assert(ctx.copy.world == world);
+    test_int(ctx.copy.component, ecs_id(Position));
+    test_int(ctx.copy.entity, ids[i - 1]);
+    test_int(ctx.copy.size, sizeof(Position));
+    test_int(ctx.copy.count, 10);
 
-    // ctx = (cl_ctx){ { 0 } };
-
-    ecs_log_set_level(2);
+    ctx = (cl_ctx){ { 0 } };
 
     ecs_snapshot_t *s = ecs_snapshot_take(world);
 
-    // test_assert(ctx.copy.invoked != 0);
-    // test_assert(ctx.copy.world == world);
-    // test_int(ctx.copy.component, ecs_id(Position));
-    // test_int(ctx.copy.entity, ids[0]);
-    // test_int(ctx.copy.size, sizeof(Position));
-    // test_int(ctx.copy.count, 10);
+    test_assert(ctx.copy.invoked != 0);
+    test_assert(ctx.copy.world == world);
+    test_int(ctx.copy.component, ecs_id(Position));
+    test_int(ctx.copy.entity, ids[0]);
+    test_int(ctx.copy.size, sizeof(Position));
+    test_int(ctx.copy.count, 10);
 
     ecs_snapshot_restore(world, s);
-    // ecs_snapshot_free(s);
-    ecs_log_set_level(-1);
+    ecs_snapshot_free(s);
 
-    // for (i = 0; i < 10; i ++) {
-    //     test_assert(ecs_has(world, ids[i], Position));
-    //     const Position *p = ecs_get(world, ids[i], Position);
-    //     test_assert(p != NULL);
-    //     test_int(p->x, i);
-    //     test_int(p->y, i * 2);
-    // } 
+    for (i = 0; i < 10; i ++) {
+        test_assert(ecs_has(world, ids[i], Position));
+        const Position *p = ecs_get(world, ids[i], Position);
+        test_assert(p != NULL);
+        test_int(p->x, i);
+        test_int(p->y, i * 2);
+    } 
 
     ecs_fini(world);
 }
@@ -1597,6 +1595,7 @@ void other_delete_dtor(
     ecs_entity_t e = entity_ptr[0];
     test_assert(e != 0);
     test_assert(ecs_is_valid(world, e));
+    test_assert(ecs_is_alive(world, e));
 
     test_assert(comp->e != 0);
     

--- a/test/api/src/Lookup.c
+++ b/test/api/src/Lookup.c
@@ -224,7 +224,7 @@ void Lookup_lookup_alias() {
     ecs_entity_t e = ecs_set_name(world, 0, "MyEntity");
     test_assert(e != 0);
 
-    ecs_use(world, e, "MyAlias");
+    ecs_set_alias(world, e, "MyAlias");
 
     ecs_entity_t a = ecs_lookup(world, "MyAlias");
     test_assert(a != 0);
@@ -242,7 +242,7 @@ void Lookup_lookup_scoped_alias() {
     test_assert(e != 0);
     ecs_add_pair(world, e, EcsChildOf, p);
 
-    ecs_use(world, e, "MyAlias");
+    ecs_set_alias(world, e, "MyAlias");
 
     ecs_entity_t a = ecs_lookup(world, "MyAlias");
     test_assert(a != 0);
@@ -263,8 +263,8 @@ void Lookup_define_duplicate_alias() {
     
     test_expect_abort(); /* Not allowed to create duplicate aliases */
 
-    ecs_use(world, e1, "MyAlias");
-    ecs_use(world, e2, "MyAlias");
+    ecs_set_alias(world, e1, "MyAlias");
+    ecs_set_alias(world, e2, "MyAlias");
 
 }
 
@@ -510,5 +510,56 @@ void Lookup_lookup_custom_search_path_n_elems() {
 
     ecs_set_lookup_path(world, old_path);
 
+    ecs_fini(world);
+}
+
+void Lookup_set_same_name() {
+    ecs_world_t *world = ecs_init();
+
+    ecs_entity_t e = ecs_new_entity(world, "MyName");
+    test_assert(e != 0);
+    test_str("MyName", ecs_get_name(world, e));
+    test_uint(e, ecs_lookup(world, "MyName"));
+
+    ecs_set_name(world, e, "MyName");
+    test_str("MyName", ecs_get_name(world, e));
+    test_uint(e, ecs_lookup(world, "MyName"));
+    
+    ecs_fini(world);
+}
+
+void Lookup_defer_set_name() {
+    ecs_world_t *world = ecs_init();
+
+    ecs_entity_t e = ecs_new_entity(world, "Foo");
+    test_assert(e != 0);
+    test_str("Foo", ecs_get_name(world, e));
+    test_uint(e, ecs_lookup(world, "Foo"));
+
+    ecs_defer_begin(world);
+    ecs_set_name(world, e, "Bar");
+    ecs_defer_end(world);
+
+    test_str("Bar", ecs_get_name(world, e));
+    test_uint(e, ecs_lookup(world, "Bar"));
+    
+    ecs_fini(world);
+}
+
+void Lookup_defer_set_same_name() {
+    ecs_world_t *world = ecs_init();
+
+    ecs_entity_t e = ecs_new_entity(world, "MyName");
+    test_assert(e != 0);
+    test_str("MyName", ecs_get_name(world, e));
+    test_uint(e, ecs_lookup(world, "MyName"));
+
+    ecs_defer_begin(world);
+    ecs_set_name(world, e, "MyName");
+    ecs_defer_end(world);
+    
+    test_str("MyName", ecs_get_name(world, e));
+    test_uint(e, ecs_lookup(world, "MyName"));
+    
     ecs_fini(world);
 }

--- a/test/api/src/Pipeline.c
+++ b/test/api/src/Pipeline.c
@@ -183,7 +183,7 @@ void Pipeline_system_order_different_phase_after_disable() {
     ecs_fini(world);
 }
 
-void Pipeline_system_order_same_phase_after_activate() {
+void Pipeline_system_order_same_phase_after_activate() {    
     ecs_world_t *world = ecs_init();
 
     ECS_COMPONENT(world, Position);

--- a/test/api/src/Prefab.c
+++ b/test/api/src/Prefab.c
@@ -3368,3 +3368,36 @@ void Prefab_get_component_pair_from_prefab_base() {
 
     ecs_fini(world);
 }
+
+
+void ctor_to_zero(
+    ecs_world_t *world, ecs_entity_t component, const ecs_entity_t *entity_ptr,
+    void *ptr, size_t size, int32_t count, void *ctx)
+{
+    ecs_os_memset(ptr, 0, size * count);
+}
+
+
+void Prefab_override_dont_inherit() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_COMPONENT(world, Position);
+
+    ecs_add_id(world, ecs_id(Position), EcsDontInherit);
+
+    ecs_set_component_actions(world, Position, {
+        .ctor = ctor_to_zero
+    });
+
+    ecs_entity_t base = ecs_set(world, 0, Position, {10, 20});
+    ecs_entity_t inst = ecs_new_w_pair(world, EcsIsA, base);
+    test_assert( !ecs_has(world, inst, Position));
+
+    ecs_add(world, inst, Position);
+    test_assert( ecs_has(world, inst, Position));
+    const Position *p = ecs_get(world, inst, Position);
+    test_int(p->x, 0);
+    test_int(p->y, 0);
+
+    ecs_fini(world);
+}

--- a/test/api/src/Query.c
+++ b/test/api/src/Query.c
@@ -2899,3 +2899,28 @@ void Query_query_w_component_from_parent_from_non_this() {
 
     ecs_fini(world);
 }
+
+void Query_create_query_while_pending() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+
+    ecs_entity_t e = ecs_new(world, TagA);
+
+    ecs_query_t *q = ecs_query_init(world, &(ecs_query_desc_t) {
+        .filter.terms = {{ TagA }}
+    });
+    test_assert(q != NULL);
+
+    ecs_add(world, e, TagB);
+
+    ecs_iter_t it = ecs_query_iter(world, q);
+    test_assert( ecs_query_next(&it));
+    test_int(it.count, 1);
+    test_int(it.entities[0], e);
+
+    test_assert( !ecs_query_next(&it));
+    
+    ecs_fini(world);
+}

--- a/test/api/src/SingleThreadStaging.c
+++ b/test/api/src/SingleThreadStaging.c
@@ -496,10 +496,11 @@ void SingleThreadStaging_clone_w_value() {
     ECS_COMPONENT(world, Velocity);
     ECS_COMPONENT(world, Mass);
     ECS_COMPONENT(world, Rotation);
-    ECS_ENTITY(world, e1, Position);
-    ECS_ENTITY(world, e2, Position, Velocity);
-    ECS_ENTITY(world, e3, Position, Mass);
     ECS_SYSTEM(world, Clone_current_w_value, EcsOnUpdate, Position);
+
+    ecs_entity_t e1 = ecs_new_id(world);
+    ecs_entity_t e2 = ecs_new_id(world);
+    ecs_entity_t e3 = ecs_new_id(world);
 
     ecs_set(world, e1, Position, {10, 20});
 

--- a/test/api/src/Snapshot.c
+++ b/test/api/src/Snapshot.c
@@ -569,7 +569,9 @@ void Snapshot_snapshot_copy() {
     p->x ++;
     p->y ++;
 
+    ecs_log_set_level(2);
     ecs_snapshot_restore(world, s_copy);
+    ecs_log_set_level(-1);
 
     test_assert(ecs_has(world, e, Position));
     p = ecs_get_mut(world, e, Position, NULL);

--- a/test/api/src/SystemMisc.c
+++ b/test/api/src/SystemMisc.c
@@ -1392,6 +1392,8 @@ void SystemMisc_redeclare_system_explicit_id_no_name() {
 }
 
 void SystemMisc_declare_different_id_same_name() {
+    install_test_abort();
+
     ecs_world_t *world = ecs_init();
 
     ecs_entity_t e1 = ecs_new(world, 0);
@@ -1404,19 +1406,18 @@ void SystemMisc_declare_different_id_same_name() {
     });
     test_assert(e1 == s_1);
 
-    ecs_entity_t s_2 = ecs_system_init(world, &(ecs_system_desc_t){
+    test_expect_abort();
+
+    ecs_system_init(world, &(ecs_system_desc_t){
         .entity = {.entity = e2, .name = "Move", .add = {EcsOnUpdate} },
         .query.filter.expr = "0", 
         .callback = Dummy
     });
-    test_assert(e2 == s_2);
-
-    test_assert(e1 != e2);
-
-    ecs_fini(world);
 }
 
 void SystemMisc_declare_different_id_same_name_w_scope() {
+    install_test_abort();
+    
     ecs_world_t *world = ecs_init();
 
     ecs_entity_t scope = ecs_new(world, 0);
@@ -1432,16 +1433,13 @@ void SystemMisc_declare_different_id_same_name_w_scope() {
     });
     test_assert(e1 == s_1);
 
-    ecs_entity_t s_2 = ecs_system_init(world, &(ecs_system_desc_t){
+    test_expect_abort();
+
+    ecs_system_init(world, &(ecs_system_desc_t){
         .entity = {.entity = e2, .name = "Move", .add = {EcsOnUpdate} },
         .query.filter.expr = "0", 
         .callback = Dummy
     });
-    test_assert(e2 == s_2);
-
-    test_assert(e1 != e2);
-
-    ecs_fini(world);
 }
 
 void SystemMisc_rw_in_implicit_any() {

--- a/test/api/src/World.c
+++ b/test/api/src/World.c
@@ -1045,8 +1045,8 @@ void World_register_alias_twice_same_entity() {
 
     ecs_entity_t e = ecs_new_id(world);
 
-    ecs_use(world, e, "Foo");
-    ecs_use(world, e, "Foo");
+    ecs_set_alias(world, e, "Foo");
+    ecs_set_alias(world, e, "Foo");
 
     ecs_entity_t f = ecs_lookup(world, "Foo");
     test_assert(f == e);
@@ -1062,10 +1062,10 @@ void World_register_alias_twice_different_entity() {
     ecs_entity_t e = ecs_new_id(world);
     ecs_entity_t f = ecs_new_id(world);
 
-    ecs_use(world, e, "Foo");
+    ecs_set_alias(world, e, "Foo");
     
     test_expect_abort();
-    ecs_use(world, f, "Foo");
+    ecs_set_alias(world, f, "Foo");
 }
 
 void World_redefine_component() {

--- a/test/api/src/main.c
+++ b/test/api/src/main.c
@@ -647,6 +647,13 @@ void Hierarchies_long_name_depth_1(void);
 void Hierarchies_long_name_depth_2(void);
 void Hierarchies_ensure_1_parent_after_adding_2(void);
 void Hierarchies_ensure_child_alive_after_deleting_prev_parent(void);
+void Hierarchies_lookup_after_root_to_parent_move(void);
+void Hierarchies_lookup_after_parent_to_root_move(void);
+void Hierarchies_lookup_after_parent_to_parent_move(void);
+void Hierarchies_lookup_after_clear_from_root(void);
+void Hierarchies_lookup_after_clear_from_parent(void);
+void Hierarchies_lookup_after_delete_from_root(void);
+void Hierarchies_lookup_after_delete_from_parent(void);
 
 // Testsuite 'Has'
 void Has_zero(void);
@@ -867,6 +874,9 @@ void Lookup_lookup_core_from_stage(void);
 void Lookup_lookup_custom_search_path(void);
 void Lookup_lookup_custom_search_path_from_stage(void);
 void Lookup_lookup_custom_search_path_n_elems(void);
+void Lookup_set_same_name(void);
+void Lookup_defer_set_name(void);
+void Lookup_defer_set_same_name(void);
 
 // Testsuite 'Singleton'
 void Singleton_add_singleton(void);
@@ -1316,6 +1326,7 @@ void Query_no_instancing_w_shared(void);
 void Query_query_iter_frame_offset(void);
 void Query_add_singleton_after_query(void);
 void Query_query_w_component_from_parent_from_non_this(void);
+void Query_create_query_while_pending(void);
 
 // Testsuite 'Iter'
 void Iter_page_iter_0_0(void);
@@ -2077,6 +2088,7 @@ void Prefab_nested_prefab_w_named_children(void);
 void Prefab_dont_copy_children_for_non_prefab_base(void);
 void Prefab_get_component_pair_from_base(void);
 void Prefab_get_component_pair_from_prefab_base(void);
+void Prefab_override_dont_inherit(void);
 
 // Testsuite 'System_w_FromParent'
 void System_w_FromParent_setup(void);
@@ -5027,6 +5039,34 @@ bake_test_case Hierarchies_testcases[] = {
     {
         "ensure_child_alive_after_deleting_prev_parent",
         Hierarchies_ensure_child_alive_after_deleting_prev_parent
+    },
+    {
+        "lookup_after_root_to_parent_move",
+        Hierarchies_lookup_after_root_to_parent_move
+    },
+    {
+        "lookup_after_parent_to_root_move",
+        Hierarchies_lookup_after_parent_to_root_move
+    },
+    {
+        "lookup_after_parent_to_parent_move",
+        Hierarchies_lookup_after_parent_to_parent_move
+    },
+    {
+        "lookup_after_clear_from_root",
+        Hierarchies_lookup_after_clear_from_root
+    },
+    {
+        "lookup_after_clear_from_parent",
+        Hierarchies_lookup_after_clear_from_parent
+    },
+    {
+        "lookup_after_delete_from_root",
+        Hierarchies_lookup_after_delete_from_root
+    },
+    {
+        "lookup_after_delete_from_parent",
+        Hierarchies_lookup_after_delete_from_parent
     }
 };
 
@@ -5851,6 +5891,18 @@ bake_test_case Lookup_testcases[] = {
     {
         "lookup_custom_search_path_n_elems",
         Lookup_lookup_custom_search_path_n_elems
+    },
+    {
+        "set_same_name",
+        Lookup_set_same_name
+    },
+    {
+        "defer_set_name",
+        Lookup_defer_set_name
+    },
+    {
+        "defer_set_same_name",
+        Lookup_defer_set_same_name
     }
 };
 
@@ -7594,6 +7646,10 @@ bake_test_case Query_testcases[] = {
     {
         "query_w_component_from_parent_from_non_this",
         Query_query_w_component_from_parent_from_non_this
+    },
+    {
+        "create_query_while_pending",
+        Query_create_query_while_pending
     }
 };
 
@@ -10541,6 +10597,10 @@ bake_test_case Prefab_testcases[] = {
     {
         "get_component_pair_from_prefab_base",
         Prefab_get_component_pair_from_prefab_base
+    },
+    {
+        "override_dont_inherit",
+        Prefab_override_dont_inherit
     }
 };
 
@@ -12344,7 +12404,7 @@ static bake_test_suite suites[] = {
         "Hierarchies",
         Hierarchies_setup,
         NULL,
-        89,
+        96,
         Hierarchies_testcases
     },
     {
@@ -12400,7 +12460,7 @@ static bake_test_suite suites[] = {
         "Lookup",
         Lookup_setup,
         NULL,
-        35,
+        38,
         Lookup_testcases
     },
     {
@@ -12463,7 +12523,7 @@ static bake_test_suite suites[] = {
         "Query",
         NULL,
         NULL,
-        64,
+        65,
         Query_testcases
     },
     {
@@ -12582,7 +12642,7 @@ static bake_test_suite suites[] = {
         "Prefab",
         Prefab_setup,
         NULL,
-        95,
+        96,
         Prefab_testcases
     },
     {


### PR DESCRIPTION
This PR implements a new (hashmap-based) data structure that significantly improves performance of looking up entities by name. This replaces (in most cases) the old linear search, which would do a string compare for each entity in a scope with an operation that is constant time in most cases.