### PR TITLE
Improve documentation and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@
 [![Try online](https://img.shields.io/badge/try-online-brightgreen)](https://godbolt.org/z/bs11T3)
 [![Documentation](https://img.shields.io/badge/docs-docsforge-blue)](http://flecs.docsforge.com/)
 
-Flecs is a fast and lightweight Entity Component System that lets you build games and simulations with millions of entities ([join the Discord!](https://discord.gg/BEzP5Rgrrp)). Here are some of the framework's highlights:
+Flecs is a fast and lightweight Entity Component System pattern implementation in C that lets you build games and simulations with millions of entities ([join the Discord!](https://discord.gg/BEzP5Rgrrp)). At it's core it uses a [refined approach to building an ECS](https://ajmmertens.medium.com/why-vanilla-ecs-is-not-enough-d7ed4e3bebe5) and as a consequence it is way more flexible than other implementations. Here are some of the framework's highlights:
 
-- Fast zero dependency [C99 API](https://flecs.docsforge.com/master/api-c/)
+- First open source ECS with full support for [Entity Relationships](https://ajmmertens.medium.com/building-games-in-ecs-with-entity-relationships-657275ba2c6c)!
+- Fast native support for [hierarchies](https://flecs.docsforge.com/master/relations-manual/#the-childof-relation) and [prefabs](https://flecs.docsforge.com/master/relations-manual/#the-isa-relation)
+- Fast and [portable](#language-bindings) zero dependency [C99 API](https://flecs.docsforge.com/master/api-c/)
 - Modern type-safe [C++11 API](https://flecs.docsforge.com/master/api-cpp/) that doesn't use STL containers
 - Minimal ECS core with optional [addons](#addons)
 - Entire codebase builds in less than 5 seconds
@@ -16,11 +18,9 @@ Flecs is a fast and lightweight Entity Component System that lets you build game
 - Cache friendly [archetype/SoA storage](https://ajmmertens.medium.com/building-an-ecs-2-archetypes-and-vectorization-fe21690805f9) that can process millions of entities every frame
 - Supports entities with hundreds of components and applications with tens of thousands of archetypes
 - Automatic component registration that works out of the box across shared libraries/DLLs
-- First open source ECS with full support for [Entity Relationships](https://ajmmertens.medium.com/building-games-in-ecs-with-entity-relationships-657275ba2c6c)!
 - Write free functions with [queries](https://github.com/SanderMertens/flecs/tree/master/examples/cpp/queries/basics) or run code automatically in [systems](https://github.com/SanderMertens/flecs/tree/master/examples/cpp/systems/pipeline)
 - Run games on multiple CPU cores with a fast lockless scheduler
 - Compiles warning-free on 8 compilers on all major platforms, with [CI](https://github.com/SanderMertens/flecs/actions) running more than 4000 tests
-- Fast native support for [hierarchies](https://flecs.docsforge.com/master/relations-manual/#the-childof-relation) and [prefabs](https://flecs.docsforge.com/master/relations-manual/#the-isa-relation)
 - Integrated [reflection framework](https://flecs.docsforge.com/master/api-meta/) with [JSON serializer](https://github.com/SanderMertens/flecs/tree/master/examples/cpp/reflection/basics_json) and support for [runtime components](https://github.com/SanderMertens/flecs/tree/master/examples/cpp/reflection/runtime_component)
 - [Unit annotations](https://github.com/SanderMertens/flecs/tree/master/examples/cpp/reflection/units) for components
 - Powerful [query language](https://github.com/SanderMertens/flecs/tree/master/examples/cpp/rules) with support for [joins](https://github.com/SanderMertens/flecs/tree/master/examples/cpp/rules/setting_variables) and [inheritance](https://github.com/SanderMertens/flecs/tree/master/examples/cpp/rules/component_inheritance)

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 [![Try online](https://img.shields.io/badge/try-online-brightgreen)](https://godbolt.org/z/bs11T3)
 [![Documentation](https://img.shields.io/badge/docs-docsforge-blue)](http://flecs.docsforge.com/)
 
-Flecs is a fast and lightweight Entity Component System pattern implementation in C that lets you build games and simulations with millions of entities ([join the Discord!](https://discord.gg/BEzP5Rgrrp)). At it's core it uses a [refined approach to building an ECS](https://ajmmertens.medium.com/why-vanilla-ecs-is-not-enough-d7ed4e3bebe5) and as a consequence it is way more flexible than other implementations. Here are some of the framework's highlights:
+Flecs is a fast and lightweight Entity Component System that lets you build games and simulations with millions of entities ([join the Discord!](https://discord.gg/BEzP5Rgrrp)). Here are some of the framework's highlights:
 
-- First open source ECS with full support for [Entity Relationships](https://ajmmertens.medium.com/building-games-in-ecs-with-entity-relationships-657275ba2c6c)!
-- Fast native support for [hierarchies](https://flecs.docsforge.com/master/relations-manual/#the-childof-relation) and [prefabs](https://flecs.docsforge.com/master/relations-manual/#the-isa-relation)
 - Fast and [portable](#language-bindings) zero dependency [C99 API](https://flecs.docsforge.com/master/api-c/)
 - Modern type-safe [C++11 API](https://flecs.docsforge.com/master/api-cpp/) that doesn't use STL containers
+- First open source ECS with full support for [Entity Relationships](https://ajmmertens.medium.com/building-games-in-ecs-with-entity-relationships-657275ba2c6c)!
+- Fast native support for [hierarchies](https://flecs.docsforge.com/master/relations-manual/#the-childof-relation) and [prefabs](https://flecs.docsforge.com/master/relations-manual/#the-isa-relation)
 - Minimal ECS core with optional [addons](#addons)
 - Entire codebase builds in less than 5 seconds
 - Runs [in the browser](https://flecs.dev/city) without modifications with emscripten
@@ -55,12 +55,12 @@ For more info on ECS, check the [ECS FAQ](https://github.com/SanderMertens/ecs-f
 - [Query Manual](docs/Queries.md) ([docsforge](https://flecs.docsforge.com/master/query-manual/))
 - [Relations Manual](docs/Relations.md) ([docsforge](https://flecs.docsforge.com/master/relations-manual/))
 
-## How to use and build
-The easiest way to add Flecs to a project is to add [flecs.c](https://raw.githubusercontent.com/SanderMertens/flecs/master/flecs.c) and [flecs.h](https://raw.githubusercontent.com/SanderMertens/flecs/master/flecs.h) to your source code. These files can be added to both C and C++ projects (the C++ API is embedded in `flecs.h`).
+## Usage
+The easiest way to add Flecs to a project is to add [flecs.c](https://raw.githubusercontent.com/SanderMertens/flecs/master/flecs.c) and [flecs.h](https://raw.githubusercontent.com/SanderMertens/flecs/master/flecs.h) to your source code. These files can be added to both C and C++ projects (the C++ API is embedded in `flecs.h`). In C++ projects, make sure to compile the `flecs.c` file as C code.
 
-Alternatively you can also build Flecs as a standalone library by using the [bake](https://github.com/SanderMertens/bake) (cmake, meson, bazel are also supported).
+Flecs can also be built as a standalone library by using the cmake, meson, bazel or [bake](https://github.com/SanderMertens/bake).
 
-If you want to customize your builds, refer to the [Addons](#addons) section.
+See the [Addons](#addons) section for learning more about customizing a build.
 
 ## Show me the code!
 C99 example:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Flecs is a fast and lightweight Entity Component System that lets you build game
 - Fast zero dependency [C99 API](https://flecs.docsforge.com/master/api-c/)
 - Modern type-safe [C++11 API](https://flecs.docsforge.com/master/api-cpp/) that doesn't use STL containers
 - Minimal ECS core with optional [addons](#addons)
-- Entire codebase builds in less than 5 seconds.
+- Entire codebase builds in less than 5 seconds
 - Runs [in the browser](https://flecs.dev/city) without modifications with emscripten
 - Cache friendly [archetype/SoA storage](https://ajmmertens.medium.com/building-an-ecs-2-archetypes-and-vectorization-fe21690805f9) that can process millions of entities every frame
 - Supports entities with hundreds of components and applications with tens of thousands of archetypes
@@ -27,20 +27,19 @@ Flecs is a fast and lightweight Entity Component System that lets you build game
 - [Statistics addon](https://flecs.docsforge.com/master/api-stats/) for profiling ECS performance
 - A web-based dashboard ([demo](https://flecs.dev/explorer), [code](https://github.com/flecs-hub/explorer)) for inspecting entities, running ECS queries and monitoring games:
 
-[<img width="1753" alt="Screen Shot 2022-06-04 at 1 36 44 AM" src="https://user-images.githubusercontent.com/9919222/171991682-5053ce51-fbb3-40ad-823f-b1957cedde18.png">](https://flecs.dev/explorer)
+[![Dashboard image](https://user-images.githubusercontent.com/9919222/171991682-5053ce51-fbb3-40ad-823f-b1957cedde18.png)](https://flecs.dev/explorer)
 
 **Flecs v3 is the latest, most stable and feature rich version of Flecs, and recommended for new projects.**
 
-Last v3 release: [Flecs v3.0.2-beta](https://github.com/SanderMertens/flecs/releases/tag/v3.0.2-beta).
-
-Last v2 release: [Flecs v2.4.8](https://github.com/SanderMertens/flecs/releases/tag/v2.4.8).
+- Latest v3 release: [Flecs v3.0.2-beta](https://github.com/SanderMertens/flecs/releases/tag/v3.0.2-beta).
+- Latest v2 release: [Flecs v2.4.8](https://github.com/SanderMertens/flecs/releases/tag/v2.4.8).
 
 ## What is an Entity Component System?
 ECS is a new way of organizing code and data that lets you build games that are larger, more complex and are easier to extend.
 
 Something is called an ECS when it:
-- Has _entities_, that uniquely identify objects in a game
-- Has _components_, which are datatypes that can be added to entities
+- Has _entities_ that uniquely identify objects in a game
+- Has _components_ which are datatypes that can be added to entities
 - Has _systems_ which are functions that run for all entities matching a component _query_
 
 For example, a game has a `Move` _system_ that has a _query_ with two _components_, `Position, Velocity`. When the system is ran it is dynamically matched with all _entities_ that have at least these two components.
@@ -73,8 +72,8 @@ typedef struct {
 void Move(ecs_iter_t *it) {
   Position *p = ecs_term(it, Position, 1);
   Velocity *v = ecs_term(it, Velocity, 2);
-  
-  for (int i = 0; i < it->count; i ++) {
+
+  for (int i = 0; i < it->count; i++) {
     p[i].x += v[i].x;
     p[i].y += v[i].y;
   }
@@ -120,10 +119,11 @@ int main(int argc, char *argv[]) {
       p = {10, 20};
       v = {1, 2};
     });
-    
+
   while (ecs.progress()) { }
 }
 ```
+
 ## Community content
 Examples and tutorials contributed by the community :heart:
 - [Bgfx/Imgui module](https://github.com/flecs-hub/flecs-systems-bgfx/tree/bgfx_imgui)
@@ -222,7 +222,7 @@ Module      | Description
 The following language bindings have been developed with Flecs! Note that these are projects built and maintained by helpful community members, and may not always be up to date with the latest commit from master!
 - [Lua](https://github.com/flecs-hub/flecs-lua)
 - [Zig](https://github.com/prime31/zig-flecs)
-- [C#](https://github.com/bottlenoselabs/flecs-cs)
+- [C#](https://github.com/flecs-hub/flecs-cs)
 
 ## Links
 - [Discord](https://discord.gg/BEzP5Rgrrp)

--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ For more info on ECS, check the [ECS FAQ](https://github.com/SanderMertens/ecs-f
 - [Query Manual](docs/Queries.md) ([docsforge](https://flecs.docsforge.com/master/query-manual/))
 - [Relations Manual](docs/Relations.md) ([docsforge](https://flecs.docsforge.com/master/relations-manual/))
 
+## How to use and build
+The easiest way to add Flecs to a project is to add [flecs.c](https://raw.githubusercontent.com/SanderMertens/flecs/master/flecs.c) and [flecs.h](https://raw.githubusercontent.com/SanderMertens/flecs/master/flecs.h) to your source code. These files can be added to both C and C++ projects (the C++ API is embedded in `flecs.h`).
+
+Alternatively you can also build Flecs as a standalone library by using the [bake](https://github.com/SanderMertens/bake) (cmake, meson, bazel are also supported).
+
+If you want to customize your builds, refer to the [Addons](#addons) section.
+
 ## Show me the code!
 C99 example:
 ```c

--- a/docs/DesignWithFlecs.md
+++ b/docs/DesignWithFlecs.md
@@ -6,7 +6,7 @@ Note that these are my own guidelines, and as a result this is an opinionated do
 One other note: this document is very light on feature documentation. The point of the document is to provide suggestions for how to design with Flecs features, not document their ins and outs. All of the features listed in this document are described in the manual and have example code.
 
 ## Entities
-Entities are probably the easiest thing to get used to. They typically map to in-game objects the same way you would create them in other game engines. 
+Entities are probably the easiest thing to get used to. They typically map to in-game objects the same way you would create them in other game engines.
 
 ### Entity Initialization
 When creating entities, you typically want to initialize them with a set of default components, and maybe even default values. Flecs introduced prefabs for this use case. Prefabs let you create entity templates that contain components with default values. Creating entities from prefabs is not just an easy way to initialize entities, it is also faster, and helps with classifying the different kinds of entities you have.
@@ -27,7 +27,7 @@ The reasoning behind this is simple: it is very cheap (at least in Flecs) to que
 
 The second reason is that it improves caching performance. If your system only needs Position, but also has to load all of the other data in Transform, you end up loading a lot of data in your cache that remains unused. This may or may not be a problem, but all else being equal it definitely won't hurt.
 
-The third reason is that you can only split up your components so far. The number of ways in which you can combine compponents is infinitely larger than the number of ways in which you can split them up, and this translates, in a very practical way, into less refactoring. When you have reduced your components to atomic units of data, there simply isn't anything left to refactor.
+The third reason is that you can only split up your components so far. The number of ways in which you can combine components is infinitely larger than the number of ways in which you can split them up, and this translates, in a very practical way, into less refactoring. When you have reduced your components to atomic units of data, there simply isn't anything left to refactor.
 
 The fourth and last reason why you want to keep your components small is code reusability. If your components are atomic units of data, they are automatically less opinionated than a component that combines more stuff. As a result, it is more likely that you find the component to work well across projects. This trickles down into the rest of your ECS code: systems written for atomic components will also be more reusable across projects.
 
@@ -54,7 +54,7 @@ Note that if you use C++, and you use templates to create your queries, putting 
 ### Annotations
 You can further annotate queries with components that are not matched with the query, but that are written using ECS operations (like add, remove, set etc.). Such operations are automatically deferred and merged at the end of the frame. With annotations you can enforce merging at an earlier point, by specifying that a component modification has been queued. When Flecs sees this, it will merge back the modifications before the next read.
 
-Annotating your queries with this information can tel. To annotate that a query writes component `Position` using `ecs_set` looks like this: `[out] :Position`. If you use `get_mut`, you could also read the component, in which case you use `[inout] :Position`. If you use `get`, use `[in] :Position`. In some cases you can't know in advance which components are going to be written. This is for example the case with the `ecs_delete` operation. To annotate a query for this use case, use `[out] :*`. 
+Annotating your queries with this information can tel. To annotate that a query writes component `Position` using `ecs_set` looks like this: `[out] :Position`. If you use `get_mut`, you could also read the component, in which case you use `[inout] :Position`. If you use `get`, use `[in] :Position`. In some cases you can't know in advance which components are going to be written. This is for example the case with the `ecs_delete` operation. To annotate a query for this use case, use `[out] :*`.
 
 ## Systems
 Designing systems is probably the hardest thing to do when you are not coming from an ECS background. Object oriented code allows you to write logic that is local to a single object, whereas systems in ECS are ran for collections of similar objects. This requires a different approach towards design.
@@ -81,21 +81,21 @@ On the other hand, if you are working with an existing framework or engine, you 
 There is no right or wrong approach here. Different projects require different approaches. Fortunately Flecs makes it really easy to do both!
 
 ## Phases and Pipelines
-Phases and pipelines are the primitves that Flecs uses to order systems. A pipeline is a set of ordered phases. Systems can be assigned to those phases. When using phases and pipelines correctly, it allows you to write plug & play systems that are easy to reuse in different projects.
+Phases and pipelines are the primitives that Flecs uses to order systems. A pipeline is a set of ordered phases. Systems can be assigned to those phases. When using phases and pipelines correctly, it allows you to write plug & play systems that are easy to reuse in different projects.
 
 ### Selecting a Phase
-When you create a system, you can assign a phase to it. By default, that phase is OnUpdate. Flecs comes with a whole bunch of phases though, and just looking at the whole list can feel a bit overwhelming:
+When you create a system, you can assign a phase to it. By default, that phase is `OnUpdate`. Flecs comes with a whole bunch of phases though, and just looking at the whole list can feel a bit overwhelming:
 
-- OnLoad
-- PostLoad
-- PreUpdate
-- OnUpdate
-- OnValidate
-- PostUpdate
-- PreStore
-- OnStore
+- `OnLoad`
+- `PostLoad`
+- `PreUpdate`
+- `OnUpdate`
+- `OnValidate`
+- `PostUpdate`
+- `PreStore`
+- `OnStore`
 
-So what do these all mean? Actually they mean nothing at all! They are just tags you can assign to systems, and those tags ensure that all systems in, say, the PreUpdate phase are executed _before_ the systems in the _OnUpdate_ phase. What is also important to realize is that this list of phases is only the default provided by Flecs. Maybe your project needs only half of those, or maybe it needs entirely different ones! Flecs lets you specify your custom phases to match your project needs.
+So what do these all mean? Actually they mean nothing at all! They are just tags you can assign to systems, and those tags ensure that all systems in, say, the `PreUpdate` phase are executed _before_ the systems in the `OnUpdate` phase. What is also important to realize is that this list of phases is only the default provided by Flecs. Maybe your project needs only half of those, or maybe it needs entirely different ones! Flecs lets you specify your custom phases to match your project needs.
 
 There are some conventions around the builtin phases, and following them helps to ensure that your code works well with the Flecs module ecosystem. Here they are:
 
@@ -142,7 +142,7 @@ The order in which you import dependencies in a module is important. If you defi
 What is key to note here is that the granularity of control is at the module level, _never_ at the individual system level. The reason for this is that modules may reimplement their features with different systems. If you have inter-system dependencies, those could break easily every time you update a module. This also makes sure that you can replace one module for another without running into annoying compatibility issues.
 
 ### Modules and Feature Swapping
-A good practice to employ with modules is to split them up into components.* modules and systems.* modules. For example, you may have a module `components.physics` that contains all the components to store data for a physics system. You may then have a module caled `systems.physics`, which imports the components module and "implements" the components. Because applications only have access to `components.physics` (they import it as well) but do not have direct access to the systems inside `systems.physics`, you can simply swap one physics implementation with another without changing application code.
+A good practice to employ with modules is to split them up into components.* modules and systems.* modules. For example, you may have a module `components.physics` that contains all the components to store data for a physics system. You may then have a module called `systems.physics`, which imports the components module and "implements" the components. Because applications only have access to `components.physics` (they import it as well) but do not have direct access to the systems inside `systems.physics`, you can simply swap one physics implementation with another without changing application code.
 
 This is a powerful pattern enabled by ECS that will give your projects a lot of flexibility and freedom in refactoring code.
 
@@ -156,7 +156,7 @@ Hierarchies are one of the most used features of Flecs, and often useful in game
 The Flecs hierarchy implementation works quite well with scene graphs. Flecs has out of the box features that let you iterate hierarchies top to bottom (see the `cascade` modifier), and this comes in handy when you want to do things like hierarchically applying a transform. Storing a scene graph is a totally fine way to use Flecs hierarchies, and there are nice cross-over benefits from, for example, using prefab hierarchies.
 
 ### Keep 'em clean!
-It can sometimes be tempting to use Flecs hierarchies as a fancy container for a list of entities. Don't. Or rather, you _can_, but keep the hierarchy separate from your scene graph hierarchy. Maybe it will work, but tomorrow someone may implement a feature that iterates all entities in the scene graph for some kind of visualization, and you don't want to see thousands of entities in that tree that are just there because it was convenient to use hierarchies. 
+It can sometimes be tempting to use Flecs hierarchies as a fancy container for a list of entities. Don't. Or rather, you _can_, but keep the hierarchy separate from your scene graph hierarchy. Maybe it will work, but tomorrow someone may implement a feature that iterates all entities in the scene graph for some kind of visualization, and you don't want to see thousands of entities in that tree that are just there because it was convenient to use hierarchies.
 
 To make sure your application can support multiple hierarchies, make sure that you use an explicit root object. This can be your scene, game world, level or whatever you fancy. This way you can always use that scene root entity to get all entities in your scene graph, and not run into unexpected clutter!
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -13,7 +13,7 @@ As long as the application is implemented in C or C++, it can use Flecs. Flecs h
 No. Flecs provides an efficient way to store your game data and run game logic, but beyond that it does not provide the features you would typically expect in a game engine, such as rendering, input management, physics and so on.
 
 ### Why is Flecs written in C?
-One of the main goals of Flecs is portability. Even though new operating systems support the most recent (and future!) versions of the C and C++ language standards, Flecs is used in a number of legacy systems that do not support modern C/C++. Additionally, the C API is easier to embed in existing frameworks and languages as it provides low-level untyped acces to component arrays, and doesn't require wrapping of template-heavy APIs.
+One of the main goals of Flecs is portability. Even though new operating systems support the most recent (and future!) versions of the C and C++ language standards, Flecs is used in a number of legacy systems that do not support modern C/C++. Additionally, the C API is easier to embed in existing frameworks and languages as it provides low-level untyped access to component arrays, and doesn't require wrapping of template-heavy APIs.
 
 ### Should I use the C or C++ API?
 It depends. The C++ API is slightly easier to work with as it reduces the amount of boilerplate code significantly. On the other hand, the C API is easier to embed in other frameworks and can more easily be ported to different platforms.
@@ -39,36 +39,36 @@ Alternatively you can define `flecs_STATIC` in the build configuration of your p
 You can ask questions on the [Discord channel](https://discord.gg/trycKxA), or by creating an issue in the repository.
 
 ### What is an archetype?
-The term "archetype" in ECS is typically (though not universally) used to describe the approach an ECS framework uses for storing components. Contrary to what the term might suggest, an "archetype" is typically not somtething you would see in the ECS API, but rather the data structure the ECS framework to store components.
+The term "archetype" in ECS is typically (though not universally) used to describe the approach an ECS framework uses for storing components. Contrary to what the term might suggest, an "archetype" is typically not something you would see in the ECS API, but rather the data structure the ECS framework to store components.
 
 An ECS that implements the archetype storage model stores entities with the same components together in the same set of component arrays (or array, depending on whether the framework uses SoA or AoS). The advantage of this approach is that it guarantees that components are always stored in packed arrays, which allows for code to be more easily vectorized by compilers (or in plain language: code runs faster).
 
 The Flecs storage model is based on the archetypes approach.
 
 ### What is a table?
-The documentation uses the terms archetype and table interchangably. They are the same. Internally in the Flecs source code an archetype is referred to as a table.
+The documentation uses the terms archetype and table interchangeably. They are the same. Internally in the Flecs source code an archetype is referred to as a table.
 
 ## Development questions
 
 ### Why is my system called multiple times per frame?
-Flecs stores entities with the same set of components in the same arrays in an "archetype". This means that entities with `Position` are stored in different arrays than entities with `Position, Velocity`. 
+Flecs stores entities with the same set of components in the same arrays in an "archetype". This means that entities with `Position` are stored in different arrays than entities with `Position, Velocity`.
 
 Because Flecs systems provide direct access to C arrays, a system is invoked multiple times, once for each set of arrays.
 
 ### Why is the value of a component not set in an OnAdd observer?
-The OnAdd observer is invoked before the component value is assigned. If you need to respond to a component value, use an `OnSet` system. For more information on when observers, monitors and OnSet systems are invoked, see this diagram: https://github.com/SanderMertens/flecs/blob/master/docs/Manual.md#component-add-flow
+The `OnAdd` observer is invoked before the component value is assigned. If you need to respond to a component value, use an `OnSet` system. For more information on when observers, monitors and `OnSet` systems are invoked, see [this diagram](Manual.md#component-add-flow).
 
 ### Why does Flecs abort when I try to use threads?
 Flecs has an operating system abstraction API with threading functions that are not set by default. Check (or use) the OS API examples to see how to set the OS API.
 
 ### Why am I getting errors like FLECS__TPosition or FLECS_EPosition not found?
-Flecs functions need access to component handles before they can do anything. In C++ this is abstracted away behind templates, but in the C API this is the responsibility of the application. See [this section of the manual](https://github.com/SanderMertens/flecs/blob/master/docs/Manual.md#component_handles) on how to pass component handles around in the application.
+Flecs functions need access to component handles before they can do anything. In C++ this is abstracted away behind templates, but in the C API this is the responsibility of the application. See [this section of the manual](Manual.md#component_handles) on how to pass component handles around in the application.
 
 ### How do I pass component handles around in an application?
 See the previous question.
 
 ### When to use each vs. iter when evaluating a query or system?
-Queries and systems offer two ways to iterate them, which is using `each` and `iter`. Each is the simpler version of the two, which iterates each individual entity: 
+Queries and systems offer two ways to iterate them, which is using `each` and `iter`. `each` is the simpler version of the two, which iterates each individual entity:
 
 ```cpp
 world.system<Position, Velocity>()
@@ -78,7 +78,7 @@ world.system<Position, Velocity>()
     });
 ```
 
-Iter is more complex, but is faster to evaluate and allows for more control over how the loop is executed:
+`iter` is more complex, but is faster to evaluate and allows for more control over how the loop is executed:
 
 ```cpp
 world.system<Position, Velocity>()
@@ -128,8 +128,7 @@ q.iter([](flecs::iter& it) {
 So in short, for simple queries, use template parameters. For complex queries, use strings.
 
 ### How do I attach resources to a system?
-If you want to attach data to a system, you can specify a `ctx` parameter in the
-`ecs_system_desc_t` struct parameter passed to the `ecs_system_init` function:
+If you want to attach data to a system, you can specify a `ctx` parameter in the `ecs_system_desc_t` struct parameter passed to the `ecs_system_init` function:
 
 ```c
 ecs_system_init(world, &(ecs_system_init_t){
@@ -139,8 +138,7 @@ ecs_system_init(world, &(ecs_system_init_t){
 });
 ```
 
-Alternatively, if you use the ECS_SYSTEM macro you can use `ecs_system_init`
-with the handle to the existing system to set the context:
+Alternatively, if you use the ECS_SYSTEM macro you can use `ecs_system_init` with the handle to the existing system to set the context:
 
 ```c
 ECS_SYSTEM(world, MySystem, EcsOnUpdate, Position, Velocity);
@@ -151,8 +149,7 @@ ecs_system_init(world, &(ecs_system_init_t) {
 })
 ```
 
-This variable will now be accessible through the `ctx` member of the system 
-iterator:
+This variable will now be accessible through the `ctx` member of the system iterator:
 
 ```c
 void MySystem(ecs_iter_t *it) {
@@ -174,7 +171,7 @@ sys.ctx(another_ptr);
 ```
 
 ### Why is my system (or query) unable to find a component from a module?
-When you import a module, components are automatically namespaced to prevent nameclashes between modules. In C this namespace is determined by taking the name of the module and convert it from PascalCase to a dot-separated notation, so that `MyModule` becomes `my.module`. If component `Position` is defined in module `MyModule`, a system or query will need to use `my.module.Position` in the query expression.
+When you import a module, components are automatically namespaced to prevent name clashes between modules. In C this namespace is determined by taking the name of the module and convert it from PascalCase to a dot-separated notation, so that `MyModule` becomes `my.module`. If component `Position` is defined in module `MyModule`, a system or query will need to use `my.module.Position` in the query expression.
 
 In C++ the component name is prefixed by the C++ namespace, so that `my::module::Position` in C++ becomes `my.module.Position` in the query expression. Note that this only needs to be specified this way when providing a query expression as a string.
 
@@ -195,7 +192,7 @@ ecs_run(world, MySystem, delta_time, &some_param);
 No, a query for `Position, Velocity` matches with the same entities as `Velocity, Position`.
 
 ### Can I add/remove components in a system?
-Yes, you can use the regular add/remove functions in systems. Note however that these operations will not have an immediate effect, as they are _deferred_ until the end of the frame. See this diagram on staging for more information: https://github.com/SanderMertens/flecs/blob/master/docs/Manual.md#staging-flow
+Yes, you can use the regular add/remove functions in systems. Note however that these operations will not have an immediate effect, as they are _deferred_ until the end of the frame. See [this diagram](Manual.md#staging-flow) on staging for more information.
 
 ### Why are updates to components made by my system lost?
 If you have a system in which you both write to component arrays as well as adding/removing components from your entity, it may happen that you lose your updates. A solution to this problem is to split up your system in two, one that sets the component values, and one that adds/removes the components.
@@ -204,7 +201,7 @@ If you have a system in which you both write to component arrays as well as addi
 They are very similar. A system is a query paired up with a function that is executed automatically by the framework each frame.
 
 ### When should I use queries versus filters?
-Queries are the fastest way to iterate over entities as they are "prematched", which means that a query does not need to search as you're iterating it. Queries also provide the most flexible mechanism for selecting entities, with many query operators and other features. Queries are expensive to create however, as they register themselves with other parts of the framework. 
+Queries are the fastest way to iterate over entities as they are "pre-matched", which means that a query does not need to search as you're iterating it. Queries also provide the most flexible mechanism for selecting entities, with many query operators and other features. Queries are expensive to create however, as they register themselves with other parts of the framework.
 
 Filters on the other hand are slower to iterate over as they perform searching while you're iterating them, but they are very cheap to create as they are simple stack-objects that require no additional setup.
 

--- a/docs/JsonFormat.md
+++ b/docs/JsonFormat.md
@@ -17,7 +17,7 @@ A label field returns the doc name of the entity as returned by `ecs_doc_get_nam
 
 Serializing labels requires the [doc](https://flecs.docsforge.com/master/api-doc/) addon.
 
-**Example**: 
+**Example**:
 ```json
 "The Earth"
 ```
@@ -31,7 +31,7 @@ An id field returns a component id or pair. It is formatted as an array of at le
 
 Each element is formatted as a [Path](#path).
 
-**Example**: 
+**Example**:
 ```json
 ["transform.Position"]
 ["Likes", "Apples"]
@@ -41,7 +41,7 @@ Each element is formatted as a [Path](#path).
 ### **Id label**
 Same as [Id](#id) but with [Label](#label)'s instead of paths.
 
-**Example**: 
+**Example**:
 ```json
 ["Entity position"]
 ["Located in", "San Francisco"]
@@ -52,7 +52,7 @@ A JSON object or scalar representing the value of a component. Component values 
 
 When a component has no value (e.g. a tag) or is not described by the reflection framework, `0` will be used as placeholder.
 
-**Example**: 
+**Example**:
 ```json
 {"x": 10, "y": 20}
 ```
@@ -60,7 +60,7 @@ When a component has no value (e.g. a tag) or is not described by the reflection
 ### **Type info**
 A JSON object that represents the structure of a component type.
 
-**Example**: 
+**Example**:
 ```json
 {
     "type_info": [{
@@ -131,9 +131,9 @@ Type: Array([Type info](#type-info)), optional
 Default serializer options:
 ```json
 {
-    "path":"Sun.Earth", 
+    "path":"Sun.Earth",
     "ids":[
-        ["Position"], 
+        ["Position"],
         ["flecs.core.ChildOf", "Sun"],
         ["flecs.core.Identifier", "flecs.core.Name"]
     ]
@@ -143,15 +143,15 @@ Default serializer options:
 This example shows an entity with a base (an `IsA` relationship) with default serializer options:
 ```json
 {
-    "path":"Sun.Earth", 
+    "path":"Sun.Earth",
     "is_a": [{
-        "path":"planets.RockyPlanet", 
+        "path":"planets.RockyPlanet",
         "ids": [
             ["planets.HasRocks"]
         ]
     }],
     "ids":[
-        ["Position"], 
+        ["Position"],
         ["flecs.core.ChildOf", "Sun"],
         ["flecs.core.Identifier", "flecs.core.Name"]
     ]
@@ -162,30 +162,30 @@ This example shows an entity with a base with all serializer options enabled:
 ```json
 {
     "path":"Sun.Earth",
-    "label": "The Earth", 
-    "brief": "The planet you call home", 
+    "label": "The Earth",
+    "brief": "The planet you call home",
     "link": "www.earth.com",
     "is_a": [{
         "path":"planets.RockyPlanet",
-        "label":"A rocky planet", 
+        "label":"A rocky planet",
         "ids": [
-            ["Position"], 
+            ["Position"],
             ["planets.HasRocks"]
         ],
         "id_labels": [
-            ["Position"], 
+            ["Position"],
             ["HasRocks"]
         ],
         "values":[0, 0],
         "hidden":[true, false]
     }],
     "ids":[
-        ["Position"], 
+        ["Position"],
         ["flecs.core.ChildOf", "Sun"],
         ["flecs.core.Identifier", "flecs.core.Name"]
     ],
     "ids_labels":[
-        ["Position"], 
+        ["Position"],
         ["ChildOf", "Sun"],
         ["Identifier", "Name"]
     ],
@@ -292,9 +292,9 @@ Type: Array([Type info](#type-info)), optional
   "ids": ["Position", "Jedi"],
   "results": [{
     "is_set": [true, true],
-    "entities": ["Luke", "Joda"],
+    "entities": ["Luke", "Yoda"],
     "values": [
-      [{ "x": 10, "y": 20 }, 
+      [{ "x": 10, "y": 20 },
        { "x": 20, "y": 30 }],
       0
     ]
@@ -353,7 +353,7 @@ Serializes the ["id_labels"](#id_labels) member.
 
 **Default**: `false`
 
-**Example**: 
+**Example**:
 ```json
 {"id_labels": [["A Rocky Planet"], ["Has surface water"]]}
 ```
@@ -363,10 +363,10 @@ Serializes the ["is_a"](#is_a) member.
 
 **Default**: `true`
 
-**Example**: 
+**Example**:
 ```json
 {"is_a": [{
-    "path":"planets.RockyPlanet", 
+    "path":"planets.RockyPlanet",
     "ids": [
         ["planets.HasRocks"]
     ]
@@ -376,7 +376,7 @@ Serializes the ["is_a"](#is_a) member.
 #### **serialize_private**
 Serialize private components. Private components are regular components with the `EcsPrivate` (or `flecs::Private`) tag. When `serialize_private` is false, private components will be hidden from all arrays.
 
-**Example**: 
+**Example**:
 ```json
 {"ids": ["Position", "PrivateComponent"]}
 ```
@@ -386,7 +386,7 @@ Serialize private components. Private components are regular components with the
 #### **serialize_hidden**
 Serializes the ["hidden"](#hidden) member.
 
-**Example**: 
+**Example**:
 ```json
 {"hidden":[true, false]}
 ```
@@ -394,9 +394,9 @@ Serializes the ["hidden"](#hidden) member.
 Full example:
 ```json
 {
-    "path":"Sun.Earth", 
+    "path":"Sun.Earth",
     "is_a": [{
-        "path":"planets.RockyPlanet", 
+        "path":"planets.RockyPlanet",
         "ids": [
             ["Position"],
             ["planets.HasRocks"]
@@ -404,7 +404,7 @@ Full example:
         "hidden":[true, false]
     }],
     "ids":[
-        ["Position"], 
+        ["Position"],
         ["flecs.core.ChildOf", "Sun"],
         ["flecs.core.Identifier", "flecs.core.Name"]
     ]
@@ -417,7 +417,7 @@ Note that `hidden[0]` is `true` in this example, because the `Position` componen
 #### **serialize_values**
 Serializes the ["values"](#values) member.
 
-**Example**: 
+**Example**:
 ```json
 {"values":[{"x":10, "y": 20}, 0]}
 ```
@@ -427,7 +427,7 @@ Serializes the ["values"](#values) member.
 #### **serialize_type_info**
 Serialize the ["type_info"](#type_info) member.
 
-**Example**: 
+**Example**:
 ```json
 {
     "type_info": [{
@@ -458,7 +458,7 @@ Example result for query `Position, Jedi`
 ```
 
 #### **serialize_ids**
-Serialize the result specific ["ids"](#ids-1) member. 
+Serialize the result specific ["ids"](#ids-1) member.
 
 If the iterated query does not contain variable ids (either an `Or` term or a term with a wildcard id) the result specific `ids` member will exactly match the top-level `ids` member.
 

--- a/docs/Manual.md
+++ b/docs/Manual.md
@@ -41,40 +41,6 @@ This diagram provides an overview of the different steps that occur when removin
 This diagram provides an overview of what happens when an application uses staging. Staging is a lockless mechanism that lets threads concurrently read & perform structural changes on the store. Changes are temporarily stored in a command queue per stage, which can be merged with the store when convenient.
 ![Staging flow](flecs-staging-flow.png)
 
-## Building
-The easiest way to add Flecs to a project is to add [flecs.c](https://raw.githubusercontent.com/SanderMertens/flecs/master/flecs.c) and [flecs.h](https://raw.githubusercontent.com/SanderMertens/flecs/master/flecs.h) to your source code. These files can be added to both C and C++ projects (the C++ API is embedded in flecs.h). Alternatively you can also build Flecs as a library by using the cmake, meson, bazel or bake buildfiles.
-
-### Custom builds
-Whether you're looking for a minimal ECS library or a full-fledged system runtime, customizable builds let you remove Flecs features you don't need. By default all features are included. To customize a build, follow these steps:
-
-- define `FLECS_CUSTOM_BUILD`. This removes all optional features from the build.
-- define constants for the features you want to include (see below)
-- remove the files of the features you don't need
-
-Features are split up in addons and modules. Addons implement a specific Flecs feature, like snapshots. Modules are like addons but register their own components and systems, and therefore need to be imported.
-
-#### Addons
-Addons are located in the `src/addons` and `include/addons` folders. The following addons are available:
-
-Addon         | Description                                      | Constant            |
---------------|--------------------------------------------------|---------------------|
-Bulk          | Efficient operations that run on many entities   | FLECS_BULK          |
-Dbg           | Debug API for inspection of internals            | FLECS_DBG           |
-Stats         | Collect statistics on entities and systems       | FLECS_STATS         |
-Direct Access | Low-level API for direct access to component data| FLECS_DIRECT_ACCESS |
-Module        | Organize components and systems in modules       | FLECS_MODULE        | 
-Queue         | A queue data structure                           | FLECS_QUEUE         |
-Snapshot      | Take a snapshot that can be restored  afterwards | FLECS_SNAPSHOT      |
-
-#### Builtin modules
-Modules are located in the `src/modules` and `include/modules` folders. The following modules are available:
-
-Module        | Description                                      | Constant            |
---------------|--------------------------------------------------|---------------------|
-System        | Support for systems, monitors and triggers       | FLECS_SYSTEM        | 
-Pipeline      | Run systems each frame and/or multithreaded      | FLECS_PIPELINE      |
-Timer         | Run systems at intervals, timeouts or fixed rate | FLECS_TIMER         | 
-
 ## API design
 
 ### Naming conventions

--- a/docs/Manual.md
+++ b/docs/Manual.md
@@ -96,8 +96,8 @@ void Move(ecs_iter_t *it) {
     // Functions use snake_case
     Position *p = ecs_term(it, Position, 1);
     Velocity *v = ecs_term(it, Velocity, 2);
-    
-    for (int i = 0; i < it->count; i ++) {
+
+    for (int i = 0; i < it->count; i++) {
         p[i].x += v[i].x;
         p[i].y += v[i].y;
     }
@@ -105,23 +105,23 @@ void Move(ecs_iter_t *it) {
 
 int main(int argc, char *argv[]) {
     ecs_world_t *world = ecs_init();
-    
-    // Declarative function-style macro's use SCREAMING_SNAKE_CASE
+
+    // Declarative function-style macros use SCREAMING_SNAKE_CASE
     ECS_COMPONENT(world, Position);
     ECS_COMPONENT(world, Velocity);
-    
+
     // Module names are PascalCase
     ECS_IMPORT(world, MyModule);
 
     // Enumeration constants ('EcsOnUpdate') use PascalCase
     ECS_SYSTEM(world, Move, EcsOnUpdate, Position, Velocity);
 
-    // Function wrapper macro's use snake_case
+    // Function wrapper macros use snake_case
     ecs_entity_t e = ecs_new(world, 0);
 
     // Builtin entities use PascalCase
     ecs_add(world, EcsWorld, Position);
-    
+
     return ecs_fini(world);
 }
 ```
@@ -151,7 +151,7 @@ ecs_set(world, e, Position, {10, 20});
 
 The effect of invoking this operation once is the same as invoking the operation multiple times, but both invocations can invoke an OnSet observer which can introduce side effects.
 
-All declarative macro's (`ECS_COMPONEN`, `ECS_SYSTEM`, ...) are idempotent:
+All declarative macros (`ECS_COMPONENT`, `ECS_SYSTEM`, ...) are idempotent:
 
 ```c
 {
@@ -162,7 +162,7 @@ All declarative macro's (`ECS_COMPONEN`, `ECS_SYSTEM`, ...) are idempotent:
 }
 ```
 
-The second time the `ECS_COMPONENT` macro is evaluated, the first instance will be found and returned. Note that because these macro's may declare variables, they cannot be defined twice in the same C scope.
+The second time the `ECS_COMPONENT` macro is evaluated, the first instance will be found and returned. Note that because these macros may declare variables, they cannot be defined twice in the same C scope.
 
 ### Error handling
 As a result of the idempotent design of many operations, the API has a very small error surface. There are essentially two conditions under which an operation is unable to fulfill its postcondition:
@@ -170,9 +170,9 @@ As a result of the idempotent design of many operations, the API has a very smal
 - The application provides invalid inputs to an operation
 - The operating system is unable to fulfill a request, like a failure to allocate memory
 
-When either of those conditions occur, the library will throw an assertion in debug mode (the source is not compiled with `NDEBUG`). Except for errors caused by the OS, errors are almost always caused by the invocation of a single operation, which makes applications easy to debug. 
+When either of those conditions occur, the library will throw an assertion in debug mode (the source is not compiled with `NDEBUG`). Except for errors caused by the OS, errors are almost always caused by the invocation of a single operation, which makes applications easy to debug.
 
-This approach has several advantages. Application code does not need to check for errors. If an error occurs, the assertion will cause application execution to halt. As a result of this, application code is cleaner and more robust, as it is impossible to forget to handle an error condition. 
+This approach has several advantages. Application code does not need to check for errors. If an error occurs, the assertion will cause application execution to halt. As a result of this, application code is cleaner and more robust, as it is impossible to forget to handle an error condition.
 
 ### Memory ownership
 Most of the API is handle based, as many API constructs are implemented using entities. There are a few instances where an application will interface with memory managed by the framework, or when an application needs to provide memory it manages to the API. In these scenarios there are four rules:
@@ -275,8 +275,8 @@ Path lookups may be relative:
 ecs_entity_t e = ecs_lookup_path(world, parent, "Child.GrandChild");
 ```
 
-### Macro's
-The C99 API heavily relies on function-style macro's, probably more than you would see in other libraries. The number one reason for this is that an ECS framework needs to work with user-defined types, and C does not provide out of the box support for generics. A few strategies have been employed in the API to improve its overall ergonomics, type safety and readability. Let's start with a simple example:
+### Macros
+The C99 API heavily relies on function-style macros, probably more than you would see in other libraries. The number one reason for this is that an ECS framework needs to work with user-defined types, and C does not provide out of the box support for generics. A few strategies have been employed in the API to improve its overall ergonomics, type safety and readability. Let's start with a simple example:
 
 ```c
 typedef struct Position {
@@ -295,7 +295,7 @@ Let's first remove the `ECS_COMPONENT` macro and replace it with equivalent code
 
 ```c
 ecs_entity_t ecs_id(Position) = ecs_component_init(world, &(ecs_component_desc_t){
-    .entity.name = "Position", 
+    .entity.name = "Position",
     .size = sizeof(Position),
     .alignment = ECS_ALIGNOF(Position)
 });
@@ -330,16 +330,16 @@ Translates into:
 
 ```c
 ecs_set_id
-    (world, e, ecs_id(Position), sizeof(Position), 
+    (world, e, ecs_id(Position), sizeof(Position),
     &(Position){10, 20});
 ```
 
 In addition to casting the value to the right type and passing in the component, this macro also captures the size of the type, which saves Flecs from having to do a component data lookup.
 
-Understanding how the macro's work will go a long way in being able to write effective code in Flecs, and will lead to less surprises when debugging the code.
+Understanding how the macros work will go a long way in being able to write effective code in Flecs, and will lead to less surprises when debugging the code.
 
 ## Entities
-Entities are uniquely identifiable objects in a game or simulation. In a real time strategy game, there may be entities for the different units, buildings, UI elements and particle effects, but also for exmaple the camera, world and player. An entity does not contain any state, and is not of a particular type. In a traditional OOP-based game, you may expect a tank in the game is of class "Tank". In ECS, an entity is simply a unique identifier, and any data and behavior associated with that entity is implemented with components and systems.
+Entities are uniquely identifiable objects in a game or simulation. In a real time strategy game, there may be entities for the different units, buildings, UI elements and particle effects, but also for example the camera, world and player. An entity does not contain any state, and is not of a particular type. In a traditional OOP-based game, you may expect a tank in the game is of class "Tank". In ECS, an entity is simply a unique identifier, and any data and behavior associated with that entity is implemented with components and systems.
 
 In Flecs, an entity is represented by a 64 bit integer, which is also how it is exposed on the API:
 
@@ -353,14 +353,14 @@ Zero indicates an invalid entity. Applications can create new entities with the 
 ecs_entity_t e = ecs_new(world, 0);
 ```
 
-This operation guarantees to return an unused entity identifier. The first entity returned is not 1, as Flecs creates a number of builtin entities during the intialization of the world. The identifier of the first returned entity is stored in the `EcsFirstUserEntityId` constant.
+This operation guarantees to return an unused entity identifier. The first entity returned is not 1, as Flecs creates a number of builtin entities during the initialization of the world. The identifier of the first returned entity is stored in the `EcsFirstUserEntityId` constant.
 
 ### Id recycling
-Entity identifiers are reused when deleted. The `ecs_new` operation will first attempt to recycle a deleted identifier before producing a new one. If no identifier can be recycled, it will return the last issued identifier + 1. 
+Entity identifiers are reused when deleted. The `ecs_new` operation will first attempt to recycle a deleted identifier before producing a new one. If no identifier can be recycled, it will return the last issued identifier + 1.
 
 Entity identifiers can only be recycled if they have been deleted with `ecs_delete`. When `ecs_delete` is invoked, the generation count of the entity is increased. The generation is encoded in the entity identifier, which means that any existing entity identifiers with the old generation encoded in it will be considered not alive. Calling a delete multiple times on an entity that is not alive has no effect.
 
-When using multiple threads, the `ecs_new` operation guarantees that the returned identifiers are unique, by using atomic increments instead of a simple increment operation. New ids generated from a thread will not be recycled ids, since this would require taking a lock on the administration. While this does not represent a memory leak, it could cause ids to rise over time. If this happens and is an issue, an application should precreate the ids.
+When using multiple threads, the `ecs_new` operation guarantees that the returned identifiers are unique, by using atomic increments instead of a simple increment operation. New ids generated from a thread will not be recycled ids, since this would require taking a lock on the administration. While this does not represent a memory leak, it could cause ids to rise over time. If this happens and is an issue, an application should pre-create the ids.
 
 ### Generations
 When an entity is deleted, the generation count for that entity id is increased. The entity generation count enables an application to test whether an entity is still alive or whether it has been deleted, even after the id has been recycled. Consider:
@@ -418,7 +418,7 @@ If the last issued id was higher than 5000, the operation will not cause the las
 ecs_set_entity_range(world, 5000, 10000);
 ```
 
-If invoking `ecs_new` would result in an id higher than `10000`, the application would assert. If `0` is provided for the maximum id, no uppper bound will be enforced.
+If invoking `ecs_new` would result in an id higher than `10000`, the application would assert. If `0` is provided for the maximum id, no upper bound will be enforced.
 
 It is possible for an application to enforce that entity operations (`ecs_add`, `ecs_remove`, `ecs_delete`) are only allowed for the configured range with the `ecs_enable_range_check` operation:
 
@@ -426,7 +426,7 @@ It is possible for an application to enforce that entity operations (`ecs_add`, 
 ecs_enable_range_check(world, true);
 ```
 
-This can be useful for enforcing that an application is not modifying entities that are owned by another datasource.
+This can be useful for enforcing that an application is not modifying entities that are owned by another data source.
 
 
 ## Types
@@ -537,7 +537,7 @@ The `ecs_get` operation returns a const pointer which should not be modified by 
 
 ```c
 Position *p = ecs_get_mut(world, e, Position);
-p->x ++;
+p->x++;
 ecs_modified(world, p, Position);
 ```
 
@@ -545,7 +545,7 @@ ecs_modified(world, p, Position);
 In order to be able to add, remove and set components on an entity, the API needs access to the component handle. A component handle uniquely identifies a component and is passed to API functions. There are two types of handles that are accepted by API functions, a type handle and an entity handle. These handles are automatically defined as variables by the `ECS_COMPONENT` macro. If an application wants to use the component in another scope, the handle will have to be either declared globally or passed to that scope explicitly.
 
 #### Global component handles
-To globally declare a component, an application can use the `ECS_COMPONENT_DECLARE` and `ECS_COMPONENT_DEFINE` macro's:
+To globally declare a component, an application can use the `ECS_COMPONENT_DECLARE` and `ECS_COMPONENT_DEFINE` macros:
 
 ```c
 // Declare component variable in the global scope
@@ -604,7 +604,7 @@ int main() {
 }
 ```
 
-The `ecs_new`, `ecs_add` and `ecs_remove` (not exhaustive) functions are wrapper macro's arround functions functions that accept a component id. The following code is equivalent to the previous example:
+The `ecs_new`, `ecs_add` and `ecs_remove` (not exhaustive) functions are wrapper macros around functions functions that accept a component id. The following code is equivalent to the previous example:
 
 ```c
 typedef struct Position {
@@ -688,7 +688,7 @@ int main() {
     ecs_add(world, e, Enemy);
 
     // Remove the Enemy tag
-    ecs_remove(world, e, Enemy);    
+    ecs_remove(world, e, Enemy);
 }
 ```
 
@@ -731,7 +731,7 @@ int main() {
 }
 ```
 
-Anyone who paid careful attention to this example will notice that the `ecs_add_id` operation accepts two regular entities. 
+Anyone who paid careful attention to this example will notice that the `ecs_add_id` operation accepts two regular entities.
 
 ## Queries
 See the [query manual](Queries.md).
@@ -757,7 +757,7 @@ The implementation of a system is a regular query iteration:
 Position *p = ecs_term(it, Position, 1);
 Velocity *v = ecs_term(it, Velocity, 2);
 
-for (int i = 0; i < it->count, i ++) {
+for (int i = 0; i < it->count, i++) {
     p[i].x += v[i].x;
     p[i].y += v[i].y;
 }
@@ -770,7 +770,7 @@ A system provides a `delta_time` which contains the time passed since the last f
 Position *p = ecs_term(it, Position, 1);
 Velocity *v = ecs_term(it, Velocity, 2);
 
-for (int i = 0; i < it->count, i ++) {
+for (int i = 0; i < it->count, i++) {
     p[i].x += v[i].x * it->delta_time;
     p[i].y += v[i].y * it->delta_time;
 }
@@ -782,7 +782,7 @@ This is the value passed into `ecs_progress`:
 ecs_progress(world, delta_time);
 ```
 
-If 0 was provided for `delta_time`, flecs will automatically measure the time passed between the last frame and the current. 
+If 0 was provided for `delta_time`, flecs will automatically measure the time passed between the last frame and the current.
 
 A system may also use the `delta_system_time` member, which is the time elapsed since the last time the system was invoked. This can be useful when a system is not invoked each frame, for example when using a timer.
 
@@ -792,7 +792,7 @@ A system may be invoked multiple times per frame. The reason this happens is bec
 The total number of tables a system will iterate over is stored in the `table_count` member of the iterator. Additionally, the `table_offset` member contains the current table being iterated over, so that a system can keep track of where it is in the iteration:
 
 ```c
-void Move(ecs_iter_t *it) { 
+void Move(ecs_iter_t *it) {
     printf("Iterating table %d / %d\n", it->table_offset, it->table_count);
     // ...
 }
@@ -803,7 +803,7 @@ Observers are callbacks that are invoked when one or more events matches the que
 
 When an observer has a query with more than one component, the observer will not match until the entity for which the event is emitted satisfies the entire query.
 
-An exmple of an observer with a single component:
+An example of an observer with a single component:
 
 ```c
 ECS_OBSERVER(world, AddPosition, EcsOnAdd, Position);
@@ -815,7 +815,7 @@ The implementation of the observer looks similar to a system:
 void AddPosition(ecs_iter_t *it) {
     Position *p = ecs_term(it, Position, 1);
 
-    for (int i = 0; i < it->count; i ++) {
+    for (int i = 0; i < it->count; i++) {
         p[i].x = 10;
         p[i].y = 20;
         printf("Position added\n");
@@ -890,7 +890,7 @@ ECS_IMPORT(world, Vehicles);
 ecs_entity_t e = ecs_new(world, Car);
 ```
 
-Module contents are namespaced, which means that the identifiers of the contenst of the module (components, tags, systems) are stored in the scope of the module. For the above example module, everything would be stored in the `vehicles` scope. To resolve the `Car` component by name, an application would have to do:
+Module contents are namespaced, which means that the identifiers of the content of the module (components, tags, systems) are stored in the scope of the module. For the above example module, everything would be stored in the `vehicles` scope. To resolve the `Car` component by name, an application would have to do:
 
 ```c
 ecs_entity_t car_entity = ecs_lookup_fullpath(world, "vehicles.Car");
@@ -966,7 +966,7 @@ Applications can iterate hierarchies breadth first with the `ecs_scope_iter` API
 ecs_iter_t it = ecs_scope_iter(world, parent);
 
 while(ecs_scope_next(&it)) {
-    for (int i = 0; i < it.count; i ++) {
+    for (int i = 0; i < it.count; i++) {
         ecs_entity_t child = it.entities[i];
         char *path = ecs_get_fullpath(world, child);
         printf(" - %s\n", path);
@@ -1163,7 +1163,7 @@ ecs_get(world, base, Position) != ecs_get(world, e, Position); // 1
 
 // Prints {10, 20}
 const Position *p = ecs_get(world, e, Position);
-printf("{%f, %f}\n", p->x, p->y); 
+printf("{%f, %f}\n", p->x, p->y);
 ```
 
 When an entity shared a component from a base entity, we say that the component is "shared". If the component is not shared, it is "owned". After an entity overrides a component, it will own the component.
@@ -1206,7 +1206,7 @@ ecs_entity_t Base = ecs_set(world, 0, Position, {10, 20});
 // Mark as OVERRIDE. This ensures that when base is derived from, Position is overridden
 ecs_add_id(world, world, Base, ECS_OVERRIDE | ecs_id(Position));
 
-// Create entity from BaseType. This adds the IsA relationship in addition 
+// Create entity from BaseType. This adds the IsA relationship in addition
 // to overriding Position, effectively initializing the Position component for the entity.
 ecs_entity_t e = ecs_new_w_pair(world, EcsIsA, Base);
 ```
@@ -1229,7 +1229,7 @@ ecs_entity_t parent = ecs_new(world, 0);
 ecs_entity_t child_1 = ecs_new_w_pair(world, EcsChildOf, parent);
 ecs_entity_t child_2 = ecs_new_w_pair(world, EcsChildOf, parent);
 
-// Derive from parent, two childs are added to the entity
+// Derive from parent, two children are added to the entity
 ecs_entity_t e = ecs_new_w_pair(world, EcsIsA, parent);
 ```
 
@@ -1241,7 +1241,7 @@ ecs_entity_t child = ecs_new_w_pair(world, EcsChildOf, parent);
 ecs_set_name(world, child, "Child"); // Give child a name, so we can look it up
 ecs_set(world, child, Position, {10, 20});
 
-// Derive from parent, two childs are added to the derived entity
+// Derive from parent, two children are added to the derived entity
 ecs_entity_t e = ecs_new_w_pair(world, EcsIsA, parent);
 ecs_entity_t e_child = ecs_lookup_path(world, e, "Child");
 const Position *p = ecs_get(world, e_child, Position);
@@ -1251,7 +1251,7 @@ printf("{%f, %f}\n", p->x, p->y); // Prints {10, 20}
 ecs_get(world, child, Position) != ecs_get(world, e_child, Position); // 1
 ```
 
-Since the children of the derived entitiy have the exact same components as the base children, their components are not shared. Component sharing between children is possible however, as `IsA` relationships are also copied over to the child of the derived entity:
+Since the children of the derived entity have the exact same components as the base children, their components are not shared. Component sharing between children is possible however, as `IsA` relationships are also copied over to the child of the derived entity:
 
 ```c
 ecs_entity_t parent = ecs_new(world, 0);
@@ -1265,7 +1265,7 @@ ecs_set_name(world, child, "Child");
 ecs_entity_t child = ecs_new_w_pair(world, EcsChildOf, parent);
 ecs_add_pair(world, child, EcsIsA, child_base);
 
-// Inherit from parent, two childs are added to the entity
+// Inherit from parent, two children are added to the entity
 ecs_entity_t e = ecs_new_w_pair(world, EcsIsA, parent);
 ecs_entity_t e_child = ecs_lookup_path(world, e, "Child");
 
@@ -1323,7 +1323,7 @@ ecs_defer_begin(world);
 ecs_defer_end(world);
 ```
 
-The effects of these operations will not be visible until the `ecs_defer_end` operation. 
+The effects of these operations will not be visible until the `ecs_defer_end` operation.
 
 There are a few things to keep in mind when deferring:
 - creating a new entity will always return a new id which increases the last used id counter of the world
@@ -1334,7 +1334,7 @@ There are a few things to keep in mind when deferring:
 ## Staging
 When an application is processing the world (using `ecs_progress`) the world enters a state in which all operations are automatically deferred. This ensures that systems can call regular operations while iterating entities without modifying the underlying storage. The queued operations are merged by default at the end of the frame. When using multiple threads, each thread has its own queue. Queues of different threads are processed sequentially.
 
-By default this means that an application will not see the effects of an operation until the end of a frame. When this is undesirable, an application can add `[in]` and `[out]` anotations to a system signature to force a merging the queues mid-frame. When using multiple threads this will represent a synchronization point. Take this (somewhat contrived) example with two systems, without annotations:
+By default this means that an application will not see the effects of an operation until the end of a frame. When this is undesirable, an application can add `[in]` and `[out]` annotations to a system signature to force a merging the queues mid-frame. When using multiple threads this will represent a synchronization point. Take this (somewhat contrived) example with two systems, without annotations:
 
 ```c
 // Sets velocity using ecs_set
@@ -1350,7 +1350,7 @@ With the following implementation for `SetVelocity`:
 void SetVelocity(ecs_iter_t *it) {
     ecs_entity_t ecs_id(Velocity) = ecs_term_id(it, 2);
 
-    for (int i = 0; i < it->count; i ++) {
+    for (int i = 0; i < it->count; i++) {
         ecs_set(world, it->entities[i], Velocity, {1, 2});
     }
 }
@@ -1377,14 +1377,14 @@ This is interpreted as the system may write any component, and forces a sync poi
 ## Pipelines
 A pipeline defines the different phases that are executed for each frame. By default an application uses the builtin pipeline which has the following phases:
 
-- EcsOnLoad
-- EcsPostLoad
-- EcsPreUpdate
-- EcsOnUpdate
-- EcsOnValidate
-- EcsPostUpdate
-- EcsPreStore
-- EcsOnStore
+- `EcsOnLoad`
+- `EcsPostLoad`
+- `EcsPreUpdate`
+- `EcsOnUpdate`
+- `EcsOnValidate`
+- `EcsPostUpdate`
+- `EcsPreStore`
+- `EcsOnStore`
 
 These phases can be provided as an argument to the `ECS_SYSTEM` macro:
 
@@ -1411,13 +1411,13 @@ ecs_add_pair(ecs, Collisions, EcsDependsOn, Physics);
 ECS_SYSTEM(world, Collide, Collisions, Position, Velocity);
 ```
 
-Pipelines are implemented using queries that return matching systems. The builtin pipeline has a query that returns systems with a DependsOn relationship on a phase, topology-sorted by the depth in the DependsOn graph:
+Pipelines are implemented using queries that return matching systems. The builtin pipeline has a query that returns systems with a DependsOn relationship on a phase, topology-sorted by the depth in the `DependsOn` graph:
 
 ```c
 flecs.system.System, flecs.pipeline.Phase(cascade(DependsOn))
 ```
 
-Applications can create their own pipelines which fully customize which systems are matched, and in which order they are executed. Custom pipelines can use phases and DependsOn, or they may use a completely different approach. This example shows how to create a pipeline that matches all systems with the `Foo` tag:
+Applications can create their own pipelines which fully customize which systems are matched, and in which order they are executed. Custom pipelines can use phases and `DependsOn`, or they may use a completely different approach. This example shows how to create a pipeline that matches all systems with the `Foo` tag:
 
 ```c
 ECS_TAG(world, Foo);
@@ -1459,7 +1459,7 @@ Custom pipelines can specify their own `order_by` and `group_by` functions. If n
 ## Threading
 Applications can multithread systems by configuring the number of threads for a world. The approach to multithreading is simple, but does not require locks and works well in applications that have "pure" ECS systems, that is systems that only modify the components subscribed for in their signature.
 
-When a world has multiple threads, each thread will run all systems. Each system will ensure that it only processes a subset of the entities that is allocated to the thread. It does this by dividing up each table into slices of equal size, and assigning those slices to the threads. Since entities do not move around inbetween synchronization points, this approach ensures that each entity will always be allocated to the same thread. When systems only access components that are queried for, race conditions cannot occur without relying on locking.
+When a world has multiple threads, each thread will run all systems. Each system will ensure that it only processes a subset of the entities that is allocated to the thread. It does this by dividing up each table into slices of equal size, and assigning those slices to the threads. Since entities do not move around in-between synchronization points, this approach ensures that each entity will always be allocated to the same thread. When systems only access components that are queried for, race conditions cannot occur without relying on locking.
 
 Threads are created when the `ecs_set_threads` function is invoked. An application may change the number of threads by repeatedly invoking this function, as long as the world is not progressing. Threads are not recreated for each frame to reduce the overhead of multithreading. Instead threads will be signalled by the main thread when a frame starts, and the main thread will wait on the threads before ending the frame.
 

--- a/docs/Queries.md
+++ b/docs/Queries.md
@@ -628,7 +628,7 @@ which is the same as:
 Likes(This, Alice)
 ```
 
-The term "object" is borrowed from English grammar. In the sentence "Bob likes Alice", "Bob" is the subject, and "Alice" is the object.
+The term "object" is borrowed from English grammar and has nothing to do with the OOP meaning of object (as in an instance of a class). In the sentence "Bob likes Alice", "Bob" is the subject, and "Alice" is the object.
 
 ### Component
 When a term refers to a component, it appears as a predicate with a single argument (subject). Components are typically referred to by their language types in APIs. While the query DSL is agnostic to this, the bindings provide dedicated ways for setting a component for a term.

--- a/docs/Queries.md
+++ b/docs/Queries.md
@@ -2,7 +2,7 @@ Queries are the mechanism that allow applications to get the entities that match
 
 **NOTE**: this manual describes queries as they are intended to work. The actual implementation may not have support for certain combinations of features. When an application attempts to use a feature that is not yet supported, an `UNSUPPORTED` error will be thrown.
 
-**NOTE**: features that rely on query variables or automatic substitution of components or objects (like when relying on component inheritance or transitive queries) require the rule query engine, included in the FLECS_RULES addon.
+**NOTE**: features that rely on query variables or automatic substitution of components or objects (like when relying on component inheritance or transitive queries) require the rule query engine, included in the `FLECS_RULES` addon.
 
 ## Query kinds
 Flecs has two different kinds of queriers: cached and uncached. The differences are described here. Note that when "query" is mentioned in the other parts of the manual it always refers to all query kinds, unless explicitly mentioned otherwise.
@@ -191,7 +191,7 @@ q.iter([](flecs::iter& it, Position *p, const Velocity *v) {
 });
 ```
 
-Note how the iter function provides direct access to the component arrays. 
+Note how the iter function provides direct access to the component arrays.
 
 The iter callback can obtain access to components that are not part of the query type:
 
@@ -224,8 +224,8 @@ q.iter([](flecs::iter& it) {
   auto likes = it.id(1);
 
   // Extract the object from the pair
-  std::cout << "Entities like " 
-    << likes.second().name() 
+  std::cout << "Entities like "
+    << likes.second().name()
     << std::endl;
 });
 ```
@@ -263,7 +263,7 @@ while (ecs_query_next(&it)) {
   Position *p = ecs_term(&it, Position, 1);
   Velocity *v = ecs_term(&it, Velocity, 2);
 
-  for (int i = 0; i < it.count; i ++) {
+  for (int i = 0; i < it.count; i++) {
     p[i].x += v[i].x;
     p[i].y += v[i].y;
   }
@@ -330,7 +330,7 @@ Applications iterate a sorted query in the same way they would iterate a regular
 while (ecs_query_next(&it)) {
     Position *p = ecs_term(&it, Position, 1);
 
-    for (int i = 0; i < it.count; i ++) {
+    for (int i = 0; i < it.count; i++) {
         printf("{%f, %f}\n", p[i].x, p[i].y); // Values printed will be in order
     }
 }
@@ -339,7 +339,7 @@ while (ecs_query_next(&it)) {
 ### Sorting algorithm
 The algorithm used for the sort is a quicksort. Each table that is matched with the query will be sorted using a quicksort. As a result, sorting one query affects the order of entities in another query. However, just sorting tables is not enough, as the list of ordered entities may have to jump between tables. For example:
 
-Entitiy | Components (table) | Value used for sorting
+Entity  | Components (table) | Value used for sorting
 --------|--------------------|-----------------------
 E1      | Position           | 1
 E2      | Position           | 3
@@ -441,7 +441,7 @@ Position, ?Velocity // Position And Optionally Velocity
 
 Optional arguments, while they do not impact query matching, are useful as they provide a quicker way to access the optional component than using `e.get<T>()`. Optional components are faster because of three reasons:
 
-1) Queries iterate archetypes, and if an archetype does not have the optional component, none of the entities in the archetype do. 
+1) Queries iterate archetypes, and if an archetype does not have the optional component, none of the entities in the archetype do.
 
 2) When an archetype does have the optional component, the query can access it as an array, just like a regular component.
 
@@ -466,7 +466,7 @@ ecs_query_t *q = ecs_query_init(world, &(ecs_query_decs_t){
 ```
 
 #### Or operator
-The Or operator instructs a query to match _at least_ one term out of a list of terms that are chained together by the operator. Here is a simple example of a query with an `Or` operator:
+The `Or` operator instructs a query to match _at least_ one term out of a list of terms that are chained together by the operator. Here is a simple example of a query with an `Or` operator:
 
 ```c
 Position || Velocity // Position Or Velocity
@@ -502,7 +502,7 @@ ecs_query_t *q = ecs_query_init(world, &(ecs_query_decs_t){
 Note that both in the builder and descriptor APIs, each term that participates in an `Or` chain must specify the `Or` operator.
 
 #### AndFrom, OrFrom, NotFrom operators
-The *From operators allow a query to match against an external list of components with the `And`, `Or` or `Not` operator. This list of components is specified as a type entity. For example, if an application has the following type entity:
+The `*From` operators allow a query to match against an external list of components with the `And`, `Or` or `Not` operator. This list of components is specified as a type entity. For example, if an application has the following type entity:
 
 ```cpp
 auto Ingredients = world.type("Ingredients")
@@ -597,7 +597,7 @@ Here `Position` is the predicate, and `Bob` is the subject. If `Bob` has `Positi
 The term "subject" is borrowed from English grammar. In the sentence "Bob has component Position", "Bob" is the subject.
 
 ### This
-"This" is the placeholder for an entity (or archetype) being evaluated by a query. When a query is looking for all matching results, it will iterate the set of entities that represent a potential match, and pass each entity (or archetype) as "This" to each term. By default "This" is used as the subject for each predicate. Thus a simple query like this:
+`This` is the placeholder for an entity (or archetype) being evaluated by a query. When a query is looking for all matching results, it will iterate the set of entities that represent a potential match, and pass each entity (or archetype) as "This" to each term. By default `This` is used as the subject for each predicate. Thus a simple query like this:
 
 ```
 Position, Velocity
@@ -691,7 +691,7 @@ auto qb = world.query_builder<>()
   .term(Likes, Apples);
 
 auto qb = world.query_builder<>()
-  .term<Likes>(Apples); 
+  .term<Likes>(Apples);
 ```
 
 In the query descriptor API relations can be specified as pairs:
@@ -905,7 +905,7 @@ Variables can occur in multiple places. For example, this query returns all the 
 (Likes, $X), ($R, $X)
 ```
 
-A useful application for variables is ensuring that an entity has a component referenced by a relationship. Consider an application that has an `ExpiryTimer` relationship that removes a component after a certain time has expired. This logic only needs to be executed when the entity actually has the component to remove. 
+A useful application for variables is ensuring that an entity has a component referenced by a relationship. Consider an application that has an `ExpiryTimer` relationship that removes a component after a certain time has expired. This logic only needs to be executed when the entity actually has the component to remove.
 
 With variables this can be ensured:
 
@@ -970,7 +970,7 @@ def find_object_w_component(This, Component):
 ```
 
 ### Parent components
-Queries may use the `parent` shortcut to select components from a parent entity which is short for `super(ChildOf)` /This query:
+Queries may use the `parent` shortcut to select components from a parent entity which is short for `super(ChildOf)` /`This` query:
 
 ```
 Position(parent)
@@ -1149,7 +1149,7 @@ To understand how transitivity is implemented, we need to look at how queries in
 (LocatedIn, SanFrancisco)
 ```
 
-To find whether the subject should match this term, it should not just consider `(LocatedIn, SanFrancisco)`, but also `(LocatedIn, Mision)` and `(LocatedIn, SOMA)`. To achieve this, a query will insert an implicit substitution on the object, when the relation is transitive:
+To find whether the subject should match this term, it should not just consider `(LocatedIn, SanFrancisco)`, but also `(LocatedIn, Mission)` and `(LocatedIn, SOMA)`. To achieve this, a query will insert an implicit substitution on the object, when the relation is transitive:
 
 ```
 (LocatedIn, SanFrancisco[self|sub(LocatedIn)])

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -190,14 +190,14 @@ e.has(Enemy); // false!
 
 Note that both options in the C++ example achieve the same effect. The only difference is that in option 1 the tag is fixed at compile time, whereas in option 2 the tag can be created dynamically at runtime.
 
-When a tag is deleted, the same rules apply as for components (see [Relation cleanup properties](Relations.md#relation_cleanup_properties)).
+When a tag is deleted, the same rules apply as for components (see [relation cleanup properties](Relations.md#relation_cleanup_properties)).
 
 ## Pair
 A pair is a combination of two entity ids. Pairs can be used to store entity relations, where the first id represents the relation kind and the second id represents the relation target (called "object"). This is best explained by an example:
 
 ```c
 // Create Likes relation
-ecs_entity_t Likes = ecs_new_id(world); 
+ecs_entity_t Likes = ecs_new_id(world);
 
 // Create a small graph with two entities that like each other
 ecs_entity_t Bob = ecs_new_id(world);
@@ -280,7 +280,7 @@ ecs_entity_t o = ecs_get_object(world, Alice, Likes, 0); // Returns Bob
 auto o = Alice.get_object<Likes>(); // Returns Bob
 ```
 
-Entity relations enable lots of interesting patterns and possibilities. Make sure to check out the [Relations manual](Relations.md).
+Entity relations enable lots of interesting patterns and possibilities. Make sure to check out the [relations manual](Relations.md).
 
 ## Hierarchies
 Flecs has builtin support for hierarchies with the builtin `EcsChildOf` (or `flecs::ChildOf`, in C++) relationship. A hierarchy can be created with the regular relationship API, or with the `child_of` shortcut in C++:
@@ -340,7 +340,7 @@ ecs_query_t *q = ecs_query_init(world, &(ecs_query_desc_t){
         { ecs_id(Position), .subj.set = {
             .mask = EcsCascade,    // Force breadth-first order
             .relation = EcsChildOf // Use ChildOf relation for ordering
-        }} 
+        }}
     }
 });
 
@@ -348,7 +348,7 @@ ecs_iter_t it = ecs_query_iter(world, q);
 while (ecs_query_next(&it)) {
     Position *p = ecs_term(&it, Position, 1);
     Position *p_parent = ecs_term(&it, Position, 2);
-    for (int i = 0; i < it.count; i ++) {
+    for (int i = 0; i < it.count; i++) {
         // Do the thing
     }
 }
@@ -422,7 +422,7 @@ std::cout << e.type().str() << std::endl; // output: 'Position,Velocity'
 A type can also be iterated by an application:
 ```c
 const ecs_type_t *type = ecs_get_type(world, e);
-for (int i = 0; i < type->count; i ++) {
+for (int i = 0; i < type->count; i++) {
     if (type->array[i] == ecs_id(Position)) {
         // Found Position component!
     }
@@ -479,7 +479,7 @@ while (ecs_term_next(&it)) {
     Position *p = ecs_term(&it, Position, 1);
 
     // Iterate the entities & their Position components
-    for (int i = 0; i < it.count; i ++) {
+    for (int i = 0; i < it.count; i++) {
         printf("%s: {%f, %f}\n", ecs_get_name(world, it.entities[i]),
             p[i].x, p[i].y);
     }
@@ -513,7 +513,7 @@ while (ecs_filter_next(&it)) {
     Position *p = ecs_term(&it, Position, 1);
 
     // Iterate all entities for the type
-    for (int i = 0; i < it.count; i ++) {
+    for (int i = 0; i < it.count; i++) {
         printf("%s: {%f, %f}\n", ecs_get_name(world, it.entities[i]),
             p[i].x, p[i].y);
     }
@@ -541,13 +541,13 @@ f.each([](flecs::entity e, Position& p) {
 // Option 2: iter() function that iterates each archetype
 f.iter([](flecs::iter& it, Position *p) {
     for (int i : it) {
-        std::cout << e.name() 
+        std::cout << e.name()
             << ": {" << p[i].x << ", " << p[i].y << "}" << std::endl;
     }
 });
 ```
 
-The time complexity of a filter is roughly O(n), where n is the number of archetypes matched by the term with the smallest number of matching archetypes. Each subsequent term adds a constant-time check per archetype, which makes the average time complexity O(n).
+The time complexity of a filter is roughly `O(n)`, where `n` is the number of archetypes matched by the term with the smallest number of matching archetypes. Each subsequent term adds a constant-time check per archetype, which makes the average time complexity `O(n)`.
 
 Filters can use operators to exclude components, optionally match components or match one out of a list of components. Additionally filters may contain wildcards for terms which is especially useful when combined with pairs.
 
@@ -626,7 +626,7 @@ void Move(ecs_iter_t *it) {
     Position *p = ecs_term(it, Position, 1);
     Velocity *v = ecs_term(it, Velocity, 2);
 
-    for (int i = 0; i < it->count; i ++) {
+    for (int i = 0; i < it->count; i++) {
         p[i].x += v[i].x * it->delta_time;
         p[i].y += v[i].y * it->delta_time;
     }
@@ -744,7 +744,7 @@ Observers are callbacks that are invoked when one or more events matches the que
 
 When an observer has a query with more than one component, the observer will not be invoked until the entity for which the event is emitted satisfies the entire query.
 
-An exmple of an observer with two components:
+An example of an observer with two components:
 
 ```c
 ecs_observer_init(world, &(ecs_observer_desc_t){

--- a/docs/Relations.md
+++ b/docs/Relations.md
@@ -78,12 +78,12 @@ auto q = world.query("(Eats, *)");
 auto q = world.query_builder<>()
   .term(Eats, Apples)
   .build();
-  
+
 // Or when using pair types, when both relation & object are compile time types:
-auto q = world.query<flecs::pair<Eats, Apples>>();  
+auto q = world.query<flecs::pair<Eats, Apples>>();
 ```
 
-This example just shows a simple relation query. Relation queries are much more powerful than this as they provide the ability to match against entity graphs of arbitrary size. For more information on relation queries see the [Query manual](Queries.md).
+This example just shows a simple relation query. Relation queries are much more powerful than this as they provide the ability to match against entity graphs of arbitrary size. For more information on relation queries see the [query manual](Queries.md).
 
 ## Relation components
 So far we've just seen relations with regular entities. When used in combination with components, relations can be associated with data:
@@ -129,12 +129,12 @@ auto r = delorean.get<RequiresGigaWatts>();
 cout << r->value << " gigawatts!" << endl;
 ```
 
-An advantage of the `flecs::pair` template is that it can be used with function-style get/set operations:
+An advantage of the `flecs::pair` template is that it can be used with function-style `get`/`set` operations:
 
 ```cpp
 // rvalue required as API converts value from 'Requires' to 'RequiresGigawatts'
 e.set([](RequiresGigawatts&& r) {
-  r->value = 1.21; // Overloaded '->' operator to get the pair value 
+  r->value = 1.21; // Overloaded '->' operator to get the pair value
 })
 
 e.get([](const RequiresGigawatts& r) {
@@ -241,9 +241,9 @@ while (ecs_query_next(&it)) {
   ecs_entity_t obj = ecs_pair_second(world, id);
 
   for (int i = 0; i < it.count; it++) {
-    printf("entity %d has relation %s, %s\n", 
+    printf("entity %d has relation %s, %s\n",
       it.entities[i],
-      ecs_get_name(world, rel), 
+      ecs_get_name(world, rel),
       ecs_get_name(world, obj));
   }
 }
@@ -365,10 +365,10 @@ auto GrannySmith = world.entity();
 GrannySmith.add(flecs::IsA, Apple);
 ```
 
-This specifies that `GrannySmith` is a subset of `Apple`. A key thing to note here is that because `Apple` is a subset of `Fruit`, `GrannySmith` is a subset of `Fruit` as well. This means that if an application were to query for `(IsA, Fruit)` it would both match `Apple` and `GrannySmith`. This property of the `IsA` relationhip is called "transitivity" and it is a feature that can be applied to any relation. See the [section on Transitivity](#transitive-property) for more details.
+This specifies that `GrannySmith` is a subset of `Apple`. A key thing to note here is that because `Apple` is a subset of `Fruit`, `GrannySmith` is a subset of `Fruit` as well. This means that if an application were to query for `(IsA, Fruit)` it would both match `Apple` and `GrannySmith`. This property of the `IsA` relationship is called "transitivity" and it is a feature that can be applied to any relation. See the [section on Transitivity](#transitive-property) for more details.
 
 #### Component sharing
-An entity with an `IsA` relation to another entity is equivalent to the other entity. So far the examples showed how querying for an `IsA` relation will find the subsets of the thing that was queried for. In order for entities to be treated as true equivalents though, everything the supserset contains (its components, tags, relations) must also be found on the subsets. Consider:
+An entity with an `IsA` relation to another entity is equivalent to the other entity. So far the examples showed how querying for an `IsA` relation will find the subsets of the thing that was queried for. In order for entities to be treated as true equivalents though, everything the superset contains (its components, tags, relations) must also be found on the subsets. Consider:
 
 ```c
 ecs_entity_t Spaceship = ecs_new_id(world);
@@ -441,7 +441,7 @@ s->value == 200; // true
 
 // Obtain the inherited component from Frigate
 const Defense *d = Frigate.get<Defense>();
-d->value == 75; // true  
+d->value == 75; // true
 ```
 
 This ability to inherit and override components is one of the key enabling features of Flecs prefabs, and is further explained in the [Inheritance section](Manual.md#Inheritance) of the manual.
@@ -507,8 +507,8 @@ In some scenarios a number of entities all need to be created with the same pare
 ecs_entity_t parent = ecs_new_id(world);
 ecs_entity_t prev = ecs_set_scope(world, parent);
 
-// Note that we're not using the ecs_new_id function for the children. This 
-// function only generates a new id, and does not add the scope to the entity. 
+// Note that we're not using the ecs_new_id function for the children. This
+// function only generates a new id, and does not add the scope to the entity.
 ecs_entity_t child_a = ecs_new(world, 0);
 ecs_entity_t child_b = ecs_new(world, 0);
 
@@ -532,7 +532,7 @@ child_a.has(flecs::ChildOf, parent); // true
 child_b.has(flecs::ChildOf, parent); // true
 ```
 
-Scopes in C++ can also be used with the `scope` function on an entity, which accepts a (typcially lambda) function:
+Scopes in C++ can also be used with the `scope` function on an entity, which accepts a (typically lambda) function:
 
 ```cpp
 auto parent = world.entity().scope([&]{
@@ -586,7 +586,7 @@ This succeeds in removing all possible references to `Archer`. Sometimes this be
 
 We also want to specify this per relationship. If an entity has `(Likes, parent)` we may not want to delete that entity, meaning the cleanup we want to perform for `Likes` and `ChildOf` may not be the same.
 
-This is what cleanup policies are for: to specify which action needs to be executed under which condition. They are applied _to_ entities that have a reference to the entity being deleted: if I delete the `Archer` tag I remove the tag _from_ all entities that have it. 
+This is what cleanup policies are for: to specify which action needs to be executed under which condition. They are applied _to_ entities that have a reference to the entity being deleted: if I delete the `Archer` tag I remove the tag _from_ all entities that have it.
 
 To configure a cleanup policy for an entity, a `(Condition, Action)` pair can be added to it. If no policy is specified, the default cleanup action (`Remove`) is performed.
 
@@ -710,11 +710,11 @@ To understand why some ways to organize entities work better than others, having
 1. **Find all root entities**
 World teardown starts by finding all root entities, which are entities that do not have the builtin `ChildOf` relationship.
 
-2. **Filter out modules, components, observers and systems** 
+2. **Filter out modules, components, observers and systems**
 This ensures that components are not cleaned up before the entities that use them, and triggers, observers and systems are not cleaned up while there are still conditions under which they could be invoked.
 
 3. **Filter out entities that have no children**
-If entities have no children they cannot cause complex cleanup logic. This also decreases the likelyhood of initiating cleanup actions that could impact other entities.
+If entities have no children they cannot cause complex cleanup logic. This also decreases the likelihood of initiating cleanup actions that could impact other entities.
 
 4. **Delete root entities**
 The root entities that were not filtered out will be deleted.
@@ -756,7 +756,7 @@ struct Position {
 
 auto e = ecs.entity()
   .set<Position>({10, 20})
-  .add<Serializable, Position>(); // Because Serializable is a tag, the pair 
+  .add<Serializable, Position>(); // Because Serializable is a tag, the pair
                                   // has a value of type Position
 
 // Gets value from Position component
@@ -906,7 +906,7 @@ ecs_add_id(world, LocatedIn, Transitive);
 LocatedIn.add(flecs::Transitive);
 ```
 
-When now querying for `(LocatedIn, USA)`, the query will follow the `LocatedIn` relation and return both `NewYork` and `Manhattan`. For more details on how queries use transitivity, see the section in the query manual on transitivity: [Query transitivity](Queries.md#Transitivity).
+When now querying for `(LocatedIn, USA)`, the query will follow the `LocatedIn` relation and return both `NewYork` and `Manhattan`. For more details on how queries use transitivity, see the [Transitivity section in the query manual](Queries.md#Transitivity).
 
 ### Reflexive property
 A relation can be marked reflexive which means that a query like `Relation(Entity, Entity)` should evaluate to true. The utility of `Reflexive` becomes more obvious with an example:
@@ -928,8 +928,7 @@ IsA(Tree, Tree)
 - Yes, even though Tree does not have (IsA, Tree)
 ```
 
-However, this does not apply to all relations. Consider a dataset with a 
-`LocatedIn` relation:
+However, this does not apply to all relations. Consider a dataset with a `LocatedIn` relation:
 
 ```
 LocatedIn(SanFrancisco, UnitedStates)
@@ -1004,13 +1003,13 @@ flecs::entity e = world.entity().add(Movement, Running);
 e.add(Movement, Walking); // replaces (Movement, Running)
 ```
 
-When compared to reguar relationships, union relationships have some differences and limitations:
+When compared to regular relationships, union relationships have some differences and limitations:
 - Relationship cleanup does not work yet for union relations
 - Removing a union relationship removes any target, even if the specified target is different
 - Filters and rules do not support union relationships
 - Union relationships cannot have data
-- Union relationship query terms can only use the And operator
-- Queries with a (R, *) term will return (R, *) as term id for each entity
+- Union relationship query terms can only use the `And` operator
+- Queries with a `(R, *)` term will return `(R, *)` as term id for each entity
 
 ### Symmetric property
 The `Symmetric` property enforces that when a relation `(R, Y)` is added to entity `X`, the relation `(R, X)` will be added to entity `Y`. The reverse is also true, if relation `(R, Y)` is removed from `X`, relation `(R, X)` will be removed from `Y`.
@@ -1068,7 +1067,7 @@ auto e = world.entity().add(Loves, Pears);
 ```
 
 ### OneOf property
-The `OneOf` property enforces that the target of the relationship is a child of a specified entity. `OneOf` can be used to either indicate that the target needs to be a child of the relation (common for enum relationships), or of another entity. 
+The `OneOf` property enforces that the target of the relationship is a child of a specified entity. `OneOf` can be used to either indicate that the target needs to be a child of the relation (common for enum relationships), or of another entity.
 
 The following example shows how to constrain the relationship target to a child of the relation:
 

--- a/docs/RestApi.md
+++ b/docs/RestApi.md
@@ -88,8 +88,7 @@ This section describes the endpoints of the REST API.
 ```
 /entity/<path>
 ```
-The entity endpoint requests data from an entity. The path is the entity
-path or name of the entity to query for. The reply is formatted according to the [JSON serializer Entity](JsonFormat.md#entity) type.
+The entity endpoint requests data from an entity. The path is the entity path or name of the entity to query for. The reply is formatted according to the [JSON serializer Entity](JsonFormat.md#entity) type.
 
 The following parameters can be provided to the endpoint:
 
@@ -173,17 +172,17 @@ Add top-level "ids" array with components as specified by query.
 Add result-specific "ids" array with components as matched. Can be different from top-level "ids" array for queries with wildcards.
 
 **Default**: true
-  
+
 #### **subjects**
 Add result-specific "subjects" array with component source. A 0 element indicates the component is matched on the current (This) entity.
 
 **Default**: true
-    
+
 #### **variables**
 Add result-specific "variables" array with values for variables, if any.
 
 **Default**: true
- 
+
 #### **is_set**
 Add result-specific "is_set" array with boolean elements indicating whether component was matched (used for optional terms).
 
@@ -225,7 +224,7 @@ Include numerical ids for variables.
 Include measurement on how long it took to serialize result.
 
 **Default**: false
-    
+
 #### **type_info**
 Add top-level "type_info" array with reflection data on the type in
 the query. If a query element has a component that has no reflection
@@ -246,8 +245,8 @@ data, a 0 element is added to the array.
 ```
 The stats endpoint returns statistics for a specified category or period. This endpoint requires the monitor module to be imported (see above). The supported categories are:
 
-- world
-- pipeline
+- `world`
+- `pipeline`
 
 The supported periods are:
 

--- a/examples/c/entities/hooks/src/main.c
+++ b/examples/c/entities/hooks/src/main.c
@@ -8,7 +8,7 @@ typedef struct {
     char *value; // Pointer to external memory
 } String;
 
-// Resource management hooks. The convenience macro's hide details of
+// Resource management hooks. The convenience macros hide details of
 // the callback signature, while allowing hooks to be called on multiple 
 // entities.
 

--- a/examples/c/rules/component_inheritance/src/main.c
+++ b/examples/c/rules/component_inheritance/src/main.c
@@ -4,7 +4,7 @@
 int main(int argc, char *argv[]) {
     ecs_world_t *ecs = ecs_init_w_args(argc, argv);
 
-    // Use convenience macro's to create simple hierarchy of unit types.
+    // Use convenience macros to create simple hierarchy of unit types.
     // This macro call:
     //   ECS_ENTITY(ecs, CombatUnit, (IsA, Unit))
     //

--- a/flecs.c
+++ b/flecs.c
@@ -32,7 +32,7 @@
  * @brief Entity index data structure.
  *
  * The entity index stores the table, row for an entity id. It is implemented as
- * a sparse set. This file contains convenience macro's for working with the
+ * a sparse set. This file contains convenience macros for working with the
  * entity index.
  */
 
@@ -25532,7 +25532,7 @@ const char* ecs_meta_get_member(
     return op->name;
 }
 
-/* Utility macro's to let the compiler do the conversion work for us */
+/* Utility macros to let the compiler do the conversion work for us */
 #define set_T(T, ptr, value)\
     ((T*)ptr)[0] = ((T)value)
 
@@ -34889,7 +34889,7 @@ const char* parse_c_identifier(
     }
 
     while ((ch = *ptr) && !isspace(ch) && ch != ';' && ch != ',' && ch != ')' && ch != '>' && ch != '}') {
-        /* Type definitions can contain macro's or templates */
+        /* Type definitions can contain macros or templates */
         if (ch == '(' || ch == '<') {
             if (!params) {
                 ecs_meta_error(ctx, ptr, "unexpected %c", *ptr);
@@ -46417,7 +46417,7 @@ ecs_table_t* ecs_table_remove_id(
 
 #include <stddef.h>
 
-/* Utility macro's to enforce consistency when initializing iterator fields */
+/* Utility macros to enforce consistency when initializing iterator fields */
 
 /* If term count is smaller than cache size, initialize with inline array,
  * otherwise allocate. */

--- a/flecs.h
+++ b/flecs.h
@@ -67,7 +67,7 @@
 /* FLECS_KEEP_ASSERT keeps asserts in release mode. */
 // #define FLECS_KEEP_ASSERT
 
-/* The following macro's let you customize with which addons Flecs is built.
+/* The following macros let you customize with which addons Flecs is built.
  * Without any addons Flecs is just a minimal ECS storage, but addons add 
  * features such as systems, scheduling and reflection. If an addon is disabled,
  * it is excluded from the build, so that it consumes no resources. By default
@@ -94,7 +94,7 @@
 // #define FLECS_CUSTOM_BUILD
 
 #ifndef FLECS_CUSTOM_BUILD
-// #define FLECS_C          /* C API convenience macro's, always enabled */
+// #define FLECS_C          /* C API convenience macros, always enabled */
 #define FLECS_CPP           /* C++ API */
 #define FLECS_MODULE        /* Module support */
 #define FLECS_PARSER        /* String parser for queries */
@@ -126,7 +126,7 @@
  * @file api_defines.h
  * @brief Supporting defines for the public API.
  *
- * This file contains constants / macro's that are typically not used by an
+ * This file contains constants / macros that are typically not used by an
  * application but support the public API, and therefore must be exposed. This
  * header should not be included by itself.
  */
@@ -346,7 +346,7 @@ extern "C" {
 /* Non-standard but required. If not provided by platform, add manually. */
 #include <stdint.h>
 
-/* Contains macro's for importing / exporting symbols */
+/* Contains macros for importing / exporting symbols */
 /*
                                    )
                                   (.)
@@ -493,7 +493,7 @@ typedef int32_t ecs_size_t;
 #define ecs_observer_t_magic  (0x65637362)
 
 ////////////////////////////////////////////////////////////////////////////////
-//// Entity id macro's
+//// Entity id macros
 ////////////////////////////////////////////////////////////////////////////////
 
 #define ECS_ROW_MASK                  (0x0FFFFFFFu)
@@ -553,7 +553,7 @@ typedef int32_t ecs_size_t;
 #define ecs_poly_id(tag) ecs_pair(ecs_id(EcsPoly), tag)
 
 ////////////////////////////////////////////////////////////////////////////////
-//// Debug macro's
+//// Debug macros
 ////////////////////////////////////////////////////////////////////////////////
 
 #ifndef FLECS_NDEBUG
@@ -566,7 +566,7 @@ typedef int32_t ecs_size_t;
 
 
 ////////////////////////////////////////////////////////////////////////////////
-//// Convenience macro's for ctor, dtor, move and copy
+//// Convenience macros for ctor, dtor, move and copy
 ////////////////////////////////////////////////////////////////////////////////
 
 #ifndef FLECS_LEGACY
@@ -675,8 +675,8 @@ typedef int32_t ecs_size_t;
  * retrieving or computing this size, the functions are wrapped in macro calls
  * that compute the header size at compile time.
  *
- * The API provides a number of _t macro's, which accept a size and alignment.
- * These macro's are used when no compile-time type is available.
+ * The API provides a number of _t macros, which accept a size and alignment.
+ * These macros are used when no compile-time type is available.
  *
  * The vector guarantees contiguous access to its elements. When an element is
  * removed from the vector, the last element is copied to the removed element.
@@ -1816,7 +1816,7 @@ char* (*ecs_os_api_module_to_path_t)(
     const char *module_id);
 
 /* Prefix members of struct with 'ecs_' as some system headers may define 
- * macro's for functions like "strdup", "log" or "_free" */
+ * macros for functions like "strdup", "log" or "_free" */
 
 typedef struct ecs_os_api_t {
     /* API init / deinit */
@@ -7522,14 +7522,14 @@ void* ecs_record_get_column(
 
 /**
  * @file flecs_c.h
- * @brief Extends the core API with convenience functions/macro's for C applications.
+ * @brief Extends the core API with convenience functions/macros for C applications.
  */
 
 #ifndef FLECS_C_
 #define FLECS_C_
 
 /**
- * @defgroup create_macros Macro's that help with creation of ECS objects.
+ * @defgroup create_macros Macros that help with creation of ECS objects.
  * @{
  */
 
@@ -7718,7 +7718,7 @@ void* ecs_record_get_column(
 /** @} */
 
 /**
- * @defgroup function_macros Convenience macro's that wrap ECS operations
+ * @defgroup function_macros Convenience macros that wrap ECS operations
  * @{
  */
 
@@ -7997,7 +7997,7 @@ void* ecs_record_get_column(
 /** @} */
 
 /**
- * @defgroup utilities Utility macro's for commonly used operations
+ * @defgroup utilities Utility macros for commonly used operations
  * @{
  */
 
@@ -8008,7 +8008,7 @@ void* ecs_record_get_column(
 /** @} */
 
 /**
- * @defgroup temporary_macros Temp macro's for easing the transition to v3
+ * @defgroup temporary_macros Temp macros for easing the transition to v3
  * @{
  */
 
@@ -8096,7 +8096,7 @@ void* ecs_record_get_column(
 #endif // FLECS_NO_REST
 #endif // ECS_TARGET_EM
 
-/* Blacklist macro's */
+/* Blacklist macros */
 #ifdef FLECS_NO_CPP
 #undef FLECS_CPP
 #endif
@@ -8167,7 +8167,7 @@ void* ecs_record_get_column(
 #undef FLECS_REST
 #endif
 
-/* Always included, if disabled log functions are replaced with dummy macro's */
+/* Always included, if disabled log functions are replaced with dummy macros */
 /**
  * @file log.h
  * @brief Logging addon.
@@ -8254,7 +8254,7 @@ const char* ecs_strerror(
 #else // FLECS_LOG
 
 ////////////////////////////////////////////////////////////////////////////////
-//// Dummy macro's for when logging is disabled
+//// Dummy macros for when logging is disabled
 ////////////////////////////////////////////////////////////////////////////////
 
 #define _ecs_deprecated(file, line, msg)\
@@ -8328,10 +8328,10 @@ void _ecs_parser_errorv(
 
 
 ////////////////////////////////////////////////////////////////////////////////
-//// Logging Macro's
+//// Logging macros
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef FLECS_LEGACY /* C89 doesn't support variadic macro's */
+#ifndef FLECS_LEGACY /* C89 doesn't support variadic macros */
 
 /* Base logging function. Accepts a custom level */
 #define ecs_log(level, ...)\
@@ -8374,7 +8374,7 @@ void _ecs_parser_errorv(
 #endif // !(defined(FLECS_LOG_0) || defined(FLECS_LOG_1) || defined(FLECS_LOG_2) || defined(FLECS_LOG_3))
 
 
-/* Define/undefine macro's based on compiled-in tracing level. This can optimize
+/* Define/undefine macros based on compiled-in tracing level. This can optimize
  * out tracing statements from a build, which improves performance. */
 
 #if defined(FLECS_LOG_3) /* All debug tracing enabled */
@@ -8563,7 +8563,7 @@ void _ecs_parser_errorv(
 
 /** Enable or disable tracing.
  * This will enable builtin tracing. For tracing to work, it will have to be
- * compiled in which requires defining one of the following macro's:
+ * compiled in which requires defining one of the following macros:
  *
  * FLECS_LOG_0 - All tracing is disabled
  * FLECS_LOG_1 - Enable tracing level 1
@@ -11550,7 +11550,7 @@ const char *ecs_parse_expr_token(
 #endif
 /**
  * @file meta_c.h
- * @brief Utility macro's for populating reflection data in C.
+ * @brief Utility macros for populating reflection data in C.
  */
 
 #ifdef FLECS_META_C
@@ -11690,7 +11690,7 @@ int ecs_meta_from_desc(
     FLECS_META_C_IMPORT extern ECS_COMPONENT_DECLARE(name)
 
 
-/* Symbol export utility macro's */
+/* Symbol export utility macros */
 #if defined(ECS_TARGET_WINDOWS)
 #define FLECS_META_C_EXPORT __declspec(dllexport)
 #define FLECS_META_C_IMPORT __declspec(dllimport)

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -65,7 +65,7 @@
 /* FLECS_KEEP_ASSERT keeps asserts in release mode. */
 // #define FLECS_KEEP_ASSERT
 
-/* The following macro's let you customize with which addons Flecs is built.
+/* The following macros let you customize with which addons Flecs is built.
  * Without any addons Flecs is just a minimal ECS storage, but addons add 
  * features such as systems, scheduling and reflection. If an addon is disabled,
  * it is excluded from the build, so that it consumes no resources. By default
@@ -92,7 +92,7 @@
 // #define FLECS_CUSTOM_BUILD
 
 #ifndef FLECS_CUSTOM_BUILD
-// #define FLECS_C          /* C API convenience macro's, always enabled */
+// #define FLECS_C          /* C API convenience macros, always enabled */
 #define FLECS_CPP           /* C++ API */
 #define FLECS_MODULE        /* Module support */
 #define FLECS_PARSER        /* String parser for queries */

--- a/include/flecs/addons/flecs_c.h
+++ b/include/flecs/addons/flecs_c.h
@@ -1,13 +1,13 @@
 /**
  * @file flecs_c.h
- * @brief Extends the core API with convenience functions/macro's for C applications.
+ * @brief Extends the core API with convenience functions/macros for C applications.
  */
 
 #ifndef FLECS_C_
 #define FLECS_C_
 
 /**
- * @defgroup create_macros Macro's that help with creation of ECS objects.
+ * @defgroup create_macros Macros that help with creation of ECS objects.
  * @{
  */
 
@@ -196,7 +196,7 @@
 /** @} */
 
 /**
- * @defgroup function_macros Convenience macro's that wrap ECS operations
+ * @defgroup function_macros Convenience macros that wrap ECS operations
  * @{
  */
 
@@ -475,7 +475,7 @@
 /** @} */
 
 /**
- * @defgroup utilities Utility macro's for commonly used operations
+ * @defgroup utilities Utility macros for commonly used operations
  * @{
  */
 
@@ -486,7 +486,7 @@
 /** @} */
 
 /**
- * @defgroup temporary_macros Temp macro's for easing the transition to v3
+ * @defgroup temporary_macros Temp macros for easing the transition to v3
  * @{
  */
 

--- a/include/flecs/addons/log.h
+++ b/include/flecs/addons/log.h
@@ -84,7 +84,7 @@ const char* ecs_strerror(
 #else // FLECS_LOG
 
 ////////////////////////////////////////////////////////////////////////////////
-//// Dummy macro's for when logging is disabled
+//// Dummy macros for when logging is disabled
 ////////////////////////////////////////////////////////////////////////////////
 
 #define _ecs_deprecated(file, line, msg)\
@@ -158,10 +158,10 @@ void _ecs_parser_errorv(
 
 
 ////////////////////////////////////////////////////////////////////////////////
-//// Logging Macro's
+//// Logging macros
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef FLECS_LEGACY /* C89 doesn't support variadic macro's */
+#ifndef FLECS_LEGACY /* C89 doesn't support variadic macros */
 
 /* Base logging function. Accepts a custom level */
 #define ecs_log(level, ...)\
@@ -204,7 +204,7 @@ void _ecs_parser_errorv(
 #endif // !(defined(FLECS_LOG_0) || defined(FLECS_LOG_1) || defined(FLECS_LOG_2) || defined(FLECS_LOG_3))
 
 
-/* Define/undefine macro's based on compiled-in tracing level. This can optimize
+/* Define/undefine macros based on compiled-in tracing level. This can optimize
  * out tracing statements from a build, which improves performance. */
 
 #if defined(FLECS_LOG_3) /* All debug tracing enabled */
@@ -393,7 +393,7 @@ void _ecs_parser_errorv(
 
 /** Enable or disable tracing.
  * This will enable builtin tracing. For tracing to work, it will have to be
- * compiled in which requires defining one of the following macro's:
+ * compiled in which requires defining one of the following macros:
  *
  * FLECS_LOG_0 - All tracing is disabled
  * FLECS_LOG_1 - Enable tracing level 1

--- a/include/flecs/addons/meta_c.h
+++ b/include/flecs/addons/meta_c.h
@@ -1,6 +1,6 @@
 /**
  * @file meta_c.h
- * @brief Utility macro's for populating reflection data in C.
+ * @brief Utility macros for populating reflection data in C.
  */
 
 #ifdef FLECS_META_C
@@ -140,7 +140,7 @@ int ecs_meta_from_desc(
     FLECS_META_C_IMPORT extern ECS_COMPONENT_DECLARE(name)
 
 
-/* Symbol export utility macro's */
+/* Symbol export utility macros */
 #if defined(ECS_TARGET_WINDOWS)
 #define FLECS_META_C_EXPORT __declspec(dllexport)
 #define FLECS_META_C_IMPORT __declspec(dllimport)

--- a/include/flecs/os_api.h
+++ b/include/flecs/os_api.h
@@ -186,7 +186,7 @@ char* (*ecs_os_api_module_to_path_t)(
     const char *module_id);
 
 /* Prefix members of struct with 'ecs_' as some system headers may define 
- * macro's for functions like "strdup", "log" or "_free" */
+ * macros for functions like "strdup", "log" or "_free" */
 
 typedef struct ecs_os_api_t {
     /* API init / deinit */

--- a/include/flecs/private/addons.h
+++ b/include/flecs/private/addons.h
@@ -19,7 +19,7 @@
 #endif // FLECS_NO_REST
 #endif // ECS_TARGET_EM
 
-/* Blacklist macro's */
+/* Blacklist macros */
 #ifdef FLECS_NO_CPP
 #undef FLECS_CPP
 #endif
@@ -90,7 +90,7 @@
 #undef FLECS_REST
 #endif
 
-/* Always included, if disabled log functions are replaced with dummy macro's */
+/* Always included, if disabled log functions are replaced with dummy macros */
 #include "flecs/addons/log.h"
 
 #ifdef FLECS_MONITOR

--- a/include/flecs/private/api_defines.h
+++ b/include/flecs/private/api_defines.h
@@ -2,7 +2,7 @@
  * @file api_defines.h
  * @brief Supporting defines for the public API.
  *
- * This file contains constants / macro's that are typically not used by an
+ * This file contains constants / macros that are typically not used by an
  * application but support the public API, and therefore must be exposed. This
  * header should not be included by itself.
  */
@@ -51,7 +51,7 @@
 /* Non-standard but required. If not provided by platform, add manually. */
 #include <stdint.h>
 
-/* Contains macro's for importing / exporting symbols */
+/* Contains macros for importing / exporting symbols */
 #include "../bake_config.h"
 
 #ifdef __cplusplus
@@ -159,7 +159,7 @@ typedef int32_t ecs_size_t;
 #define ecs_observer_t_magic  (0x65637362)
 
 ////////////////////////////////////////////////////////////////////////////////
-//// Entity id macro's
+//// Entity id macros
 ////////////////////////////////////////////////////////////////////////////////
 
 #define ECS_ROW_MASK                  (0x0FFFFFFFu)
@@ -219,7 +219,7 @@ typedef int32_t ecs_size_t;
 #define ecs_poly_id(tag) ecs_pair(ecs_id(EcsPoly), tag)
 
 ////////////////////////////////////////////////////////////////////////////////
-//// Debug macro's
+//// Debug macros
 ////////////////////////////////////////////////////////////////////////////////
 
 #ifndef FLECS_NDEBUG
@@ -232,7 +232,7 @@ typedef int32_t ecs_size_t;
 
 
 ////////////////////////////////////////////////////////////////////////////////
-//// Convenience macro's for ctor, dtor, move and copy
+//// Convenience macros for ctor, dtor, move and copy
 ////////////////////////////////////////////////////////////////////////////////
 
 #ifndef FLECS_LEGACY

--- a/include/flecs/private/vector.h
+++ b/include/flecs/private/vector.h
@@ -11,8 +11,8 @@
  * retrieving or computing this size, the functions are wrapped in macro calls
  * that compute the header size at compile time.
  *
- * The API provides a number of _t macro's, which accept a size and alignment.
- * These macro's are used when no compile-time type is available.
+ * The API provides a number of _t macros, which accept a size and alignment.
+ * These macros are used when no compile-time type is available.
  *
  * The vector guarantees contiguous access to its elements. When an element is
  * removed from the vector, the last element is copied to the removed element.

--- a/src/addons/meta/cursor.c
+++ b/src/addons/meta/cursor.c
@@ -431,7 +431,7 @@ const char* ecs_meta_get_member(
     return op->name;
 }
 
-/* Utility macro's to let the compiler do the conversion work for us */
+/* Utility macros to let the compiler do the conversion work for us */
 #define set_T(T, ptr, value)\
     ((T*)ptr)[0] = ((T)value)
 

--- a/src/addons/meta_c.c
+++ b/src/addons/meta_c.c
@@ -128,7 +128,7 @@ const char* parse_c_identifier(
     }
 
     while ((ch = *ptr) && !isspace(ch) && ch != ';' && ch != ',' && ch != ')' && ch != '>' && ch != '}') {
-        /* Type definitions can contain macro's or templates */
+        /* Type definitions can contain macros or templates */
         if (ch == '(' || ch == '<') {
             if (!params) {
                 ecs_meta_error(ctx, ptr, "unexpected %c", *ptr);

--- a/src/datastructures/entity_index.h
+++ b/src/datastructures/entity_index.h
@@ -3,7 +3,7 @@
  * @brief Entity index data structure.
  *
  * The entity index stores the table, row for an entity id. It is implemented as
- * a sparse set. This file contains convenience macro's for working with the
+ * a sparse set. This file contains convenience macros for working with the
  * entity index.
  */
 

--- a/src/iter.c
+++ b/src/iter.c
@@ -1,7 +1,7 @@
 #include "private_api.h"
 #include <stddef.h>
 
-/* Utility macro's to enforce consistency when initializing iterator fields */
+/* Utility macros to enforce consistency when initializing iterator fields */
 
 /* If term count is smaller than cache size, initialize with inline array,
  * otherwise allocate. */


### PR DESCRIPTION
- Fixed typos, trailing whitespaces, styling inconsistencies all over the documentation, readme and even some comments (in case of "macro's") specifically;
- Emphasized Flecs' unique features more by moving the hierarchies and relations up the key features list in README and adding another sentence highlighting the core design to brief description;
- Brought back the building and usage mini-section from manual (it wasn't intuitive for it to be there, usually such info is placed on project README);
- Removed the addons section from manual as it a) overlaps with the README one, b) seems to be way outdated from a quick glance on blame and the codebase.