### PR TITLE
#818 Scope into the module being imported automatically (20.09 14:06)

### DIFF
--- a/include/flecs/addons/cpp/mixins/module/impl.hpp
+++ b/include/flecs/addons/cpp/mixins/module/impl.hpp
@@ -14,7 +14,8 @@ ecs_entity_t do_import(world& world, const char *symbol) {
     // tag, as this would prevent calling emplace()
     auto m_c = component<T>(world, nullptr, false);
     ecs_add_id(world, m_c, EcsModule);
-
+    
+    world.module<T>();
     world.emplace<T>(world);
 
     ecs_set_scope(world, scope);


### PR DESCRIPTION
Implements #818 , works fine with excessive `world.module<T>()` call remaining in the constructor, correctly applies `ChildOf(Module)`, saves from having to ever write or remember to write `world.module<T>()` again.

**Cons:** Limits the abilities of the users to decide the scope for components and systems in their modules, so a better solution might be a different function called `.import_scoped<T>()`.