### PR TITLE
#839 Invoke constructors and on_add hooks during bulk_init (16.10 18:22)

### DIFF
--- a/src/private_api.h
+++ b/src/private_api.h
@@ -83,6 +83,38 @@ int32_t flecs_relation_depth(
     ecs_table_t *table);
 
 ////////////////////////////////////////////////////////////////////////////////
+//// Table API
+////////////////////////////////////////////////////////////////////////////////
+void flecs_on_component_callback(
+    ecs_world_t *world,
+    ecs_table_t *table,
+    ecs_iter_action_t callback,
+    ecs_entity_t event,
+    ecs_vec_t *column,
+    ecs_entity_t *entities,
+    ecs_id_t id,
+    int32_t row,
+    int32_t count,
+    ecs_type_info_t *ti);
+
+void flecs_ctor_component(
+    ecs_type_info_t *ti,
+    ecs_vec_t *column,
+    int32_t row,
+    int32_t count);
+
+void flecs_run_add_hooks(
+    ecs_world_t *world,
+    ecs_table_t *table,
+    ecs_type_info_t *ti,
+    ecs_vec_t *column,
+    ecs_entity_t *entities,
+    ecs_id_t id,
+    int32_t row,
+    int32_t count,
+    bool construct);
+
+////////////////////////////////////////////////////////////////////////////////
 //// Query API
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/src/table.c
+++ b/src/table.c
@@ -685,9 +685,6 @@ void flecs_table_notify_on_remove(
     }
 }
 
-/* -- Private functions -- */
-
-static
 void flecs_on_component_callback(
     ecs_world_t *world,
     ecs_table_t *table,
@@ -719,12 +716,12 @@ void flecs_on_component_callback(
     it.ctx = ti->hooks.ctx;
     it.binding_ctx = ti->hooks.binding_ctx;
     it.count = count;
+    it.offset = row;
     flecs_iter_validate(&it);
     callback(&it);
     ecs_iter_fini(&it);
 }
 
-static
 void flecs_ctor_component(
     ecs_type_info_t *ti,
     ecs_vec_t *column,
@@ -740,7 +737,6 @@ void flecs_ctor_component(
     }
 }
 
-static
 void flecs_run_add_hooks(
     ecs_world_t *world,
     ecs_table_t *table,
@@ -764,6 +760,8 @@ void flecs_run_add_hooks(
             entities, id, row, count, ti);
     }
 }
+
+/* -- Private functions -- */
 
 static
 void flecs_dtor_component(


### PR DESCRIPTION
Invokes constructors and on_add hooks during bulk_init
Logic pattern is from table.c `flecs_table_move`

Fixes #839 