### PR TITLE
Query improvements & bugfixes

### DIFF
--- a/flecs.c
+++ b/flecs.c
@@ -45436,6 +45436,11 @@ bool flecs_query_get_match_monitor(
             continue; /* If term isn't read, don't monitor */
         }
 
+        /* If term is not matched on this, don't track */
+        if (!ecs_term_match_this(&f->terms[i])) {
+            continue;
+        }
+
         int32_t column = match->columns[t];
         if (column == 0) {
             continue; /* Don't track terms that aren't matched */

--- a/flecs.c
+++ b/flecs.c
@@ -28940,6 +28940,7 @@ const char* flecs_parse_expr(
         /* Used to track of the result of the parsed token can be used as the
          * lvalue for a binary expression */
         bool is_lvalue = false;
+        bool newline = false;
 
         if (!ecs_os_strcmp(token, "(")) {
             ecs_value_t temp_result, *out;
@@ -29078,7 +29079,12 @@ const char* flecs_parse_expr(
             is_lvalue = true;
 
         } else {
-            ptr = ecs_parse_fluff(ptr, NULL);
+            const char *tptr = ecs_parse_fluff(ptr, NULL);
+            for (; ptr != tptr; ptr ++) {
+                if (ptr[0] == '\n') {
+                    newline = true;
+                }
+            }
 
             if (ptr[0] == ':') {
                 /* Member assignment */
@@ -29095,8 +29101,9 @@ const char* flecs_parse_expr(
             is_lvalue = true;
         }
 
-        /* If lvalue was parsed, apply operators */
-        if (is_lvalue) {
+        /* If lvalue was parsed, apply operators. Expressions cannot start
+         * directly after a newline character. */
+        if (is_lvalue && !newline) {
             if (unary_op != EcsExprOperUnknown) {
                 if (unary_op == EcsMin) {
                     int64_t v = -1;

--- a/flecs.c
+++ b/flecs.c
@@ -17717,9 +17717,6 @@ ecs_entity_t ecs_cpp_component_register(
         const EcsComponent *component = ecs_get(world, ent, EcsComponent);
         if (component != NULL) {
             const char *sym = ecs_get_symbol(world, ent);
-            ecs_assert(!existing || (sym != NULL), ECS_MISSING_SYMBOL, 
-                ecs_get_name(world, ent));
-
             if (sym && ecs_os_strcmp(sym, symbol)) {
                 /* Application is trying to register a type with an entity that
                  * was already associated with another type. In most cases this
@@ -17749,6 +17746,8 @@ ecs_entity_t ecs_cpp_component_register(
                     ecs_abort(ECS_NAME_IN_USE, NULL);
                 }
                 ecs_os_free(type_path);
+            } else if (!sym) {
+                ecs_set_symbol(world, ent, symbol);
             }
         }
 

--- a/flecs.c
+++ b/flecs.c
@@ -584,7 +584,8 @@ struct ecs_query_table_node_t {
 struct ecs_query_table_match_t {
     ecs_query_table_node_t node; /* Embedded list node */
 
-    int32_t *columns;         /* Mapping from query terms to table columns */
+    int32_t *columns;         /* Mapping from query fields to table columns */
+    int32_t *storage_columns; /* Mapping from query fields to storage columns */
     ecs_id_t *ids;            /* Resolved (component) ids for current table */
     ecs_entity_t *sources;    /* Subjects (sources) of ids */
     ecs_size_t *sizes;        /* Sizes for ids for current table */
@@ -45383,9 +45384,7 @@ void flecs_query_get_dirty_state(
 
     if (!subject) {
         table = match->node.table;
-        column = match->columns[term] - 1;
-        ecs_assert(column >= 0, ECS_INTERNAL_ERROR, NULL);
-        column = ecs_table_type_to_storage_index(table, column);
+        column = match->storage_columns[term];
     } else {
         table = ecs_get_table(world, subject);
         int32_t ref_index = -match->columns[term] - 1;
@@ -45543,26 +45542,54 @@ bool flecs_query_check_match_monitor(
     ecs_table_t *table = match->node.table;
     int32_t *dirty_state = flecs_table_get_dirty_state(query->world, table);
     ecs_assert(dirty_state != NULL, ECS_INTERNAL_ERROR, NULL);
-    table_dirty_state_t cur;
 
     if (monitor[0] != dirty_state[0]) {
         return true;
     }
 
-    ecs_filter_t *f = &query->filter;
-    int32_t i, term_count = f->term_count;
-    for (i = 0; i < term_count; i ++) {
-        ecs_term_t *term = &f->terms[i];
-        int32_t t = term->field_index;
-        if (monitor[t + 1] == -1) {
+    ecs_world_t *world = query->world;
+    int32_t i, field_count = query->filter.field_count;
+    int32_t *storage_columns = match->storage_columns;
+    int32_t *columns = match->columns;
+    ecs_vec_t *refs = &match->refs;
+    for (i = 0; i < field_count; i ++) {
+        int32_t mon = monitor[i + 1];
+        if (mon == -1) {
             continue;
         }
 
-        flecs_query_get_dirty_state(query, match, t, &cur);
-        ecs_assert(cur.column != -1, ECS_INTERNAL_ERROR, NULL);
+        int32_t column = storage_columns[i];
+        if (column >= 0) {
+            /* owned component */
+            if (mon != dirty_state[column + 1]) {
+                return true;
+            }
+            continue;
+        } else if (column == -1) {
+            continue; /* owned but not a component */
+        }
 
-        if (monitor[t + 1] != cur.dirty_state[cur.column + 1]) {
-            return true;
+        column = columns[i];
+        if (!column) {
+            /* Not matched */
+            continue;
+        }
+
+        ecs_assert(column < 0, ECS_INTERNAL_ERROR, NULL);
+
+        int32_t ref_index = -column - 1;
+        ecs_ref_t *ref = ecs_vec_get_t(refs, ecs_ref_t, ref_index);
+        if (ref->id != 0) {
+            ecs_ref_update(world, ref);
+            ecs_table_record_t *tr = ref->tr;
+            ecs_table_t *src_table = tr->hdr.table;
+            column = tr->column;
+            column = ecs_table_type_to_storage_index(src_table, column);
+            int32_t *src_dirty_state = flecs_table_get_dirty_state(
+                world, src_table);
+            if (mon != src_dirty_state[column + 1]) {
+                return true;
+            }
         }
     }
 
@@ -45687,6 +45714,7 @@ ecs_query_table_match_t* flecs_query_add_table_match(
     qm->node.table = table;
 
     qm->columns = flecs_balloc(&query->allocators.columns);
+    qm->storage_columns = flecs_balloc(&query->allocators.columns);
     qm->ids = flecs_balloc(&query->allocators.ids);
     qm->sources = flecs_balloc(&query->allocators.sources);
     qm->sizes = flecs_balloc(&query->allocators.sizes);
@@ -45730,8 +45758,20 @@ void flecs_query_set_table_match(
     ecs_os_memcpy_n(qm->sources, it->sources, ecs_entity_t, field_count);
     ecs_os_memcpy_n(qm->sizes, it->sizes, ecs_size_t, field_count);
 
-    /* Look for union & disabled terms */
     if (table) {
+        /* Initialize storage columns for faster access to component storage */
+        for (i = 0; i < field_count; i ++) {
+            int32_t column = qm->columns[i];
+            if (column > 0) {
+                qm->storage_columns[i] = ecs_table_type_to_storage_index(table,
+                    qm->columns[i] - 1);
+            } else {
+                /* Shared field (not from table) */
+                qm->storage_columns[i] = -2;
+            }
+        }
+
+        /* Look for union fields */
         if (table->flags & EcsTableHasUnion) {
             for (i = 0; i < term_count; i ++) {
                 if (ecs_term_match_0(&terms[i])) {
@@ -45762,6 +45802,8 @@ void flecs_query_set_table_match(
                 qm->ids[field] = id;
             }
         }
+
+        /* Look for disabled fields */
         if (table->flags & EcsTableHasToggle) {
             for (i = 0; i < term_count; i ++) {
                 if (ecs_term_match_0(&terms[i])) {
@@ -47424,36 +47466,31 @@ void flecs_query_mark_columns_dirty(
     ecs_query_table_match_t *qm)
 {
     ecs_table_t *table = qm->node.table;
+    if (!table) {
+        return;
+    }
 
-    if (table && table->dirty_state) {
-        ecs_term_t *terms = query->filter.terms;
-        int32_t i, count = query->filter.term_count;
+    int32_t *dirty_state = table->dirty_state;
+    if (dirty_state) {
+        int32_t *storage_columns = qm->storage_columns;
+        ecs_filter_t *filter = &query->filter;
+        ecs_term_t *terms = filter->terms;
+        int32_t i, count = filter->term_count;
+
         for (i = 0; i < count; i ++) {
             ecs_term_t *term = &terms[i];
-            int32_t ti = term->field_index;
-
             if (term->inout == EcsIn || term->inout == EcsInOutNone) {
                 /* Don't mark readonly terms dirty */
                 continue;
             }
 
-            if (qm->sources[ti] != 0) {
-                /* Don't mark table dirty if term is not from the table */
+            int32_t field = term->field_index;
+            int32_t column = storage_columns[field];
+            if (column < 0) {
                 continue;
             }
 
-            int32_t index = qm->columns[ti];
-            if (index <= 0) {
-                /* If term is not set, there's nothing to mark dirty */
-                continue;
-            }
-
-            /* Potential candidate for marking table dirty, if a component */
-            int32_t storage_index = ecs_table_type_to_storage_index(
-                table, index - 1);
-            if (storage_index >= 0) {
-                table->dirty_state[storage_index + 1] ++;
-            }
+            dirty_state[column + 1] ++;
         }
     }
 }
@@ -47478,6 +47515,64 @@ bool ecs_query_next_table(
 
 error:
     return false;
+}
+
+void ecs_query_populate(
+    ecs_iter_t *it)
+{
+    ecs_check(it != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(it->next == ecs_query_next, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(ECS_BIT_IS_SET(it->flags, EcsIterIsValid), 
+        ECS_INVALID_PARAMETER, NULL);
+
+    ecs_query_iter_t *iter = &it->priv.iter.query;
+    ecs_query_table_node_t *node = iter->prev;
+    ecs_assert(node != NULL, ECS_INVALID_OPERATION, NULL);
+
+    ecs_table_t *table = node->table;
+    ecs_query_table_match_t *match = node->match;
+    ecs_query_t *query = iter->query;
+    ecs_world_t *world = query->world;
+    const ecs_filter_t *filter = &query->filter;
+    bool only_this = filter->flags & EcsFilterMatchOnlyThis;
+
+    /* Match has been iterated, update monitor for change tracking */
+    if (query->flags & EcsQueryHasMonitor) {
+        flecs_query_sync_match_monitor(query, match);
+    }
+    if (query->flags & EcsQueryHasOutColumns) {
+        flecs_query_mark_columns_dirty(query, match);
+    }
+
+    if (only_this) {
+        /* If query has only This terms, reuse cache storage */
+        it->ids = match->ids;
+        it->columns = match->columns;
+        it->sizes = match->sizes;
+    } else {
+        /* If query has non-This terms make sure not to overwrite them */
+        int32_t t, term_count = filter->term_count;
+        for (t = 0; t < term_count; t ++) {
+            ecs_term_t *term = &filter->terms[t];
+            if (!ecs_term_match_this(term)) {
+                continue;
+            }
+
+            int32_t field = term->field_index;
+            it->ids[field] = match->ids[field];
+            it->columns[field] = match->columns[field];
+            it->sizes[field] = match->sizes[field];
+        }
+    }
+
+    it->sources = match->sources;
+    it->references = ecs_vec_first(&match->refs);
+    it->instance_count = 0;
+
+    flecs_iter_populate_data(world, it, table, 0, ecs_table_count(table),
+        it->ptrs, NULL);
+error:
+    return;
 }
 
 bool ecs_query_next(

--- a/flecs.c
+++ b/flecs.c
@@ -39422,7 +39422,7 @@ ecs_ftime_t flecs_insert_sleep(
 {
     ecs_poly_assert(world, ecs_world_t);  
 
-    ecs_time_t start = *stop;
+    ecs_time_t start = *stop, now = start;
     ecs_ftime_t delta_time = (ecs_ftime_t)ecs_time_measure(stop);
 
     if (world->info.target_fps == (ecs_ftime_t)0.0) {
@@ -39447,11 +39447,12 @@ ecs_ftime_t flecs_insert_sleep(
             ecs_sleepf((double)sleep_time);
         }
 
-        ecs_time_t now = start;
+        now = start;
         delta_time = (ecs_ftime_t)ecs_time_measure(&now);
     } while ((target_delta_time - delta_time) > 
         (sleep_time / (ecs_ftime_t)2.0));
 
+    *stop = now;
     return delta_time;
 }
 
@@ -39469,8 +39470,6 @@ ecs_ftime_t flecs_start_measure_frame(
         do {
             if (world->frame_start_time.nanosec || world->frame_start_time.sec){ 
                 delta_time = flecs_insert_sleep(world, &t);
-
-                ecs_time_measure(&t);
             } else {
                 ecs_time_measure(&t);
                 if (world->info.target_fps != 0) {
@@ -46458,6 +46457,7 @@ void flecs_query_table_match_free(
 
     for (cur = first; cur != NULL; cur = next) {
         flecs_bfree(&query->allocators.columns, cur->columns);
+        flecs_bfree(&query->allocators.columns, cur->storage_columns);
         flecs_bfree(&query->allocators.ids, cur->ids);
         flecs_bfree(&query->allocators.sources, cur->sources);
         flecs_bfree(&query->allocators.sizes, cur->sizes);

--- a/flecs.c
+++ b/flecs.c
@@ -47509,16 +47509,27 @@ bool ecs_query_next_table(
     flecs_iter_validate(it);
 
     ecs_query_iter_t *iter = &it->priv.iter.query;
-    ecs_query_table_node_t *node = iter->node;
+    ecs_query_table_node_t *node = iter->node; 
+    ecs_query_t *query = iter->query;
+    
+    if ((query->flags & EcsQueryHasOutColumns)) {
+        ecs_query_table_node_t *prev = iter->prev;
+        if (prev && it->count) {
+            flecs_query_mark_columns_dirty(query, prev->match);
+        }
+    }
+
     if (node != iter->last) {
         it->table = node->table;
         it->group_id = node->group_id;
+        it->count = 0;
         iter->node = node->next;
         iter->prev = node;
         return true;
     }
 
 error:
+    ecs_iter_fini(it);
     return false;
 }
 
@@ -47544,9 +47555,6 @@ void ecs_query_populate(
     /* Match has been iterated, update monitor for change tracking */
     if (query->flags & EcsQueryHasMonitor) {
         flecs_query_sync_match_monitor(query, match);
-    }
-    if (query->flags & EcsQueryHasOutColumns) {
-        flecs_query_mark_columns_dirty(query, match);
     }
 
     if (only_this) {

--- a/flecs.h
+++ b/flecs.h
@@ -6630,7 +6630,6 @@ bool ecs_query_next_table(
  * union relationships, or queries that use order_by.
  * 
  * @param iter The iterator.
- * @returns True if more data is available, false if not.
  */
 FLECS_API
 void ecs_query_populate(

--- a/flecs.h
+++ b/flecs.h
@@ -6619,6 +6619,23 @@ FLECS_API
 bool ecs_query_next_table(
     ecs_iter_t *iter);
 
+/** Populate iterator fields.
+ * This operation can be combined with ecs_query_next_table to populate the
+ * iterator fields for the current table.
+ * 
+ * Populating fields conditionally can save time when a query uses change 
+ * detection, and only needs iterator data when the table has changed.
+ * 
+ * This operation does not work for queries that match disabled components,
+ * union relationships, or queries that use order_by.
+ * 
+ * @param iter The iterator.
+ * @returns True if more data is available, false if not.
+ */
+FLECS_API
+void ecs_query_populate(
+    ecs_iter_t *iter);
+
 /** Returns whether the query data changed since the last iteration.
  * The operation will return true after:
  * - new entities have been matched with

--- a/flecs.h
+++ b/flecs.h
@@ -6610,7 +6610,11 @@ bool ecs_query_next_instanced(
     ecs_iter_t *iter);
 
 /** Fast alternative to ecs_query_next that only returns matched tables.
- * This operation only populates the ecs_iter_t::table field.
+ * This operation only populates the ecs_iter_t::table field. To access the
+ * matched components, call ecs_query_populate.
+ * 
+ * If this operation is used with a query that has inout/out terms, those terms
+ * will not be marked dirty unless ecs_query_populate is called. 
  * 
  * @param iter The iterator.
  * @returns True if more data is available, false if not.
@@ -6624,10 +6628,15 @@ bool ecs_query_next_table(
  * iterator fields for the current table.
  * 
  * Populating fields conditionally can save time when a query uses change 
- * detection, and only needs iterator data when the table has changed.
+ * detection, and only needs iterator data when the table has changed. When this
+ * operation is called, inout/out terms will be marked dirty.
  * 
- * This operation does not work for queries that match disabled components,
- * union relationships, or queries that use order_by.
+ * In cases where inout/out terms are conditionally written and no changes
+ * were made after calling ecs_query_populate, the ecs_query_skip function can
+ * be called to prevent the matched table components from being marked dirty.
+ * 
+ * This operation does should not be used with queries that match disabled 
+ * components, union relationships, or with queries that use order_by.
  * 
  * @param iter The iterator.
  */

--- a/flecs.h
+++ b/flecs.h
@@ -5130,6 +5130,18 @@ void* ecs_ref_get_id(
     ecs_ref_t *ref,
     ecs_id_t id);
 
+/** Update ref.
+ * Ensures contents of ref are up to date. Same as ecs_ref_get_id, but does not
+ * return pointer to component id. 
+ * 
+ * @param world The world.
+ * @param ref The ref.
+ */
+FLECS_API
+void ecs_ref_update(
+    const ecs_world_t *world,
+    ecs_ref_t *ref);
+
 /** @} */
 
 
@@ -6575,7 +6587,7 @@ const ecs_filter_t* ecs_query_get_filter(
 FLECS_API
 ecs_iter_t ecs_query_iter(
     const ecs_world_t *world,
-    ecs_query_t *query);  
+    ecs_query_t *query);
 
 /** Progress the query iterator.
  * This operation progresses the query iterator to the next table. The 
@@ -6595,6 +6607,16 @@ bool ecs_query_next(
  */
 FLECS_API
 bool ecs_query_next_instanced(
+    ecs_iter_t *iter);
+
+/** Fast alternative to ecs_query_next that only returns matched tables.
+ * This operation only populates the ecs_iter_t::table field.
+ * 
+ * @param iter The iterator.
+ * @returns True if more data is available, false if not.
+ */
+FLECS_API
+bool ecs_query_next_table(
     ecs_iter_t *iter);
 
 /** Returns whether the query data changed since the last iteration.

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -3441,7 +3441,11 @@ bool ecs_query_next_instanced(
     ecs_iter_t *iter);
 
 /** Fast alternative to ecs_query_next that only returns matched tables.
- * This operation only populates the ecs_iter_t::table field.
+ * This operation only populates the ecs_iter_t::table field. To access the
+ * matched components, call ecs_query_populate.
+ * 
+ * If this operation is used with a query that has inout/out terms, those terms
+ * will not be marked dirty unless ecs_query_populate is called. 
  * 
  * @param iter The iterator.
  * @returns True if more data is available, false if not.
@@ -3455,10 +3459,15 @@ bool ecs_query_next_table(
  * iterator fields for the current table.
  * 
  * Populating fields conditionally can save time when a query uses change 
- * detection, and only needs iterator data when the table has changed.
+ * detection, and only needs iterator data when the table has changed. When this
+ * operation is called, inout/out terms will be marked dirty.
  * 
- * This operation does not work for queries that match disabled components,
- * union relationships, or queries that use order_by.
+ * In cases where inout/out terms are conditionally written and no changes
+ * were made after calling ecs_query_populate, the ecs_query_skip function can
+ * be called to prevent the matched table components from being marked dirty.
+ * 
+ * This operation does should not be used with queries that match disabled 
+ * components, union relationships, or with queries that use order_by.
  * 
  * @param iter The iterator.
  */

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -1961,6 +1961,18 @@ void* ecs_ref_get_id(
     ecs_ref_t *ref,
     ecs_id_t id);
 
+/** Update ref.
+ * Ensures contents of ref are up to date. Same as ecs_ref_get_id, but does not
+ * return pointer to component id. 
+ * 
+ * @param world The world.
+ * @param ref The ref.
+ */
+FLECS_API
+void ecs_ref_update(
+    const ecs_world_t *world,
+    ecs_ref_t *ref);
+
 /** @} */
 
 
@@ -3406,7 +3418,7 @@ const ecs_filter_t* ecs_query_get_filter(
 FLECS_API
 ecs_iter_t ecs_query_iter(
     const ecs_world_t *world,
-    ecs_query_t *query);  
+    ecs_query_t *query);
 
 /** Progress the query iterator.
  * This operation progresses the query iterator to the next table. The 
@@ -3426,6 +3438,16 @@ bool ecs_query_next(
  */
 FLECS_API
 bool ecs_query_next_instanced(
+    ecs_iter_t *iter);
+
+/** Fast alternative to ecs_query_next that only returns matched tables.
+ * This operation only populates the ecs_iter_t::table field.
+ * 
+ * @param iter The iterator.
+ * @returns True if more data is available, false if not.
+ */
+FLECS_API
+bool ecs_query_next_table(
     ecs_iter_t *iter);
 
 /** Returns whether the query data changed since the last iteration.

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -3461,7 +3461,6 @@ bool ecs_query_next_table(
  * union relationships, or queries that use order_by.
  * 
  * @param iter The iterator.
- * @returns True if more data is available, false if not.
  */
 FLECS_API
 void ecs_query_populate(

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -3450,6 +3450,23 @@ FLECS_API
 bool ecs_query_next_table(
     ecs_iter_t *iter);
 
+/** Populate iterator fields.
+ * This operation can be combined with ecs_query_next_table to populate the
+ * iterator fields for the current table.
+ * 
+ * Populating fields conditionally can save time when a query uses change 
+ * detection, and only needs iterator data when the table has changed.
+ * 
+ * This operation does not work for queries that match disabled components,
+ * union relationships, or queries that use order_by.
+ * 
+ * @param iter The iterator.
+ * @returns True if more data is available, false if not.
+ */
+FLECS_API
+void ecs_query_populate(
+    ecs_iter_t *iter);
+
 /** Returns whether the query data changed since the last iteration.
  * The operation will return true after:
  * - new entities have been matched with

--- a/src/addons/expr/deserialize.c
+++ b/src/addons/expr/deserialize.c
@@ -817,6 +817,7 @@ const char* flecs_parse_expr(
         /* Used to track of the result of the parsed token can be used as the
          * lvalue for a binary expression */
         bool is_lvalue = false;
+        bool newline = false;
 
         if (!ecs_os_strcmp(token, "(")) {
             ecs_value_t temp_result, *out;
@@ -955,7 +956,12 @@ const char* flecs_parse_expr(
             is_lvalue = true;
 
         } else {
-            ptr = ecs_parse_fluff(ptr, NULL);
+            const char *tptr = ecs_parse_fluff(ptr, NULL);
+            for (; ptr != tptr; ptr ++) {
+                if (ptr[0] == '\n') {
+                    newline = true;
+                }
+            }
 
             if (ptr[0] == ':') {
                 /* Member assignment */
@@ -972,8 +978,9 @@ const char* flecs_parse_expr(
             is_lvalue = true;
         }
 
-        /* If lvalue was parsed, apply operators */
-        if (is_lvalue) {
+        /* If lvalue was parsed, apply operators. Expressions cannot start
+         * directly after a newline character. */
+        if (is_lvalue && !newline) {
             if (unary_op != EcsExprOperUnknown) {
                 if (unary_op == EcsMin) {
                     int64_t v = -1;

--- a/src/addons/flecs_cpp.c
+++ b/src/addons/flecs_cpp.c
@@ -274,9 +274,6 @@ ecs_entity_t ecs_cpp_component_register(
         const EcsComponent *component = ecs_get(world, ent, EcsComponent);
         if (component != NULL) {
             const char *sym = ecs_get_symbol(world, ent);
-            ecs_assert(!existing || (sym != NULL), ECS_MISSING_SYMBOL, 
-                ecs_get_name(world, ent));
-
             if (sym && ecs_os_strcmp(sym, symbol)) {
                 /* Application is trying to register a type with an entity that
                  * was already associated with another type. In most cases this
@@ -306,6 +303,8 @@ ecs_entity_t ecs_cpp_component_register(
                     ecs_abort(ECS_NAME_IN_USE, NULL);
                 }
                 ecs_os_free(type_path);
+            } else if (!sym) {
+                ecs_set_symbol(world, ent, symbol);
             }
         }
 

--- a/src/addons/rules.c
+++ b/src/addons/rules.c
@@ -4113,6 +4113,9 @@ void populate_iterator(
             table = slice.table;
             count = slice.count;
             offset = slice.offset;
+            if (!count) {
+                count = ecs_table_count(table);
+            }
         } else {
             /* If a single entity is returned, simply return the
              * iterator with count 1 and a pointer to the entity id */

--- a/src/datastructures/stack_allocator.c
+++ b/src/datastructures/stack_allocator.c
@@ -77,6 +77,10 @@ void flecs_stack_restore_cursor(
     const ecs_stack_cursor_t *cursor)
 {
     ecs_stack_page_t *cur = cursor->cur;
+    if (!cur) {
+        return;
+    }
+
     if (cur == stack->cur) {
         if (cursor->sp > stack->cur->sp) {
             return;

--- a/src/entity.c
+++ b/src/entity.c
@@ -3002,12 +3002,41 @@ ecs_ref_t ecs_ref_init_id(
 
     ecs_table_t *table = record->table;
     if (table) {
-        result.tr = flecs_table_record_get(world, table->storage_table, id);
+        result.tr = flecs_table_record_get(world, table, id);
     }
 
     return result;
 error:
     return (ecs_ref_t){0};
+}
+
+void ecs_ref_update(
+    const ecs_world_t *world,
+    ecs_ref_t *ref)
+{
+    ecs_check(world != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(ref != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(ref->entity != 0, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(ref->id != 0, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(ref->record != NULL, ECS_INVALID_PARAMETER, NULL);
+
+    ecs_record_t *r = ref->record;
+    ecs_table_t *table = r->table;
+    if (!table) {
+        return;
+    }
+
+    ecs_table_record_t *tr = ref->tr;
+    if (!tr || tr->hdr.table != table) {
+        tr = ref->tr = flecs_table_record_get(world, table, ref->id);
+        if (!tr) {
+            return;
+        }
+
+        ecs_assert(tr->hdr.table == r->table, ECS_INTERNAL_ERROR, NULL);
+    }
+error:
+    return;
 }
 
 void* ecs_ref_get_id(

--- a/src/entity.c
+++ b/src/entity.c
@@ -3033,13 +3033,17 @@ void* ecs_ref_get_id(
 
     ecs_table_record_t *tr = ref->tr;
     if (!tr || tr->hdr.table != table) {
-        tr = ref->tr = flecs_table_record_get(world, table->storage_table, id);
+        tr = ref->tr = flecs_table_record_get(world, table, id);
         if (!tr) {
             return NULL;
         }
+
+        ecs_assert(tr->hdr.table == r->table, ECS_INTERNAL_ERROR, NULL);
     }
 
-    return get_component_w_index(table, tr->column, row).ptr;
+    int32_t column = ecs_table_type_to_storage_index(table, tr->column);
+    ecs_assert(column != -1, ECS_INTERNAL_ERROR, NULL);
+    return get_component_w_index(table, column, row).ptr;
 error:
     return NULL;
 }

--- a/src/filter.c
+++ b/src/filter.c
@@ -2128,7 +2128,8 @@ bool ecs_term_next(
     }
 
 yield:
-    flecs_iter_populate_data(world, it, table, 0, 0, it->ptrs, it->sizes);
+    flecs_iter_populate_data(world, it, table, 0, ecs_table_count(table), 
+        it->ptrs, it->sizes);
     ECS_BIT_SET(it->flags, EcsIterIsValid);
     return true;
 done:
@@ -2532,7 +2533,8 @@ error:
 
 yield:
     it->offset = 0;
-    flecs_iter_populate_data(world, it, table, 0, 0, it->ptrs, it->sizes);
+    flecs_iter_populate_data(world, it, table, 0, 
+        table ? ecs_table_count(table) : 0, it->ptrs, it->sizes);
     ECS_BIT_SET(it->flags, EcsIterIsValid);
     return true;    
 }

--- a/src/iter.c
+++ b/src/iter.c
@@ -120,10 +120,6 @@ bool flecs_iter_populate_term_data(
         goto no_data;
     }
 
-    if (!it->terms) {
-        goto no_data;
-    }
-
     /* Filter terms may match with data but don't return it */
     if (it->terms[t].inout == EcsInOutNone) {
         if (size_out) {
@@ -201,9 +197,7 @@ bool flecs_iter_populate_term_data(
     } else {
         /* Data is from This, use table from iterator */
         table = it->table;
-        if (!table) {
-            goto no_data;
-        }
+        ecs_assert(table != NULL, ECS_INTERNAL_ERROR, NULL);
 
         row = it->offset;
 
@@ -218,13 +212,13 @@ bool flecs_iter_populate_term_data(
         }
 
         ecs_type_info_t *ti = table->type_info[storage_column];
-        ecs_vec_t *s = &table->data.columns[storage_column];
         size = ti->size;
-        data = ecs_vec_first(s);
-
-        if (!table || !ecs_table_count(table)) {
+        if (!it->count) {
             goto no_data;
         }
+
+        ecs_vec_t *s = &table->data.columns[storage_column];
+        data = ecs_vec_first(s);
 
         /* Fallthrough to has_data */
     }
@@ -301,7 +295,7 @@ void flecs_iter_populate_data(
                 &ptrs[t], 
                 &sizes[t]);
         }
-    } else {
+    } else if (ptrs || sizes) {
         for (t = 0; t < field_count; t ++) {
             ecs_assert(it->columns != NULL, ECS_INTERNAL_ERROR, NULL);
 

--- a/src/private_types.h
+++ b/src/private_types.h
@@ -241,10 +241,12 @@ typedef struct ecs_query_table_match_t ecs_query_table_match_t;
  * query. A single node may refer to the table multiple times with different
  * offset/count parameters, which enables features such as sorting. */
 struct ecs_query_table_node_t {
-    ecs_query_table_match_t *match;  /* Reference to the match */
+    ecs_query_table_node_t *next, *prev;
+    ecs_table_t *table;              /* The current table. */
+    uint64_t group_id;        /* Value used to organize tables in groups */
     int32_t offset;                  /* Starting point in table  */
     int32_t count;                   /* Number of entities to iterate in table */
-    ecs_query_table_node_t *next, *prev;
+    ecs_query_table_match_t *match;  /* Reference to the match */
 };
 
 /** Type containing data for a table matched with a query. 
@@ -252,7 +254,6 @@ struct ecs_query_table_node_t {
 struct ecs_query_table_match_t {
     ecs_query_table_node_t node; /* Embedded list node */
 
-    ecs_table_t *table;       /* The current table. */
     int32_t *columns;         /* Mapping from query terms to table columns */
     ecs_id_t *ids;            /* Resolved (component) ids for current table */
     ecs_entity_t *sources;    /* Subjects (sources) of ids */
@@ -261,8 +262,6 @@ struct ecs_query_table_match_t {
 
     ecs_vector_t *sparse_columns;  /* Column ids of sparse columns */
     ecs_vector_t *bitset_columns;  /* Column ids with disabled flags */
-
-    uint64_t group_id;        /* Value used to organize tables in groups */
 
     /* Next match in cache for same table (includes empty tables) */
     ecs_query_table_match_t *next_match;

--- a/src/private_types.h
+++ b/src/private_types.h
@@ -254,7 +254,8 @@ struct ecs_query_table_node_t {
 struct ecs_query_table_match_t {
     ecs_query_table_node_t node; /* Embedded list node */
 
-    int32_t *columns;         /* Mapping from query terms to table columns */
+    int32_t *columns;         /* Mapping from query fields to table columns */
+    int32_t *storage_columns; /* Mapping from query fields to storage columns */
     ecs_id_t *ids;            /* Resolved (component) ids for current table */
     ecs_entity_t *sources;    /* Subjects (sources) of ids */
     ecs_size_t *sizes;        /* Sizes for ids for current table */

--- a/src/query.c
+++ b/src/query.c
@@ -1466,6 +1466,7 @@ void flecs_query_table_match_free(
 
     for (cur = first; cur != NULL; cur = next) {
         flecs_bfree(&query->allocators.columns, cur->columns);
+        flecs_bfree(&query->allocators.columns, cur->storage_columns);
         flecs_bfree(&query->allocators.ids, cur->ids);
         flecs_bfree(&query->allocators.sources, cur->sources);
         flecs_bfree(&query->allocators.sizes, cur->sizes);

--- a/src/query.c
+++ b/src/query.c
@@ -450,6 +450,11 @@ bool flecs_query_get_match_monitor(
             continue; /* If term isn't read, don't monitor */
         }
 
+        /* If term is not matched on this, don't track */
+        if (!ecs_term_match_this(&f->terms[i])) {
+            continue;
+        }
+
         int32_t column = match->columns[t];
         if (column == 0) {
             continue; /* Don't track terms that aren't matched */

--- a/src/world.c
+++ b/src/world.c
@@ -1485,7 +1485,7 @@ ecs_ftime_t flecs_insert_sleep(
 {
     ecs_poly_assert(world, ecs_world_t);  
 
-    ecs_time_t start = *stop;
+    ecs_time_t start = *stop, now = start;
     ecs_ftime_t delta_time = (ecs_ftime_t)ecs_time_measure(stop);
 
     if (world->info.target_fps == (ecs_ftime_t)0.0) {
@@ -1510,11 +1510,12 @@ ecs_ftime_t flecs_insert_sleep(
             ecs_sleepf((double)sleep_time);
         }
 
-        ecs_time_t now = start;
+        now = start;
         delta_time = (ecs_ftime_t)ecs_time_measure(&now);
     } while ((target_delta_time - delta_time) > 
         (sleep_time / (ecs_ftime_t)2.0));
 
+    *stop = now;
     return delta_time;
 }
 
@@ -1532,8 +1533,6 @@ ecs_ftime_t flecs_start_measure_frame(
         do {
             if (world->frame_start_time.nanosec || world->frame_start_time.sec){ 
                 delta_time = flecs_insert_sleep(world, &t);
-
-                ecs_time_measure(&t);
             } else {
                 ecs_time_measure(&t);
                 if (world->info.target_fps != 0) {

--- a/test/addons/project.json
+++ b/test/addons/project.json
@@ -333,7 +333,8 @@
                 "const_var_string",
                 "const_var_struct",
                 "const_var_redeclare",
-                "const_var_scoped"
+                "const_var_scoped",
+                "scope_w_component_after_const_var"
             ]
         }, {
             "id": "Doc",

--- a/test/addons/src/Plecs.c
+++ b/test/addons/src/Plecs.c
@@ -4058,3 +4058,34 @@ void Plecs_const_var_scoped() {
 
     ecs_fini(world);
 }
+
+void Plecs_scope_w_component_after_const_var() {
+    ecs_world_t *world = ecs_init();
+
+    ecs_entity_t ecs_id(Position) = ecs_struct(world, {
+        .entity = ecs_entity(world, {.name = "Position"}),
+        .members = {
+            {"x", ecs_id(ecs_f32_t)},
+            {"y", ecs_id(ecs_f32_t)}
+        }
+    });
+
+    const char *expr =
+    HEAD "Foo {"
+    LINE "  const var = 5"
+    LINE "  - Position{x: 10, y: $var}"
+    LINE "}";
+
+    test_assert(ecs_plecs_from_str(world, NULL, expr) == 0);
+
+    ecs_entity_t foo = ecs_lookup_fullpath(world, "Foo");
+    test_assert(foo != 0);
+    test_assert(ecs_has(world, foo, Position));
+
+    const Position *p = ecs_get(world, foo, Position);
+    test_assert(p != NULL);
+    test_int(p->x, 10);
+    test_int(p->y, 5);
+
+    ecs_fini(world);
+}

--- a/test/addons/src/main.c
+++ b/test/addons/src/main.c
@@ -327,6 +327,7 @@ void Plecs_const_var_string(void);
 void Plecs_const_var_struct(void);
 void Plecs_const_var_redeclare(void);
 void Plecs_const_var_scoped(void);
+void Plecs_scope_w_component_after_const_var(void);
 
 // Testsuite 'Doc'
 void Doc_get_set_name(void);
@@ -2206,6 +2207,10 @@ bake_test_case Plecs_testcases[] = {
     {
         "const_var_scoped",
         Plecs_const_var_scoped
+    },
+    {
+        "scope_w_component_after_const_var",
+        Plecs_scope_w_component_after_const_var
     }
 };
 
@@ -4522,7 +4527,7 @@ static bake_test_suite suites[] = {
         "Plecs",
         NULL,
         NULL,
-        146,
+        147,
         Plecs_testcases
     },
     {

--- a/test/api/project.json
+++ b/test/api/project.json
@@ -1284,6 +1284,7 @@
                 "query_change_skip_non_instanced",
                 "query_changed_w_or",
                 "query_changed_or",
+                "query_changed_w_singleton",
                 "subquery_match_existing",
                 "subquery_match_new",
                 "subquery_inactive",

--- a/test/api/project.json
+++ b/test/api/project.json
@@ -1389,7 +1389,15 @@
                 "rematch_after_delete_obj_of_inherited_pair",
                 "rematch_empty_table_w_superset",
                 "query_w_short_notation",
-                "query_w_invalid_filter_flag"
+                "query_w_invalid_filter_flag",
+                "query_next_table",
+                "query_next_table_w_changed",
+                "query_next_table_w_populate",
+                "query_next_table_w_skip",
+                "query_next_table_w_populate_first_changed",
+                "query_next_table_w_populate_last_changed",
+                "query_next_table_w_populate_skip_first",
+                "query_next_table_w_populate_skip_last"
             ]
         }, {
             "id": "Iter",

--- a/test/api/project.json
+++ b/test/api/project.json
@@ -940,6 +940,7 @@
             "id": "Filter",
             "testcases": [
                 "filter_1_term",
+                "filter_1_term_component",
                 "filter_2_terms",
                 "filter_3_terms",
                 "filter_3_terms_w_or",

--- a/test/api/src/Filter.c
+++ b/test/api/src/Filter.c
@@ -16,8 +16,38 @@ void Filter_filter_1_term() {
     test_assert(f.terms != NULL);
     test_int(f.terms[0].id, TagA);
     test_int(f.terms[0].oper, EcsAnd);
+    test_int(f.terms[0].inout, EcsInOutDefault);
     test_int(f.terms[0].field_index, 0);
     test_int(f.terms[0].first.id, TagA);
+    test_int(f.terms[0].first.flags, EcsSelf|EcsDown|EcsIsEntity);
+    test_int(f.terms[0].src.id, EcsThis);
+    test_int(f.terms[0].src.flags, EcsSelf|EcsUp|EcsIsVariable);
+    test_int(f.terms[0].src.trav, EcsIsA);
+
+    ecs_filter_fini(&f);
+
+    ecs_fini(world);
+}
+
+void Filter_filter_1_term_component() {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_COMPONENT(world, Position);
+
+    ecs_filter_t f = ECS_FILTER_INIT;
+    ecs_filter_init(world, &(ecs_filter_desc_t){
+        .storage = &f,
+        .terms = {{ ecs_id(Position) }}
+    });
+
+    test_int(f.term_count, 1);
+    test_int(f.field_count, 1);
+    test_assert(f.terms != NULL);
+    test_int(f.terms[0].id, ecs_id(Position));
+    test_int(f.terms[0].oper, EcsAnd);
+    test_int(f.terms[0].inout, EcsInOutDefault);
+    test_int(f.terms[0].field_index, 0);
+    test_int(f.terms[0].first.id, ecs_id(Position));
     test_int(f.terms[0].first.flags, EcsSelf|EcsDown|EcsIsEntity);
     test_int(f.terms[0].src.id, EcsThis);
     test_int(f.terms[0].src.flags, EcsSelf|EcsUp|EcsIsVariable);
@@ -4672,16 +4702,16 @@ void Filter_term_iter_w_readonly_term() {
 void Filter_filter_iter_w_readonly_term() {
     ecs_world_t *world = ecs_mini();
 
-    ECS_TAG(world, TagA);
-    ECS_TAG(world, TagB);
+    ECS_COMPONENT(world, Position);
+    ECS_COMPONENT(world, Velocity);
 
-    ecs_entity_t e_1 = ecs_new(world, TagA);
-    ecs_add_id(world, e_1, TagB);
+    ecs_entity_t e_1 = ecs_new(world, Position);
+    ecs_add(world, e_1, Velocity);
 
     ecs_filter_t f = ECS_FILTER_INIT;
     ecs_filter_init(world, &(ecs_filter_desc_t){
         .storage = &f,
-        .terms = {{ TagA, .inout = EcsIn }, { TagB }}
+        .terms = {{ ecs_id(Position), .inout = EcsIn }, { ecs_id(Velocity) }}
     });
 
     ecs_iter_t it = ecs_filter_iter(world, &f);
@@ -4689,7 +4719,7 @@ void Filter_filter_iter_w_readonly_term() {
     test_assert(ecs_filter_next(&it));
     test_int(it.count, 1);
     test_int(it.entities[0], e_1);
-    test_int(ecs_field_id(&it, 1), TagA);
+    test_int(ecs_field_id(&it, 1), ecs_id(Position));
     test_int(ecs_field_src(&it, 1), 0);
     test_bool(ecs_field_is_readonly(&it, 1), true);
     test_bool(ecs_field_is_readonly(&it, 2), false);

--- a/test/api/src/Query.c
+++ b/test/api/src/Query.c
@@ -2978,6 +2978,40 @@ void Query_query_changed_or() {
     ecs_fini(world);
 }
 
+void Query_query_changed_w_singleton() {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_COMPONENT(world, Position);
+    ECS_COMPONENT(world, Velocity);
+
+    ecs_singleton_set(world, Velocity, {1, 2});
+
+    ecs_query_t *q = ecs_query(world, {
+        .filter.terms = {{
+            .id = ecs_id(Position)
+        }, {
+            .id = ecs_id(Velocity),
+            .src.id = ecs_id(Velocity)
+        }}
+    });
+
+    ecs_entity_t e = ecs_set(world, 0, Position, {10, 20});
+
+    ecs_iter_t it = ecs_query_iter(world, q);
+    test_bool(true, ecs_query_next(&it));
+    test_bool(true, ecs_query_changed(NULL, &it));
+    test_uint(e, it.entities[0]);
+    Position *p = ecs_field(&it, Position, 1);
+    Velocity *v = ecs_field(&it, Velocity, 2);
+    test_int(p->x, 10);
+    test_int(p->y, 20);
+    test_int(v->x, 1);
+    test_int(v->y, 2);
+    test_bool(false, ecs_query_next(&it));
+
+    ecs_fini(world);
+}
+
 void Query_subquery_match_existing() {
     ecs_world_t *world = ecs_mini();
 
@@ -7647,3 +7681,4 @@ void Query_query_w_invalid_filter_flag() {
         }
     });
 }
+

--- a/test/api/src/main.c
+++ b/test/api/src/main.c
@@ -883,6 +883,7 @@ void SortingEntireTable_dont_resort_after_set_unsorted_component_w_tag_w_out_ter
 
 // Testsuite 'Filter'
 void Filter_filter_1_term(void);
+void Filter_filter_1_term_component(void);
 void Filter_filter_2_terms(void);
 void Filter_filter_3_terms(void);
 void Filter_filter_3_terms_w_or(void);
@@ -5533,6 +5534,10 @@ bake_test_case Filter_testcases[] = {
     {
         "filter_1_term",
         Filter_filter_1_term
+    },
+    {
+        "filter_1_term_component",
+        Filter_filter_1_term_component
     },
     {
         "filter_2_terms",
@@ -10830,7 +10835,7 @@ static bake_test_suite suites[] = {
         "Filter",
         NULL,
         NULL,
-        233,
+        234,
         Filter_testcases
     },
     {

--- a/test/api/src/main.c
+++ b/test/api/src/main.c
@@ -1329,6 +1329,14 @@ void Query_rematch_after_delete_obj_of_inherited_pair(void);
 void Query_rematch_empty_table_w_superset(void);
 void Query_query_w_short_notation(void);
 void Query_query_w_invalid_filter_flag(void);
+void Query_query_next_table(void);
+void Query_query_next_table_w_changed(void);
+void Query_query_next_table_w_populate(void);
+void Query_query_next_table_w_skip(void);
+void Query_query_next_table_w_populate_first_changed(void);
+void Query_query_next_table_w_populate_last_changed(void);
+void Query_query_next_table_w_populate_skip_first(void);
+void Query_query_next_table_w_populate_skip_last(void);
 
 // Testsuite 'Iter'
 void Iter_page_iter_0_0(void);
@@ -7309,6 +7317,38 @@ bake_test_case Query_testcases[] = {
     {
         "query_w_invalid_filter_flag",
         Query_query_w_invalid_filter_flag
+    },
+    {
+        "query_next_table",
+        Query_query_next_table
+    },
+    {
+        "query_next_table_w_changed",
+        Query_query_next_table_w_changed
+    },
+    {
+        "query_next_table_w_populate",
+        Query_query_next_table_w_populate
+    },
+    {
+        "query_next_table_w_skip",
+        Query_query_next_table_w_skip
+    },
+    {
+        "query_next_table_w_populate_first_changed",
+        Query_query_next_table_w_populate_first_changed
+    },
+    {
+        "query_next_table_w_populate_last_changed",
+        Query_query_next_table_w_populate_last_changed
+    },
+    {
+        "query_next_table_w_populate_skip_first",
+        Query_query_next_table_w_populate_skip_first
+    },
+    {
+        "query_next_table_w_populate_skip_last",
+        Query_query_next_table_w_populate_skip_last
     }
 };
 
@@ -10854,7 +10894,7 @@ static bake_test_suite suites[] = {
         "Query",
         NULL,
         NULL,
-        190,
+        198,
         Query_testcases
     },
     {

--- a/test/api/src/main.c
+++ b/test/api/src/main.c
@@ -1223,6 +1223,7 @@ void Query_query_change_prefab_term_w_tag(void);
 void Query_query_change_skip_non_instanced(void);
 void Query_query_changed_w_or(void);
 void Query_query_changed_or(void);
+void Query_query_changed_w_singleton(void);
 void Query_subquery_match_existing(void);
 void Query_subquery_match_new(void);
 void Query_subquery_inactive(void);
@@ -6886,6 +6887,10 @@ bake_test_case Query_testcases[] = {
         Query_query_changed_or
     },
     {
+        "query_changed_w_singleton",
+        Query_query_changed_w_singleton
+    },
+    {
         "subquery_match_existing",
         Query_subquery_match_existing
     },
@@ -10849,7 +10854,7 @@ static bake_test_suite suites[] = {
         "Query",
         NULL,
         NULL,
-        189,
+        190,
         Query_testcases
     },
     {

--- a/test/cpp_api/project.json
+++ b/test/cpp_api/project.json
@@ -221,6 +221,7 @@
                 "entity_w_type_defer",
                 "prefab_hierarchy_w_types",
                 "prefab_hierarchy_w_root_types",
+                "prefab_hierarchy_w_child_override",
                 "entity_array",
                 "add_if_true_T",
                 "add_if_false_T",

--- a/test/cpp_api/src/Entity.cpp
+++ b/test/cpp_api/src/Entity.cpp
@@ -3716,6 +3716,7 @@ struct Turret {
 };
 
 struct Railgun {
+    struct Base { };
     struct Head { };
     struct Beam { };
 };
@@ -3782,6 +3783,30 @@ void Entity_prefab_hierarchy_w_root_types() {
 
     auto inst_base = inst.lookup("Base");
     test_assert(inst_base != 0);
+}
+
+void Entity_prefab_hierarchy_w_child_override() {
+    flecs::world ecs;
+
+    struct Foo {};
+    struct Bar {};
+
+    auto t = ecs.prefab<Turret>();
+    auto tb = ecs.prefab<Turret::Base>().add<Foo>();
+    test_assert(t != 0);
+    test_assert(tb != 0);
+
+    auto r = ecs.prefab<Railgun>().is_a<Turret>();
+    auto rb = ecs.prefab<Railgun::Base>().add<Bar>();
+    test_assert(r != 0);
+    test_assert(rb != 0);
+
+    auto i = ecs.entity().is_a<Railgun>();
+    test_assert(i != 0);
+    auto ib = i.lookup("Base");
+    test_assert(ib != 0);
+    test_assert(ib.has<Foo>());
+    test_assert(ib.has<Bar>());
 }
 
 struct Parent {

--- a/test/cpp_api/src/main.cpp
+++ b/test/cpp_api/src/main.cpp
@@ -215,6 +215,7 @@ void Entity_entity_w_nested_type(void);
 void Entity_entity_w_type_defer(void);
 void Entity_prefab_hierarchy_w_types(void);
 void Entity_prefab_hierarchy_w_root_types(void);
+void Entity_prefab_hierarchy_w_child_override(void);
 void Entity_entity_array(void);
 void Entity_add_if_true_T(void);
 void Entity_add_if_false_T(void);
@@ -1846,6 +1847,10 @@ bake_test_case Entity_testcases[] = {
     {
         "prefab_hierarchy_w_root_types",
         Entity_prefab_hierarchy_w_root_types
+    },
+    {
+        "prefab_hierarchy_w_child_override",
+        Entity_prefab_hierarchy_w_child_override
     },
     {
         "entity_array",
@@ -4944,7 +4949,7 @@ static bake_test_suite suites[] = {
         "Entity",
         NULL,
         NULL,
-        222,
+        223,
         Entity_testcases
     },
     {


### PR DESCRIPTION
This PR adds features fixes bugs and improves performance when working with queries
- Fixed issue that caused unnecessary lookups when using `ecs_ref_t`
- Add `ecs_query_next_table` function that only populates `ecs_iter_t::table` to improve iteration speed
- Add `ecs_query_populate` function to conditionally populate iterator data after `ecs_query_next_table`
- Improve performance of query change detection
- Fix assert when using change detection with query that has fixed source term

Additionally these non-query related issues were fixed:
- Fixed issue in plecs where a number followed by a newline and `-` was be interpreted as binary expression
- Fixed issue where overriding a prefab child associated with a type would assert
- Removed redundant call to `ecs_time_measure`