### PR TITLE
Issue 677 - Use Windows os_api_impl on non-MSVC Windows Targets

### DIFF
--- a/flecs.c
+++ b/flecs.c
@@ -15921,7 +15921,7 @@ int32_t ecs_cpp_reset_count_inc(void) {
 
 
 #ifdef FLECS_OS_API_IMPL
-#ifdef ECS_TARGET_MSVC
+#ifdef ECS_TARGET_WINDOWS
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif

--- a/src/addons/os_api_impl/os_api_impl.c
+++ b/src/addons/os_api_impl/os_api_impl.c
@@ -1,7 +1,7 @@
 #include "../../private_api.h"
 
 #ifdef FLECS_OS_API_IMPL
-#ifdef ECS_TARGET_MSVC
+#ifdef ECS_TARGET_WINDOWS
 #include "windows_impl.inl"
 #else
 #include "posix_impl.inl"


### PR DESCRIPTION
I manually modified `flecs.c` since bake-amalgamate doesn't currently work on Windows.