### PR TITLE
Fix Windows headers case to make MinGW compiler happy

### DIFF
--- a/src/addons/http.c
+++ b/src/addons/http.c
@@ -39,9 +39,9 @@
 #define WIN32_LEAN_AND_MEAN
 #endif
 #pragma comment(lib, "Ws2_32.lib")
-#include <WinSock2.h>
-#include <Ws2tcpip.h>
-#include <Windows.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <windows.h>
 typedef SOCKET ecs_http_socket_t;
 #else
 #include <unistd.h>

--- a/src/addons/os_api_impl/windows_impl.inl
+++ b/src/addons/os_api_impl/windows_impl.inl
@@ -1,7 +1,7 @@
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
-#include <WinSock2.h>
+#include <winsock2.h>
 #include <windows.h>
 
 static


### PR DESCRIPTION
Hello! This PR makes it possible to compile Flecs using MinGW (since MinGW's own compiler, GCC, is case-sensitive regarding header names).