### PR TITLE
meta_c: expand struct definition before stringifying

### DIFF
--- a/include/flecs/addons/meta_c.h
+++ b/include/flecs/addons/meta_c.h
@@ -44,9 +44,11 @@ extern "C" {
     ecs_meta_from_desc(world, ecs_id(name),\
         FLECS__##name##_kind, FLECS__##name##_desc)
 
+#define ECS__META_STRINGIFY(...) #__VA_ARGS__
+
 /** ECS_STRUCT(name, body) */
 #define ECS_STRUCT(name, ...)\
-    ECS_META_IMPL_CALL(ECS_STRUCT_, ECS_META_IMPL, name, #__VA_ARGS__);\
+    ECS_META_IMPL_CALL(ECS_STRUCT_, ECS_META_IMPL, name, ECS__META_STRINGIFY(__VA_ARGS__));\
     ECS_STRUCT_TYPE(name, __VA_ARGS__)
 
 /** ECS_ENUM(name, body) */

--- a/src/addons/meta_c.c
+++ b/src/addons/meta_c.c
@@ -121,7 +121,7 @@ const char* parse_c_identifier(
     /* Ignore whitespaces */
     ptr = ecs_parse_eol_and_whitespace(ptr);
 
-    if (!isalpha(*ptr)) {
+    if (!isalpha(*ptr) && *ptr != '_') {
         ecs_meta_error(ctx, ptr, 
             "invalid identifier (starts with '%c')", *ptr);
         goto error;


### PR DESCRIPTION
This should make it possible to use macros inside struct definitions:
```c
struct foo
{
   float bar[BAZ]; //This should work with this patch
};
```
Needs a test case and adjusting the rest of the type macros