### PR TITLE
Implement stack allocator for deferred ops

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -46,6 +46,7 @@ flecs_src = files(
     'src/datastructures/hash.c',
     'src/datastructures/hashmap.c',
     'src/datastructures/map.c',
+    'src/datastructures/stack_allocator.c',
     'src/datastructures/name_index.c',
     'src/datastructures/qsort.c',
     'src/datastructures/sparse.c',

--- a/src/datastructures/stack_allocator.c
+++ b/src/datastructures/stack_allocator.c
@@ -1,0 +1,82 @@
+#include "../private_api.h"
+
+#define FLECS_STACK_PAGE_OFFSET ECS_ALIGN(ECS_SIZEOF(ecs_stack_page_t), 16)
+
+static
+ecs_stack_page_t* flecs_stack_page_new(void) {
+    ecs_stack_page_t *result = ecs_os_malloc(
+        FLECS_STACK_PAGE_OFFSET + ECS_STACK_PAGE_SIZE);
+    result->data = ECS_OFFSET(result, FLECS_STACK_PAGE_OFFSET);
+    result->next = NULL;
+    return result;
+}
+
+void* flecs_stack_alloc(
+    ecs_stack_t *stack, 
+    ecs_size_t size,
+    ecs_size_t align)
+{
+    ecs_stack_page_t *page = stack->cur;
+    if (page == &stack->first && !page->data) {
+        page->data = ecs_os_malloc(ECS_STACK_PAGE_SIZE);
+    }
+
+    ecs_size_t sp = ECS_ALIGN(page->sp, align);
+    ecs_size_t next_sp = sp + size;
+
+    if (next_sp > ECS_STACK_PAGE_SIZE) {
+        if (size > ECS_STACK_PAGE_SIZE) {
+            return ecs_os_malloc(size); /* Too large for page */
+        }
+
+        if (page->next) {
+            page = page->next;
+        } else {
+            page = page->next = flecs_stack_page_new();
+        }
+        sp = 0;
+        next_sp = size;
+        stack->cur = page;
+    }
+
+    page->sp = next_sp;
+
+    return ECS_OFFSET(page->data, sp);
+}
+
+void flecs_stack_free(
+    void *ptr,
+    ecs_size_t size)
+{
+    if (size > ECS_STACK_PAGE_SIZE) {
+        ecs_os_free(ptr);
+    }
+}
+
+void flecs_stack_reset(
+    ecs_stack_t *stack)
+{
+    stack->cur = &stack->first;
+}
+
+void flecs_stack_init(
+    ecs_stack_t *stack)
+{
+    ecs_os_zeromem(stack);
+    stack->cur = &stack->first;
+    stack->first.data = NULL;
+}
+
+void flecs_stack_fini(
+    ecs_stack_t *stack)
+{
+    ecs_stack_page_t *next, *cur = &stack->first;
+    do {
+        next = cur->next;
+        if (cur == &stack->first) {
+            ecs_os_free(cur->data);
+        } else {
+            ecs_os_free(cur);
+        }
+    } while ((cur = next));
+}

--- a/src/datastructures/stack_allocator.h
+++ b/src/datastructures/stack_allocator.h
@@ -1,0 +1,27 @@
+/**
+ * @file stack_allocator.h
+ * @brief Data structure used for temporary small allocations.
+ */
+
+#ifndef FLECS_STACK_ALLOCATOR_H
+#define FLECS_STACK_ALLOCATOR_H
+
+void flecs_stack_init(
+    ecs_stack_t *stack);
+
+void flecs_stack_fini(
+    ecs_stack_t *stack);
+
+void* flecs_stack_alloc(
+    ecs_stack_t *stack, 
+    ecs_size_t size,
+    ecs_size_t align);
+
+void flecs_stack_free(
+    void *ptr,
+    ecs_size_t size);
+
+void flecs_stack_reset(
+    ecs_stack_t *stack);
+
+#endif

--- a/src/observer.c
+++ b/src/observer.c
@@ -193,7 +193,6 @@ ecs_entity_t ecs_observer_init(
         ecs_observer_t *observer = ecs_poly_new(ecs_observer_t);
         ecs_assert(observer != NULL, ECS_INTERNAL_ERROR, NULL);
         
-        poly->poly = observer;
         observer->world = world;
         observer->dtor = (ecs_poly_dtor_t)flecs_observer_fini;
         observer->entity = entity;
@@ -210,6 +209,8 @@ ecs_entity_t ecs_observer_init(
             flecs_observer_fini(observer);
             return 0;
         }
+
+        poly->poly = observer;
 
         /* Creating an observer with no terms has no effect */
         ecs_assert(observer->filter.term_count != 0, 

--- a/src/private_api.h
+++ b/src/private_api.h
@@ -18,6 +18,7 @@
 #include "world.h"
 #include "datastructures/qsort.h"
 #include "datastructures/name_index.h"
+#include "datastructures/stack_allocator.h"
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/test/api/project.json
+++ b/test/api/project.json
@@ -1983,7 +1983,8 @@
                 "create_observer_while_deferred",
                 "create_query_while_deferred",
                 "update_trigger_while_deferred",
-                "update_observer_while_deferred"
+                "update_observer_while_deferred",
+                "defer_set_large_component"
             ]
         }, {
             "id": "SingleThreadStaging",

--- a/test/api/src/DeferredActions.c
+++ b/test/api/src/DeferredActions.c
@@ -2180,3 +2180,32 @@ void DeferredActions_update_observer_while_deferred() {
 
     ecs_fini(world);
 }
+
+typedef struct {
+    int16_t arr[8096];
+} LargeComponent;
+
+void DeferredActions_defer_set_large_component() {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_COMPONENT(world, LargeComponent);
+
+    ecs_entity_t e = ecs_new_id(world);
+
+    ecs_defer_begin(world);
+    LargeComponent *ptr = ecs_get_mut(world, e, LargeComponent);
+    test_assert(ptr != NULL);
+    for (int i = 0; i < 8096; i ++) {
+        ptr->arr[i] = i;
+    }
+    test_assert(!ecs_has(world, e, LargeComponent));
+    ecs_defer_end(world);
+
+    ptr = ecs_get_mut(world, e, LargeComponent);
+    test_assert(ptr != NULL);
+    for (int i = 0; i < 8096; i ++) {
+        test_int(ptr->arr[i], i);
+    }
+
+    ecs_fini(world);
+}

--- a/test/api/src/Set.c
+++ b/test/api/src/Set.c
@@ -596,6 +596,7 @@ void Set_get_mut_w_realloc_in_on_add() {
         test_assert( ecs_has(world, entities[i], Velocity));
         const Velocity *vptr = ecs_get(world, entities[i], Velocity);
         test_assert(vptr != NULL);
+        // printf("e = {%f, %f}\n", vptr->x, vptr->y);
         test_int(vptr->x, i);
         test_int(vptr->y, i * 2);
         test_assert(ecs_get_table(world, e) == 

--- a/test/api/src/main.c
+++ b/test/api/src/main.c
@@ -1895,6 +1895,7 @@ void DeferredActions_create_observer_while_deferred(void);
 void DeferredActions_create_query_while_deferred(void);
 void DeferredActions_update_trigger_while_deferred(void);
 void DeferredActions_update_observer_while_deferred(void);
+void DeferredActions_defer_set_large_component(void);
 
 // Testsuite 'SingleThreadStaging'
 void SingleThreadStaging_setup(void);
@@ -9318,6 +9319,10 @@ bake_test_case DeferredActions_testcases[] = {
     {
         "update_observer_while_deferred",
         DeferredActions_update_observer_while_deferred
+    },
+    {
+        "defer_set_large_component",
+        DeferredActions_defer_set_large_component
     }
 };
 
@@ -10107,7 +10112,7 @@ static bake_test_suite suites[] = {
         "DeferredActions",
         NULL,
         NULL,
-        71,
+        72,
         DeferredActions_testcases
     },
     {


### PR DESCRIPTION
Improve performance of deferred `set` and `get_mut` operations by using a stack allocator for temporary component values.