### PR TITLE
#728 Remove is_added argument from get_mut

### DIFF
--- a/examples/c/reflection/basics_deserialize/src/main.c
+++ b/examples/c/reflection/basics_deserialize/src/main.c
@@ -22,7 +22,7 @@ int main(int argc, char *argv[]) {
 
     // Create entity, set value of position using reflection API
     ecs_entity_t ent = ecs_new_entity(ecs, "ent");
-    Position *ptr = ecs_get_mut(ecs, ent, Position, 0);
+    Position *ptr = ecs_get_mut(ecs, ent, Position);
 
     ecs_meta_cursor_t cur = ecs_meta_cursor(ecs, ecs_id(Position), ptr);
     ecs_meta_push(&cur);          // {

--- a/examples/c/reflection/nested_set_member/src/main.c
+++ b/examples/c/reflection/nested_set_member/src/main.c
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
     ECS_META_COMPONENT(ecs, Line);
 
     ecs_entity_t ent = ecs_new_id(ecs);
-    Line *ptr = ecs_get_mut(ecs, ent, Line, 0);
+    Line *ptr = ecs_get_mut(ecs, ent, Line);
 
     ecs_meta_cursor_t cur = ecs_meta_cursor(ecs, ecs_id(Line), ptr);
     ecs_meta_push(&cur);            // {

--- a/examples/c/reflection/runtime_component/src/main.c
+++ b/examples/c/reflection/runtime_component/src/main.c
@@ -5,7 +5,7 @@ int main(int argc, char *argv[]) {
     ecs_world_t *ecs = ecs_init_w_args(argc, argv);
 
     // Create component for a type that isn't known at compile time
-    ecs_entity_t ecs_id(Position) = ecs_struct_init(ecs, &(ecs_struct_desc_t) {
+    ecs_entity_t Position = ecs_struct_init(ecs, &(ecs_struct_desc_t) {
         .members = {
             { .name = "x", .type = ecs_id(ecs_f32_t) }, // builtin float type
             { .name = "y", .type = ecs_id(ecs_f32_t) }
@@ -14,9 +14,9 @@ int main(int argc, char *argv[]) {
 
     // Create entity, set value of position using reflection API
     ecs_entity_t ent = ecs_new_entity(ecs, "ent");
-    void *ptr = ecs_get_mut_id(ecs, ent, ecs_id(Position), 0);
+    void *ptr = ecs_get_mut_id(ecs, ent, Position);
 
-    ecs_meta_cursor_t cur = ecs_meta_cursor(ecs, ecs_id(Position), ptr);
+    ecs_meta_cursor_t cur = ecs_meta_cursor(ecs, Position, ptr);
     ecs_meta_push(&cur);          // {
     ecs_meta_set_float(&cur, 10); //   10
     ecs_meta_next(&cur);          //   ,
@@ -24,7 +24,7 @@ int main(int argc, char *argv[]) {
     ecs_meta_pop(&cur);           // }
 
     // Convert component to string
-    char *str = ecs_ptr_to_expr(ecs, ecs_id(Position), ptr);
+    char *str = ecs_ptr_to_expr(ecs, Position, ptr);
     printf("%s\n", str); // {x: 10, y: 20}
     ecs_os_free(str);
 

--- a/examples/c/reflection/runtime_nested_component/src/main.c
+++ b/examples/c/reflection/runtime_nested_component/src/main.c
@@ -5,25 +5,25 @@ int main(int argc, char *argv[]) {
     ecs_world_t *ecs = ecs_init_w_args(argc, argv);
 
     // Create components for types that aren't known at compile time
-    ecs_entity_t ecs_id(Point) = ecs_struct_init(ecs, &(ecs_struct_desc_t) {
+    ecs_entity_t Point = ecs_struct_init(ecs, &(ecs_struct_desc_t) {
         .members = {
             { .name = "x", .type = ecs_id(ecs_f32_t) }, // builtin float type
             { .name = "y", .type = ecs_id(ecs_f32_t) }
         }
     });
 
-    ecs_entity_t ecs_id(Line) = ecs_struct_init(ecs, &(ecs_struct_desc_t) {
+    ecs_entity_t Line = ecs_struct_init(ecs, &(ecs_struct_desc_t) {
         .members = {
-            { .name = "start", .type = ecs_id(Point) },
-            { .name = "stop", .type = ecs_id(Point) }
+            { .name = "start", .type = Point },
+            { .name = "stop", .type = Point }
         }
     });
 
     // Create entity, set value of position using reflection API
     ecs_entity_t ent = ecs_new_entity(ecs, "ent");
-    void *ptr = ecs_get_mut_id(ecs, ent, ecs_id(Line), 0);
+    void *ptr = ecs_get_mut_id(ecs, ent, Line);
 
-    ecs_meta_cursor_t cur = ecs_meta_cursor(ecs, ecs_id(Line), ptr);
+    ecs_meta_cursor_t cur = ecs_meta_cursor(ecs, Line, ptr);
     ecs_meta_push(&cur);          // {
     ecs_meta_push(&cur);          //   {
     ecs_meta_set_float(&cur, 10); //     10
@@ -39,7 +39,7 @@ int main(int argc, char *argv[]) {
     ecs_meta_pop(&cur);           // }
 
     // Convert component to string
-    char *str = ecs_ptr_to_expr(ecs, ecs_id(Line), ptr);
+    char *str = ecs_ptr_to_expr(ecs, Line, ptr);
     printf("%s\n", str); // {start: {x: 10.00, y: 20.00}, stop: {x: 30.00, y: 40.00}}
     ecs_os_free(str);
 

--- a/examples/c/reflection/units/src/main.c
+++ b/examples/c/reflection/units/src/main.c
@@ -51,7 +51,7 @@ int main(int argc, char *argv[]) {
     ecs_entity_t e = ecs_set(ecs, 0, WeatherStation, {24, 1.2, 0.5});
 
     // Use cursor API to print values with units
-    WeatherStation *ptr = ecs_get_mut(ecs, e, WeatherStation, 0);
+    WeatherStation *ptr = ecs_get_mut(ecs, e, WeatherStation);
     ecs_meta_cursor_t cur = ecs_meta_cursor(ecs, ecs_id(WeatherStation), ptr);
 
     ecs_meta_push(&cur);

--- a/flecs.h
+++ b/flecs.h
@@ -4855,15 +4855,13 @@ void* ecs_ref_get_id(
  * @param world The world.
  * @param entity The entity.
  * @param id The entity id of the component to obtain.
- * @param is_added Out parameter that returns true if the component was added.
  * @return The component pointer.
  */
 FLECS_API
 void* ecs_get_mut_id(
     ecs_world_t *world,
     ecs_entity_t entity,
-    ecs_id_t id,
-    bool *is_added); 
+    ecs_id_t id); 
 
 /** Begin exclusive write access to entity.
  * This operation provides safe exclusive access to the components of an entity
@@ -8003,16 +8001,16 @@ void* ecs_record_get_column(
 
 /* -- Get mut & Modified -- */
 
-#define ecs_get_mut(world, entity, T, is_added)\
-    (ECS_CAST(T*, ecs_get_mut_id(world, entity, ecs_id(T), is_added)))
+#define ecs_get_mut(world, entity, T)\
+    (ECS_CAST(T*, ecs_get_mut_id(world, entity, ecs_id(T))))
 
-#define ecs_get_mut_pair(world, subject, relation, object, is_added)\
+#define ecs_get_mut_pair(world, subject, relation, object)\
     (ECS_CAST(relation*, ecs_get_mut_id(world, subject,\
-        ecs_pair(ecs_id(relation), object), is_added)))
+        ecs_pair(ecs_id(relation), object))))
 
-#define ecs_get_mut_pair_second(world, subject, relation, object, is_added)\
+#define ecs_get_mut_pair_second(world, subject, relation, object)\
     (ECS_CAST(object*, ecs_get_mut_id(world, subject,\
-        ecs_pair(relation, ecs_id(object)), is_added)))
+        ecs_pair(relation, ecs_id(object)))))
 
 #define ecs_get_mut_pair_object ecs_get_mut_pair_second
 
@@ -8038,7 +8036,7 @@ void* ecs_record_get_column(
     ecs_set(world, ecs_id(comp), comp, __VA_ARGS__)
 
 #define ecs_singleton_get_mut(world, comp)\
-    ecs_get_mut(world, ecs_id(comp), comp, NULL)
+    ecs_get_mut(world, ecs_id(comp), comp)
 
 #define ecs_singleton_modified(world, comp)\
     ecs_modified(world, ecs_id(comp), comp)

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -1985,15 +1985,13 @@ void* ecs_ref_get_id(
  * @param world The world.
  * @param entity The entity.
  * @param id The entity id of the component to obtain.
- * @param is_added Out parameter that returns true if the component was added.
  * @return The component pointer.
  */
 FLECS_API
 void* ecs_get_mut_id(
     ecs_world_t *world,
     ecs_entity_t entity,
-    ecs_id_t id,
-    bool *is_added); 
+    ecs_id_t id); 
 
 /** Begin exclusive write access to entity.
  * This operation provides safe exclusive access to the components of an entity

--- a/include/flecs/addons/cpp/entity.hpp
+++ b/include/flecs/addons/cpp/entity.hpp
@@ -68,15 +68,13 @@ struct entity : entity_builder<entity>
      * will be copied to the entity before this function returns.
      *
      * @tparam T The component to get.
-     * @param is_added If provided, this parameter will be set to true if the component was added.
      * @return Pointer to the component value.
      */
     template <typename T>
-    T* get_mut(bool *is_added = nullptr) const {
+    T* get_mut() const {
         auto comp_id = _::cpp_type<T>::id(m_world);
         ecs_assert(_::cpp_type<T>::size() != 0, ECS_INVALID_PARAMETER, NULL);
-        return static_cast<T*>(
-            ecs_get_mut_id(m_world, m_id, comp_id, is_added));
+        return static_cast<T*>(ecs_get_mut_id(m_world, m_id, comp_id));
     }
 
     /** Get mutable component value (untyped).
@@ -86,11 +84,10 @@ struct entity : entity_builder<entity>
      * will be copied to the entity before this function returns.
      *
      * @param comp The component to get.
-     * @param is_added If provided, this parameter will be set to true if the component was added.
      * @return Pointer to the component value.
      */
-    void* get_mut(entity_t comp, bool *is_added = nullptr) const {
-        return ecs_get_mut_id(m_world, m_id, comp, is_added);
+    void* get_mut(entity_t comp) const {
+        return ecs_get_mut_id(m_world, m_id, comp);
     }
 
     /** Get mutable pointer for a pair.
@@ -100,9 +97,8 @@ struct entity : entity_builder<entity>
      * @tparam Object the object type.
      */
     template <typename Relation, typename Object>
-    Relation* get_mut(bool *is_added = nullptr) const {
-        return this->get_mut<Relation>(
-            _::cpp_type<Object>::id(m_world), is_added);
+    Relation* get_mut() const {
+        return this->get_mut<Relation>(_::cpp_type<Object>::id(m_world));
     }
 
     /** Get mutable pointer for a pair.
@@ -112,12 +108,11 @@ struct entity : entity_builder<entity>
      * @param object the object.
      */
     template <typename Relation>
-    Relation* get_mut(entity_t object, bool *is_added = nullptr) const {
+    Relation* get_mut(entity_t object) const {
         auto comp_id = _::cpp_type<Relation>::id(m_world);
         ecs_assert(_::cpp_type<Relation>::size() != 0, ECS_INVALID_PARAMETER, NULL);
         return static_cast<Relation*>(
-            ecs_get_mut_id(m_world, m_id, 
-                ecs_pair(comp_id, object), is_added));
+            ecs_get_mut_id(m_world, m_id, ecs_pair(comp_id, object)));
     }
 
     /** Get mutable pointer for a pair (untyped).
@@ -127,9 +122,8 @@ struct entity : entity_builder<entity>
      * @param relation the relation.
      * @param object the object.
      */
-    void* get_mut(entity_t relation, entity_t object, bool *is_added = nullptr) const {
-        return ecs_get_mut_id(m_world, m_id, 
-                ecs_pair(relation, object), is_added);
+    void* get_mut(entity_t relation, entity_t object) const {
+        return ecs_get_mut_id(m_world, m_id, ecs_pair(relation, object));
     }
 
     /** Get mutable pointer for the object from a pair.
@@ -139,12 +133,11 @@ struct entity : entity_builder<entity>
      * @param relation the relation.
      */
     template <typename Object>
-    Object* get_mut_w_object(entity_t relation, bool *is_added = nullptr) const {
+    Object* get_mut_w_object(entity_t relation) const {
         auto comp_id = _::cpp_type<Object>::id(m_world);
         ecs_assert(_::cpp_type<Object>::size() != 0, ECS_INVALID_PARAMETER, NULL);
         return static_cast<Object*>(
-            ecs_get_mut_id(m_world, m_id, 
-                ecs_pair(relation, comp_id), is_added));
+            ecs_get_mut_id(m_world, m_id, ecs_pair(relation, comp_id)));
     }           
 
     /** Signal that component was modified.

--- a/include/flecs/addons/cpp/invoker.hpp
+++ b/include/flecs/addons/cpp/invoker.hpp
@@ -467,7 +467,7 @@ struct entity_with_invoker_impl<arg_list<Args ...>> {
         size_t i = 0;
         DummyArray dummy ({
             (ptrs[i ++] = ecs_get_mut_id(world, e, 
-                _::cpp_type<Args>().id(world), NULL), 0)...
+                _::cpp_type<Args>().id(world)), 0)...
         });
 
         return true;

--- a/include/flecs/addons/cpp/world.hpp
+++ b/include/flecs/addons/cpp/world.hpp
@@ -9,7 +9,7 @@ template <typename T, if_t< is_flecs_constructible<T>::value > = 0>
 inline void set(world_t *world, entity_t entity, T&& value, ecs_id_t id) {
     ecs_assert(_::cpp_type<T>::size() != 0, ECS_INVALID_PARAMETER, NULL);
 
-    T& dst = *static_cast<T*>(ecs_get_mut_id(world, entity, id, NULL));
+    T& dst = *static_cast<T*>(ecs_get_mut_id(world, entity, id));
     dst = FLECS_MOV(value);
 
     ecs_modified_id(world, entity, id);
@@ -20,7 +20,7 @@ template <typename T, if_t< is_flecs_constructible<T>::value > = 0>
 inline void set(world_t *world, entity_t entity, const T& value, ecs_id_t id) {
     ecs_assert(_::cpp_type<T>::size() != 0, ECS_INVALID_PARAMETER, NULL);
 
-    T& dst = *static_cast<T*>(ecs_get_mut_id(world, entity, id, NULL));
+    T& dst = *static_cast<T*>(ecs_get_mut_id(world, entity, id));
     dst = value;
 
     ecs_modified_id(world, entity, id);
@@ -31,11 +31,7 @@ template <typename T, if_not_t< is_flecs_constructible<T>::value > = 0>
 inline void set(world_t *world, entity_t entity, T&& value, ecs_id_t id) {
     ecs_assert(_::cpp_type<T>::size() != 0, ECS_INVALID_PARAMETER, NULL);
 
-    bool is_new = false;
-    T& dst = *static_cast<T*>(ecs_get_mut_id(world, entity, id, &is_new));
-
-    /* If type is not constructible get_mut should assert on new values */
-    ecs_assert(!is_new, ECS_INTERNAL_ERROR, NULL);
+    T& dst = *static_cast<T*>(ecs_get_mut_id(world, entity, id));
 
     dst = FLECS_MOV(value);
 
@@ -47,11 +43,7 @@ template <typename T, if_not_t< is_flecs_constructible<T>::value > = 0>
 inline void set(world_t *world, id_t entity, const T& value, id_t id) {
     ecs_assert(_::cpp_type<T>::size() != 0, ECS_INVALID_PARAMETER, NULL);
 
-    bool is_new = false;
-    T& dst = *static_cast<T*>(ecs_get_mut_id(world, entity, id, &is_new));
-
-    /* If type is not constructible get_mut should assert on new values */
-    ecs_assert(!is_new, ECS_INTERNAL_ERROR, NULL);
+    T& dst = *static_cast<T*>(ecs_get_mut_id(world, entity, id));
     dst = value;
 
     ecs_modified_id(world, entity, id);

--- a/include/flecs/addons/flecs_c.h
+++ b/include/flecs/addons/flecs_c.h
@@ -358,16 +358,16 @@
 
 /* -- Get mut & Modified -- */
 
-#define ecs_get_mut(world, entity, T, is_added)\
-    (ECS_CAST(T*, ecs_get_mut_id(world, entity, ecs_id(T), is_added)))
+#define ecs_get_mut(world, entity, T)\
+    (ECS_CAST(T*, ecs_get_mut_id(world, entity, ecs_id(T))))
 
-#define ecs_get_mut_pair(world, subject, relation, object, is_added)\
+#define ecs_get_mut_pair(world, subject, relation, object)\
     (ECS_CAST(relation*, ecs_get_mut_id(world, subject,\
-        ecs_pair(ecs_id(relation), object), is_added)))
+        ecs_pair(ecs_id(relation), object))))
 
-#define ecs_get_mut_pair_second(world, subject, relation, object, is_added)\
+#define ecs_get_mut_pair_second(world, subject, relation, object)\
     (ECS_CAST(object*, ecs_get_mut_id(world, subject,\
-        ecs_pair(relation, ecs_id(object)), is_added)))
+        ecs_pair(relation, ecs_id(object)))))
 
 #define ecs_get_mut_pair_object ecs_get_mut_pair_second
 
@@ -393,7 +393,7 @@
     ecs_set(world, ecs_id(comp), comp, __VA_ARGS__)
 
 #define ecs_singleton_get_mut(world, comp)\
-    ecs_get_mut(world, ecs_id(comp), comp, NULL)
+    ecs_get_mut(world, ecs_id(comp), comp)
 
 #define ecs_singleton_modified(world, comp)\
     ecs_modified(world, ecs_id(comp), comp)

--- a/src/addons/meta/api.c
+++ b/src/addons/meta/api.c
@@ -211,7 +211,7 @@ ecs_entity_t ecs_unit_init(
         ecs_remove_pair(world, t, EcsQuantity, EcsWildcard);
     }
 
-    EcsUnit *value = ecs_get_mut(world, t, EcsUnit, 0);
+    EcsUnit *value = ecs_get_mut(world, t, EcsUnit);
     value->base = desc->base;
     value->over = desc->over;
     value->translation = desc->translation;

--- a/src/addons/meta/meta.c
+++ b/src/addons/meta/meta.c
@@ -230,9 +230,8 @@ int init_type(
     ecs_assert(world != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(type != 0, ECS_INTERNAL_ERROR, NULL);
 
-    bool is_added = false;
-    EcsMetaType *meta_type = ecs_get_mut(world, type, EcsMetaType, &is_added);
-    if (is_added) {
+    EcsMetaType *meta_type = ecs_get_mut(world, type, EcsMetaType);
+    if (meta_type->kind == 0) {
         meta_type->existing = ecs_has(world, type, EcsComponent);
 
         /* Ensure that component has a default constructor, to prevent crashing
@@ -250,7 +249,7 @@ int init_type(
     }
 
     if (!meta_type->existing) {
-        EcsComponent *comp = ecs_get_mut(world, type, EcsComponent, NULL);
+        EcsComponent *comp = ecs_get_mut(world, type, EcsComponent);
         comp->size = size;
         comp->alignment = alignment;
         ecs_modified(world, type, EcsComponent);
@@ -366,7 +365,7 @@ int add_member_to_struct(
         }
     }
 
-    EcsStruct *s = ecs_get_mut(world, type, EcsStruct, NULL);
+    EcsStruct *s = ecs_get_mut(world, type, EcsStruct);
     ecs_assert(s != NULL, ECS_INTERNAL_ERROR, NULL);
 
     /* First check if member is already added to struct */
@@ -472,7 +471,7 @@ int add_member_to_struct(
 
     /* If current struct is also a member, assign to itself */
     if (ecs_has(world, type, EcsMember)) {
-        EcsMember *type_mbr = ecs_get_mut(world, type, EcsMember, NULL);
+        EcsMember *type_mbr = ecs_get_mut(world, type, EcsMember);
         ecs_assert(type_mbr != NULL, ECS_INTERNAL_ERROR, NULL);
 
         type_mbr->type = type;
@@ -491,7 +490,7 @@ int add_constant_to_enum(
     ecs_entity_t e,
     ecs_id_t constant_id)
 {
-    EcsEnum *ptr = ecs_get_mut(world, type, EcsEnum, NULL);
+    EcsEnum *ptr = ecs_get_mut(world, type, EcsEnum);
     
     /* Remove constant from map if it was already added */
     ecs_map_iter_t it = ecs_map_iter(ptr->constants);
@@ -551,7 +550,7 @@ int add_constant_to_enum(
     c->constant = e;
 
     ecs_i32_t *cptr = ecs_get_mut_pair_object(
-        world, e, EcsConstant, ecs_i32_t, NULL);
+        world, e, EcsConstant, ecs_i32_t);
     ecs_assert(cptr != NULL, ECS_INTERNAL_ERROR, NULL);
     cptr[0] = value;
 
@@ -565,7 +564,7 @@ int add_constant_to_bitmask(
     ecs_entity_t e,
     ecs_id_t constant_id)
 {
-    EcsBitmask *ptr = ecs_get_mut(world, type, EcsBitmask, NULL);
+    EcsBitmask *ptr = ecs_get_mut(world, type, EcsBitmask);
     
     /* Remove constant from map if it was already added */
     ecs_map_iter_t it = ecs_map_iter(ptr->constants);
@@ -618,7 +617,7 @@ int add_constant_to_bitmask(
     c->constant = e;
 
     ecs_u32_t *cptr = ecs_get_mut_pair_object(
-        world, e, EcsConstant, ecs_u32_t, NULL);
+        world, e, EcsConstant, ecs_u32_t);
     ecs_assert(cptr != NULL, ECS_INTERNAL_ERROR, NULL);
     cptr[0] = value;
 

--- a/src/addons/meta/serialized.c
+++ b/src/addons/meta/serialized.c
@@ -286,7 +286,7 @@ void ecs_meta_type_serialized_init(
         ecs_assert(ops != NULL, ECS_INTERNAL_ERROR, NULL);
 
         EcsMetaTypeSerialized *ptr = ecs_get_mut(
-            world, e, EcsMetaTypeSerialized, NULL);
+            world, e, EcsMetaTypeSerialized);
         if (ptr->ops) {
             ecs_meta_dtor_serialized(ptr);
         }

--- a/src/addons/pipeline/pipeline.c
+++ b/src/addons/pipeline/pipeline.c
@@ -472,9 +472,7 @@ bool ecs_pipeline_update(
         ecs_run_aperiodic(world, 0);
     }
 
-    bool added = false;
-    EcsPipeline *pq = ecs_get_mut(world, pipeline, EcsPipeline, &added);
-    ecs_assert(added == false, ECS_INTERNAL_ERROR, NULL);
+    EcsPipeline *pq = ecs_get_mut(world, pipeline, EcsPipeline);
     ecs_assert(pq != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(pq->query != NULL, ECS_INTERNAL_ERROR, NULL);
 

--- a/src/addons/pipeline/worker.c
+++ b/src/addons/pipeline/worker.c
@@ -279,7 +279,7 @@ void ecs_workers_progress(
         ecs_time_measure(&start);
     }
 
-    EcsPipeline *pq = ecs_get_mut(world, pipeline, EcsPipeline, 0);
+    EcsPipeline *pq = ecs_get_mut(world, pipeline, EcsPipeline);
     ecs_assert(pq != NULL, ECS_INTERNAL_ERROR, NULL);
 
     if (stage_count != pq->iter_count) {
@@ -325,7 +325,7 @@ void ecs_workers_progress(
 
             if (ecs_pipeline_update(world, pipeline, false)) {
                 ecs_assert(!ecs_is_deferred(world), ECS_INVALID_OPERATION, NULL);
-                pq = ecs_get_mut(world, pipeline, EcsPipeline, 0);
+                pq = ecs_get_mut(world, pipeline, EcsPipeline);
                 /* Refetch, in case pipeline itself has moved */
                 op = pq->cur_op - 1;
                 op_last = ecs_vector_last(pq->ops, ecs_pipeline_op_t);

--- a/src/addons/plecs.c
+++ b/src/addons/plecs.c
@@ -468,8 +468,7 @@ const char* plecs_parse_assign_expr(
         return NULL;
     }
 
-    void *value_ptr = ecs_get_mut_id(
-        world, assign_to, assign_id, NULL);
+    void *value_ptr = ecs_get_mut_id(world, assign_to, assign_id);
 
     ptr = ecs_parse_expr(world, ptr, type, value_ptr, 
         &(ecs_parse_expr_desc_t) {

--- a/src/addons/timer.c
+++ b/src/addons/timer.c
@@ -179,7 +179,7 @@ void ecs_start_timer(
     ecs_world_t *world,
     ecs_entity_t timer)
 {
-    EcsTimer *ptr = ecs_get_mut(world, timer, EcsTimer, NULL);
+    EcsTimer *ptr = ecs_get_mut(world, timer, EcsTimer);
     ecs_check(ptr != NULL, ECS_INVALID_PARAMETER, NULL);
     ptr->active = true;
     ptr->time = 0;
@@ -191,7 +191,7 @@ void ecs_stop_timer(
     ecs_world_t *world,
     ecs_entity_t timer)
 {
-    EcsTimer *ptr = ecs_get_mut(world, timer, EcsTimer, NULL);
+    EcsTimer *ptr = ecs_get_mut(world, timer, EcsTimer);
     ecs_check(ptr != NULL, ECS_INVALID_PARAMETER, NULL);
     ptr->active = false;
 error:

--- a/src/poly.c
+++ b/src/poly.c
@@ -175,7 +175,7 @@ EcsPoly* _ecs_poly_bind(
 
     /* If this is a new poly, leave the actual creation up to the caller so they
      * call tell the difference between a create or an update */
-    EcsPoly *result = ecs_get_mut_pair(world, entity, EcsPoly, tag, NULL);
+    EcsPoly *result = ecs_get_mut_pair(world, entity, EcsPoly, tag);
 
     if (deferred) {
         ecs_defer_resume(world);

--- a/src/stage.c
+++ b/src/stage.c
@@ -299,8 +299,7 @@ bool flecs_defer_set(
     ecs_id_t id,
     ecs_size_t size,
     const void *value,
-    void **value_out,
-    bool *is_added)
+    void **value_out)
 {
     if (flecs_defer_op(world, stage)) {
         world->info.set_count ++;
@@ -320,9 +319,6 @@ bool flecs_defer_set(
 
         if (!value) {
             value = ecs_get_id(world, entity, id);
-            if (is_added) {
-                *is_added = value == NULL;
-            }
         }
 
         const ecs_type_info_t *ti = NULL;

--- a/src/stage.h
+++ b/src/stage.h
@@ -94,8 +94,7 @@ bool flecs_defer_set(
     ecs_entity_t component,
     ecs_size_t size,
     const void *value,
-    void **value_out,
-    bool *is_added);
+    void **value_out);
 
 bool flecs_defer_end(
     ecs_world_t *world,

--- a/test/addons/src/MultiThread.c
+++ b/test/addons/src/MultiThread.c
@@ -919,11 +919,11 @@ void MultiThread_change_thread_count() {
     ecs_progress(world, 0);
 
     for (i = 0; i < ENTITIES / 2; i ++) {
-        Position *p = ecs_get_mut(world, ids_1[i], Position, NULL);
+        Position *p = ecs_get_mut(world, ids_1[i], Position);
         test_int(p->x, ENTITIES - i);
         p->x = 1;
 
-        p = ecs_get_mut(world, ids_2[i], Position, NULL);
+        p = ecs_get_mut(world, ids_2[i], Position);
         test_int(p->x, ENTITIES - (i + ENTITIES / 2));
         p->x = 1;
     }

--- a/test/addons/src/Snapshot.c
+++ b/test/addons/src/Snapshot.c
@@ -11,7 +11,7 @@ void Snapshot_simple_snapshot() {
 
     ecs_snapshot_t *s = ecs_snapshot_take(world);
 
-    Position *p = ecs_get_mut(world, e, Position, NULL);
+    Position *p = ecs_get_mut(world, e, Position);
     test_int(p->x, 10);
     test_int(p->y, 20);
 
@@ -21,7 +21,7 @@ void Snapshot_simple_snapshot() {
     ecs_snapshot_restore(world, s);
 
     test_assert(ecs_has(world, e, Position));
-    p = ecs_get_mut(world, e, Position, NULL);
+    p = ecs_get_mut(world, e, Position);
     test_int(p->x, 10);
     test_int(p->y, 20);    
 
@@ -181,7 +181,7 @@ void Snapshot_snapshot_w_include_filter() {
     ecs_iter_t it = ecs_filter_iter(world, &f);
     ecs_snapshot_t *s = ecs_snapshot_take_w_iter(&it);
 
-    Position *p = ecs_get_mut(world, e1, Position, NULL);
+    Position *p = ecs_get_mut(world, e1, Position);
     test_assert(p != NULL);
     test_int(p->x, 10);
     test_int(p->y, 20);
@@ -189,7 +189,7 @@ void Snapshot_snapshot_w_include_filter() {
     p->x ++;
     p->y ++;
 
-    p = ecs_get_mut(world, e2, Position, NULL);
+    p = ecs_get_mut(world, e2, Position);
     test_assert(p != NULL);
     test_int(p->x, 15);
     test_int(p->y, 25);
@@ -197,7 +197,7 @@ void Snapshot_snapshot_w_include_filter() {
     p->x ++;
     p->y ++;
 
-    Velocity *v = ecs_get_mut(world, e3, Velocity, NULL);
+    Velocity *v = ecs_get_mut(world, e3, Velocity);
     test_assert(v != NULL);
     test_int(v->x, 25); 
     test_int(v->y, 35);
@@ -208,19 +208,19 @@ void Snapshot_snapshot_w_include_filter() {
     ecs_snapshot_restore(world, s);
 
     /* Restored */
-    p = ecs_get_mut(world, e1, Position, NULL);
+    p = ecs_get_mut(world, e1, Position);
     test_assert(p != NULL);
     test_int(p->x, 10);
     test_int(p->y, 20);
 
     /* Restored */
-    p = ecs_get_mut(world, e2, Position, NULL);
+    p = ecs_get_mut(world, e2, Position);
     test_assert(p != NULL);
     test_int(p->x, 15);
     test_int(p->y, 25);
 
     /* Not restored */
-    v = ecs_get_mut(world, e3, Velocity, NULL);
+    v = ecs_get_mut(world, e3, Velocity);
     test_assert(v != NULL);
     test_int(v->x, 26); 
     test_int(v->y, 36);
@@ -258,7 +258,7 @@ void Snapshot_snapshot_w_exclude_filter() {
     ecs_iter_t it = ecs_filter_iter(world, &f);
     ecs_snapshot_t *s = ecs_snapshot_take_w_iter(&it);
 
-    Position *p = ecs_get_mut(world, e1, Position, NULL);
+    Position *p = ecs_get_mut(world, e1, Position);
     test_assert(p != NULL);
     test_int(p->x, 10);
     test_int(p->y, 20);
@@ -266,7 +266,7 @@ void Snapshot_snapshot_w_exclude_filter() {
     p->x ++;
     p->y ++;
 
-    p = ecs_get_mut(world, e2, Position, NULL);
+    p = ecs_get_mut(world, e2, Position);
     test_assert(p != NULL);
     test_int(p->x, 15);
     test_int(p->y, 25);
@@ -274,7 +274,7 @@ void Snapshot_snapshot_w_exclude_filter() {
     p->x ++;
     p->y ++;
 
-    Velocity *v = ecs_get_mut(world, e3, Velocity, NULL);
+    Velocity *v = ecs_get_mut(world, e3, Velocity);
     test_assert(v != NULL);
     test_int(v->x, 25); 
     test_int(v->y, 35);
@@ -285,19 +285,19 @@ void Snapshot_snapshot_w_exclude_filter() {
     ecs_snapshot_restore(world, s);
 
     /* Not restored */
-    p = ecs_get_mut(world, e1, Position, NULL);
+    p = ecs_get_mut(world, e1, Position);
     test_assert(p != NULL);
     test_int(p->x, 11);
     test_int(p->y, 21);
 
     /* Not restored */
-    p = ecs_get_mut(world, e2, Position, NULL);
+    p = ecs_get_mut(world, e2, Position);
     test_assert(p != NULL);
     test_int(p->x, 16);
     test_int(p->y, 26);
 
     /* Restored */
-    v = ecs_get_mut(world, e3, Velocity, NULL);
+    v = ecs_get_mut(world, e3, Velocity);
     test_assert(v != NULL);
     test_int(v->x, 25); 
     test_int(v->y, 35);
@@ -562,7 +562,7 @@ void Snapshot_snapshot_copy() {
     ecs_snapshot_t *s_copy = ecs_snapshot_take_w_iter(&it);
     ecs_snapshot_free(s);
 
-    Position *p = ecs_get_mut(world, e, Position, NULL);
+    Position *p = ecs_get_mut(world, e, Position);
     test_int(p->x, 10);
     test_int(p->y, 20);
 
@@ -572,7 +572,7 @@ void Snapshot_snapshot_copy() {
     ecs_snapshot_restore(world, s_copy);
 
     test_assert(ecs_has(world, e, Position));
-    p = ecs_get_mut(world, e, Position, NULL);
+    p = ecs_get_mut(world, e, Position);
     test_int(p->x, 10);
     test_int(p->y, 20);    
 
@@ -596,7 +596,7 @@ void Snapshot_snapshot_get_ref_after_restore() {
 
     ecs_snapshot_t *s = ecs_snapshot_take(world);
 
-    Position *p_mut = ecs_get_mut(world, e, Position, NULL);
+    Position *p_mut = ecs_get_mut(world, e, Position);
     test_int(p_mut->x, 10);
     test_int(p_mut->y, 20);
 

--- a/test/api/src/DeferredActions.c
+++ b/test/api/src/DeferredActions.c
@@ -427,7 +427,7 @@ void DeferredActions_defer_get_mut_no_modify() {
 
     ecs_defer_begin(world);
 
-    Velocity *v = ecs_get_mut(world, e, Velocity, NULL);
+    Velocity *v = ecs_get_mut(world, e, Velocity);
     v->x = 1;
     v->y = 2;
 
@@ -457,7 +457,7 @@ void DeferredActions_defer_get_mut_w_modify() {
 
     ecs_defer_begin(world);
 
-    Velocity *v = ecs_get_mut(world, e, Velocity, NULL);
+    Velocity *v = ecs_get_mut(world, e, Velocity);
     v->x = 1;
     v->y = 2;
     test_assert(!on_set_invoked);
@@ -630,7 +630,7 @@ void DeferredActions_defer_get_mut_after_delete() {
     ecs_defer_begin(world);
 
     ecs_delete(world, e);
-    Velocity *v = ecs_get_mut(world, e, Velocity, NULL);
+    Velocity *v = ecs_get_mut(world, e, Velocity);
     v->x = 1;
     v->y = 2;
 
@@ -669,7 +669,7 @@ void DeferredActions_defer_get_mut_after_delete_2nd_to_last() {
     ecs_defer_begin(world);
 
     ecs_delete(world, e);
-    Velocity *v = ecs_get_mut(world, e, Velocity, NULL);
+    Velocity *v = ecs_get_mut(world, e, Velocity);
     v->x = 1;
     v->y = 2;
 
@@ -1481,7 +1481,7 @@ void DeferredActions_defer_get_mut_pair() {
 
     ecs_defer_begin(world);
 
-    Position *p = ecs_get_mut_pair(world, e, Position, Pair, NULL);
+    Position *p = ecs_get_mut_pair(world, e, Position, Pair);
     test_assert(p != NULL);
     p->x = 10;
     p->y = 20;
@@ -1895,7 +1895,7 @@ static void update_counter(ecs_iter_t *it) {
         ecs_entity_t parent = ecs_get_object(world, e, EcsChildOf, 0);
         test_assert(parent != 0);
 
-        Counter *ptr = ecs_get_mut(world, parent, Counter, 0);
+        Counter *ptr = ecs_get_mut(world, parent, Counter);
         test_assert(ptr != NULL);
 
         if (it->event == EcsOnAdd) {

--- a/test/api/src/Observer.c
+++ b/test/api/src/Observer.c
@@ -728,7 +728,7 @@ void Observer_wildcard_pair_w_pred_component() {
 
     /* Change existing component without triggering OnSet as the callback
      * expects value {10, 20}, then add a new component with {10, 20} */
-    Position *p = ecs_get_mut_pair(world, e, Position, ObjA, 0);
+    Position *p = ecs_get_mut_pair(world, e, Position, ObjA);
     test_assert(p != NULL);
     test_int(p->x, 10);
     test_int(p->y, 20);
@@ -783,7 +783,7 @@ void Observer_wildcard_pair_w_obj_component() {
 
     /* Change existing component without triggering OnSet as the callback
      * expects value {10, 20}, then add a new component with {10, 20} */
-    Position *p = ecs_get_mut_pair_second(world, e, RelA, Position, 0);
+    Position *p = ecs_get_mut_pair_second(world, e, RelA, Position);
     test_assert(p != NULL);
     test_int(p->x, 10);
     test_int(p->y, 20);

--- a/test/api/src/Set.c
+++ b/test/api/src/Set.c
@@ -329,10 +329,8 @@ void Set_get_mut_new() {
     ecs_entity_t e = ecs_new(world, 0);
     test_assert(e != 0);
 
-    bool is_added = false;
-    Position *p = ecs_get_mut(world, e, Position, &is_added);
+    Position *p = ecs_get_mut(world, e, Position);
     test_assert(p != NULL);
-    test_bool(is_added, true);
     test_assert( ecs_has(world, e, Position));
     test_assert(p == ecs_get(world, e, Position));
     
@@ -349,10 +347,8 @@ void Set_get_mut_existing() {
     test_assert( ecs_has(world, e, Position));
     const Position *p_prev = ecs_get(world, e, Position);
 
-    bool is_added = false;
-    Position *p = ecs_get_mut(world, e, Position, &is_added);
+    Position *p = ecs_get_mut(world, e, Position);
     test_assert(p != NULL);
-    test_bool(is_added, false);
     test_assert( ecs_has(world, e, Position));
     test_assert(p == p_prev);
     
@@ -371,8 +367,7 @@ void Set_get_mut_tag_new() {
 
     test_expect_abort();
 
-    bool is_added = false;
-    ecs_get_mut_id(world, e, MyTag, &is_added);
+    ecs_get_mut_id(world, e, MyTag);
 }
 
 void Set_get_mut_tag_existing() {
@@ -388,8 +383,7 @@ void Set_get_mut_tag_existing() {
 
     test_expect_abort();
 
-    bool is_added = false;
-    ecs_get_mut_id(world, e, MyTag, &is_added);
+    ecs_get_mut_id(world, e, MyTag);
 }
 
 void Set_get_mut_tag_new_w_comp() {
@@ -405,8 +399,7 @@ void Set_get_mut_tag_new_w_comp() {
 
     test_expect_abort();
 
-    bool is_added = false;
-    ecs_get_mut_id(world, e, MyTag, &is_added);
+    ecs_get_mut_id(world, e, MyTag);
 }
 
 void Set_get_mut_tag_existing_w_comp() {
@@ -424,8 +417,7 @@ void Set_get_mut_tag_existing_w_comp() {
 
     test_expect_abort();
 
-    bool is_added = false;
-    ecs_get_mut_id(world, e, MyTag, &is_added);
+    ecs_get_mut_id(world, e, MyTag);
 }
 
 void Set_get_mut_tag_new_w_pair() {
@@ -442,8 +434,7 @@ void Set_get_mut_tag_new_w_pair() {
 
     test_expect_abort();
 
-    bool is_added = false;
-    ecs_get_mut_id(world, e, MyTag, &is_added);
+    ecs_get_mut_id(world, e, MyTag);
 }
 
 void Set_get_mut_tag_existing_w_pair() {
@@ -462,8 +453,7 @@ void Set_get_mut_tag_existing_w_pair() {
 
     test_expect_abort();
 
-    bool is_added = false;
-    ecs_get_mut_id(world, e, MyTag, &is_added);
+    ecs_get_mut_id(world, e, MyTag);
 }
 
 static bool is_invoked = false;
@@ -481,10 +471,8 @@ void Set_modified_w_on_set() {
     ecs_entity_t e = ecs_new(world, 0);
     test_assert(e != 0);
 
-    bool is_added = false;
-    Position *p = ecs_get_mut(world, e, Position, &is_added);
+    Position *p = ecs_get_mut(world, e, Position);
     test_assert(p != NULL);
-    test_bool(is_added, true);
     test_assert( ecs_has(world, e, Position));
     test_assert(p == ecs_get(world, e, Position));
 
@@ -543,10 +531,8 @@ void Set_get_mut_w_add_in_on_add() {
 
     ecs_entity_t e = ecs_new_id(world);
 
-    bool added = false;
-    Position *p = ecs_get_mut(world, e, Position, &added);
+    Position *p = ecs_get_mut(world, e, Position);
     test_assert(p != NULL);
-    test_bool(added, true);
     p->x = 10;
     p->y = 20;
 
@@ -571,8 +557,7 @@ void Set_get_mut_w_remove_in_on_add() {
 
     /* get_mut is guaranteed to always return a valid pointer, so removing the
      * component from the OnAdd trigger is not allowed */
-    bool added = false;
-    ecs_get_mut(world, e, Position, &added);
+    ecs_get_mut(world, e, Position);
 }
 
 static
@@ -604,7 +589,7 @@ void Set_get_mut_w_realloc_in_on_add() {
     });
 
     ecs_entity_t e = ecs_new(world, Velocity);
-    const Position *ptr = ecs_get_mut(world, e, Position, 0);
+    const Position *ptr = ecs_get_mut(world, e, Position);
     test_assert(ptr == ecs_get(world, e, Position));
 
     for (int i = 0; i < 1000; i ++) {

--- a/test/api/src/SingleThreadStaging.c
+++ b/test/api/src/SingleThreadStaging.c
@@ -2437,9 +2437,8 @@ void MutableTest(ecs_iter_t *it) {
 
     int32_t i;
     for (i = 0; i < it->count; i ++) {
-        bool is_added;
-        Velocity *v_mut = ecs_get_mut(
-            world, it->entities[i], Velocity, &is_added);
+        bool is_added = !ecs_has(world, it->entities[i], Velocity);
+        Velocity *v_mut = ecs_get_mut(world, it->entities[i], Velocity);
 
         test_assert(v_mut != NULL);
         test_assert(v_mut != v);
@@ -2541,9 +2540,8 @@ void MutableTest_w_Add(ecs_iter_t *it) {
     for (i = 0; i < it->count; i ++) {
         ecs_add(world, it->entities[i], MyTag);
 
-        bool is_added;
-        Velocity *v_mut = ecs_get_mut(
-            world, it->entities[i], Velocity, &is_added);
+        bool is_added = !ecs_has(world, it->entities[i], Velocity);
+        Velocity *v_mut = ecs_get_mut(world, it->entities[i], Velocity);
 
         // Even though component is added to stage, is_added should only be true
         // if the component is added for the first time, which requires the app

--- a/test/api/src/Trigger.c
+++ b/test/api/src/Trigger.c
@@ -916,7 +916,7 @@ void Trigger_wildcard_pair_w_pred_component() {
 
     /* Change existing component without triggering OnSet as the callback
      * expects value {10, 20}, then add a new component with {10, 20} */
-    Position *p = ecs_get_mut_pair(world, e, Position, ObjA, 0);
+    Position *p = ecs_get_mut_pair(world, e, Position, ObjA);
     test_assert(p != NULL);
     test_int(p->x, 10);
     test_int(p->y, 20);
@@ -971,7 +971,7 @@ void Trigger_wildcard_pair_w_obj_component() {
 
     /* Change existing component without triggering OnSet as the callback
      * expects value {10, 20}, then add a new component with {10, 20} */
-    Position *p = ecs_get_mut_pair_second(world, e, RelA, Position, 0);
+    Position *p = ecs_get_mut_pair_second(world, e, RelA, Position);
     test_assert(p != NULL);
     test_int(p->x, 10);
     test_int(p->y, 20);

--- a/test/cpp_api/src/Pairs.cpp
+++ b/test/cpp_api/src/Pairs.cpp
@@ -255,10 +255,8 @@ void Pairs_get_mut_pair() {
 
     auto e = ecs.entity();
 
-    bool added = false;
-    Pair *t = e.get_mut<Pair, Position>(&added);
+    Pair *t = e.get_mut<Pair, Position>();
     test_assert(t != NULL);
-    test_bool(added, true);
     t->value = 10;
 
     const Pair *t_2 = e.get<Pair, Position>();
@@ -272,10 +270,8 @@ void Pairs_get_mut_pair_existing() {
     auto e = ecs.entity()
         .set<Pair, Position>({20});
 
-    bool added = false;
-    Pair *t = e.get_mut<Pair, Position>(&added);
+    Pair *t = e.get_mut<Pair, Position>();
     test_assert(t != NULL);
-    test_bool(added, false);
     test_int(t->value, 20);
     t->value = 10;
 
@@ -291,10 +287,8 @@ void Pairs_get_mut_pair_tag() {
 
     auto e = ecs.entity();
 
-    bool added = false;
-    Position *p = e.get_mut_w_object<Position>(Pair, &added);
+    Position *p = e.get_mut_w_object<Position>(Pair);
     test_assert(p != NULL);
-    test_bool(added, true);
     p->x = 10;
     p->y = 20;
 
@@ -312,10 +306,8 @@ void Pairs_get_mut_pair_tag_existing() {
     auto e = ecs.entity()
         .set_w_object<Position>(Pair, {10, 20});
 
-    bool added = false;
-    Position *p = e.get_mut_w_object<Position>(Pair, &added);
+    Position *p = e.get_mut_w_object<Position>(Pair);
     test_assert(p != NULL);
-    test_bool(added, false);
     test_int(p->x, 10);
     test_int(p->y, 20);
 

--- a/test/meta/src/Units.c
+++ b/test/meta/src/Units.c
@@ -107,7 +107,7 @@ void Units_cursor_get_unit() {
     });
 
     ecs_entity_t e = ecs_new_id(world);
-    void *ptr = ecs_get_mut_id(world, e, s, 0);
+    void *ptr = ecs_get_mut_id(world, e, s);
     test_assert(ptr != NULL);
 
     ecs_meta_cursor_t cur = ecs_meta_cursor(world, s, ptr);
@@ -140,7 +140,7 @@ void Units_cursor_get_unit_type() {
     });
 
     ecs_entity_t e = ecs_new_id(world);
-    void *ptr = ecs_get_mut_id(world, e, s, 0);
+    void *ptr = ecs_get_mut_id(world, e, s);
     test_assert(ptr != NULL);
 
     ecs_meta_cursor_t cur = ecs_meta_cursor(world, s, ptr);


### PR DESCRIPTION
This PR removes the `is_added` argument from all `get_mut` operations.