### PR TITLE
Change query DSL syntax of singletons and variables

### DIFF
--- a/examples/c/rules/basics/src/main.c
+++ b/examples/c/rules/basics/src/main.c
@@ -27,14 +27,13 @@ int main(int argc, char *argv[]) {
     ecs_add_pair(ecs, alice, Eats, Apples);
 
     // Here we're creating a rule that in the query DSL would look like this:
-    //   Eats(This, _Food), Healthy(_Food)
+    //   Eats(This, $Food), Healthy($Food)
     //
     // Rules are similar to queries, but support more advanced features. This
     // example shows how the basics of how to use rules & variables.
     ecs_rule_t *r = ecs_rule_init(ecs, &(ecs_filter_desc_t) {
         .terms = {
-            // Identifiers that start with _ are query variables. Query
-            // variables are like wildcards, but enforce that the entity
+            // Query variables are like wildcards, but enforce that the entity
             // substituted by the wildcard is the same across terms.
             //
             // For example, in this query it is not guaranteed that the entity
@@ -43,8 +42,12 @@ int main(int argc, char *argv[]) {
             //
             // By replacing * with _Food, both terms are constrained to use the
             // same entity.
-            { .pred.entity = Eats, .obj.name = (char*)"_Food" },
-            { .pred.entity = Healthy, .subj.name = (char*)"_Food" }
+            { .pred.entity = Eats, .obj = { 
+                .name = (char*)"Food", .var = EcsVarIsVariable },
+            },
+            { .pred.entity = Healthy, .subj = {
+                .name = (char*)"Food", .var = EcsVarIsVariable }
+            }
         }
     });
 

--- a/examples/c/rules/cyclic_variables/src/main.c
+++ b/examples/c/rules/cyclic_variables/src/main.c
@@ -24,12 +24,12 @@ int main(int argc, char *argv[]) {
     // relationship- that is they must both like each other.
     //
     // The equivalent query in the DSL is:
-    //   Likes(_X, _Y), Likes(_Y, _X)
+    //   Likes($X, $Y), Likes($Y, $X)
     //
     // This is also an example of a query where all subjects are variables. By
     // default queries use the builtin "This" variable as subject, which is what
     // populates the entities array in the query result (accessed by the
-    // iter::entity function). 
+    // iter::entity function).
     //
     // Because this query does not use This at all, the entities array will not
     // be populated, and it.count() will always be 0.
@@ -38,12 +38,14 @@ int main(int argc, char *argv[]) {
         .terms = {
             { 
                 .pred.entity = Likes, 
-                .subj.name = (char*)"_X", .obj.name = (char*)"_Y" 
+                .subj = { .name = (char*)"X", .var = EcsVarIsVariable },
+                .obj = { .name = (char*)"Y", .var = EcsVarIsVariable }
             },
             { 
                 .pred.entity = Likes, 
-                .subj.name = (char*)"_Y", .obj.name = (char*)"_X" 
-            },
+                .subj = { .name = (char*)"Y", .var = EcsVarIsVariable },
+                .obj = { .name = (char*)"X", .var = EcsVarIsVariable }
+            }
         }
     });
 

--- a/examples/c/rules/facts/src/main.c
+++ b/examples/c/rules/facts/src/main.c
@@ -39,6 +39,9 @@ int main(int argc, char *argv[]) {
     // rule is not a fact, but we can use it to check facts by populating both
     // of its variables.
     //
+    // The equivalent of this query in the DSL is:
+    //   Likes($X, $Y), Likes($Y, $X)
+    //
     // Instead of using variables we could have created a rule that referred the
     // entities directly, but then we would have to create a rule for each
     // fact, vs reusing a single rule for multiple facts.
@@ -48,11 +51,13 @@ int main(int argc, char *argv[]) {
         .terms = {
             { 
                 .pred.entity = Likes, 
-                .subj.name = (char*)"_X", .obj.name = (char*)"_Y" 
+                .subj = { .name = (char*)"X", .var = EcsVarIsVariable },
+                .obj = { .name = (char*)"Y", .var = EcsVarIsVariable }
             },
             { 
                 .pred.entity = Likes, 
-                .subj.name = (char*)"_Y", .obj.name = (char*)"_X" 
+                .subj = { .name = (char*)"Y", .var = EcsVarIsVariable },
+                .obj = { .name = (char*)"X", .var = EcsVarIsVariable }
             }
         }
     });

--- a/examples/c/rules/setting_variables/src/main.c
+++ b/examples/c/rules/setting_variables/src/main.c
@@ -63,7 +63,7 @@ int main(int argc, char *argv[]) {
 
     // Create a rule to find all RangedUnits for a platoon/player. The 
     // equivalent query in the query DSL would look like this:
-    //   (Platoon, _Platoon), Player(_Platoon, _Player)
+    //   (Platoon, $Platoon), Player($Platoon, $Player)
     //
     // The way to read how this query is evaluated is:
     // - find all entities with (Platoon, *), store * in _Platoon
@@ -71,11 +71,14 @@ int main(int argc, char *argv[]) {
     ecs_rule_t *r = ecs_rule_init(ecs, &(ecs_filter_desc_t) {
         .terms = {
             { .pred.entity = RangedUnit },
-            { .pred.entity = Platoon, .obj.name = (char*)"_Platoon" },
+            {
+                .pred.entity = Platoon, 
+                .obj = { .name = (char*)"Platoon", .var = EcsVarIsVariable },
+            },
             { 
                 .pred.entity = Player, 
-                .subj.name = (char*)"_Platoon", 
-                .obj.name = (char*)"_Player" 
+                .subj = { .name = (char*)"Platoon", .var = EcsVarIsVariable },
+                .obj = { .name = (char*)"Player", .var = EcsVarIsVariable },
             }
         }
     });

--- a/examples/c/rules/transitive_queries/src/main.c
+++ b/examples/c/rules/transitive_queries/src/main.c
@@ -96,12 +96,18 @@ int main(int argc, char *argv[]) {
     // until it found something that is a country.
     // 
     // The equivalent of this query in the DSL is:
-    //   Person, (LocatedIn, _Location), Country(_Location)
+    //   Person, (LocatedIn, $Location), Country($Location)
     ecs_rule_t *r = ecs_rule_init(ecs, &(ecs_filter_desc_t) {
         .terms = {
             { .id = Person },
-            { .pred.entity = LocatedIn, .obj.name = (char*)"_Location" },
-            { .pred.entity = Country, .subj.name = (char*)"_Location" },
+            { 
+                .pred.entity = LocatedIn, 
+                .obj = { .name = (char*)"Location", .var = EcsVarIsVariable },
+            },
+            {
+                .pred.entity = Country, 
+                .subj = { .name = (char*)"Location", .var = EcsVarIsVariable },
+            },
         }
     });
 

--- a/examples/cpp/rules/basics/src/main.cpp
+++ b/examples/cpp/rules/basics/src/main.cpp
@@ -24,7 +24,7 @@ int main(int, char *[]) {
         .add<Eats>(Apples);
 
     // Here we're creating a rule that in the query DSL would look like this:
-    //   Eats(This, _Food), Healthy(_Food)
+    //   Eats(This, $Food), Healthy($Food)
     //
     // Rules are similar to queries, but support more advanced features. This
     // example shows how the basics of how to use rules & variables.
@@ -39,8 +39,8 @@ int main(int, char *[]) {
         //
         // By replacing * with _Food, both terms are constrained to use the
         // same entity.
-        .term<Eats>().obj("_Food")
-        .term<Healthy>().subj("_Food")
+        .term<Eats>().obj().var("Food")
+        .term<Healthy>().subj().var("Food")
         .build();
     
     // Lookup the index of the variable. This will let us quickly lookup its

--- a/examples/cpp/rules/cyclic_variables/src/main.cpp
+++ b/examples/cpp/rules/cyclic_variables/src/main.cpp
@@ -24,7 +24,7 @@ int main(int, char *[]) {
     // relationship- that is they must both like each other.
     //
     // The equivalent query in the DSL is:
-    //   Likes(_X, _Y), Likes(_Y, _X)
+    //   Likes($X, $Y), Likes($Y, $X)
     //
     // This is also an example of a query where all subjects are variables. By
     // default queries use the builtin "This" variable as subject, which is what
@@ -34,8 +34,8 @@ int main(int, char *[]) {
     // Because this query does not use This at all, the entities array will not
     // be populated, and it.count() will always be 0.
     auto r = ecs.rule_builder()
-        .term<Likes>().subj("_X").obj("_Y")
-        .term<Likes>().subj("_Y").obj("_X")
+        .term<Likes>().subj().var("X").obj().var("Y")
+        .term<Likes>().subj().var("Y").obj().var("X")
         .build();
 
     // Lookup the index of the variables. This will let us quickly lookup their

--- a/examples/cpp/rules/facts/src/main.cpp
+++ b/examples/cpp/rules/facts/src/main.cpp
@@ -39,12 +39,16 @@ int main(int, char *[]) {
     // Create a rule that checks if two entities like each other. By itself this
     // rule is not a fact, but we can use it to check facts by populating both
     // of its variables.
+    //
+    // The equivalent query in the DSL is:
+    //  Likes($X, $Y), Likes($Y, $X)
+    //
     // Instead of using variables we could have created a rule that referred the
     // entities directly, but then we would have to create a rule for each
     // fact, vs reusing a single rule for multiple facts.
     auto friends = ecs.rule_builder()
-        .term<Likes>().subj("_X").obj("_Y")
-        .term<Likes>().subj("_Y").obj("_X")
+        .term<Likes>().subj().var("X").obj().var("Y")
+        .term<Likes>().subj().var("Y").obj().var("X")
         .build();
 
     int x_var = friends.find_var("X");

--- a/examples/cpp/rules/setting_variables/src/main.cpp
+++ b/examples/cpp/rules/setting_variables/src/main.cpp
@@ -65,14 +65,14 @@ int main(int, char *[]) {
 
     // Create a rule to find all RangedUnits for a platoon/player. The 
     // equivalent query in the query DSL would look like this:
-    //   (Platoon, _Platoon), Player(_Platoon, _Player)
+    //   (Platoon, $Platoon), Player($Platoon, $Player)
     //
     // The way to read how this query is evaluated is:
     // - find all entities with (Platoon, *), store * in _Platoon
     // - check if _Platoon has (Player, *), store * in _Player
     auto r = ecs.rule_builder<RangedUnit>()
-        .term<Platoon>().obj("_Platoon")
-        .term<Player>().subj("_Platoon").obj("_Player")
+        .term<Platoon>().obj().var("Platoon")
+        .term<Player>().subj().var("Platoon").obj().var("Player")
         .build();
 
     // If we would iterate this rule it would return all ranged units for all

--- a/examples/cpp/rules/transitive_queries/src/main.cpp
+++ b/examples/cpp/rules/transitive_queries/src/main.cpp
@@ -95,11 +95,11 @@ int main(int, char *[]) {
     // until it found something that is a country.
     // 
     // The equivalent of this query in the DSL is:
-    //   Person, (LocatedIn, _Location), Country(_Location)
+    //   Person, (LocatedIn, $Location), Country($Location)
     auto r = ecs.rule_builder()
         .term<Person>()
-        .term<LocatedIn>().obj("_Location")
-        .term<Country>().subj("_Location")
+        .term<LocatedIn>().obj().var("Location")
+        .term<Country>().subj().var("Location")
         .build();
     
     // Lookup the index of the variable. This will let us quickly lookup its

--- a/flecs.c
+++ b/flecs.c
@@ -12831,15 +12831,17 @@ const ecs_entity_t EcsDisabled =              ECS_HI_COMPONENT_ID + 7;
 const ecs_entity_t EcsWildcard =              ECS_HI_COMPONENT_ID + 10;
 const ecs_entity_t EcsAny =                   ECS_HI_COMPONENT_ID + 11;
 const ecs_entity_t EcsThis =                  ECS_HI_COMPONENT_ID + 12;
-const ecs_entity_t EcsTransitive =            ECS_HI_COMPONENT_ID + 13;
-const ecs_entity_t EcsReflexive =             ECS_HI_COMPONENT_ID + 14;
-const ecs_entity_t EcsSymmetric =             ECS_HI_COMPONENT_ID + 15;
-const ecs_entity_t EcsFinal =                 ECS_HI_COMPONENT_ID + 16;
-const ecs_entity_t EcsDontInherit =           ECS_HI_COMPONENT_ID + 17;
-const ecs_entity_t EcsTag =                   ECS_HI_COMPONENT_ID + 18;
-const ecs_entity_t EcsExclusive =             ECS_HI_COMPONENT_ID + 19;
-const ecs_entity_t EcsAcyclic =               ECS_HI_COMPONENT_ID + 20;
-const ecs_entity_t EcsWith =                  ECS_HI_COMPONENT_ID + 21;
+const ecs_entity_t EcsVariable =              ECS_HI_COMPONENT_ID + 13;
+
+const ecs_entity_t EcsTransitive =            ECS_HI_COMPONENT_ID + 14;
+const ecs_entity_t EcsReflexive =             ECS_HI_COMPONENT_ID + 15;
+const ecs_entity_t EcsSymmetric =             ECS_HI_COMPONENT_ID + 16;
+const ecs_entity_t EcsFinal =                 ECS_HI_COMPONENT_ID + 17;
+const ecs_entity_t EcsDontInherit =           ECS_HI_COMPONENT_ID + 18;
+const ecs_entity_t EcsTag =                   ECS_HI_COMPONENT_ID + 19;
+const ecs_entity_t EcsExclusive =             ECS_HI_COMPONENT_ID + 20;
+const ecs_entity_t EcsAcyclic =               ECS_HI_COMPONENT_ID + 21;
+const ecs_entity_t EcsWith =                  ECS_HI_COMPONENT_ID + 22;
 
 /* Builtin relations */
 const ecs_entity_t EcsChildOf =               ECS_HI_COMPONENT_ID + 25;
@@ -20549,9 +20551,10 @@ void flecs_bootstrap(
 
     /* Initialize builtin entities */
     bootstrap_entity(world, EcsWorld, "World", EcsFlecsCore);
-    bootstrap_entity(world, EcsThis, "This", EcsFlecsCore);
     bootstrap_entity(world, EcsWildcard, "*", EcsFlecsCore);
     bootstrap_entity(world, EcsAny, "_", EcsFlecsCore);
+    bootstrap_entity(world, EcsThis, "This", EcsFlecsCore);
+    bootstrap_entity(world, EcsVariable, "$", EcsFlecsCore);
 
     /* Component/relationship properties */
     flecs_bootstrap_tag(world, EcsTransitive);
@@ -23949,16 +23952,6 @@ int finalize_term_var(
     ecs_term_id_t *identifier,
     const char *name)
 {
-    if (identifier->var == EcsVarDefault) {
-        const char *var = ecs_identifier_is_var(identifier->name);
-        if (var) {
-            char *var_dup = ecs_os_strdup(var);
-            ecs_os_free(identifier->name);
-            identifier->name = var_dup;
-            identifier->var = EcsVarIsVariable;
-        }
-    }
-
     if (identifier->var == EcsVarDefault && identifier->set.mask != EcsNothing){
         identifier->var = EcsVarIsEntity;
     }
@@ -24086,7 +24079,7 @@ static
 bool entity_is_var(
     ecs_entity_t e)
 {
-    if (e == EcsThis || e == EcsWildcard || e == EcsAny) {
+    if (e == EcsThis || e == EcsWildcard || e == EcsAny || e == EcsVariable) {
         return true;
     }
     return false;
@@ -24157,10 +24150,21 @@ int finalize_term_identifiers(
     {
         term->subj.entity = EcsThis;
     }
-    
+
     if (entity_is_var(term->pred.entity)) {
         term->pred.var = EcsVarIsVariable;
     }
+
+    /* If EcsVariable is used by itself, assign to predicate (singleton) */
+    if (term->subj.entity == EcsVariable) {
+        term->subj.entity = term->pred.entity;
+        term->subj.var = term->pred.var;
+    }
+    if (term->obj.entity == EcsVariable) {
+        term->obj.entity = term->pred.entity;
+        term->obj.var = term->pred.var;
+    }
+    
     if (entity_is_var(term->subj.entity)) {
         term->subj.var = EcsVarIsVariable;
     }
@@ -45230,10 +45234,9 @@ void FlecsCoreDocImport(
 #define TOK_BRACKET_OPEN '['
 #define TOK_BRACKET_CLOSE ']'
 #define TOK_WILDCARD '*'
-#define TOK_SINGLETON '$'
+#define TOK_VARIABLE '$'
 #define TOK_PAREN_OPEN '('
 #define TOK_PAREN_CLOSE ')'
-#define TOK_AS_ENTITY '\\'
 
 #define TOK_SELF "self"
 #define TOK_SUPERSET "super"
@@ -45364,7 +45367,7 @@ bool valid_identifier_start_char(
     char ch)
 {
     if (ch && (isalpha(ch) || (ch == '.') || (ch == '_') || (ch == '*') ||
-        (ch == '0') || (ch == TOK_AS_ENTITY) || isdigit(ch))) 
+        (ch == '0') || (ch == TOK_VARIABLE) || isdigit(ch))) 
     {
         return true;
     }
@@ -45514,18 +45517,13 @@ int parse_identifier(
     const char *token,
     ecs_term_id_t *out)
 {
-    char ch = token[0];
-
     const char *tptr = token;
-    if (ch == TOK_AS_ENTITY) {
+    if (tptr[0] == TOK_VARIABLE && tptr[1]) {
+        out->var = EcsVarIsVariable;
         tptr ++;
     }
 
     out->name = ecs_os_strdup(tptr);
-
-    if (ch == TOK_AS_ENTITY) {
-        out->var = EcsVarIsEntity;
-    }
 
     return 0;
 }
@@ -45943,23 +45941,6 @@ const char* parse_term(
         /* Next token must be a predicate */
         goto parse_predicate;
 
-    /* If next token is a singleton, assign identifier to pred and subject */
-    } else if (ptr[0] == TOK_SINGLETON) {
-        ptr ++;
-        if (valid_token_start_char(ptr[0])) {
-            ptr = ecs_parse_identifier(name, expr, ptr, token);
-            if (!ptr) {
-                goto error;
-            }
-
-            goto parse_singleton;
-
-        } else {
-            ecs_parser_error(name, expr, (ptr - expr), 
-                "expected identifier after singleton operator");
-            goto error;
-        }
-
     /* Pair with implicit subject */
     } else if (ptr[0] == TOK_PAREN_OPEN) {
         goto parse_pair;
@@ -46113,16 +46094,6 @@ parse_pair_object:
     }
 
     ptr = ecs_parse_whitespace(ptr);
-    goto parse_done; 
-
-parse_singleton:
-    if (parse_identifier(token, &term.pred)) {
-        ecs_parser_error(name, expr, (ptr - expr), 
-            "invalid identifier '%s'", token); 
-        goto error; 
-    }
-
-    parse_identifier(token, &term.subj);
     goto parse_done;
 
 parse_done:

--- a/flecs.h
+++ b/flecs.h
@@ -3834,8 +3834,11 @@ FLECS_API extern const ecs_entity_t EcsWildcard;
 /* Any entity ("_"). Matches any id, returns only the first. */
 FLECS_API extern const ecs_entity_t EcsAny;
 
-/* This entity (".", "This"). Used in expressions to indicate This entity */
+/* This entity ("."). Used in expressions to indicate This variable */
 FLECS_API extern const ecs_entity_t EcsThis;
+
+/* Variable entity ("$"). Used in expressions to prefix variable names */
+FLECS_API extern const ecs_entity_t EcsVariable;
 
 /* Marks a relationship as transitive. 
  * Behavior: 
@@ -11138,26 +11141,21 @@ extern "C" {
  * But this doesn't work, as term 1 returns entities with missions, and term 2
  * returns all combat missions for all entities. Query variables make it 
  * possible to apply CombatMission to the found mission:
- *   (Mission, _M), CombatMission(_M)
+ *   (Mission, $M), CombatMission($M)
  * 
  * By using the same variable ('M') we ensure that CombatMission is applied to
  * the mission found in the current result.
  * 
  * Variables can be used in each part of the term (predicate, subject, object).
  * This is a valid query:
- *   Likes(_X, _Y), Likes(_Y, _X)
+ *   Likes($X, $Y), Likes($Y, $X)
  * 
  * This is also a valid query:
  *   _Component, Serializable(_Component)
  * 
- * In the query expression syntax, variables are prefixed with a _. When using
- * the descriptor, do this:
- *   desc.terms[0].obj.name = "_X";
- * 
- * or
- * 
- *   desc.terms[0].obj.name = "X";
- *   desc.terms[0].obj.var = EcsVarIsVariable;
+ * In the query expression syntax, variables are prefixed with a $. When using
+ * the descriptor, specify the variable kind:
+ *   desc.terms[0].obj = { .name = "X", .var = EcsVarIsVariable }
  * 
  * Different terms with the same variable name are automatically correlated by
  * the query engine.

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -1060,8 +1060,11 @@ FLECS_API extern const ecs_entity_t EcsWildcard;
 /* Any entity ("_"). Matches any id, returns only the first. */
 FLECS_API extern const ecs_entity_t EcsAny;
 
-/* This entity (".", "This"). Used in expressions to indicate This entity */
+/* This entity ("."). Used in expressions to indicate This variable */
 FLECS_API extern const ecs_entity_t EcsThis;
+
+/* Variable entity ("$"). Used in expressions to prefix variable names */
+FLECS_API extern const ecs_entity_t EcsVariable;
 
 /* Marks a relationship as transitive. 
  * Behavior: 

--- a/include/flecs/addons/rules.h
+++ b/include/flecs/addons/rules.h
@@ -41,26 +41,21 @@ extern "C" {
  * But this doesn't work, as term 1 returns entities with missions, and term 2
  * returns all combat missions for all entities. Query variables make it 
  * possible to apply CombatMission to the found mission:
- *   (Mission, _M), CombatMission(_M)
+ *   (Mission, $M), CombatMission($M)
  * 
  * By using the same variable ('M') we ensure that CombatMission is applied to
  * the mission found in the current result.
  * 
  * Variables can be used in each part of the term (predicate, subject, object).
  * This is a valid query:
- *   Likes(_X, _Y), Likes(_Y, _X)
+ *   Likes($X, $Y), Likes($Y, $X)
  * 
  * This is also a valid query:
  *   _Component, Serializable(_Component)
  * 
- * In the query expression syntax, variables are prefixed with a _. When using
- * the descriptor, do this:
- *   desc.terms[0].obj.name = "_X";
- * 
- * or
- * 
- *   desc.terms[0].obj.name = "X";
- *   desc.terms[0].obj.var = EcsVarIsVariable;
+ * In the query expression syntax, variables are prefixed with a $. When using
+ * the descriptor, specify the variable kind:
+ *   desc.terms[0].obj = { .name = "X", .var = EcsVarIsVariable }
  * 
  * Different terms with the same variable name are automatically correlated by
  * the query engine.

--- a/src/bootstrap.c
+++ b/src/bootstrap.c
@@ -649,9 +649,10 @@ void flecs_bootstrap(
 
     /* Initialize builtin entities */
     bootstrap_entity(world, EcsWorld, "World", EcsFlecsCore);
-    bootstrap_entity(world, EcsThis, "This", EcsFlecsCore);
     bootstrap_entity(world, EcsWildcard, "*", EcsFlecsCore);
     bootstrap_entity(world, EcsAny, "_", EcsFlecsCore);
+    bootstrap_entity(world, EcsThis, "This", EcsFlecsCore);
+    bootstrap_entity(world, EcsVariable, "$", EcsFlecsCore);
 
     /* Component/relationship properties */
     flecs_bootstrap_tag(world, EcsTransitive);

--- a/src/filter.c
+++ b/src/filter.c
@@ -84,16 +84,6 @@ int finalize_term_var(
     ecs_term_id_t *identifier,
     const char *name)
 {
-    if (identifier->var == EcsVarDefault) {
-        const char *var = ecs_identifier_is_var(identifier->name);
-        if (var) {
-            char *var_dup = ecs_os_strdup(var);
-            ecs_os_free(identifier->name);
-            identifier->name = var_dup;
-            identifier->var = EcsVarIsVariable;
-        }
-    }
-
     if (identifier->var == EcsVarDefault && identifier->set.mask != EcsNothing){
         identifier->var = EcsVarIsEntity;
     }
@@ -221,7 +211,7 @@ static
 bool entity_is_var(
     ecs_entity_t e)
 {
-    if (e == EcsThis || e == EcsWildcard || e == EcsAny) {
+    if (e == EcsThis || e == EcsWildcard || e == EcsAny || e == EcsVariable) {
         return true;
     }
     return false;
@@ -292,10 +282,21 @@ int finalize_term_identifiers(
     {
         term->subj.entity = EcsThis;
     }
-    
+
     if (entity_is_var(term->pred.entity)) {
         term->pred.var = EcsVarIsVariable;
     }
+
+    /* If EcsVariable is used by itself, assign to predicate (singleton) */
+    if (term->subj.entity == EcsVariable) {
+        term->subj.entity = term->pred.entity;
+        term->subj.var = term->pred.var;
+    }
+    if (term->obj.entity == EcsVariable) {
+        term->obj.entity = term->pred.entity;
+        term->obj.var = term->pred.var;
+    }
+    
     if (entity_is_var(term->subj.entity)) {
         term->subj.var = EcsVarIsVariable;
     }

--- a/src/world.c
+++ b/src/world.c
@@ -55,15 +55,17 @@ const ecs_entity_t EcsDisabled =              ECS_HI_COMPONENT_ID + 7;
 const ecs_entity_t EcsWildcard =              ECS_HI_COMPONENT_ID + 10;
 const ecs_entity_t EcsAny =                   ECS_HI_COMPONENT_ID + 11;
 const ecs_entity_t EcsThis =                  ECS_HI_COMPONENT_ID + 12;
-const ecs_entity_t EcsTransitive =            ECS_HI_COMPONENT_ID + 13;
-const ecs_entity_t EcsReflexive =             ECS_HI_COMPONENT_ID + 14;
-const ecs_entity_t EcsSymmetric =             ECS_HI_COMPONENT_ID + 15;
-const ecs_entity_t EcsFinal =                 ECS_HI_COMPONENT_ID + 16;
-const ecs_entity_t EcsDontInherit =           ECS_HI_COMPONENT_ID + 17;
-const ecs_entity_t EcsTag =                   ECS_HI_COMPONENT_ID + 18;
-const ecs_entity_t EcsExclusive =             ECS_HI_COMPONENT_ID + 19;
-const ecs_entity_t EcsAcyclic =               ECS_HI_COMPONENT_ID + 20;
-const ecs_entity_t EcsWith =                  ECS_HI_COMPONENT_ID + 21;
+const ecs_entity_t EcsVariable =              ECS_HI_COMPONENT_ID + 13;
+
+const ecs_entity_t EcsTransitive =            ECS_HI_COMPONENT_ID + 14;
+const ecs_entity_t EcsReflexive =             ECS_HI_COMPONENT_ID + 15;
+const ecs_entity_t EcsSymmetric =             ECS_HI_COMPONENT_ID + 16;
+const ecs_entity_t EcsFinal =                 ECS_HI_COMPONENT_ID + 17;
+const ecs_entity_t EcsDontInherit =           ECS_HI_COMPONENT_ID + 18;
+const ecs_entity_t EcsTag =                   ECS_HI_COMPONENT_ID + 19;
+const ecs_entity_t EcsExclusive =             ECS_HI_COMPONENT_ID + 20;
+const ecs_entity_t EcsAcyclic =               ECS_HI_COMPONENT_ID + 21;
+const ecs_entity_t EcsWith =                  ECS_HI_COMPONENT_ID + 22;
 
 /* Builtin relations */
 const ecs_entity_t EcsChildOf =               ECS_HI_COMPONENT_ID + 25;

--- a/test/addons/project.json
+++ b/test/addons/project.json
@@ -65,8 +65,6 @@
                 "variable_multi_char_w_underscore",
                 "variable_multi_char_w_number",
                 "variable_multi_char_not_allcaps",
-                "escaped_all_caps_single_char",
-                "escaped_all_caps_multi_char",
                 "component_not",
                 "pair_implicit_subject_not",
                 "pair_explicit_subject_not",

--- a/test/addons/src/Iter.c
+++ b/test/addons/src/Iter.c
@@ -1253,7 +1253,7 @@ void Iter_worker_iter_w_singleton() {
     ecs_entity_t e3 = ecs_new(world, Position);
     ecs_entity_t e4 = ecs_new(world, Position);
 
-    ecs_query_t *q = ecs_query_new(world, "Position, $Singleton");
+    ecs_query_t *q = ecs_query_new(world, "Position, Singleton($)");
 
     ecs_iter_t it_1 = ecs_query_iter(world, q);
     ecs_iter_t wit_1 = ecs_worker_iter(&it_1, 0, 2);
@@ -1292,7 +1292,7 @@ void Iter_worker_iter_w_singleton_instanced() {
 
     ecs_query_t *q = ecs_query_init(world, &(ecs_query_desc_t){
         .filter = {
-            .expr = "Position, $Singleton",
+            .expr = "Position, Singleton($)",
             .instanced = true
         }
     });
@@ -1328,7 +1328,7 @@ void Iter_paged_iter_w_singleton() {
     ecs_entity_t e3 = ecs_new(world, Position);
     ecs_entity_t e4 = ecs_new(world, Position);
 
-    ecs_query_t *q = ecs_query_new(world, "Position, $Singleton");
+    ecs_query_t *q = ecs_query_new(world, "Position, Singleton($)");
 
     ecs_iter_t it_1 = ecs_query_iter(world, q);
     ecs_iter_t pit_1 = ecs_page_iter(&it_1, 0, 2);
@@ -1367,7 +1367,7 @@ void Iter_paged_iter_w_singleton_instanced() {
 
     ecs_query_t *q = ecs_query_init(world, &(ecs_query_desc_t){
         .filter = {
-            .expr = "Position, $Singleton",
+            .expr = "Position, Singleton($)",
             .instanced = true
         }
     });

--- a/test/addons/src/Parser.c
+++ b/test/addons/src/Parser.c
@@ -1047,7 +1047,7 @@ void Parser_component_singleton() {
 
     ecs_filter_t f;
     test_int(0, ecs_filter_init(world, &f, &(ecs_filter_desc_t){
-        .expr = "$Pred"
+        .expr = "Pred($)"
     }));
     test_int(filter_count(&f), 1);
 
@@ -1073,7 +1073,7 @@ void Parser_this_singleton() {
 
     ecs_filter_t f;
     test_int(0, ecs_filter_init(world, &f, &(ecs_filter_desc_t){
-        .expr = "$."
+        .expr = ".($)"
     }));
     test_int(filter_count(&f), 1);
 
@@ -1172,7 +1172,7 @@ void Parser_variable_single_char() {
 
     ecs_filter_t f;
     test_int(0, ecs_filter_init(world, &f, &(ecs_filter_desc_t){
-        .expr = "Pred(_X)"
+        .expr = "Pred($X)"
     }));
     test_int(filter_count(&f), 1);
 
@@ -1197,7 +1197,7 @@ void Parser_variable_multi_char() {
 
     ecs_filter_t f;
     test_int(0, ecs_filter_init(world, &f, &(ecs_filter_desc_t){
-        .expr = "Pred(_XYZ)"
+        .expr = "Pred($XYZ)"
     }));
     test_int(filter_count(&f), 1);
 
@@ -1222,7 +1222,7 @@ void Parser_variable_multi_char_w_underscore() {
 
     ecs_filter_t f;
     test_int(0, ecs_filter_init(world, &f, &(ecs_filter_desc_t){
-        .expr = "Pred(_XY_Z)"
+        .expr = "Pred($XY_Z)"
     }));
     test_int(filter_count(&f), 1);
 
@@ -1247,7 +1247,7 @@ void Parser_variable_multi_char_w_number() {
 
     ecs_filter_t f;
     test_int(0, ecs_filter_init(world, &f, &(ecs_filter_desc_t){
-        .expr = "Pred(_XY_1)"
+        .expr = "Pred($XY_1)"
     }));
     test_int(filter_count(&f), 1);
 
@@ -1272,63 +1272,13 @@ void Parser_variable_multi_char_not_allcaps() {
 
     ecs_filter_t f;
     test_int(0, ecs_filter_init(world, &f, &(ecs_filter_desc_t){
-        .expr = "Pred(_xyZ)"
+        .expr = "Pred($xyZ)"
     }));
     test_int(filter_count(&f), 1);
 
     ecs_term_t *terms = filter_terms(&f);
     test_pred(terms[0], Pred, EcsSelf|EcsSubSet);
     test_subj_var(terms[0], 0, EcsSelf|EcsSuperSet, "xyZ");
-    test_int(terms[0].oper, EcsAnd);
-    test_int(terms[0].inout, EcsInOutDefault);
-
-    test_legacy(f);
-
-    ecs_filter_fini(&f);
-
-    ecs_fini(world);
-}
-
-void Parser_escaped_all_caps_single_char() {
-    ecs_world_t *world = ecs_init();
-
-    ECS_TAG(world, Pred);
-    ECS_TAG(world, X);
-
-    ecs_filter_t f;
-    test_int(0, ecs_filter_init(world, &f, &(ecs_filter_desc_t){
-        .expr = "Pred(\\X)"
-    }));
-    test_int(filter_count(&f), 1);
-
-    ecs_term_t *terms = filter_terms(&f);
-    test_pred(terms[0], Pred, EcsSelf|EcsSubSet);
-    test_subj(terms[0], X, EcsSelf|EcsSuperSet);
-    test_int(terms[0].oper, EcsAnd);
-    test_int(terms[0].inout, EcsInOutDefault);
-
-    test_legacy(f);
-
-    ecs_filter_fini(&f);
-
-    ecs_fini(world);
-}
-
-void Parser_escaped_all_caps_multi_char() {
-    ecs_world_t *world = ecs_init();
-
-    ECS_TAG(world, Pred);
-    ECS_TAG(world, XYZ);
-
-    ecs_filter_t f;
-    test_int(0, ecs_filter_init(world, &f, &(ecs_filter_desc_t){
-        .expr = "Pred(\\XYZ)"
-    }));
-    test_int(filter_count(&f), 1);
-
-    ecs_term_t *terms = filter_terms(&f);
-    test_pred(terms[0], Pred, EcsSelf|EcsSubSet);
-    test_subj(terms[0], XYZ, EcsSelf|EcsSuperSet);
     test_int(terms[0].oper, EcsAnd);
     test_int(terms[0].inout, EcsInOutDefault);
 

--- a/test/addons/src/Rules.c
+++ b/test/addons/src/Rules.c
@@ -145,7 +145,7 @@ void Rules_pair_recycled_final_pred() {
     test_assert(ecs_has_id(world, e, ecs_pair(Pred, Obj)));
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "Pred(., _X)"
+        .expr = "Pred(., $X)"
     });
 
     test_assert(r != NULL);
@@ -183,7 +183,7 @@ void Rules_pair_recycled_pred() {
     test_assert(ecs_has_id(world, e, ecs_pair(Pred, Obj)));
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "Pred(., _X)"
+        .expr = "Pred(., $X)"
     });
 
     test_assert(r != NULL);
@@ -301,7 +301,7 @@ void Rules_pair_recycled_matched_obj() {
     test_assert(ecs_has_id(world, e, ecs_pair(Pred, Obj)));
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "Pred(., _X)"
+        .expr = "Pred(., $X)"
     });
 
     test_assert(r != NULL);
@@ -347,7 +347,7 @@ void Rules_pair_recycled_matched_obj_2_terms() {
     test_assert(ecs_has_id(world, e, ecs_pair(Pred_2, Obj)));
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "Pred(., _X), Pred_2(., _X)"
+        .expr = "Pred(., $X), Pred_2(., $X)"
     });
 
     test_assert(r != NULL);
@@ -394,7 +394,7 @@ void Rules_pair_recycled_matched_pred_2_terms() {
     test_assert(ecs_has_id(world, e, ecs_pair(Pred, Obj_2)));
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "_X(., Obj), _X(., Obj_2)"
+        .expr = "$X(., Obj), $X(., Obj_2)"
     });
 
     test_assert(r != NULL);
@@ -434,7 +434,7 @@ void Rules_recycled_var() {
 
     ecs_add_pair(world, obj_a, Rel, obj_b_2);
 
-    ecs_rule_t *r = ecs_rule_new(world, "(Rel, _X)");
+    ecs_rule_t *r = ecs_rule_new(world, "(Rel, $X)");
     test_assert(r != NULL);
 
     int x_var = ecs_rule_find_var(r, "X");
@@ -509,7 +509,7 @@ void Rules_superset_from_recycled_w_var() {
 
     ecs_add_pair(world, obj_a, Rel, obj_b_2);
 
-    ecs_rule_t *r = ecs_rule_new(world, "(Rel, _X)");
+    ecs_rule_t *r = ecs_rule_new(world, "(Rel, $X)");
     test_assert(r != NULL);
 
     int x_var = ecs_rule_find_var(r, "X");
@@ -557,7 +557,7 @@ void Rules_superset_from_recycled_2_lvls_w_var() {
     ecs_add_pair(world, obj_a, Rel, obj_b_2);
     ecs_add_pair(world, obj_b_2, Rel, obj_c_2);
 
-    ecs_rule_t *r = ecs_rule_new(world, "(Rel, _X)");
+    ecs_rule_t *r = ecs_rule_new(world, "(Rel, $X)");
     test_assert(r != NULL);
 
     ecs_iter_t it = ecs_rule_iter(world, r);
@@ -635,7 +635,7 @@ void Rules_superset_from_recycled_2_lvls_2_tbls_w_var() {
     ecs_add_pair(world, obj_b_2, Rel, obj_d_2);
     ecs_add_pair(world, obj_c_2, Rel, obj_d_2);
 
-    ecs_rule_t *r = ecs_rule_new(world, "(Rel, _X)");
+    ecs_rule_t *r = ecs_rule_new(world, "(Rel, $X)");
     test_assert(r != NULL);
 
     ecs_iter_t it = ecs_rule_iter(world, r);
@@ -1468,7 +1468,7 @@ void Rules_find_w_pred_var() {
     test_assert(ecs_plecs_from_str(world, NULL, rules) == 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "_X(.), Jedi(.)"
+        .expr = "$X(.), Jedi(.)"
     });
 
     test_assert(r != NULL);
@@ -1512,7 +1512,7 @@ void Rules_find_w_pred_var_explicit_subject() {
     test_assert(ecs_plecs_from_str(world, NULL, rules) == 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "_X(Luke)"
+        .expr = "$X(Luke)"
     });
 
     test_assert(r != NULL);
@@ -1544,7 +1544,7 @@ void Rules_find_1_pair_w_object_var() {
     test_assert(ecs_plecs_from_str(world, NULL, rules) == 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "HomePlanet(., _X)"
+        .expr = "HomePlanet(., $X)"
     });
 
     test_assert(r != NULL);
@@ -1579,7 +1579,7 @@ void Rules_find_2_pairs_w_object_var() {
     test_assert(ecs_plecs_from_str(world, NULL, rules) == 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "HomePlanet(., _X), Enemy(., _Y)"
+        .expr = "HomePlanet(., $X), Enemy(., $Y)"
     });
 
     test_assert(r != NULL);
@@ -1621,7 +1621,7 @@ void Rules_find_1_pair_w_pred_var() {
     test_assert(ecs_plecs_from_str(world, NULL, rules) == 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "_X(., Tatooine)"
+        .expr = "$X(., Tatooine)"
     });
 
     test_assert(r != NULL);
@@ -1654,7 +1654,7 @@ void Rules_find_2_pairs_w_pred_var() {
     test_assert(ecs_plecs_from_str(world, NULL, rules) == 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "_X(., Tatooine), _Y(., Palpatine)"
+        .expr = "$X(., Tatooine), $Y(., Palpatine)"
     });
 
     test_assert(r != NULL);
@@ -1692,7 +1692,7 @@ void Rules_find_cyclic_pairs() {
     test_assert(ecs_plecs_from_str(world, NULL, rules) == 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "Likes(., _X), Likes(_X, .)"
+        .expr = "Likes(., $X), Likes($X, .)"
     });
 
     test_assert(r != NULL);
@@ -1726,7 +1726,7 @@ void Rules_join_by_object() {
     test_assert(ecs_plecs_from_str(world, NULL, rules) == 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "Parent(., _X), Parent(_Y, _X)"
+        .expr = "Parent(., $X), Parent($Y, $X)"
     });
 
     test_assert(r != NULL);
@@ -1774,7 +1774,7 @@ void Rules_join_by_predicate() {
     test_assert(ecs_plecs_from_str(world, NULL, rules) == 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "_X(., DarthVader), _X(_Y, DarthVader)"
+        .expr = "$X(., DarthVader), $X($Y, DarthVader)"
     });
 
     test_assert(r != NULL);
@@ -1888,7 +1888,7 @@ void Rules_join_by_predicate_from_subject() {
     test_assert(ecs_plecs_from_str(world, NULL, rules) == 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "Transitive(.), .(_X, Character)"
+        .expr = "Transitive(.), .($X, Character)"
     });
 
     test_assert(r != NULL);
@@ -2166,7 +2166,7 @@ void Rules_transitive_w_table_object() {
     test_assert(ecs_plecs_from_str(world, NULL, rules) == 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "Sentient(_X), IsA(_Y, _X)"
+        .expr = "Sentient($X), IsA($Y, $X)"
     });
 
     test_assert(r != NULL);
@@ -2263,7 +2263,7 @@ void Rules_transitive_superset_w_subj_var() {
     test_assert(ecs_plecs_from_str(world, NULL, rules) == 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = ".(\\R2D2), IsA(., _X)"
+        .expr = ".(R2D2), IsA(., $X)"
     });
 
     test_assert(r != NULL);
@@ -2336,7 +2336,7 @@ void Rules_transitive_superset_w_subj_var_2_term() {
     test_assert(ecs_plecs_from_str(world, NULL, rules) == 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "IsA(SentientMachine, .), IsA(., _X)"
+        .expr = "IsA(SentientMachine, .), IsA(., $X)"
     });
 
     test_assert(r != NULL);
@@ -2426,7 +2426,7 @@ void Rules_transitive_constraint_on_superset_var() {
     test_assert(ecs_plecs_from_str(world, NULL, rules) == 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "_X(C3PO), IsA(_X, _Y), Sentient(_Y)"
+        .expr = "$X(C3PO), IsA($X, $Y), Sentient($Y)"
     });
 
     test_assert(r != NULL);
@@ -2460,7 +2460,7 @@ void Rules_transitive_instances() {
     test_assert(ecs_plecs_from_str(world, NULL, rules) == 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "_X, IsA(_X, Character)"
+        .expr = "$X, IsA($X, Character)"
     });
 
     test_assert(r != NULL);
@@ -2554,7 +2554,7 @@ void Rules_transitive_instances_2_terms() {
     test_assert(ecs_plecs_from_str(world, NULL, rules) == 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "_X, IsA(_X, Character), IsA(_X, Machine)"
+        .expr = "$X, IsA($X, Character), IsA($X, Machine)"
     });
 
     test_assert(r != NULL);
@@ -2673,7 +2673,7 @@ void Rules_same_pred_obj() {
     ecs_add_id(world, e2, t2);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "_X(., _X)"
+        .expr = "$X(., $X)"
     });
 
     test_assert(r != NULL);
@@ -2704,7 +2704,7 @@ void Rules_same_pred_obj_explicit_subject() {
     ecs_add_id(world, Ent, t1);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "_X(Ent, _X)"
+        .expr = "$X(Ent, $X)"
     });
 
     test_assert(r != NULL);
@@ -2925,7 +2925,7 @@ void Rules_transitive_all() {
     test_assert(ecs_plecs_from_str(world, NULL, small_ruleset) == 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "IsA(_X, _Y)"
+        .expr = "IsA($X, $Y)"
     });
 
     test_assert(r != NULL);
@@ -3114,7 +3114,7 @@ void Rules_transitive_fact_subset_superset() {
     test_assert(ecs_plecs_from_str(world, NULL, rules) == 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "IsA(SpaceShip, _X), IsA(_X, Machine)"
+        .expr = "IsA(SpaceShip, $X), IsA($X, Machine)"
     });
 
     test_assert(r != NULL);
@@ -3539,7 +3539,7 @@ void Rules_implicit_is_a_pred_var() {
     test_assert(ecs_plecs_from_str(world, NULL, small_rules) == 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "_X(MonaLisa)"
+        .expr = "$X(MonaLisa)"
     });
 
     test_assert(r != NULL);
@@ -3577,7 +3577,7 @@ void Rules_implicit_is_a_pair_var() {
     test_assert(ecs_plecs_from_str(world, NULL, small_rules) == 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "_X(MonaLisa, _Y)"
+        .expr = "$X(MonaLisa, $Y)"
     });
 
     test_assert(r != NULL);
@@ -3741,7 +3741,7 @@ void Rules_2_constrained_vars_by_subject_literal() {
     test_assert(ecs_plecs_from_str(world, NULL, small_rules) == 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "Eats(Cat, _X), Eats(Dog, _Y)"
+        .expr = "Eats(Cat, $X), Eats(Dog, $Y)"
     });
 
     test_assert(r != NULL);
@@ -3773,7 +3773,7 @@ void Rules_2_constrained_vars_by_subject_literal_2_var_terms() {
     test_assert(ecs_plecs_from_str(world, NULL, small_rules) == 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "Eats(Cat, _X), Eats(Dog, _Y), Food(_X), Food(_Y)"
+        .expr = "Eats(Cat, $X), Eats(Dog, $Y), Food($X), Food($Y)"
     });
 
     test_assert(r != NULL);
@@ -3906,7 +3906,7 @@ void Rules_not_term_w_subj_var() {
     ecs_add_id(world, e_4, TagC);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "TagA(_X), !TagB(_X)"
+        .expr = "TagA($X), !TagB($X)"
     });
 
     test_assert(r != NULL);
@@ -3955,7 +3955,7 @@ void Rules_not_term_w_subj_var_match_n_per_type() {
     ecs_add(world, e_6, TagB);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "TagA(_X), !TagB(_X)"
+        .expr = "TagA($X), !TagB($X)"
     });
 
     test_assert(r != NULL);
@@ -4021,7 +4021,7 @@ void Rules_invalid_rule_w_not_term_unknown_var() {
     ECS_ENTITY(world, TagB, 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "TagA, !TagB(_X)"
+        .expr = "TagA, !TagB($X)"
     });
 
     test_assert(r == NULL);
@@ -4038,7 +4038,7 @@ void Rules_invalid_rule_w_not_term_unknown_pair_var() {
     ECS_ENTITY(world, TagB, 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "TagA, !TagB(This, _X)"
+        .expr = "TagA, !TagB(This, $X)"
     });
 
     test_assert(r == NULL);
@@ -4055,7 +4055,7 @@ void Rules_invalid_rule_w_not_term_unknown_pair_var_subj_var() {
     ECS_ENTITY(world, TagB, 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "TagA(_Y), !TagB(_Y, _X)"
+        .expr = "TagA($Y), !TagB($Y, $X)"
     });
 
     test_assert(r == NULL);
@@ -4257,7 +4257,7 @@ void Rules_childof_this() {
     ecs_entity_t child2 = ecs_new_w_pair(world, EcsChildOf, e1);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t) {
-        .expr = "Tag, ChildOf(_X, .)"
+        .expr = "Tag, ChildOf($X, .)"
     });
 
     test_assert(r != NULL);
@@ -4305,7 +4305,7 @@ void Rules_childof_this_as_identifier() {
     ecs_entity_t child2 = ecs_new_w_pair(world, EcsChildOf, e1);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t) {
-        .expr = "Tag, ChildOf(_X, This)"
+        .expr = "Tag, ChildOf($X, This)"
     });
 
     test_assert(r != NULL);
@@ -4456,7 +4456,7 @@ void Rules_optional_term_on_entity() {
     ECS_ENTITY(world, E, TagA);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t) {
-        .expr = "TagA(\\E), ?TagB(\\E)"
+        .expr = "TagA(E), ?TagB(E)"
     });
 
     test_assert(r != NULL);
@@ -4499,7 +4499,7 @@ void Rules_optional_term_on_variable() {
     ecs_add_pair(world, e, Likes, obj_3);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t) {
-        .expr = "(Likes, _X), TagA(_X), ?TagB(_X), ?TagC(_X)"
+        .expr = "(Likes, $X), TagA($X), ?TagB($X), ?TagC($X)"
     });
 
     test_assert(r != NULL);
@@ -4658,7 +4658,7 @@ void Rules_optional_w_subj_var() {
     test_int(ecs_plecs_from_str(world, NULL, expr), 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t) {
-        .expr = "Likes(_X, _Y), ?Likes(_Z, _X)"
+        .expr = "Likes($X, $Y), ?Likes($Z, $X)"
     });
 
     test_assert(r != NULL);
@@ -4723,7 +4723,7 @@ void Rules_optional_w_obj_var() {
     ecs_add(world, e3, Foo);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t) {
-        .expr = "Tag, ?(Likes, _X)"
+        .expr = "Tag, ?(Likes, $X)"
     });
 
     test_assert(r != NULL);
@@ -4903,7 +4903,7 @@ void Rules_term_w_x_x_x() {
     ecs_add_pair(world, e4, e, e);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t) {
-        .expr = "_X(_X, _X)"
+        .expr = "$X($X, $X)"
     });
 
     int32_t x_var = ecs_rule_find_var(r, "X");
@@ -5171,10 +5171,7 @@ void Rules_rule_iter_set_var() {
     ecs_entity_t e2 = ecs_new_w_pair(world, Rel, ObjB);
     ecs_entity_t e3 = ecs_new_w_pair(world, Rel, ObjC);
 
-    ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t) {
-        .terms = {{ .pred.entity = Rel, .obj.name = "_X"}}
-    });
-
+    ecs_rule_t *r = ecs_rule_new(world, "(Rel, $X)");
     test_assert(r != NULL);
 
     int32_t x_var = ecs_rule_find_var(r, "X");
@@ -5230,13 +5227,7 @@ void Rules_rule_iter_set_2_vars() {
     ecs_add_pair(world, e2, RelY, ObjB);
     ecs_add_pair(world, e3, RelY, ObjA);
 
-    ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t) {
-        .terms = {
-            { .pred.entity = RelX, .obj.name = "_X"},
-            { .pred.entity = RelY, .obj.name = "_Y"},
-        }
-    });
-
+    ecs_rule_t *r = ecs_rule_new(world, "(RelX, $X), (RelY, $Y)");
     test_assert(r != NULL);
 
     int32_t x_var = ecs_rule_find_var(r, "X");
@@ -5308,10 +5299,7 @@ void Rules_rule_iter_set_pred_var() {
     ecs_entity_t e2 = ecs_new(world, TagB);
     ecs_entity_t e3 = ecs_new(world, TagC);
 
-    ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t) {
-        .terms = {{ .pred.name = "_X"}}
-    });
-
+    ecs_rule_t *r = ecs_rule_new(world, "$X");
     test_assert(r != NULL);
 
     int32_t x_var = ecs_rule_find_var(r, "X");
@@ -5369,13 +5357,7 @@ void Rules_rule_iter_set_var_for_2_terms() {
     ecs_add_pair(world, e3, RelY, ObjC);
     ecs_add_pair(world, e4, RelY, ObjB);
 
-    ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t) {
-        .terms = {
-            { .pred.entity = RelX, .obj.name = "_X"},
-            { .pred.entity = RelY, .obj.name = "_X"}
-        }
-    });
-
+    ecs_rule_t *r = ecs_rule_new(world, "(RelX, $X), (RelY, $X)");
     test_assert(r != NULL);
 
     int32_t x_var = ecs_rule_find_var(r, "X");
@@ -5432,13 +5414,7 @@ void Rules_rule_iter_set_cyclic_variable() {
     ecs_add_pair(world, jane, Likes, john);
     ecs_add_pair(world, john, Likes, jane);
 
-    ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t) {
-        .terms = {
-            { .pred.entity = Likes, .subj.name = "_X", .obj.name = "_Y"},
-            { .pred.entity = Likes, .subj.name = "_Y", .obj.name = "_X"}
-        }
-    });
-
+    ecs_rule_t *r = ecs_rule_new(world, "Likes($X, $Y), Likes($Y, $X)");
     int x_var = ecs_rule_find_var(r, "X");
     int y_var = ecs_rule_find_var(r, "Y");
 
@@ -5502,13 +5478,7 @@ void Rules_rule_iter_set_cyclic_variable_w_this() {
     ecs_add_pair(world, jane, Likes, john);
     ecs_add_pair(world, john, Likes, jane);
 
-    ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t) {
-        .terms = {
-            { .pred.entity = Likes, .subj.entity = EcsThis, .obj.name = "_X"},
-            { .pred.entity = Likes, .subj.name = "_X", .obj.entity = EcsThis}
-        }
-    });
-
+    ecs_rule_t *r = ecs_rule_new(world, "(Likes, $X), Likes($X, .)");
     int x_var = ecs_rule_find_var(r, "X");
 
     ecs_iter_t it = ecs_rule_iter(world, r);
@@ -5566,7 +5536,7 @@ void Rules_term_w_same_subj_obj_var() {
     ECS_ENTITY(world, Rel, Final);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t) {
-        .expr = "Rel(_X, _X)"
+        .expr = "Rel($X, $X)"
     });
 
     int x_var = ecs_rule_find_var(r, "X");
@@ -5877,7 +5847,7 @@ void Rules_test_subj_w_wildcard_w_pairs_var() {
     ecs_add_pair(world, e, RelB, TagA);
     ecs_add_pair(world, e, RelB, TagB);
 
-    ecs_rule_t *r = ecs_rule_new(world, "_C(e)");
+    ecs_rule_t *r = ecs_rule_new(world, "$C(e)");
     test_assert(r != NULL);
 
     int c_var = ecs_rule_find_var(r, "C");
@@ -5916,7 +5886,7 @@ void Rules_test_subj_w_wildcard_wildcard_w_pairs_var() {
     ecs_add_pair(world, e, Rel, TagA);
     ecs_add_pair(world, e, Rel, TagB);
 
-    ecs_rule_t *r = ecs_rule_new(world, "_R(e, _O)");
+    ecs_rule_t *r = ecs_rule_new(world, "$R(e, $O)");
     test_assert(r != NULL);
 
     int r_var = ecs_rule_find_var(r, "R");
@@ -5967,7 +5937,7 @@ void Rules_test_this_w_wildcard_w_pairs_var() {
     ecs_add_pair(world, e, Rel, TagA);
     ecs_add_pair(world, e, Rel, TagB);
 
-    ecs_rule_t *r = ecs_rule_new(world, "_C, MyTag");
+    ecs_rule_t *r = ecs_rule_new(world, "$C, MyTag");
     test_assert(r != NULL);
 
     int c_var = ecs_rule_find_var(r, "C");
@@ -6016,7 +5986,7 @@ void Rules_test_this_w_wildcard_wildcard_w_pairs_var() {
     ecs_add_pair(world, e, Rel, TagA);
     ecs_add_pair(world, e, Rel, TagB);
 
-    ecs_rule_t *r = ecs_rule_new(world, "(_R, _O), MyTag");
+    ecs_rule_t *r = ecs_rule_new(world, "($R, $O), MyTag");
     test_assert(r != NULL);
 
     int r_var = ecs_rule_find_var(r, "R");
@@ -6575,7 +6545,7 @@ void Rules_variable_order() {
     ECS_TAG(world, ObjA);
     ECS_TAG(world, ObjB);
 
-    ecs_rule_t *r = ecs_rule_new(world, "RelX(_X, _Y), RelX(_Y, _Z)");
+    ecs_rule_t *r = ecs_rule_new(world, "RelX($X, $Y), RelX($Y, $Z)");
     test_assert(r != NULL);
 
     int x_var = ecs_rule_find_var(r, "X");

--- a/test/addons/src/SystemManual.c
+++ b/test/addons/src/SystemManual.c
@@ -209,7 +209,7 @@ void SystemManual_dont_run_w_unmatching_entity_query() {
 
     ECS_TAG(world, Tag);
 
-    ECS_SYSTEM(world, DummySystem, 0, !$Tag);
+    ECS_SYSTEM(world, DummySystem, 0, !Tag($));
 
     ecs_run(world, DummySystem, 0, NULL);
     test_int(dummy_ran, 1);

--- a/test/addons/src/TransitiveRules.c
+++ b/test/addons/src/TransitiveRules.c
@@ -15,7 +15,7 @@ void TransitiveRules_trans_X_X() {
     test_int(ecs_plecs_from_str(world, NULL, ruleset), 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "LocatedIn(_X, _X)"
+        .expr = "LocatedIn($X, $X)"
     });
     test_assert(r == NULL);
 
@@ -33,7 +33,7 @@ void TransitiveRules_trans_reflexive_X_X() {
     test_int(ecs_plecs_from_str(world, NULL, ruleset), 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "LocatedIn(_X, _X)"
+        .expr = "LocatedIn($X, $X)"
     });
     test_assert(r != NULL);
 
@@ -67,7 +67,7 @@ void TransitiveRules_trans_reflexive_X_X_2() {
     test_int(ecs_plecs_from_str(world, NULL, ruleset), 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "LocatedIn(_X, _X)"
+        .expr = "LocatedIn($X, $X)"
     });
     test_assert(r != NULL);
 
@@ -109,7 +109,7 @@ void TransitiveRules_trans_reflexive_X_Y() {
     test_int(ecs_plecs_from_str(world, NULL, ruleset), 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "LocatedIn(_X, _Y)"
+        .expr = "LocatedIn($X, $Y)"
     });
     test_assert(r != NULL);
 
@@ -152,7 +152,7 @@ void TransitiveRules_trans_X_Y_2_levels() {
     test_int(ecs_plecs_from_str(world, NULL, ruleset), 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "LocatedIn(_X, _Y)"
+        .expr = "LocatedIn($X, $Y)"
     });
     test_assert(r != NULL);
 
@@ -221,7 +221,7 @@ void TransitiveRules_trans_X_Y_2_levels_nonfinal() {
     test_int(ecs_plecs_from_str(world, NULL, ruleset), 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "LocatedIn(_X, _Y)"
+        .expr = "LocatedIn($X, $Y)"
     });
     test_assert(r != NULL);
 
@@ -290,7 +290,7 @@ void TransitiveRules_trans_pred_This_X__pred_X() {
     test_int(ecs_plecs_from_str(world, NULL, ruleset), 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "(LocatedIn, _X), Location(_X)"
+        .expr = "(LocatedIn, $X), Location($X)"
     });
     test_assert(r != NULL);
 
@@ -328,7 +328,7 @@ void TransitiveRules_trans_constrained_x_y() {
     test_int(ecs_plecs_from_str(world, NULL, ruleset), 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "LocatedIn(_X, _Y), Location(_X), Location(_Y)"
+        .expr = "LocatedIn($X, $Y), Location($X), Location($Y)"
     });
     test_assert(r != NULL);
 
@@ -373,7 +373,7 @@ void TransitiveRules_trans_entity_X_non_inclusive() {
     test_int(ecs_plecs_from_str(world, NULL, ruleset), 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "LocatedIn(Earth, _X)"
+        .expr = "LocatedIn(Earth, $X)"
     });
     test_assert(r != NULL);
 
@@ -406,7 +406,7 @@ void TransitiveRules_trans_X_entity_non_inclusive() {
     test_int(ecs_plecs_from_str(world, NULL, ruleset), 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "LocatedIn(_X, Universe)"
+        .expr = "LocatedIn($X, Universe)"
     });
     test_assert(r != NULL);
 
@@ -460,7 +460,7 @@ void TransitiveRules_trans_this_x_after_tag_this() {
     test_int(ecs_plecs_from_str(world, NULL, ruleset), 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "Planet(This), LocatedIn(This, _X)"
+        .expr = "Planet(This), LocatedIn(This, $X)"
     });
     test_assert(r != NULL);
 
@@ -496,7 +496,7 @@ void TransitiveRules_trans_this_x_before_tag_this() {
     test_int(ecs_plecs_from_str(world, NULL, ruleset), 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "LocatedIn(This, _X), Planet(This)"
+        .expr = "LocatedIn(This, $X), Planet(This)"
     });
     test_assert(r != NULL);
 
@@ -533,7 +533,7 @@ void TransitiveRules_trans_this_x_after_tag_this_2_lvls() {
     test_int(ecs_plecs_from_str(world, NULL, ruleset), 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "Continent(This), LocatedIn(This, _X)"
+        .expr = "Continent(This), LocatedIn(This, $X)"
     });
     test_assert(r != NULL);
 
@@ -581,7 +581,7 @@ void TransitiveRules_trans_this_x_before_tag_this_2_lvls() {
     test_int(ecs_plecs_from_str(world, NULL, ruleset), 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "LocatedIn(This, _X), Continent(This)"
+        .expr = "LocatedIn(This, $X), Continent(This)"
     });
     test_assert(r != NULL);
 
@@ -636,7 +636,7 @@ void TransitiveRules_transitive_not_w_var() {
     test_int(ecs_plecs_from_str(world, NULL, ruleset), 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "City(_X), !LocatedIn(_X, UnitedStates)"
+        .expr = "City($X), !LocatedIn($X, UnitedStates)"
     });
     test_assert(r != NULL);
 
@@ -776,7 +776,7 @@ void TransitiveRules_transitive_w_optional_nonfinal_w_var() {
     test_int(ecs_plecs_from_str(world, NULL, ruleset), 0);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t){
-        .expr = "Foo(_X), ?Likes(_X, _Y)"
+        .expr = "Foo($X), ?Likes($X, $Y)"
     });
     test_assert(r != NULL);
 
@@ -828,7 +828,7 @@ void TransitiveRules_rule_iter_set_transitive_variable() {
     ECS_ENTITY(world, Soma, (LocatedIn, SanFrancisco));
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t) {
-        .expr = "LocatedIn(SanFrancisco, _X)"
+        .expr = "LocatedIn(SanFrancisco, $X)"
     });
 
     test_assert(r != NULL);
@@ -899,7 +899,7 @@ void TransitiveRules_rule_iter_set_transitive_self_variable() {
     ECS_ENTITY(world, Soma, (LocatedIn, SanFrancisco));
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t) {
-        .expr = "LocatedIn(SanFrancisco, _X)"
+        .expr = "LocatedIn(SanFrancisco, $X)"
     });
 
     test_assert(r != NULL);
@@ -935,7 +935,7 @@ void TransitiveRules_rule_iter_set_transitive_2_variables_set_one() {
     ECS_ENTITY(world, Soma, (LocatedIn, SanFrancisco));
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t) {
-        .expr = "LocatedIn(_X, _Y)"
+        .expr = "LocatedIn($X, $Y)"
     });
 
     test_assert(r != NULL);
@@ -999,7 +999,7 @@ void TransitiveRules_rule_iter_set_transitive_2_variables_set_both() {
     ECS_ENTITY(world, Soma, (LocatedIn, SanFrancisco));
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t) {
-        .expr = "LocatedIn(_X, _Y)"
+        .expr = "LocatedIn($X, $Y)"
     });
 
     test_assert(r != NULL);
@@ -1063,7 +1063,7 @@ void TransitiveRules_rule_iter_set_transitive_self_2_variables_set_both() {
     ECS_ENTITY(world, SanFrancisco, (LocatedIn, UnitedStates));
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t) {
-        .expr = "LocatedIn(_X, _Y)"
+        .expr = "LocatedIn($X, $Y)"
     });
 
     test_assert(r != NULL);

--- a/test/addons/src/main.c
+++ b/test/addons/src/main.c
@@ -60,8 +60,6 @@ void Parser_variable_multi_char(void);
 void Parser_variable_multi_char_w_underscore(void);
 void Parser_variable_multi_char_w_number(void);
 void Parser_variable_multi_char_not_allcaps(void);
-void Parser_escaped_all_caps_single_char(void);
-void Parser_escaped_all_caps_multi_char(void);
 void Parser_component_not(void);
 void Parser_pair_implicit_subject_not(void);
 void Parser_pair_explicit_subject_not(void);
@@ -1111,14 +1109,6 @@ bake_test_case Parser_testcases[] = {
     {
         "variable_multi_char_not_allcaps",
         Parser_variable_multi_char_not_allcaps
-    },
-    {
-        "escaped_all_caps_single_char",
-        Parser_escaped_all_caps_single_char
-    },
-    {
-        "escaped_all_caps_multi_char",
-        Parser_escaped_all_caps_multi_char
     },
     {
         "component_not",
@@ -4355,7 +4345,7 @@ static bake_test_suite suites[] = {
         "Parser",
         NULL,
         NULL,
-        157,
+        155,
         Parser_testcases
     },
     {

--- a/test/api/src/Filter.c
+++ b/test/api/src/Filter.c
@@ -359,7 +359,11 @@ void Filter_filter_1_term_same_subj_obj_var() {
 
     ecs_filter_t f;
     int r = ecs_filter_init(world, &f, &(ecs_filter_desc_t) {
-        .terms = {{ .pred.entity = Rel, .subj.name = "_X", .obj.name = "_X" }}
+        .terms = {{ 
+            .pred.entity = Rel, 
+            .subj = { .name = "X", .var = EcsVarIsVariable },
+            .obj = { .name = "X", .var = EcsVarIsVariable }
+        }}
     });
     test_assert(r == 0);
 
@@ -392,7 +396,11 @@ void Filter_filter_1_term_acyclic_same_subj_obj_var() {
 
     ecs_filter_t f;
     int r = ecs_filter_init(world, &f, &(ecs_filter_desc_t) {
-        .terms = {{ .pred.entity = Rel, .subj.name = "_X", .obj.name = "_X" }}
+        .terms = {{ 
+            .pred.entity = Rel, 
+            .subj = { .name = "X", .var = EcsVarIsVariable },
+            .obj = { .name = "X", .var = EcsVarIsVariable }
+        }}
     });
     test_assert(r != 0);
 
@@ -406,7 +414,11 @@ void Filter_filter_1_term_acyclic_reflexive_same_subj_obj_var() {
 
     ecs_filter_t f;
     int r = ecs_filter_init(world, &f, &(ecs_filter_desc_t) {
-        .terms = {{ .pred.entity = Rel, .subj.name = "_X", .obj.name = "_X" }}
+        .terms = {{ 
+            .pred.entity = Rel, 
+            .subj = { .name = "X", .var = EcsVarIsVariable },
+            .obj = { .name = "X", .var = EcsVarIsVariable }
+        }}
     });
     test_assert(r == 0);
 
@@ -5494,7 +5506,7 @@ void Filter_filter_instanced_w_singleton() {
 
     ecs_filter_t f;
     test_int(0, ecs_filter_init(world, &f, &(ecs_filter_desc_t){
-        .expr = "Position, $Velocity",
+        .expr = "Position, Velocity($)",
         .instanced = true
     }));
 
@@ -5691,7 +5703,7 @@ void Filter_filter_no_instancing_w_singleton() {
 
     ecs_filter_t f;
     test_int(0, ecs_filter_init(world, &f, &(ecs_filter_desc_t){
-        .expr = "Position, $Velocity"
+        .expr = "Position, Velocity($)"
     }));
 
     ecs_iter_t it = ecs_filter_iter(world, &f);

--- a/test/api/src/Iter.c
+++ b/test/api/src/Iter.c
@@ -1253,7 +1253,7 @@ void Iter_worker_iter_w_singleton() {
     ecs_entity_t e3 = ecs_new(world, Position);
     ecs_entity_t e4 = ecs_new(world, Position);
 
-    ecs_query_t *q = ecs_query_new(world, "Position, $Singleton");
+    ecs_query_t *q = ecs_query_new(world, "Position, Singleton($)");
 
     ecs_iter_t it_1 = ecs_query_iter(world, q);
     ecs_iter_t wit_1 = ecs_worker_iter(&it_1, 0, 2);
@@ -1292,7 +1292,7 @@ void Iter_worker_iter_w_singleton_instanced() {
 
     ecs_query_t *q = ecs_query_init(world, &(ecs_query_desc_t){
         .filter = {
-            .expr = "Position, $Singleton",
+            .expr = "Position, Singleton($)",
             .instanced = true
         }
     });
@@ -1328,7 +1328,7 @@ void Iter_paged_iter_w_singleton() {
     ecs_entity_t e3 = ecs_new(world, Position);
     ecs_entity_t e4 = ecs_new(world, Position);
 
-    ecs_query_t *q = ecs_query_new(world, "Position, $Singleton");
+    ecs_query_t *q = ecs_query_new(world, "Position, Singleton($)");
 
     ecs_iter_t it_1 = ecs_query_iter(world, q);
     ecs_iter_t pit_1 = ecs_page_iter(&it_1, 0, 2);
@@ -1367,7 +1367,7 @@ void Iter_paged_iter_w_singleton_instanced() {
 
     ecs_query_t *q = ecs_query_init(world, &(ecs_query_desc_t){
         .filter = {
-            .expr = "Position, $Singleton",
+            .expr = "Position, Singleton($)",
             .instanced = true
         }
     });

--- a/test/api/src/Query.c
+++ b/test/api/src/Query.c
@@ -437,7 +437,7 @@ void Query_query_only_from_singleton() {
 
     ecs_singleton_add(world, Tag);
 
-    ecs_query_t *q = ecs_query_new(world, "$Tag");
+    ecs_query_t *q = ecs_query_new(world, "Tag($)");
     test_assert(q != NULL);
 
     ecs_iter_t it = ecs_query_iter(world, q);
@@ -477,7 +477,7 @@ void Query_query_only_from_singleton_match_after() {
 
     ECS_TAG(world, Tag);
 
-    ecs_query_t *q = ecs_query_new(world, "$Tag");
+    ecs_query_t *q = ecs_query_new(world, "Tag($)");
     test_assert(q != NULL);
     
     ecs_singleton_add(world, Tag);
@@ -546,7 +546,7 @@ void Query_query_w_from_singleton() {
 
     ecs_entity_t e2 = ecs_new(world, TagA);
 
-    ecs_query_t *q = ecs_query_new(world, "TagA, $TagB");
+    ecs_query_t *q = ecs_query_new(world, "TagA, TagB($)");
     test_assert(q != NULL);
 
     ecs_iter_t it = ecs_query_iter(world, q);
@@ -597,7 +597,7 @@ void Query_query_w_from_singleton_match_after() {
 
     ecs_entity_t e2 = ecs_new(world, TagA);
 
-    ecs_query_t *q = ecs_query_new(world, "TagA, $TagB");
+    ecs_query_t *q = ecs_query_new(world, "TagA, TagB($)");
     test_assert(q != NULL);
 
     ecs_singleton_add(world, TagB);
@@ -2429,7 +2429,7 @@ void Query_only_from_singleton() {
 
     ecs_entity_t e = ecs_set_name(world, 0, "e");
 
-    ecs_query_t *q = ecs_query_new(world, "$e");
+    ecs_query_t *q = ecs_query_new(world, "e($)");
     ecs_iter_t it = ecs_query_iter(world, q);
     test_assert(!ecs_query_next(&it));
 
@@ -2471,7 +2471,7 @@ void Query_only_not_from_singleton() {
 
     ecs_entity_t e = ecs_set_name(world, 0, "e");
 
-    ecs_query_t *q = ecs_query_new(world, "!$e");
+    ecs_query_t *q = ecs_query_new(world, "!e($)");
     ecs_iter_t it = ecs_query_iter(world, q);
     test_assert(ecs_query_next(&it));
     test_assert(ecs_term_source(&it, 1) == e);
@@ -3432,7 +3432,7 @@ void Query_no_instancing_w_singleton() {
     ecs_add(world, e4, Tag);
     ecs_add(world, e5, Tag);
 
-    ecs_query_t *q = ecs_query_new(world, "Position, $Velocity");
+    ecs_query_t *q = ecs_query_new(world, "Position, Velocity($)");
     test_assert(q != NULL);
 
     ecs_iter_t it = ecs_query_iter(world, q);

--- a/test/api/src/Singleton.c
+++ b/test/api/src/Singleton.c
@@ -76,7 +76,7 @@ void Singleton_singleton_system() {
 
     ECS_COMPONENT(world, Position);
 
-    ECS_SYSTEM(world, IncSingleton, EcsOnUpdate, $Position);
+    ECS_SYSTEM(world, IncSingleton, EcsOnUpdate, Position($));
 
     ecs_singleton_set(world, Position, {10, 20});
 

--- a/test/cpp_api/src/RuleBuilder.cpp
+++ b/test/cpp_api/src/RuleBuilder.cpp
@@ -206,7 +206,7 @@ void RuleBuilder_pair_term_w_var() {
         .add<Likes, Pears>();
 
     auto r = ecs.rule_builder()
-        .term<Likes>().obj("_Food")
+        .term<Likes>().obj().var("Food")
         .build();
 
     int food_var = r.find_var("Food");
@@ -249,8 +249,8 @@ void RuleBuilder_2_pair_terms_w_var() {
     Bob.add<Likes>(Alice);
 
     auto r = ecs.rule_builder()
-        .term<Eats>().obj("_Food")
-        .term<Likes>().obj("_Person")
+        .term<Eats>().obj().var("Food")
+        .term<Likes>().obj().var("Person")
         .build();
 
     int food_var = r.find_var("Food");
@@ -298,7 +298,7 @@ void RuleBuilder_set_var() {
         .add<Likes>(Pears);
 
     auto r = ecs.rule_builder()
-        .term<Likes>().obj("_Food")
+        .term<Likes>().obj().var("Food")
         .build();
 
     int food_var = r.find_var("Food");
@@ -337,8 +337,8 @@ void RuleBuilder_set_2_vars() {
     Bob.add<Likes>(Alice);
 
     auto r = ecs.rule_builder()
-        .term<Eats>().obj("_Food")
-        .term<Likes>().obj("_Person")
+        .term<Eats>().obj().var("Food")
+        .term<Likes>().obj().var("Person")
         .build();
 
     int food_var = r.find_var("Food");
@@ -377,7 +377,7 @@ void RuleBuilder_set_var_by_name() {
         .add<Likes>(Pears);
 
     auto r = ecs.rule_builder()
-        .term<Likes>().obj("_Food")
+        .term<Likes>().obj().var("Food")
         .build();
 
     int count = 0;
@@ -411,8 +411,8 @@ void RuleBuilder_set_2_vars_by_name() {
     Bob.add<Likes>(Alice);
 
     auto r = ecs.rule_builder()
-        .term<Eats>().obj("_Food")
-        .term<Likes>().obj("_Person")
+        .term<Eats>().obj().var("Food")
+        .term<Likes>().obj().var("Person")
         .build();
 
     int food_var = r.find_var("Food");
@@ -445,7 +445,7 @@ void RuleBuilder_expr_w_var() {
     auto e = ecs.entity().add(rel, obj);
 
     auto r = ecs.rule_builder()
-        .term("(Rel, _X)")
+        .term("(Rel, $X)")
         .build();
 
     int x_var = r.find_var("X");

--- a/test/cpp_api/src/Singleton.cpp
+++ b/test/cpp_api/src/Singleton.cpp
@@ -107,7 +107,7 @@ void Singleton_singleton_system() {
     world.set<Position>({10, 20});
 
     world.system<>()
-        .expr("[inout] $Position")
+        .expr("[inout] Position($)")
         .iter([](flecs::iter it) {
             auto p = it.term<Position>(1);
             test_int(p->x, 10);

--- a/test/meta/src/SerializeToJson.c
+++ b/test/meta/src/SerializeToJson.c
@@ -2201,7 +2201,7 @@ void SerializeToJson_serialize_iterator_w_var() {
     ecs_add_pair(world, e2, Rel, ObjB);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t) {
-        .expr = "(Rel, _X)"
+        .expr = "(Rel, $X)"
     });
 
     ecs_iter_t it = ecs_rule_iter(world, r);
@@ -2260,7 +2260,7 @@ void SerializeToJson_serialize_iterator_w_2_vars() {
     ecs_add_pair(world, e2, RelY, ObjD);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t) {
-        .expr = "(RelX, _X), (RelY, _Y)"
+        .expr = "(RelX, $X), (RelY, $Y)"
     });
 
     ecs_iter_t it = ecs_rule_iter(world, r);
@@ -2905,7 +2905,7 @@ void SerializeToJson_serialize_iterator_w_var_labels() {
     ecs_doc_set_name(world, ObjA, "Object A");
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t) {
-        .expr = "(Rel, _X)"
+        .expr = "(Rel, $X)"
     });
 
     ecs_iter_t it = ecs_rule_iter(world, r);
@@ -2970,7 +2970,7 @@ void SerializeToJson_serialize_iterator_w_var_component() {
     ecs_set(world, Obj, T, {10});
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t) {
-        .expr = "(Rel, _X), T(_X)"
+        .expr = "(Rel, $X), T($X)"
     });
 
     ecs_iter_t it = ecs_rule_iter(world, r);
@@ -3420,7 +3420,7 @@ void SerializeToJson_serialize_iterator_component_from_var() {
 
     ecs_set(world, e1, Position, {10, 20});
 
-    ecs_rule_t *r = ecs_rule_new(world, "Position(_E)");
+    ecs_rule_t *r = ecs_rule_new(world, "Position($E)");
     ecs_iter_t it = ecs_rule_iter(world, r);
 
     char *json = ecs_iter_to_json(world, &it, NULL);
@@ -3610,7 +3610,7 @@ void SerializeToJson_serialize_paged_iterator_w_vars() {
     ecs_new_w_pair(world, Rel, ObjB);
 
     ecs_rule_t *r = ecs_rule_init(world, &(ecs_filter_desc_t) {
-        .expr = "(Rel, _Var)"
+        .expr = "(Rel, $Var)"
     });
 
     int32_t var = ecs_rule_find_var(r, "Var");


### PR DESCRIPTION
This PR changes the DSL syntax for singletons and variables. This is a high-impact change that is likely to break existing code that uses singletons or variables with filters, queries, systems, observers or rules.

More details can be found here:
https://github.com/SanderMertens/flecs/discussions/466#discussioncomment-2458927