### PR TITLE
Fix memory leak, improve memory statistics

### DIFF
--- a/flecs.c
+++ b/flecs.c
@@ -9420,19 +9420,21 @@ void flecs_cmd_batch_for_entity(
 
         /* Check if added id is still valid (like is the parent of a ChildOf 
          * pair still alive), if not run cleanup actions for entity */
-        if (flecs_remove_invalid(world, id, &id)) {
-            if (!id) {
-                /* Entity should remain alive but id should not be added */
+        if (id) {
+            if (flecs_remove_invalid(world, id, &id)) {
+                if (!id) {
+                    /* Entity should remain alive but id should not be added */
+                    cmd->kind = EcsOpSkip;
+                    continue;
+                }
+                /* Entity should remain alive and id is still valid */
+            } else {
+                /* Id was no longer valid and had a Delete policy) */
                 cmd->kind = EcsOpSkip;
-                continue;
+                ecs_delete(world, entity);
+                flecs_table_diff_builder_clear(diff);
+                return;
             }
-            /* Entity should remain alive and id is still valid */
-        } else {
-            /* Id was no longer valid and had a Delete policy) */
-            cmd->kind = EcsOpSkip;
-            ecs_delete(world, entity);
-            flecs_table_diff_builder_clear(diff);
-            return;
         }
 
         ecs_cmd_kind_t kind = cmd->kind;

--- a/flecs.h
+++ b/flecs.h
@@ -1512,10 +1512,10 @@ ecs_map_t* ecs_map_copy(
 #define FLECS_ALLOCATOR_H
 
 
-extern int64_t ecs_block_allocator_alloc_count;
-extern int64_t ecs_block_allocator_free_count;
-extern int64_t ecs_stack_allocator_alloc_count;
-extern int64_t ecs_stack_allocator_free_count;
+FLECS_DBG_API extern int64_t ecs_block_allocator_alloc_count;
+FLECS_DBG_API extern int64_t ecs_block_allocator_free_count;
+FLECS_DBG_API extern int64_t ecs_stack_allocator_alloc_count;
+FLECS_DBG_API extern int64_t ecs_stack_allocator_free_count;
 
 typedef struct ecs_allocator_t {
     struct ecs_map_t sizes; /* <size, block_allocator_t> */

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -29,6 +29,11 @@
 /* FLECS_NO_DEPRECATED_WARNINGS disables deprecated warnings */
 #define FLECS_NO_DEPRECATED_WARNINGS
 
+/* FLECS_ACCURATE_COUNTERS ensures that global counters used for statistics 
+ * (such as the allocation counters in the OS API) are accurate in multithreaded
+ * applications, at the cost of increased overhead. */
+// #define FLECS_ACCURATE_COUNTERS
+
 /* Make sure provided configuration is valid */
 #if defined(FLECS_DEBUG) && defined(FLECS_NDEBUG)
 #error "invalid configuration: cannot both define FLECS_DEBUG and FLECS_NDEBUG"

--- a/include/flecs/addons/stats.h
+++ b/include/flecs/addons/stats.h
@@ -92,11 +92,19 @@ typedef struct ecs_world_stats_t {
     ecs_metric_t pipeline_build_count_total; /* Number of system pipeline rebuilds (occurs when an inactive system becomes active). */
     ecs_metric_t systems_ran_frame;          /* Number of systems ran in the last frame. */
 
-    /* OS API data */
+    /* Memory allocation data */
     ecs_metric_t alloc_count;                /* Allocs per frame */
     ecs_metric_t realloc_count;              /* Reallocs per frame */
     ecs_metric_t free_count;                 /* Frees per frame */
     ecs_metric_t outstanding_alloc_count;    /* Difference between allocs & frees */
+
+    /* Memory allocator data */
+    ecs_metric_t block_alloc_count;           /* Block allocations per frame */
+    ecs_metric_t block_free_count;            /* Block frees per frame */
+    ecs_metric_t block_outstanding_alloc_count; /* Difference between allocs & frees */
+    ecs_metric_t stack_alloc_count;           /* Page allocations per frame */
+    ecs_metric_t stack_free_count;            /* Page frees per frame */
+    ecs_metric_t stack_outstanding_alloc_count; /* Difference between allocs & frees */
 
     int32_t last_;
 

--- a/include/flecs/os_api.h
+++ b/include/flecs/os_api.h
@@ -33,7 +33,7 @@ typedef struct ecs_time_t {
     uint32_t nanosec;
 } ecs_time_t;
 
-/* Allocation counters (not thread safe) */
+/* Allocation counters */
 extern int64_t ecs_os_api_malloc_count;
 extern int64_t ecs_os_api_realloc_count;
 extern int64_t ecs_os_api_calloc_count;
@@ -95,9 +95,12 @@ void* (*ecs_os_api_thread_join_t)(
 
 /* Atomic increment / decrement */
 typedef
-int (*ecs_os_api_ainc_t)(
+int32_t (*ecs_os_api_ainc_t)(
     int32_t *value);
 
+typedef
+int64_t (*ecs_os_api_lainc_t)(
+    int64_t *value);
 
 /* Mutex */
 typedef
@@ -209,6 +212,8 @@ typedef struct ecs_os_api_t {
     /* Atomic incremenet / decrement */
     ecs_os_api_ainc_t ainc_;
     ecs_os_api_ainc_t adec_;
+    ecs_os_api_lainc_t lainc_;
+    ecs_os_api_lainc_t ladec_;
 
     /* Mutex */
     ecs_os_api_mutex_new_t mutex_new_;
@@ -390,6 +395,8 @@ void ecs_os_set_api_defaults(void);
 /* Atomic increment / decrement */
 #define ecs_os_ainc(value) ecs_os_api.ainc_(value)
 #define ecs_os_adec(value) ecs_os_api.adec_(value)
+#define ecs_os_lainc(value) ecs_os_api.lainc_(value)
+#define ecs_os_ladec(value) ecs_os_api.ladec_(value)
 
 /* Mutex */
 #define ecs_os_mutex_new() ecs_os_api.mutex_new_()
@@ -427,6 +434,18 @@ void ecs_os_fatal(const char *file, int32_t line, const char *msg);
 
 FLECS_API
 const char* ecs_os_strerror(int err);
+
+#ifdef FLECS_ACCURATE_COUNTERS
+#define ecs_os_inc(v)  (ecs_os_ainc(v))
+#define ecs_os_linc(v) (ecs_os_lainc(v))
+#define ecs_os_dec(v)  (ecs_os_adec(v))
+#define ecs_os_ldec(v) (ecs_os_ladec(v))
+#else
+#define ecs_os_inc(v)  (++(*v))
+#define ecs_os_linc(v) (++(*v))
+#define ecs_os_dec(v)  (--(*v))
+#define ecs_os_ldec(v) (--(*v))
+#endif
 
 /* Application termination */
 #define ecs_os_abort() ecs_os_api.abort_()

--- a/include/flecs/private/allocator.h
+++ b/include/flecs/private/allocator.h
@@ -8,10 +8,10 @@
 
 #include "api_defines.h"
 
-extern int64_t ecs_block_allocator_alloc_count;
-extern int64_t ecs_block_allocator_free_count;
-extern int64_t ecs_stack_allocator_alloc_count;
-extern int64_t ecs_stack_allocator_free_count;
+FLECS_DBG_API extern int64_t ecs_block_allocator_alloc_count;
+FLECS_DBG_API extern int64_t ecs_block_allocator_free_count;
+FLECS_DBG_API extern int64_t ecs_stack_allocator_alloc_count;
+FLECS_DBG_API extern int64_t ecs_stack_allocator_free_count;
 
 typedef struct ecs_allocator_t {
     struct ecs_map_t sizes; /* <size, block_allocator_t> */

--- a/include/flecs/private/allocator.h
+++ b/include/flecs/private/allocator.h
@@ -8,6 +8,11 @@
 
 #include "api_defines.h"
 
+extern int64_t ecs_block_allocator_alloc_count;
+extern int64_t ecs_block_allocator_free_count;
+extern int64_t ecs_stack_allocator_alloc_count;
+extern int64_t ecs_stack_allocator_free_count;
+
 typedef struct ecs_allocator_t {
     struct ecs_map_t sizes; /* <size, block_allocator_t> */
 } ecs_allocator_t;

--- a/src/addons/os_api_impl/posix_impl.inl
+++ b/src/addons/os_api_impl/posix_impl.inl
@@ -51,7 +51,35 @@ static
 int32_t posix_adec(
     int32_t *count) 
 {
-    int value;
+    int32_t value;
+#ifdef __GNUC__
+    value = __sync_sub_and_fetch (count, 1);
+    return value;
+#else
+    /* Unsupported */
+    abort();
+#endif
+}
+
+static
+int64_t posix_lainc(
+    int64_t *count)
+{
+    int64_t value;
+#ifdef __GNUC__
+    value = __sync_add_and_fetch (count, 1);
+    return value;
+#else
+    /* Unsupported */
+    abort();
+#endif
+}
+
+static
+int64_t posix_ladec(
+    int64_t *count) 
+{
+    int64_t value;
 #ifdef __GNUC__
     value = __sync_sub_and_fetch (count, 1);
     return value;
@@ -237,6 +265,8 @@ void ecs_set_os_api_impl(void) {
     api.thread_join_ = posix_thread_join;
     api.ainc_ = posix_ainc;
     api.adec_ = posix_adec;
+    api.lainc_ = posix_lainc;
+    api.ladec_ = posix_ladec;
     api.mutex_new_ = posix_mutex_new;
     api.mutex_free_ = posix_mutex_free;
     api.mutex_lock_ = posix_mutex_lock;

--- a/src/addons/os_api_impl/windows_impl.inl
+++ b/src/addons/os_api_impl/windows_impl.inl
@@ -43,6 +43,20 @@ int32_t win_adec(
 }
 
 static
+int64_t win_lainc(
+    int64_t *count) 
+{
+    return InterlockedIncrement64(count);
+}
+
+static
+int64_t win_ladec(
+    int64_t *count) 
+{
+    return InterlockedDecrement64(count);
+}
+
+static
 ecs_os_mutex_t win_mutex_new(void) {
     CRITICAL_SECTION *mutex = ecs_os_malloc_t(CRITICAL_SECTION);
     InitializeCriticalSection(mutex);
@@ -223,6 +237,8 @@ void ecs_set_os_api_impl(void) {
     api.thread_join_ = win_thread_join;
     api.ainc_ = win_ainc;
     api.adec_ = win_adec;
+    api.lainc_ = win_lainc;
+    api.ladec_ = win_ladec;
     api.mutex_new_ = win_mutex_new;
     api.mutex_free_ = win_mutex_free;
     api.mutex_lock_ = win_mutex_lock;

--- a/src/addons/rest.c
+++ b/src/addons/rest.c
@@ -352,6 +352,12 @@ void flecs_world_stats_to_json(
     ECS_COUNTER_APPEND(reply, stats, realloc_count);
     ECS_COUNTER_APPEND(reply, stats, free_count);
     ECS_GAUGE_APPEND(reply, stats, outstanding_alloc_count);
+    ECS_COUNTER_APPEND(reply, stats, block_alloc_count);
+    ECS_COUNTER_APPEND(reply, stats, block_free_count);
+    ECS_GAUGE_APPEND(reply, stats, block_outstanding_alloc_count);
+    ECS_COUNTER_APPEND(reply, stats, stack_alloc_count);
+    ECS_COUNTER_APPEND(reply, stats, stack_free_count);
+    ECS_GAUGE_APPEND(reply, stats, stack_outstanding_alloc_count);
     ecs_strbuf_list_pop(reply, "}");
 }
 

--- a/src/addons/stats.c
+++ b/src/addons/stats.c
@@ -305,10 +305,19 @@ void ecs_world_stats_get(
         ecs_os_api_calloc_count);
     ECS_COUNTER_RECORD(&s->realloc_count, t, ecs_os_api_realloc_count);
     ECS_COUNTER_RECORD(&s->free_count, t, ecs_os_api_free_count);
-
     int64_t outstanding_allocs = ecs_os_api_malloc_count + 
         ecs_os_api_calloc_count - ecs_os_api_free_count;
     ECS_GAUGE_RECORD(&s->outstanding_alloc_count, t, outstanding_allocs);
+
+    ECS_COUNTER_RECORD(&s->block_alloc_count, t, ecs_block_allocator_alloc_count);
+    ECS_COUNTER_RECORD(&s->block_free_count, t, ecs_block_allocator_free_count);
+    outstanding_allocs = ecs_block_allocator_alloc_count - ecs_block_allocator_free_count;
+    ECS_GAUGE_RECORD(&s->block_outstanding_alloc_count, t, outstanding_allocs);
+
+    ECS_COUNTER_RECORD(&s->stack_alloc_count, t, ecs_stack_allocator_alloc_count);
+    ECS_COUNTER_RECORD(&s->stack_free_count, t, ecs_stack_allocator_free_count);
+    outstanding_allocs = ecs_stack_allocator_alloc_count - ecs_stack_allocator_free_count;
+    ECS_GAUGE_RECORD(&s->stack_outstanding_alloc_count, t, outstanding_allocs);
 
 error:
     return;

--- a/src/datastructures/block_allocator.c
+++ b/src/datastructures/block_allocator.c
@@ -4,6 +4,9 @@
 // #define FLECS_USE_OS_ALLOC
 #endif
 
+int64_t ecs_block_allocator_alloc_count = 0;
+int64_t ecs_block_allocator_free_count = 0;
+
 static
 ecs_block_allocator_chunk_header_t* flecs_balloc_block(
     ecs_block_allocator_t *allocator)
@@ -36,6 +39,8 @@ ecs_block_allocator_chunk_header_t* flecs_balloc_block(
         chunk->next = ECS_OFFSET(chunk, allocator->chunk_size);
         chunk = chunk->next;
     }
+
+    ecs_os_linc(&ecs_block_allocator_alloc_count);
 
     chunk->next = NULL;
     return first_chunk;
@@ -80,6 +85,7 @@ void flecs_ballocator_fini(
     for (block = ba->block_head; block;) {
         ecs_block_allocator_block_t *next = block->next;
         ecs_os_free(block);
+        ecs_os_linc(&ecs_block_allocator_free_count);
         block = next;
     }
     ba->block_head = NULL;

--- a/src/datastructures/map.c
+++ b/src/datastructures/map.c
@@ -332,19 +332,25 @@ void ecs_map_fini(
 {
     ecs_assert(map != NULL, ECS_INTERNAL_ERROR, NULL);
 #ifdef FLECS_SANITIZE
-    /* Free buckets in sanirized mode, so we can replace the allocator with
-        * regular malloc/free and use asan/valgrind to find memory errors. */
-    ecs_bucket_t *bucket = map->buckets;
-    while ((bucket != map->buckets_end)) {
-        ecs_bucket_entry_t *entry = bucket->first;
-        while (entry) {
-            ecs_bucket_entry_t *next = entry->next;
-            flecs_bfree(map->entry_allocator, entry);
-            entry = next;
-        }
-        bucket ++;
-    }
+    bool sanitize = true;
+#else
+    bool sanitize = false;
 #endif
+
+    /* Free buckets in sanirized mode, so we can replace the allocator with
+     * regular malloc/free and use asan/valgrind to find memory errors. */
+    if (map->shared_allocator || sanitize) {
+        ecs_bucket_t *bucket = map->buckets;
+        while ((bucket != map->buckets_end)) {
+            ecs_bucket_entry_t *entry = bucket->first;
+            while (entry) {
+                ecs_bucket_entry_t *next = entry->next;
+                flecs_bfree(map->entry_allocator, entry);
+                entry = next;
+            }
+            bucket ++;
+        }
+    }
 
     if (map->entry_allocator && !map->shared_allocator) {
         flecs_ballocator_free(map->entry_allocator);

--- a/src/entity.c
+++ b/src/entity.c
@@ -4268,19 +4268,21 @@ void flecs_cmd_batch_for_entity(
 
         /* Check if added id is still valid (like is the parent of a ChildOf 
          * pair still alive), if not run cleanup actions for entity */
-        if (flecs_remove_invalid(world, id, &id)) {
-            if (!id) {
-                /* Entity should remain alive but id should not be added */
+        if (id) {
+            if (flecs_remove_invalid(world, id, &id)) {
+                if (!id) {
+                    /* Entity should remain alive but id should not be added */
+                    cmd->kind = EcsOpSkip;
+                    continue;
+                }
+                /* Entity should remain alive and id is still valid */
+            } else {
+                /* Id was no longer valid and had a Delete policy) */
                 cmd->kind = EcsOpSkip;
-                continue;
+                ecs_delete(world, entity);
+                flecs_table_diff_builder_clear(diff);
+                return;
             }
-            /* Entity should remain alive and id is still valid */
-        } else {
-            /* Id was no longer valid and had a Delete policy) */
-            cmd->kind = EcsOpSkip;
-            ecs_delete(world, entity);
-            flecs_table_diff_builder_clear(diff);
-            return;
         }
 
         ecs_cmd_kind_t kind = cmd->kind;

--- a/src/os_api.c
+++ b/src/os_api.c
@@ -284,14 +284,14 @@ void ecs_os_gettime(ecs_time_t *time) {
 
 static
 void* ecs_os_api_malloc(ecs_size_t size) {
-    ecs_os_api_malloc_count ++;
+    ecs_os_linc(&ecs_os_api_malloc_count);
     ecs_assert(size > 0, ECS_INVALID_PARAMETER, NULL);
     return malloc((size_t)size);
 }
 
 static
 void* ecs_os_api_calloc(ecs_size_t size) {
-    ecs_os_api_calloc_count ++;
+    ecs_os_linc(&ecs_os_api_calloc_count);
     ecs_assert(size > 0, ECS_INVALID_PARAMETER, NULL);
     return calloc(1, (size_t)size);
 }
@@ -301,10 +301,10 @@ void* ecs_os_api_realloc(void *ptr, ecs_size_t size) {
     ecs_assert(size > 0, ECS_INVALID_PARAMETER, NULL);
 
     if (ptr) {
-        ecs_os_api_realloc_count ++;
+        ecs_os_linc(&ecs_os_api_realloc_count);
     } else {
         /* If not actually reallocing, treat as malloc */
-        ecs_os_api_malloc_count ++; 
+        ecs_os_linc(&ecs_os_api_malloc_count);
     }
     
     return realloc(ptr, (size_t)size);
@@ -313,7 +313,7 @@ void* ecs_os_api_realloc(void *ptr, ecs_size_t size) {
 static
 void ecs_os_api_free(void *ptr) {
     if (ptr) {
-        ecs_os_api_free_count ++;
+        ecs_os_linc(&ecs_os_api_free_count);
     }
     free(ptr);
 }

--- a/src/table.c
+++ b/src/table.c
@@ -1078,7 +1078,8 @@ void flecs_table_free(
     }
 
     flecs_wfree_n(world, int32_t, table->storage_count + 1, table->dirty_state);
-    flecs_wfree_n(world, int32_t, table->storage_count + table->type.count, table->storage_map);
+    flecs_wfree_n(world, int32_t, table->storage_count + table->type.count, 
+        table->storage_map);
     flecs_table_records_unregister(world, table);
 
     ecs_table_t *storage_table = table->storage_table;

--- a/src/table_cache.c
+++ b/src/table_cache.c
@@ -192,7 +192,6 @@ void* ecs_table_cache_remove(
     ecs_assert(elem->table == table, ECS_INTERNAL_ERROR, NULL);
 
     flecs_table_cache_list_remove(cache, elem);
-
     ecs_map_remove(&cache->index, table->id);
 
     return elem;

--- a/test/api/project.json
+++ b/test/api/project.json
@@ -2157,7 +2157,8 @@
                 "add_2_in_observer_while_on_remove_for_delete",
                 "add_2_in_observer_while_on_remove_for_delete_child",
                 "add_2_in_observer_while_on_remove_for_delete_recycled_id",
-                "add_2_in_observer_while_on_remove_for_deferred_delete_recycled_id"
+                "add_2_in_observer_while_on_remove_for_deferred_delete_recycled_id",
+                "defer_add_after_clear"
             ]
         }, {
             "id": "SingleThreadStaging",

--- a/test/api/project.json
+++ b/test/api/project.json
@@ -2289,7 +2289,8 @@
                 "table_observed_after_clear",
                 "table_observed_after_delete",
                 "table_observed_after_on_remove",
-                "table_observed_after_entity_flag"
+                "table_observed_after_entity_flag",
+                "table_create_leak_check"
             ]
         }, {
             "id": "Error",

--- a/test/api/src/DeferredActions.c
+++ b/test/api/src/DeferredActions.c
@@ -2617,3 +2617,21 @@ void DeferredActions_add_2_in_observer_while_on_remove_for_deferred_delete_recyc
 
     ecs_fini(world);
 }
+
+void DeferredActions_defer_add_after_clear() {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_COMPONENT(world, Position);
+    ECS_TAG(world, Tag);
+
+    ecs_entity_t e = ecs_new_id(world);
+
+    ecs_defer_begin(world);
+    ecs_clear(world, e);
+    ecs_add(world, e, Position);
+    ecs_defer_end(world);
+
+    test_assert(ecs_has(world, e, Position));
+
+    ecs_fini(world);
+}

--- a/test/api/src/Internals.c
+++ b/test/api/src/Internals.c
@@ -492,3 +492,26 @@ void Internals_table_observed_after_entity_flag() {
     ecs_fini(world);
 
 }
+
+void Internals_table_create_leak_check() {
+    ecs_world_t *world = ecs_mini();
+
+    int64_t max_block_count;
+
+    ecs_entity_t tag = ecs_new_id(world);
+    ecs_entity_t e = ecs_new_w_id(world, tag);
+    max_block_count = ecs_block_allocator_alloc_count - 
+        ecs_block_allocator_free_count;
+    ecs_delete(world, tag);
+
+    for (int i = 0; i < 25000; i ++) {
+        tag = ecs_new_id(world);
+        ecs_add_id(world, e, tag);
+        ecs_delete(world, tag);
+    }
+
+    test_int(max_block_count, ecs_block_allocator_alloc_count - 
+        ecs_block_allocator_free_count);
+
+    ecs_fini(world);
+}

--- a/test/api/src/main.c
+++ b/test/api/src/main.c
@@ -2193,6 +2193,7 @@ void Internals_table_observed_after_clear(void);
 void Internals_table_observed_after_delete(void);
 void Internals_table_observed_after_on_remove(void);
 void Internals_table_observed_after_entity_flag(void);
+void Internals_table_create_leak_check(void);
 
 // Testsuite 'Error'
 void Error_setup(void);
@@ -10659,6 +10660,10 @@ bake_test_case Internals_testcases[] = {
     {
         "table_observed_after_entity_flag",
         Internals_table_observed_after_entity_flag
+    },
+    {
+        "table_create_leak_check",
+        Internals_table_create_leak_check
     }
 };
 
@@ -11040,7 +11045,7 @@ static bake_test_suite suites[] = {
         "Internals",
         Internals_setup,
         NULL,
-        17,
+        18,
         Internals_testcases
     },
     {

--- a/test/api/src/main.c
+++ b/test/api/src/main.c
@@ -2069,6 +2069,7 @@ void DeferredActions_add_2_in_observer_while_on_remove_for_delete(void);
 void DeferredActions_add_2_in_observer_while_on_remove_for_delete_child(void);
 void DeferredActions_add_2_in_observer_while_on_remove_for_delete_recycled_id(void);
 void DeferredActions_add_2_in_observer_while_on_remove_for_deferred_delete_recycled_id(void);
+void DeferredActions_defer_add_after_clear(void);
 
 // Testsuite 'SingleThreadStaging'
 void SingleThreadStaging_setup(void);
@@ -10194,6 +10195,10 @@ bake_test_case DeferredActions_testcases[] = {
     {
         "add_2_in_observer_while_on_remove_for_deferred_delete_recycled_id",
         DeferredActions_add_2_in_observer_while_on_remove_for_deferred_delete_recycled_id
+    },
+    {
+        "defer_add_after_clear",
+        DeferredActions_defer_add_after_clear
     }
 };
 
@@ -11007,7 +11012,7 @@ static bake_test_suite suites[] = {
         "DeferredActions",
         NULL,
         NULL,
-        87,
+        88,
         DeferredActions_testcases
     },
     {


### PR DESCRIPTION
This PR fixes a memory leak that occurred during cleanup of a map. The leak was introduced by the allocator PR (https://github.com/SanderMertens/flecs/pull/805) and caused a map to not free memory if it used a shared allocator.

The PR also adds new statistics for allocators, and a `FLECS_ACCURATE_COUNTS` define that, when enabled, ensures that allocation counts are correct in multithreaded applications.