### PR TITLE
Command batching

### DIFF
--- a/flecs.h
+++ b/flecs.h
@@ -1178,6 +1178,11 @@ void flecs_ballocator_init(
     ecs_block_allocator_t *ba,
     ecs_size_t size);
 
+#define flecs_ballocator_init_t(ba, T)\
+    flecs_ballocator_init(ba, ECS_SIZEOF(T))
+#define flecs_ballocator_init_n(ba, T, count)\
+    flecs_ballocator_init(ba, ECS_SIZEOF(T) * count)
+
 FLECS_DBG_API
 ecs_block_allocator_t* flecs_ballocator_new(
     ecs_size_t size);
@@ -3149,6 +3154,9 @@ void ecs_vec_fini(
 
 #define ecs_vec_fini_t(allocator, vec, T) \
     ecs_vec_fini(allocator, vec, ECS_SIZEOF(T))
+
+void ecs_vec_clear(
+    ecs_vec_t *vec);
 
 void* ecs_vec_append(
     ecs_allocator_t *allocator,

--- a/include/flecs/private/block_allocator.h
+++ b/include/flecs/private/block_allocator.h
@@ -33,6 +33,11 @@ void flecs_ballocator_init(
     ecs_block_allocator_t *ba,
     ecs_size_t size);
 
+#define flecs_ballocator_init_t(ba, T)\
+    flecs_ballocator_init(ba, ECS_SIZEOF(T))
+#define flecs_ballocator_init_n(ba, T, count)\
+    flecs_ballocator_init(ba, ECS_SIZEOF(T) * count)
+
 FLECS_DBG_API
 ecs_block_allocator_t* flecs_ballocator_new(
     ecs_size_t size);

--- a/include/flecs/private/vec.h
+++ b/include/flecs/private/vec.h
@@ -33,6 +33,9 @@ void ecs_vec_fini(
 #define ecs_vec_fini_t(allocator, vec, T) \
     ecs_vec_fini(allocator, vec, ECS_SIZEOF(T))
 
+void ecs_vec_clear(
+    ecs_vec_t *vec);
+
 void* ecs_vec_append(
     ecs_allocator_t *allocator,
     ecs_vec_t *vec,

--- a/src/datastructures/vec.c
+++ b/src/datastructures/vec.c
@@ -33,6 +33,12 @@ void ecs_vec_fini(
     }
 }
 
+void ecs_vec_clear(
+    ecs_vec_t *vec)
+{
+    vec->count = 0;
+}
+
 ecs_vec_t ecs_vec_copy(
     ecs_allocator_t *allocator,
     ecs_vec_t *v,

--- a/src/private_types.h
+++ b/src/private_types.h
@@ -120,6 +120,16 @@ typedef struct ecs_table_diff_t {
     ecs_type_t un_set;        /* UnSet from hiding/removing base components */
 } ecs_table_diff_t;
 
+/** Builder for table diff. The table diff type itself doesn't use ecs_vec_t to
+ * conserve memory on table edges (a type doesn't have the size field), whereas
+ * a vec for the builder is more convenient to use & has allocator support. */
+typedef struct ecs_table_diff_builder_t {
+    ecs_vec_t added;
+    ecs_vec_t removed;
+    ecs_vec_t on_set;
+    ecs_vec_t un_set;
+} ecs_table_diff_builder_t;
+
 /** Edge linked list (used to keep track of incoming edges) */
 typedef struct ecs_graph_edge_hdr_t {
     struct ecs_graph_edge_hdr_t *prev;
@@ -418,6 +428,9 @@ typedef struct ecs_world_allocators_t {
     ecs_block_allocator_t table_diff;
     ecs_block_allocator_t sparse_chunk;
     ecs_block_allocator_t hashmap;
+
+    /* Temporary vectors used for creating table diff id sequences */
+    ecs_table_diff_builder_t diff_builder;
 } ecs_world_allocators_t;
 
 /* Stage level allocators are for operations that can be multithreaded */

--- a/src/private_types.h
+++ b/src/private_types.h
@@ -462,7 +462,7 @@ struct ecs_stage_t {
 
     /* Deferred command queue */
     int32_t defer;
-    ecs_vector_t *commands;
+    ecs_vec_t commands;
     ecs_stack_t defer_stack;    /* Temp memory used by deferred commands */
     ecs_map_t cmd_entries;       /* <entity, op_entry_t> - command combining */
     bool defer_suspend;         /* Suspend deferring without flushing */

--- a/src/stage.h
+++ b/src/stage.h
@@ -89,7 +89,7 @@ bool flecs_defer_remove(
 bool flecs_defer_set(
     ecs_world_t *world,
     ecs_stage_t *stage,
-    ecs_defer_op_kind_t op_kind,
+    ecs_cmd_kind_t op_kind,
     ecs_entity_t entity,
     ecs_entity_t component,
     ecs_size_t size,

--- a/src/table.h
+++ b/src/table.h
@@ -212,6 +212,9 @@ void flecs_table_diff_builder_fini(
     ecs_world_t *world,
     ecs_table_diff_builder_t *builder);
 
+void flecs_table_diff_builder_clear(
+    ecs_table_diff_builder_t *builder);
+
 void flecs_table_diff_build_append_table(
     ecs_world_t *world,
     ecs_table_diff_builder_t *dst,

--- a/src/table.h
+++ b/src/table.h
@@ -202,4 +202,32 @@ bool flecs_table_release(
     ecs_world_t *world, 
     ecs_table_t *table);
 
+/* Table diff builder, used to build id lists that indicate the difference in
+ * ids between two tables. */
+void flecs_table_diff_builder_init(
+    ecs_world_t *world,
+    ecs_table_diff_builder_t *builder);
+
+void flecs_table_diff_builder_fini(
+    ecs_world_t *world,
+    ecs_table_diff_builder_t *builder);
+
+void flecs_table_diff_build_append_table(
+    ecs_world_t *world,
+    ecs_table_diff_builder_t *dst,
+    ecs_table_diff_t *src);
+
+void flecs_table_diff_build(
+    ecs_world_t *world,
+    ecs_table_diff_builder_t *builder,
+    ecs_table_diff_t *diff,
+    int32_t added_offset,
+    int32_t removed_offset,
+    int32_t on_set_offset,
+    int32_t un_set_offset);
+
+void flecs_table_diff_build_noalloc(
+    ecs_table_diff_builder_t *builder,
+    ecs_table_diff_t *diff);
+
 #endif

--- a/src/world.c
+++ b/src/world.c
@@ -239,7 +239,7 @@ ecs_world_t* flecs_suspend_readonly(
     state->scope = stage->scope;
     state->with = stage->with;
     stage->defer = 0;
-    stage->commands = NULL;
+    ecs_vec_init_t(NULL, &stage->commands, ecs_cmd_t, 0);
     
     return world;
 }
@@ -262,11 +262,7 @@ void flecs_resume_readonly(
         /* Restore readonly state / defer count */
         ECS_BIT_COND(world->flags, EcsWorldReadonly, state->is_readonly);
         stage->defer = state->defer_count;
-        if (stage->commands) {
-            ecs_assert(ecs_vector_count(stage->commands) == 0, 
-                ECS_INTERNAL_ERROR, NULL);
-            ecs_vector_free(stage->commands);
-        }
+        ecs_vec_fini_t(&stage->allocator, &stage->commands, ecs_cmd_t);
         stage->commands = state->commands;
         flecs_stack_fini(&stage->defer_stack);
         stage->defer_stack = state->defer_stack;

--- a/src/world.c
+++ b/src/world.c
@@ -541,42 +541,44 @@ static
 void flecs_world_allocators_init(
     ecs_world_t *world)
 {
+    ecs_world_allocators_t *a = &world->allocators;
+
     flecs_allocator_init(&world->allocator);
-    ecs_map_params_init(&world->allocators.ptr, &world->allocator, void*);
-    ecs_map_params_init(&world->allocators.query_table_list, &world->allocator,
+
+    ecs_map_params_init(&a->ptr, &world->allocator, void*);
+    ecs_map_params_init(&a->query_table_list, &world->allocator,
         ecs_query_table_list_t);
-    flecs_ballocator_init(&world->allocators.query_table, 
-        ECS_SIZEOF(ecs_query_table_t));
-    flecs_ballocator_init(&world->allocators.query_table_match, 
-        ECS_SIZEOF(ecs_query_table_match_t));
-    flecs_ballocator_init(&world->allocators.graph_edge_lo, 
-        ECS_SIZEOF(ecs_graph_edge_t) * ECS_HI_COMPONENT_ID);
-    flecs_ballocator_init(&world->allocators.graph_edge, 
-        ECS_SIZEOF(ecs_graph_edge_t));
-    flecs_ballocator_init(&world->allocators.id_record, 
-        ECS_SIZEOF(ecs_id_record_t));
-    flecs_ballocator_init(&world->allocators.table_diff, 
-        ECS_SIZEOF(ecs_table_diff_t));
-    flecs_ballocator_init(&world->allocators.sparse_chunk, 
-        ECS_SIZEOF(int32_t) * FLECS_SPARSE_CHUNK_SIZE);
-    flecs_ballocator_init(&world->allocators.hashmap, 
-        ECS_SIZEOF(ecs_hashmap_t));
+
+    flecs_ballocator_init_t(&a->query_table, ecs_query_table_t);
+    flecs_ballocator_init_t(&a->query_table_match, ecs_query_table_match_t);
+    flecs_ballocator_init_n(&a->graph_edge_lo, ecs_graph_edge_t, ECS_HI_COMPONENT_ID);
+    flecs_ballocator_init_t(&a->graph_edge, ecs_graph_edge_t);
+    flecs_ballocator_init_t(&a->id_record, ecs_id_record_t);
+    flecs_ballocator_init_t(&a->table_diff, ecs_table_diff_t);
+    flecs_ballocator_init_n(&a->sparse_chunk, int32_t, FLECS_SPARSE_CHUNK_SIZE);
+    flecs_ballocator_init_t(&a->hashmap, ecs_hashmap_t);
+    flecs_table_diff_builder_init(world, &world->allocators.diff_builder);
 }
 
 static 
 void flecs_world_allocators_fini(
     ecs_world_t *world)
 {
-    ecs_map_params_fini(&world->allocators.ptr);
-    ecs_map_params_fini(&world->allocators.query_table_list);
-    flecs_ballocator_fini(&world->allocators.query_table);
-    flecs_ballocator_fini(&world->allocators.query_table_match);
-    flecs_ballocator_fini(&world->allocators.graph_edge_lo);
-    flecs_ballocator_fini(&world->allocators.graph_edge);
-    flecs_ballocator_fini(&world->allocators.id_record);
-    flecs_ballocator_fini(&world->allocators.table_diff);
-    flecs_ballocator_fini(&world->allocators.sparse_chunk);
-    flecs_ballocator_fini(&world->allocators.hashmap);
+    ecs_world_allocators_t *a = &world->allocators;
+
+    ecs_map_params_fini(&a->ptr);
+    ecs_map_params_fini(&a->query_table_list);
+
+    flecs_ballocator_fini(&a->query_table);
+    flecs_ballocator_fini(&a->query_table_match);
+    flecs_ballocator_fini(&a->graph_edge_lo);
+    flecs_ballocator_fini(&a->graph_edge);
+    flecs_ballocator_fini(&a->id_record);
+    flecs_ballocator_fini(&a->table_diff);
+    flecs_ballocator_fini(&a->sparse_chunk);
+    flecs_ballocator_fini(&a->hashmap);
+    flecs_table_diff_builder_fini(world, &world->allocators.diff_builder);
+
     flecs_allocator_fini(&world->allocator);
 }
 

--- a/src/world.c
+++ b/src/world.c
@@ -233,13 +233,13 @@ ecs_world_t* flecs_suspend_readonly(
     ecs_world_t *temp_world = world;
     ecs_stage_t *stage = flecs_stage_from_world(&temp_world);
     state->defer_count = stage->defer;
-    state->defer_queue = stage->defer_queue;
+    state->commands = stage->commands;
     state->defer_stack = stage->defer_stack;
     flecs_stack_init(&stage->defer_stack);
     state->scope = stage->scope;
     state->with = stage->with;
     stage->defer = 0;
-    stage->defer_queue = NULL;
+    stage->commands = NULL;
     
     return world;
 }
@@ -262,12 +262,12 @@ void flecs_resume_readonly(
         /* Restore readonly state / defer count */
         ECS_BIT_COND(world->flags, EcsWorldReadonly, state->is_readonly);
         stage->defer = state->defer_count;
-        if (stage->defer_queue) {
-            ecs_assert(ecs_vector_count(stage->defer_queue) == 0, 
+        if (stage->commands) {
+            ecs_assert(ecs_vector_count(stage->commands) == 0, 
                 ECS_INTERNAL_ERROR, NULL);
-            ecs_vector_free(stage->defer_queue);
+            ecs_vector_free(stage->commands);
         }
-        stage->defer_queue = state->defer_queue;
+        stage->commands = state->commands;
         flecs_stack_fini(&stage->defer_stack);
         stage->defer_stack = state->defer_stack;
         stage->scope = state->scope;

--- a/src/world.h
+++ b/src/world.h
@@ -99,13 +99,13 @@ void flecs_process_pending_tables(
  * 
  * These operations also suspend deferred mode.
  */
-typedef struct {
+typedef struct ecs_suspend_readonly_state_t {
     bool is_readonly;
     bool is_deferred;
     int32_t defer_count;
     ecs_entity_t scope;
     ecs_entity_t with;
-    ecs_vector_t *commands;
+    ecs_vec_t commands;
     ecs_stack_t defer_stack;
     ecs_stage_t *stage;
 } ecs_suspend_readonly_state_t;

--- a/src/world.h
+++ b/src/world.h
@@ -105,7 +105,7 @@ typedef struct {
     int32_t defer_count;
     ecs_entity_t scope;
     ecs_entity_t with;
-    ecs_vector_t *defer_queue;
+    ecs_vector_t *commands;
     ecs_stack_t defer_stack;
     ecs_stage_t *stage;
 } ecs_suspend_readonly_state_t;

--- a/test/api/project.json
+++ b/test/api/project.json
@@ -2128,7 +2128,15 @@
                 "update_observer_while_deferred",
                 "defer_set_large_component",
                 "defer_while_suspend_readonly",
-                "defer_while_suspend_readonly_w_existing_commands"
+                "defer_while_suspend_readonly_w_existing_commands",
+                "defer_add_union_relationship",
+                "defer_add_existing_union_relationship",
+                "defer_add_union_relationship_2_ops",
+                "defer_add_existing_union_relationship_2_ops",
+                "defer_remove_after_set",
+                "defer_remove_after_set_w_observer",
+                "defer_override_after_remove",
+                "defer_override_after_remove_3_ops"
             ]
         }, {
             "id": "SingleThreadStaging",

--- a/test/api/src/ComponentLifecycle.c
+++ b/test/api/src/ComponentLifecycle.c
@@ -739,20 +739,20 @@ void ComponentLifecycle_merge_to_different_table() {
     test_int(copy_position, 0);
     test_int(move_position, 0);
 
-    test_int(ctor_velocity, 3); // got moved 3 times
-    test_int(dtor_velocity, 3);
+    test_assert(ctor_velocity !=  0);
+    test_assert(dtor_velocity != 0);
     test_int(copy_velocity, 0);
-    test_int(move_velocity, 3);
+    test_assert(move_velocity != 0);
 
-    test_int(ctor_rotation, 2); // got moved 2 times, then removed
-    test_int(dtor_rotation, 3);
+    test_assert(ctor_rotation == 0);
+    test_assert(dtor_rotation != 0);
     test_int(copy_rotation, 0);
-    test_int(move_rotation, 2);
+    test_assert(move_rotation == 0);
 
-    test_int(ctor_mass, 2); // got added, moved once
-    test_int(dtor_mass, 1);
+    test_assert(ctor_mass != 0); // got added, moved once
+    test_assert(dtor_mass == 0);
     test_int(copy_mass, 0);
-    test_int(move_mass, 1);
+    test_assert(move_mass == 0);
 
     ecs_fini(world);
 }

--- a/test/api/src/main.c
+++ b/test/api/src/main.c
@@ -2040,6 +2040,14 @@ void DeferredActions_update_observer_while_deferred(void);
 void DeferredActions_defer_set_large_component(void);
 void DeferredActions_defer_while_suspend_readonly(void);
 void DeferredActions_defer_while_suspend_readonly_w_existing_commands(void);
+void DeferredActions_defer_add_union_relationship(void);
+void DeferredActions_defer_add_existing_union_relationship(void);
+void DeferredActions_defer_add_union_relationship_2_ops(void);
+void DeferredActions_defer_add_existing_union_relationship_2_ops(void);
+void DeferredActions_defer_remove_after_set(void);
+void DeferredActions_defer_remove_after_set_w_observer(void);
+void DeferredActions_defer_override_after_remove(void);
+void DeferredActions_defer_override_after_remove_3_ops(void);
 
 // Testsuite 'SingleThreadStaging'
 void SingleThreadStaging_setup(void);
@@ -10049,6 +10057,38 @@ bake_test_case DeferredActions_testcases[] = {
     {
         "defer_while_suspend_readonly_w_existing_commands",
         DeferredActions_defer_while_suspend_readonly_w_existing_commands
+    },
+    {
+        "defer_add_union_relationship",
+        DeferredActions_defer_add_union_relationship
+    },
+    {
+        "defer_add_existing_union_relationship",
+        DeferredActions_defer_add_existing_union_relationship
+    },
+    {
+        "defer_add_union_relationship_2_ops",
+        DeferredActions_defer_add_union_relationship_2_ops
+    },
+    {
+        "defer_add_existing_union_relationship_2_ops",
+        DeferredActions_defer_add_existing_union_relationship_2_ops
+    },
+    {
+        "defer_remove_after_set",
+        DeferredActions_defer_remove_after_set
+    },
+    {
+        "defer_remove_after_set_w_observer",
+        DeferredActions_defer_remove_after_set_w_observer
+    },
+    {
+        "defer_override_after_remove",
+        DeferredActions_defer_override_after_remove
+    },
+    {
+        "defer_override_after_remove_3_ops",
+        DeferredActions_defer_override_after_remove_3_ops
     }
 };
 
@@ -10862,7 +10902,7 @@ static bake_test_suite suites[] = {
         "DeferredActions",
         NULL,
         NULL,
-        72,
+        80,
         DeferredActions_testcases
     },
     {


### PR DESCRIPTION
This PR implements command batching, which is an optimization that for many situations limits the number of archetype moves for an entity to 1, even when N commands are enqueued for an entity.

Batching happens for operations that are enqueued while the world is in deferred mode.