### PR TITLE
Lazy definition of ECS_HI_COMPONENT_ID (23.09 22:42)

### DIFF
--- a/include/flecs/private/api_support.h
+++ b/include/flecs/private/api_support.h
@@ -21,7 +21,9 @@ extern "C" {
  * lower than this constant are looked up in an array, whereas constants higher
  * than this id are looked up in a map. Increasing this value can improve
  * performance at the cost of (significantly) higher memory usage. */
+#ifndef ECS_HI_COMPONENT_ID
 #define ECS_HI_COMPONENT_ID (256) /* Maximum number of components */
+#endif
 
 /** The maximum number of nested function calls before the core will throw a
  * cycle detected error */


### PR DESCRIPTION
Allow defining custom ECS_HI_COMPONENT_ID value without the "macro redefined" warnings (which are errors with pedantic compilation).