### PR TITLE
Add support for setting query variables on filter iterator

### DIFF
--- a/flecs.c
+++ b/flecs.c
@@ -19482,16 +19482,16 @@ error:
     return;
 }
 
-void ecs_iter_set_var_table(
+void ecs_iter_set_var_as_table(
     ecs_iter_t *it,
     int32_t var_id,
     const ecs_table_t *table)
 {
     ecs_table_range_t range = { .table = (ecs_table_t*)table };
-    ecs_iter_set_var_range(it, var_id, &range);
+    ecs_iter_set_var_as_range(it, var_id, &range);
 }
 
-void ecs_iter_set_var_range(
+void ecs_iter_set_var_as_range(
     ecs_iter_t *it,
     int32_t var_id,
     const ecs_table_range_t *range)
@@ -25432,6 +25432,34 @@ bool term_iter_next(
     return true;
 }
 
+static
+bool term_iter_set_table(
+    ecs_term_iter_t *iter,
+    ecs_table_t *table)
+{
+    /* Can't set a (This) table if iterator has no self index */
+    const ecs_id_record_t *idr = iter->self_index;
+    if (!idr) {
+        return false;
+    }
+
+    /* Table must be in id cache of term iterator, or it won't match */
+    ecs_table_record_t *tr = ecs_table_cache_get(&idr->cache, table);
+    if (!tr) {
+        return false;
+    }
+
+    /* Populate fields as usual */
+    iter->table = table;
+    iter->match_count = tr->count;
+    iter->cur_match = 0;
+    iter->last_column = tr->column;
+    iter->column = tr->column + 1;
+    iter->id = ecs_vector_get(table->type, ecs_id_t, tr->column)[0];
+
+    return true;
+}
+
 bool ecs_term_next(
     ecs_iter_t *it)
 {
@@ -25599,7 +25627,7 @@ ecs_iter_t ecs_filter_iter(
         int32_t pivot_term = -1;
         ecs_check(terms != NULL, ECS_INVALID_PARAMETER, NULL);
 
-        iter->kind = EcsIterEvalIndex;
+        iter->kind = EcsIterEvalTables;
 
         pivot_term = ecs_filter_pivot_term(world, filter);
 
@@ -25729,7 +25757,7 @@ bool ecs_filter_next_instanced(
         } while (!match);
 
         goto yield;
-    } else if (kind == EcsIterEvalIndex || kind == EcsIterEvalCondition) {
+    } else if (kind == EcsIterEvalTables || kind == EcsIterEvalCondition) {
         ecs_term_iter_t *term_iter = &iter->term_iter;
         ecs_term_t *term = &term_iter->term;
         int32_t pivot_term = term->index;
@@ -25737,10 +25765,23 @@ bool ecs_filter_next_instanced(
 
         /* Check if the This variable has been set on the iterator. If set,
          * the filter should only be applied to the variable value */
-        // bool this_is_set = false;
-        // if (it->variable_count) {
-        //     this_is_set = ecs_iter_var_is_constrained(it, 0);
-        // }
+        ecs_var_t *this_var = NULL;
+        ecs_table_t *this_table = NULL;
+        if (it->variable_count) {
+            if (ecs_iter_var_is_constrained(it, 0)) {
+                this_var = it->variables;
+                this_table = this_var->range.table;
+
+                /* If variable is constrained, make sure it's a value that's
+                 * pointing to a table, as a filter can't iterate single
+                 * entities (yet) */
+                ecs_assert(this_table != NULL, ECS_INVALID_OPERATION, NULL);
+
+                /* Can't set variable for filter that does not iterate tables */
+                ecs_assert(kind == EcsIterEvalTables, 
+                    ECS_INVALID_OPERATION, NULL);
+            }
+        }
 
         do {
             /* If there are no matches left for the previous table, this is the
@@ -25749,11 +25790,33 @@ bool ecs_filter_next_instanced(
 
             if (first) {
                 if (kind != EcsIterEvalCondition) {
-                    /* Find new match, starting with the leading term */
-                    if (!term_iter_next(world, term_iter, 
-                        filter->match_prefab, filter->match_disabled)) 
-                    {
-                        goto done;
+                    /* Check if this variable was constrained */
+                    if (this_table != NULL) {
+                        /* If this is the first match of a new result and the
+                         * previous result was equal to the value of a 
+                         * constrained var, there's nothing left to iterate */
+                        if (it->table == this_table) {
+                            goto done;
+                        }
+
+                        /* If table doesn't match term iterator, it doesn't
+                         * match filter. */
+                        if (!term_iter_set_table(term_iter, this_table)){
+                            goto done;
+                        }
+
+                        /* But if it does, forward it to filter matching */
+                        ecs_assert(term_iter->table == this_table,
+                            ECS_INTERNAL_ERROR, NULL);
+
+                    /* If This variable is not constrained, iterate as usual */
+                    } else {
+                        /* Find new match, starting with the leading term */
+                        if (!term_iter_next(world, term_iter, 
+                            filter->match_prefab, filter->match_disabled)) 
+                        {
+                            goto done;
+                        }
                     }
 
                     ecs_assert(term_iter->match_count != 0, 

--- a/flecs.h
+++ b/flecs.h
@@ -2552,7 +2552,7 @@ typedef struct ecs_term_iter_t {
 } ecs_term_iter_t;
 
 typedef enum ecs_iter_kind_t {
-    EcsIterEvalIndex,
+    EcsIterEvalTables,
     EcsIterEvalChain,
     EcsIterEvalCondition,
     EcsIterEvalNone
@@ -6391,7 +6391,7 @@ void ecs_iter_set_var(
  * @param table The table variable value.
  */
 FLECS_API
-void ecs_iter_set_var_table(
+void ecs_iter_set_var_as_table(
     ecs_iter_t *it,
     int32_t var_id,
     const ecs_table_t *table);
@@ -6404,7 +6404,7 @@ void ecs_iter_set_var_table(
  * @param range The range variable value.
  */
 FLECS_API
-void ecs_iter_set_var_range(
+void ecs_iter_set_var_as_range(
     ecs_iter_t *it,
     int32_t var_id,
     const ecs_table_range_t *range);

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -3632,7 +3632,7 @@ void ecs_iter_set_var(
  * @param table The table variable value.
  */
 FLECS_API
-void ecs_iter_set_var_table(
+void ecs_iter_set_var_as_table(
     ecs_iter_t *it,
     int32_t var_id,
     const ecs_table_t *table);
@@ -3645,7 +3645,7 @@ void ecs_iter_set_var_table(
  * @param range The range variable value.
  */
 FLECS_API
-void ecs_iter_set_var_range(
+void ecs_iter_set_var_as_range(
     ecs_iter_t *it,
     int32_t var_id,
     const ecs_table_range_t *range);

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -475,6 +475,7 @@ struct ecs_filter_t {
     
     char *name;                /* Name of filter (optional) */
     char *expr;                /* Expression of filter (if provided) */
+    char *variable_names[1];   /* Array with variable names */
 
     ecs_iterable_t iterable;   /* Iterable mixin */
 };
@@ -3020,6 +3021,21 @@ int ecs_filter_finalize(
     const ecs_world_t *world,
     ecs_filter_t *filter); 
 
+/** Find index for This variable.
+ * This operation looks up the index of the This variable. This index can
+ * be used in operations like ecs_iter_set_var and ecs_iter_get_var.
+ * 
+ * The operation will return -1 if the variable was not found. This happens when
+ * a filter only has terms that are not matched on the This variable, like a
+ * filter that exclusively matches singleton components.
+ * 
+ * @param filter The rule.
+ * @return The index of the This variable.
+ */
+FLECS_API
+int32_t ecs_filter_find_this_var(
+    const ecs_filter_t *filter);
+
 /** Convert ter, to string expression.
  * Convert term to a string expression. The resulting expression is equivalent
  * to the same term, with the exception of And & Or operators.
@@ -3634,7 +3650,13 @@ void ecs_iter_set_var_range(
     int32_t var_id,
     const ecs_table_range_t *range);
 
-/** Get value for iterator variable.
+/** Get value of iterator variable as entity.
+ * A variable can be interpreted as entity if it is set to an entity, or if it
+ * is set to a table range with count 1.
+ * 
+ * This operation can only be invoked on valid iterators. The variable index
+ * must be smaller than the total number of variables provided by the iterator
+ * (as set in ecs_iter_t::variable_count).
  * 
  * @param it The iterator.
  * @param var_id The variable index.
@@ -3643,6 +3665,41 @@ FLECS_API
 ecs_entity_t ecs_iter_get_var(
     ecs_iter_t *it,
     int32_t var_id);
+
+/** Get value of iterator variable as table.
+ * A variable can be interpreted as table if it is set as table range with
+ * both offset and count set to 0, or if offset is 0 and count matches the
+ * number of elements in the table.
+ * 
+ * This operation can only be invoked on valid iterators. The variable index
+ * must be smaller than the total number of variables provided by the iterator
+ * (as set in ecs_iter_t::variable_count).
+ * 
+ * @param it The iterator.
+ * @param var_id The variable index.
+ */
+FLECS_API
+ecs_table_t* ecs_iter_get_var_as_table(
+    ecs_iter_t *it,
+    int32_t var_id);
+
+/** Get value of iterator variable as table range.
+ * A value can be interpreted as table range if it is set as table range, or if
+ * it is set to an entity with a non-empty type (the entity must have at least
+ * one component, tag or relationship in its type).
+ * 
+ * This operation can only be invoked on valid iterators. The variable index
+ * must be smaller than the total number of variables provided by the iterator
+ * (as set in ecs_iter_t::variable_count).
+ * 
+ * @param it The iterator.
+ * @param var_id The variable index.
+ */
+FLECS_API
+ecs_table_range_t ecs_iter_get_var_as_range(
+    ecs_iter_t *it,
+    int32_t var_id);
+
 
 /** Returns whether variable is constrained.
  * This operation returns true for variables set by one of the ecs_iter_set_var*

--- a/include/flecs/private/api_types.h
+++ b/include/flecs/private/api_types.h
@@ -146,7 +146,7 @@ typedef struct ecs_term_iter_t {
 } ecs_term_iter_t;
 
 typedef enum ecs_iter_kind_t {
-    EcsIterEvalIndex,
+    EcsIterEvalTables,
     EcsIterEvalChain,
     EcsIterEvalCondition,
     EcsIterEvalNone

--- a/src/iter.c
+++ b/src/iter.c
@@ -764,16 +764,16 @@ error:
     return;
 }
 
-void ecs_iter_set_var_table(
+void ecs_iter_set_var_as_table(
     ecs_iter_t *it,
     int32_t var_id,
     const ecs_table_t *table)
 {
     ecs_table_range_t range = { .table = (ecs_table_t*)table };
-    ecs_iter_set_var_range(it, var_id, &range);
+    ecs_iter_set_var_as_range(it, var_id, &range);
 }
 
-void ecs_iter_set_var_range(
+void ecs_iter_set_var_as_range(
     ecs_iter_t *it,
     int32_t var_id,
     const ecs_table_range_t *range)

--- a/test/api/project.json
+++ b/test/api/project.json
@@ -900,8 +900,7 @@
                 "filter_wo_this_var",
                 "set_this_to_table_1_term",
                 "set_this_to_table_2_terms",
-                "set_this_to_entity_1_term",
-                "set_this_to_entity_2_terms"
+                "set_this_to_table_1_wildcard"
             ]
         }, {
             "id": "FilterStr",

--- a/test/api/project.json
+++ b/test/api/project.json
@@ -893,7 +893,15 @@
                 "match_switch_w_case_2_terms",
                 "and_term",
                 "or_term",
-                "iter_while_creating_components"
+                "iter_while_creating_components",
+                "iter_w_this_var_as_entity",
+                "iter_w_this_var_as_table",
+                "iter_w_this_var_as_table_range",
+                "filter_wo_this_var",
+                "set_this_to_table_1_term",
+                "set_this_to_table_2_terms",
+                "set_this_to_entity_1_term",
+                "set_this_to_entity_2_terms"
             ]
         }, {
             "id": "FilterStr",

--- a/test/api/src/Filter.c
+++ b/test/api/src/Filter.c
@@ -6215,7 +6215,6 @@ void Filter_iter_w_this_var_as_table_range() {
     test_assert(this_var_id != -1);
 
     ecs_iter_t it = ecs_filter_iter(world, &f);
-
     test_assert(ecs_filter_next(&it));
     test_int(it.count, 1);
     test_uint(it.entities[0], e1);
@@ -6280,18 +6279,221 @@ void Filter_filter_wo_this_var() {
 }
 
 void Filter_set_this_to_table_1_term() {
-    // Implement testcase
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+    ECS_TAG(world, TagC);
+
+    ecs_entity_t e1 = ecs_new(world, TagA);
+    ecs_entity_t e2 = ecs_new(world, TagA);
+    ecs_entity_t e3 = ecs_new(world, TagA);
+    ecs_entity_t e4 = ecs_new(world, TagA);
+    ecs_add(world, e2, TagB);
+    ecs_add(world, e3, TagC);
+    ecs_add(world, e4, TagC);
+
+    ecs_table_t *t1 = ecs_get_table(world, e1);
+    test_assert(t1 != NULL);
+
+    ecs_table_t *t2 = ecs_get_table(world, e2);
+    test_assert(t2 != NULL);
+    test_assert(t2 != t1);
+
+    ecs_table_t *t3 = ecs_get_table(world, e3);
+    test_assert(t3 != NULL);
+    test_assert(t3 != t1);
+    test_assert(t3 != t2);
+    test_assert(t3 == ecs_get_table(world, e4));
+
+    ecs_filter_t f;
+    test_int(0, ecs_filter_init(world, &f, &(ecs_filter_desc_t) {
+        .terms = {{ TagA }}
+    }));
+
+    int this_var_id = ecs_filter_find_this_var(&f);
+    test_assert(this_var_id != -1);
+
+    ecs_iter_t it = ecs_filter_iter(world, &f);
+    ecs_iter_set_var_as_table(&it, this_var_id, t1);
+    test_assert(ecs_filter_next(&it));
+    test_int(it.count, 1);
+    test_uint(it.entities[0], e1);
+    test_assert(!ecs_filter_next(&it));
+
+    it = ecs_filter_iter(world, &f);
+    ecs_iter_set_var_as_table(&it, this_var_id, t2);
+    test_assert(ecs_filter_next(&it));
+    test_int(it.count, 1);
+    test_uint(it.entities[0], e2);
+    test_assert(!ecs_filter_next(&it));
+
+    it = ecs_filter_iter(world, &f);
+    ecs_iter_set_var_as_table(&it, this_var_id, t3);
+    test_assert(ecs_filter_next(&it));
+    test_int(it.count, 2);
+    test_uint(it.entities[0], e3);
+    test_uint(it.entities[1], e4);
+    test_assert(!ecs_filter_next(&it));
+
+    ecs_filter_fini(&f);
+
+    ecs_fini(world);
 }
 
 void Filter_set_this_to_table_2_terms() {
-    // Implement testcase
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+    ECS_TAG(world, TagC);
+    ECS_TAG(world, TagD);
+
+    ecs_entity_t e1 = ecs_new(world, TagA);
+    ecs_entity_t e2 = ecs_new(world, TagA);
+    ecs_entity_t e3 = ecs_new(world, TagA);
+    ecs_entity_t e4 = ecs_new(world, TagA);
+    ecs_add(world, e1, TagB);
+    ecs_add(world, e2, TagB);
+    ecs_add(world, e3, TagB);
+    ecs_add(world, e4, TagB);
+    ecs_add(world, e2, TagC);
+    ecs_add(world, e3, TagD);
+    ecs_add(world, e4, TagD);
+
+    ecs_table_t *t1 = ecs_get_table(world, e1);
+    test_assert(t1 != NULL);
+
+    ecs_table_t *t2 = ecs_get_table(world, e2);
+    test_assert(t2 != NULL);
+    test_assert(t2 != t1);
+
+    ecs_table_t *t3 = ecs_get_table(world, e3);
+    test_assert(t3 != NULL);
+    test_assert(t3 != t1);
+    test_assert(t3 != t2);
+    test_assert(t3 == ecs_get_table(world, e4));
+
+    ecs_filter_t f;
+    test_int(0, ecs_filter_init(world, &f, &(ecs_filter_desc_t) {
+        .terms = {{ TagA }, { TagB }}
+    }));
+
+    int this_var_id = ecs_filter_find_this_var(&f);
+    test_assert(this_var_id != -1);
+
+    ecs_iter_t it = ecs_filter_iter(world, &f);
+    ecs_iter_set_var_as_table(&it, this_var_id, t1);
+    test_assert(ecs_filter_next(&it));
+    test_int(it.count, 1);
+    test_uint(it.entities[0], e1);
+    test_assert(!ecs_filter_next(&it));
+
+    it = ecs_filter_iter(world, &f);
+    ecs_iter_set_var_as_table(&it, this_var_id, t2);
+    test_assert(ecs_filter_next(&it));
+    test_int(it.count, 1);
+    test_uint(it.entities[0], e2);
+    test_assert(!ecs_filter_next(&it));
+
+    it = ecs_filter_iter(world, &f);
+    ecs_iter_set_var_as_table(&it, this_var_id, t3);
+    test_assert(ecs_filter_next(&it));
+    test_int(it.count, 2);
+    test_uint(it.entities[0], e3);
+    test_uint(it.entities[1], e4);
+    test_assert(!ecs_filter_next(&it));
+
+    ecs_filter_fini(&f);
+
+    ecs_fini(world);
 }
 
-void Filter_set_this_to_entity_1_term() {
-    // Implement testcase
-}
+void Filter_set_this_to_table_1_wildcard() {
+    ecs_world_t *world = ecs_mini();
 
-void Filter_set_this_to_entity_2_terms() {
-    // Implement testcase
-}
+    ECS_TAG(world, Tag);
+    ECS_TAG(world, Rel);
+    ECS_TAG(world, ObjA);
+    ECS_TAG(world, ObjB);
+    ECS_TAG(world, ObjC);
 
+    ecs_entity_t e1 = ecs_new(world, Tag);
+    ecs_entity_t e2 = ecs_new(world, Tag);
+    ecs_entity_t e3 = ecs_new(world, Tag);
+    ecs_entity_t e4 = ecs_new(world, Tag);
+    ecs_add_pair(world, e1, Rel, ObjA);
+    ecs_add_pair(world, e2, Rel, ObjA);
+    ecs_add_pair(world, e3, Rel, ObjA);
+    ecs_add_pair(world, e4, Rel, ObjA);
+
+    ecs_add_pair(world, e2, Rel, ObjB);
+    ecs_add_pair(world, e3, Rel, ObjC);
+    ecs_add_pair(world, e4, Rel, ObjC);
+
+    ecs_table_t *t1 = ecs_get_table(world, e1);
+    test_assert(t1 != NULL);
+
+    ecs_table_t *t2 = ecs_get_table(world, e2);
+    test_assert(t2 != NULL);
+    test_assert(t2 != t1);
+
+    ecs_table_t *t3 = ecs_get_table(world, e3);
+    test_assert(t3 != NULL);
+    test_assert(t3 != t1);
+    test_assert(t3 != t2);
+    test_assert(t3 == ecs_get_table(world, e4));
+
+    ecs_filter_t f;
+    test_int(0, ecs_filter_init(world, &f, &(ecs_filter_desc_t) {
+        .terms = {{ Tag }, { ecs_pair(Rel, EcsWildcard) }}
+    }));
+
+    int this_var_id = ecs_filter_find_this_var(&f);
+    test_assert(this_var_id != -1);
+
+    ecs_iter_t it = ecs_filter_iter(world, &f);
+    ecs_iter_set_var_as_table(&it, this_var_id, t1);
+    test_assert(ecs_filter_next(&it));
+    test_int(it.count, 1);
+    test_uint(it.entities[0], e1);
+    test_uint(ecs_term_id(&it, 1), Tag);
+    test_uint(ecs_term_id(&it, 2), ecs_pair(Rel, ObjA));
+    test_assert(!ecs_filter_next(&it));
+
+    it = ecs_filter_iter(world, &f);
+    ecs_iter_set_var_as_table(&it, this_var_id, t2);
+    test_assert(ecs_filter_next(&it));
+    test_int(it.count, 1);
+    test_uint(it.entities[0], e2);
+    test_uint(ecs_term_id(&it, 1), Tag);
+    test_uint(ecs_term_id(&it, 2), ecs_pair(Rel, ObjA));
+
+    test_assert(ecs_filter_next(&it));
+    test_int(it.count, 1);
+    test_uint(it.entities[0], e2);
+    test_uint(ecs_term_id(&it, 1), Tag);
+    test_uint(ecs_term_id(&it, 2), ecs_pair(Rel, ObjB));
+    test_assert(!ecs_filter_next(&it));
+
+    it = ecs_filter_iter(world, &f);
+    ecs_iter_set_var_as_table(&it, this_var_id, t3);
+    test_assert(ecs_filter_next(&it));
+    test_int(it.count, 2);
+    test_uint(it.entities[0], e3);
+    test_uint(it.entities[1], e4);
+    test_uint(ecs_term_id(&it, 1), Tag);
+    test_uint(ecs_term_id(&it, 2), ecs_pair(Rel, ObjA));
+
+    test_assert(ecs_filter_next(&it));
+    test_int(it.count, 2);
+    test_uint(it.entities[0], e3);
+    test_uint(it.entities[1], e4);
+    test_uint(ecs_term_id(&it, 1), Tag);
+    test_uint(ecs_term_id(&it, 2), ecs_pair(Rel, ObjC));
+    test_assert(!ecs_filter_next(&it));
+
+    ecs_filter_fini(&f);
+
+    ecs_fini(world);
+}

--- a/test/api/src/Filter.c
+++ b/test/api/src/Filter.c
@@ -6057,3 +6057,241 @@ void Filter_iter_while_creating_components() {
 
     ecs_fini(world);
 }
+
+void Filter_iter_w_this_var_as_entity() {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+    ECS_TAG(world, TagC);
+
+    ecs_entity_t e1 = ecs_new(world, TagA);
+    ecs_entity_t e2 = ecs_new(world, TagA);
+    ecs_entity_t e3 = ecs_new(world, TagA);
+    ecs_entity_t e4 = ecs_new(world, TagA);
+    ecs_add(world, e2, TagB);
+    ecs_add(world, e3, TagC);
+    ecs_add(world, e4, TagC);
+
+    ecs_filter_t f;
+    test_int(0, ecs_filter_init(world, &f, &(ecs_filter_desc_t) {
+        .terms = {{ TagA }}
+    }));
+
+    int this_var_id = ecs_filter_find_this_var(&f);
+    test_assert(this_var_id != -1);
+
+    ecs_iter_t it = ecs_filter_iter(world, &f);
+
+    test_assert(ecs_filter_next(&it));
+    test_int(it.count, 1);
+    test_uint(it.entities[0], e1);
+    ecs_entity_t this_var = ecs_iter_get_var(&it, this_var_id);
+    test_assert(this_var != 0);
+    test_assert(this_var == e1);
+
+    test_assert(ecs_filter_next(&it));
+    test_int(it.count, 1);
+    test_uint(it.entities[0], e2);
+    this_var = ecs_iter_get_var(&it, this_var_id);
+    test_assert(this_var != 0);
+    test_assert(this_var == e2);
+
+    test_assert(ecs_filter_next(&it));
+    test_int(it.count, 2);
+    test_uint(it.entities[0], e3);
+    test_uint(it.entities[1], e4);
+    this_var = ecs_iter_get_var(&it, this_var_id);
+    test_assert(this_var == 0); /* more than one entity matches */
+
+    test_assert(!ecs_filter_next(&it));
+
+    ecs_filter_fini(&f);
+
+    ecs_fini(world);
+}
+
+void Filter_iter_w_this_var_as_table() {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+    ECS_TAG(world, TagC);
+
+    ecs_entity_t e1 = ecs_new(world, TagA);
+    ecs_entity_t e2 = ecs_new(world, TagA);
+    ecs_entity_t e3 = ecs_new(world, TagA);
+    ecs_entity_t e4 = ecs_new(world, TagA);
+    ecs_add(world, e2, TagB);
+    ecs_add(world, e3, TagC);
+    ecs_add(world, e4, TagC);
+
+    ecs_table_t *t1 = ecs_get_table(world, e1);
+    test_assert(t1 != NULL);
+
+    ecs_table_t *t2 = ecs_get_table(world, e2);
+    test_assert(t2 != NULL);
+    test_assert(t2 != t1);
+
+    ecs_table_t *t3 = ecs_get_table(world, e3);
+    test_assert(t3 != NULL);
+    test_assert(t3 != t1);
+    test_assert(t3 != t2);
+    test_assert(t3 == ecs_get_table(world, e4));
+
+    ecs_filter_t f;
+    test_int(0, ecs_filter_init(world, &f, &(ecs_filter_desc_t) {
+        .terms = {{ TagA }}
+    }));
+
+    int this_var_id = ecs_filter_find_this_var(&f);
+    test_assert(this_var_id != -1);
+
+    ecs_iter_t it = ecs_filter_iter(world, &f);
+
+    test_assert(ecs_filter_next(&it));
+    test_int(it.count, 1);
+    test_uint(it.entities[0], e1);
+    ecs_table_t *this_var = ecs_iter_get_var_as_table(&it, this_var_id);
+    test_assert(this_var != NULL);
+    test_assert(this_var == t1);
+
+    test_assert(ecs_filter_next(&it));
+    test_int(it.count, 1);
+    test_uint(it.entities[0], e2);
+    this_var = ecs_iter_get_var_as_table(&it, this_var_id);
+    test_assert(this_var != NULL);
+    test_assert(this_var == t2);
+
+    test_assert(ecs_filter_next(&it));
+    test_int(it.count, 2);
+    test_uint(it.entities[0], e3);
+    test_uint(it.entities[1], e4);
+    this_var = ecs_iter_get_var_as_table(&it, this_var_id);
+    test_assert(this_var != NULL);
+    test_assert(this_var == t3);
+
+    test_assert(!ecs_filter_next(&it));
+
+    ecs_filter_fini(&f);
+
+    ecs_fini(world);
+}
+
+void Filter_iter_w_this_var_as_table_range() {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+    ECS_TAG(world, TagC);
+
+    ecs_entity_t e1 = ecs_new(world, TagA);
+    ecs_entity_t e2 = ecs_new(world, TagA);
+    ecs_entity_t e3 = ecs_new(world, TagA);
+    ecs_entity_t e4 = ecs_new(world, TagA);
+    ecs_add(world, e2, TagB);
+    ecs_add(world, e3, TagC);
+    ecs_add(world, e4, TagC);
+
+    ecs_table_t *t1 = ecs_get_table(world, e1);
+    test_assert(t1 != NULL);
+
+    ecs_table_t *t2 = ecs_get_table(world, e2);
+    test_assert(t2 != NULL);
+    test_assert(t2 != t1);
+
+    ecs_table_t *t3 = ecs_get_table(world, e3);
+    test_assert(t3 != NULL);
+    test_assert(t3 != t1);
+    test_assert(t3 != t2);
+    test_assert(t3 == ecs_get_table(world, e4));
+
+    ecs_filter_t f;
+    test_int(0, ecs_filter_init(world, &f, &(ecs_filter_desc_t) {
+        .terms = {{ TagA }}
+    }));
+
+    int this_var_id = ecs_filter_find_this_var(&f);
+    test_assert(this_var_id != -1);
+
+    ecs_iter_t it = ecs_filter_iter(world, &f);
+
+    test_assert(ecs_filter_next(&it));
+    test_int(it.count, 1);
+    test_uint(it.entities[0], e1);
+    ecs_table_range_t this_var = ecs_iter_get_var_as_range(&it, this_var_id);
+    test_assert(this_var.table != NULL);
+    test_assert(this_var.table == t1);
+    test_assert(this_var.offset == 0);
+    test_assert(this_var.count == 1);
+
+    test_assert(ecs_filter_next(&it));
+    test_int(it.count, 1);
+    test_uint(it.entities[0], e2);
+    this_var = ecs_iter_get_var_as_range(&it, this_var_id);
+    test_assert(this_var.table != NULL);
+    test_assert(this_var.table == t2);
+    test_assert(this_var.offset == 0);
+    test_assert(this_var.count == 1);
+
+    test_assert(ecs_filter_next(&it));
+    test_int(it.count, 2);
+    test_uint(it.entities[0], e3);
+    test_uint(it.entities[1], e4);
+    this_var = ecs_iter_get_var_as_range(&it, this_var_id);
+    test_assert(this_var.table != NULL);
+    test_assert(this_var.table == t3);
+    test_assert(this_var.offset == 0);
+    test_assert(this_var.count == 2);
+
+    test_assert(!ecs_filter_next(&it));
+
+    ecs_filter_fini(&f);
+
+    ecs_fini(world);
+}
+
+void Filter_filter_wo_this_var() {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, TagA);
+
+    ecs_entity_t e1 = ecs_new(world, TagA);
+
+    ecs_filter_t f;
+    test_int(0, ecs_filter_init(world, &f, &(ecs_filter_desc_t) {
+        .terms = {{ .id = TagA, .subj.entity = e1 }}
+    }));
+
+    int this_var_id = ecs_filter_find_this_var(&f);
+    test_assert(this_var_id == -1); /* Filter has no This terms */
+
+    /* Make sure it matches for good measure */
+    ecs_iter_t it = ecs_filter_iter(world, &f);
+    test_assert(ecs_filter_next(&it));
+    test_int(it.count, 0);
+    test_int(it.subjects[0], e1);
+
+    test_assert(!ecs_filter_next(&it));
+
+    ecs_filter_fini(&f);
+
+    ecs_fini(world);
+}
+
+void Filter_set_this_to_table_1_term() {
+    // Implement testcase
+}
+
+void Filter_set_this_to_table_2_terms() {
+    // Implement testcase
+}
+
+void Filter_set_this_to_entity_1_term() {
+    // Implement testcase
+}
+
+void Filter_set_this_to_entity_2_terms() {
+    // Implement testcase
+}
+

--- a/test/api/src/main.c
+++ b/test/api/src/main.c
@@ -850,8 +850,7 @@ void Filter_iter_w_this_var_as_table_range(void);
 void Filter_filter_wo_this_var(void);
 void Filter_set_this_to_table_1_term(void);
 void Filter_set_this_to_table_2_terms(void);
-void Filter_set_this_to_entity_1_term(void);
-void Filter_set_this_to_entity_2_terms(void);
+void Filter_set_this_to_table_1_wildcard(void);
 
 // Testsuite 'FilterStr'
 void FilterStr_one_term(void);
@@ -4913,12 +4912,8 @@ bake_test_case Filter_testcases[] = {
         Filter_set_this_to_table_2_terms
     },
     {
-        "set_this_to_entity_1_term",
-        Filter_set_this_to_entity_1_term
-    },
-    {
-        "set_this_to_entity_2_terms",
-        Filter_set_this_to_entity_2_terms
+        "set_this_to_table_1_wildcard",
+        Filter_set_this_to_table_1_wildcard
     }
 };
 
@@ -8277,7 +8272,7 @@ static bake_test_suite suites[] = {
         "Filter",
         NULL,
         NULL,
-        148,
+        147,
         Filter_testcases
     },
     {

--- a/test/api/src/main.c
+++ b/test/api/src/main.c
@@ -844,6 +844,14 @@ void Filter_match_switch_w_case_2_terms(void);
 void Filter_and_term(void);
 void Filter_or_term(void);
 void Filter_iter_while_creating_components(void);
+void Filter_iter_w_this_var_as_entity(void);
+void Filter_iter_w_this_var_as_table(void);
+void Filter_iter_w_this_var_as_table_range(void);
+void Filter_filter_wo_this_var(void);
+void Filter_set_this_to_table_1_term(void);
+void Filter_set_this_to_table_2_terms(void);
+void Filter_set_this_to_entity_1_term(void);
+void Filter_set_this_to_entity_2_terms(void);
 
 // Testsuite 'FilterStr'
 void FilterStr_one_term(void);
@@ -4879,6 +4887,38 @@ bake_test_case Filter_testcases[] = {
     {
         "iter_while_creating_components",
         Filter_iter_while_creating_components
+    },
+    {
+        "iter_w_this_var_as_entity",
+        Filter_iter_w_this_var_as_entity
+    },
+    {
+        "iter_w_this_var_as_table",
+        Filter_iter_w_this_var_as_table
+    },
+    {
+        "iter_w_this_var_as_table_range",
+        Filter_iter_w_this_var_as_table_range
+    },
+    {
+        "filter_wo_this_var",
+        Filter_filter_wo_this_var
+    },
+    {
+        "set_this_to_table_1_term",
+        Filter_set_this_to_table_1_term
+    },
+    {
+        "set_this_to_table_2_terms",
+        Filter_set_this_to_table_2_terms
+    },
+    {
+        "set_this_to_entity_1_term",
+        Filter_set_this_to_entity_1_term
+    },
+    {
+        "set_this_to_entity_2_terms",
+        Filter_set_this_to_entity_2_terms
     }
 };
 
@@ -8237,7 +8277,7 @@ static bake_test_suite suites[] = {
         "Filter",
         NULL,
         NULL,
-        140,
+        148,
         Filter_testcases
     },
     {


### PR DESCRIPTION
This PR adds the ability to set a value for the `This` variable of a filter iterator to a table. This restricts the results of the iterator to the table, and can be used to check whether a table matches with a filter, and with which ids. If a filter contains a wildcard, the iterator will, just like a regular iterator, return a result for each matching column.

This feature will eventually get expanded to the ability to specify entity variables (allowing the iterator to match with a single entity) and the ability to use filters with more than one variable.

Example:
```c
// (Likes, *)
ecs_filter_t f;
ecs_filter_init(world, &f, &(ecs_filter_desc_t){
  .terms = {
    { ecs_pair(Likes, EcsWildcard) }
  }
});

// Find id for This variable
int var_id = ecs_filter_find_this_var(&f);

// Create iterator & set This variable to table
ecs_iter_t it = ecs_filter_iter(world, &f);
ecs_iter_set_var_as_table(&it, var_id, table);

// Iterate. Only returns entities in specified table
while (ecs_filter_next(&it)) {
  // iterate as usual
}
```