### PR TITLE
Fix pipe rendering in Queries.md

### DIFF
--- a/docs/Queries.md
+++ b/docs/Queries.md
@@ -1035,12 +1035,12 @@ The following operators are supported by queries:
 | Name     | DSL operator   | C identifier  | C++ identifier    | Description |
 |----------|----------------|---------------|-------------------|-------------|
 | And      | `,`            | `EcsAnd`      | `flecs::And`      | Match at least once with term |
-| Or       | `||`           | `EcsOr`       | `flecs::Or`       | Match at least once with one of the OR terms |
+| Or       | `\|\|`         | `EcsOr`       | `flecs::Or`       | Match at least once with one of the OR terms |
 | Not      | `!`            | `EcsNot`      | `flecs::Not`      | Must not match with term |
 | Optional | `?`            | `EcsOptional` | `flecs::Optional` | May match with term |
-| AndFrom  | `AND |`        | `EcsAndFrom`  | `flecs::AndFrom`  | Match all components from id at least once |
-| OrFrom   | `OR |`         | `EcsOrFrom`   | `flecs::OrFrom`   | Match at least one component from id at least once |
-| NotFrom  | `NOT |`        | `EcsNotFrom`  | `flecs::NotFrom`  | Don't match any components from id |
+| AndFrom  | `AND \|`        | `EcsAndFrom`  | `flecs::AndFrom`  | Match all components from id at least once |
+| OrFrom   | `OR \|`         | `EcsOrFrom`   | `flecs::OrFrom`   | Match at least one component from id at least once |
+| NotFrom  | `NOT \|`        | `EcsNotFrom`  | `flecs::NotFrom`  | Don't match any components from id |
 
 ### And Operator
 > *Supported by: filters, cached queries, rules*


### PR DESCRIPTION
## Description

The `Operator Overview` table in `Queries.md` doesn't render properly because of `|`.
When writing a pipe in a code block, it needs to be espaced with `\` as per the [GFM spec](https://github.github.com/gfm/#example-200).

## Changelog
- Escaped `|` in the `Operator Overview` table to render them properly 

## Results

Before
<img width="375" alt="image" src="https://user-images.githubusercontent.com/2550726/186141451-672ba7fa-ccd5-49d5-a1c6-6017184b9a07.png">

After
<img width="440" alt="image" src="https://user-images.githubusercontent.com/2550726/186141689-9c18730e-8b68-4bcf-ac85-74e757acb72e.png">
