### PR TITLE
Revert "Expose m_world in flecs::query"

### DIFF
--- a/include/flecs/addons/cpp/mixins/query/impl.hpp
+++ b/include/flecs/addons/cpp/mixins/query/impl.hpp
@@ -98,7 +98,7 @@ struct query_base {
         char *result = ecs_filter_str(m_world, f);
         return flecs::string(result);
     }
-    
+
     operator query<>() const;
 
 protected:
@@ -121,10 +121,6 @@ private:
 
     ecs_iter_next_action_t next_each_action() const override {
         return ecs_query_next_instanced;
-    }
-    
-    flecs::world world() const {
-        return flecs::world(m_world);
     }
 
 public:

--- a/include/flecs/addons/cpp/mixins/query/impl.hpp
+++ b/include/flecs/addons/cpp/mixins/query/impl.hpp
@@ -108,11 +108,6 @@ protected:
 
 template<typename ... Components>
 struct query final : query_base, iterable<Components...> {
-public:
-    flecs::world world() const {
-        return flecs::world(m_world);
-    }
-    
 private:
     using Terms = typename _::term_ptrs<Components...>::array;
 
@@ -126,6 +121,10 @@ private:
 
     ecs_iter_next_action_t next_each_action() const override {
         return ecs_query_next_instanced;
+    }
+    
+    flecs::world world() const {
+        return flecs::world(m_world);
     }
 
 public:


### PR DESCRIPTION
This did not help me in my scenario - comparing static storage query's world to argument world was succeeding, but in fact it was just world pointers being the same, while in fact the world has changed, so I ended up storing an unique ID of the world inside a singleton and comparing it instead, feel free to revert this extraneous interface