### PR TITLE
Fix enum reflection for Apple Clang 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,8 +79,6 @@ jobs:
             cxx: g++-10
           - cc: gcc-11
             cxx: g++-11
-          - cc: gcc-12
-            cxx: g++-12
           - cc: clang-8
             cxx: clang++-8
           - cc: clang-9
@@ -219,8 +217,6 @@ jobs:
             cxx: g++-10
           - cc: gcc-11
             cxx: g++-11
-          - cc: gcc-12
-            cxx: g++-12
           - cc: clang-8
             cxx: clang++-8
           - cc: clang-9
@@ -262,7 +258,7 @@ jobs:
       - name: test c++
         run: bake run test/cpp_api -- -j 8
 
-  test-cpp-macos-11:
+  test-cpp-macos:
     needs: [build-macos]
     runs-on: ${{ matrix.os.version }}
     timeout-minutes: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [ push, pull_request ]
 jobs:
   build-linux:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       fail-fast: false
 
@@ -24,7 +24,7 @@ jobs:
 
   build-macos:
     runs-on: macOS-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       fail-fast: false
 
@@ -43,7 +43,7 @@ jobs:
 
   build-windows:
     runs-on: windows-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       fail-fast: false
 
@@ -64,7 +64,7 @@ jobs:
   build-configs:
     needs: build-linux
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -79,6 +79,8 @@ jobs:
             cxx: g++-10
           - cc: gcc-11
             cxx: g++-11
+          - cc: gcc-12
+            cxx: g++-12
           - cc: clang-8
             cxx: clang++-8
           - cc: clang-9
@@ -133,7 +135,7 @@ jobs:
   build-configs-windows:
     needs: [build-windows]
     runs-on: windows-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       fail-fast: false
 
@@ -160,7 +162,7 @@ jobs:
       - name: build examples (release)
         run: bake/bake examples --strict --cfg debug
 
-  test-unix:
+  test-c-unix:
     needs: [build-linux, build-macos]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
@@ -171,6 +173,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
+      - name: compiler version
+        run: |
+          gcc --version
+          clang --version
+
       - name: install bake
         run: |
           git clone https://github.com/SanderMertens/bake
@@ -191,6 +199,105 @@ jobs:
 
       - name: test collections
         run: bake run test/collections -- -j 8
+
+  test-cpp-unix:
+    needs: [build-linux]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler:
+          # Currently not supported for C++ API, as enum reflection doesn't work
+          # - cc: gcc-7
+          #   cxx: g++-7
+          # - cc: gcc-8
+          #   cxx: g++-8
+          - cc: gcc-9
+            cxx: g++-9
+          - cc: gcc-10
+            cxx: g++-10
+          - cc: gcc-11
+            cxx: g++-11
+          - cc: gcc-12
+            cxx: g++-12
+          - cc: clang-8
+            cxx: clang++-8
+          - cc: clang-9
+            cxx: clang++-9
+          - cc: clang-10
+            cxx: clang++-10
+          - cc: clang-11
+            cxx: clang++-11
+          - cc: clang-12
+            cxx: clang++-12
+
+    env:
+      CC: ${{ matrix.compiler.cc }}
+      CXX: ${{ matrix.compiler.cxx }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: install compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ${{ matrix.compiler.cc }}
+          sudo apt-get install -y ${{ matrix.compiler.cxx }}
+
+      - name: compiler version
+        run: |
+          ${{ matrix.compiler.cc }} --version
+          ${{ matrix.compiler.cxx }} --version
+
+      - name: install bake
+        run: |
+          git clone https://github.com/SanderMertens/bake
+          make -C bake/build-$(uname)
+          bake/bake setup
+
+      - name: build flecs
+        run: bake --strict
+
+      - name: test c++
+        run: bake run test/cpp_api -- -j 8
+
+  test-cpp-macos-11:
+    needs: [build-macos]
+    runs-on: ${{ matrix.os.version }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os: 
+          - { version: macOS-11, xcode: '11.7' }
+          - { version: macOS-11, xcode: '12.4' }
+          - { version: macOS-12, xcode: '13.1' }
+          - { version: macOS-12, xcode: '14.0' }
+
+    env:
+      CC: clang
+      CXX: clang++
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ matrix.os.xcode }}
+
+      - name: compiler version
+        run: |
+          clang --version
+
+      - name: install bake
+        run: |
+          git clone https://github.com/SanderMertens/bake
+          make -C bake/build-$(uname)
+          bake/bake setup
+
+      - name: build flecs
+        run: bake --strict
 
       - name: test c++
         run: bake run test/cpp_api -- -j 8
@@ -263,12 +370,10 @@ jobs:
 
   analyze-sanitized-api:
     needs: build-macos
-    runs-on: ${{ matrix.os }}
+    runs-on: macOS-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
-      matrix:
-        os: [ macOS-latest ]
 
     steps:
       - uses: actions/checkout@v3
@@ -287,12 +392,10 @@ jobs:
 
   analyze-sanitized-addons:
     needs: build-macos
-    runs-on: ${{ matrix.os }}
+    runs-on: macOS-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
-      matrix:
-        os: [ macOS-latest ]
 
     steps:
       - uses: actions/checkout@v3
@@ -311,12 +414,10 @@ jobs:
 
   analyze-sanitized-meta:
     needs: build-macos
-    runs-on: ${{ matrix.os }}
+    runs-on: macOS-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
-      matrix:
-        os: [ macOS-latest ]
 
     steps:
       - uses: actions/checkout@v3
@@ -335,12 +436,10 @@ jobs:
 
   analyze-sanitized-collections:
     needs: build-macos
-    runs-on: ${{ matrix.os }}
+    runs-on: macOS-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
-      matrix:
-        os: [ macOS-latest ]
 
     steps:
       - uses: actions/checkout@v3
@@ -359,12 +458,10 @@ jobs:
 
   analyze-sanitized-cpp_api:
     needs: build-macos
-    runs-on: ${{ matrix.os }}
+    runs-on: macOS-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
-      matrix:
-        os: [ macOS-latest ]
 
     steps:
       - uses: actions/checkout@v3
@@ -422,7 +519,7 @@ jobs:
 
   buildsystem-meson:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     strategy:
       fail-fast: false
 
@@ -445,7 +542,7 @@ jobs:
   flecs-custom-builds:
     needs: build-linux
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -581,7 +678,7 @@ jobs:
 
   flecs-amalgamated:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/include/flecs/addons/cpp/utils/enum.hpp
+++ b/include/flecs/addons/cpp/utils/enum.hpp
@@ -61,8 +61,8 @@ constexpr size_t enum_type_len() {
  * This function leverages that when a valid value is provided, 
  * __PRETTY_FUNCTION__ contains the enumeration name, whereas if a value is
  * invalid, the string contains a number. */
-#if defined(__clang__)
-#if __clang_major__ < 13 || (defined(__APPLE__) && __clang_minor__ < 1)
+#if defined(ECS_TARGET_CLANG)
+#if ECS_CLANG_VERSION < 13
 template <typename E, E C>
 constexpr bool enum_constant_is_valid() {
     return !(
@@ -78,7 +78,7 @@ constexpr bool enum_constant_is_valid() {
         enum_type_len<E>() + 6 /* ', E C = ' */] != '(');
 }
 #endif
-#elif defined(__GNUC__)
+#elif defined(ECS_TARGET_GNU)
 template <typename E, E C>
 constexpr bool enum_constant_is_valid() {
     return (ECS_FUNC_NAME[ECS_FUNC_NAME_FRONT(constepxr bool, enum_constant_is_valid) +

--- a/include/flecs/private/api_defines.h
+++ b/include/flecs/private/api_defines.h
@@ -41,8 +41,30 @@
 #endif
 #endif
 
+#if defined(__clang__)
+#define ECS_TARGET_CLANG
+#endif
+
 #if defined(__GNUC__)
 #define ECS_TARGET_GNU
+#endif
+
+/* Map between clang and apple clang versions, as version 13 has a difference in
+ * the format of __PRETTY_FUNCTION__ which enum reflection depends on. */
+#if defined(__clang__)
+    #if defined(__APPLE__)
+        #if __clang_major__ == 13
+            #if __clang_minor__ < 1
+                #define ECS_CLANG_VERSION 12
+            #else
+                #define ECS_CLANG_VERSION 13
+            #endif
+        #else
+            #define ECS_CLANG_VERSION __clang_major__
+        #endif
+    #else
+        #define ECS_CLANG_VERSION __clang_major__
+    #endif
 #endif
 
 /* Standard library dependencies */

--- a/test/cpp_api/project.json
+++ b/test/cpp_api/project.json
@@ -13,6 +13,12 @@
     },
     "test": {
         "testsuites": [{
+            "id": "PrettyFunction",
+            "testcases": [
+                "component",
+                "enum"
+            ]
+        }, {
             "id": "Entity",
             "testcases": [
                 "new",

--- a/test/cpp_api/src/PrettyFunction.cpp
+++ b/test/cpp_api/src/PrettyFunction.cpp
@@ -1,0 +1,31 @@
+#include <cpp_api.h>
+#include <iostream>
+
+// Helper to debug differences in function name strings across compilers
+
+enum Color {
+    Red, Green, Blue
+};
+
+template <typename T>
+static size_t pretty_type() {
+    std::cout << ECS_FUNC_NAME << std::endl;
+    return 0;
+}
+
+template <typename E, E C>
+static size_t pretty_enum() {
+    std::cout << ECS_FUNC_NAME << std::endl;
+    return 0;
+}
+
+void PrettyFunction_component() {
+    pretty_type<Position>();
+    test_assert(true);
+}
+
+void PrettyFunction_enum() {
+    pretty_enum<Color, Color::Red>();
+    pretty_enum<Color, (Color)3>();
+    test_assert(true);
+}

--- a/test/cpp_api/src/main.cpp
+++ b/test/cpp_api/src/main.cpp
@@ -8,6 +8,10 @@
 
 #include <cpp_api.h>
 
+// Testsuite 'PrettyFunction'
+void PrettyFunction_component(void);
+void PrettyFunction_enum(void);
+
 // Testsuite 'Entity'
 void Entity_new(void);
 void Entity_new_named(void);
@@ -1043,6 +1047,17 @@ void Doc_set_name(void);
 void Doc_set_link(void);
 void Doc_set_color(void);
 void Doc_get_name_no_doc_name(void);
+
+bake_test_case PrettyFunction_testcases[] = {
+    {
+        "component",
+        PrettyFunction_component
+    },
+    {
+        "enum",
+        PrettyFunction_enum
+    }
+};
 
 bake_test_case Entity_testcases[] = {
     {
@@ -5051,6 +5066,13 @@ bake_test_case Doc_testcases[] = {
 
 static bake_test_suite suites[] = {
     {
+        "PrettyFunction",
+        NULL,
+        NULL,
+        2,
+        PrettyFunction_testcases
+    },
+    {
         "Entity",
         NULL,
         NULL,
@@ -5242,5 +5264,5 @@ static bake_test_suite suites[] = {
 };
 
 int main(int argc, char *argv[]) {
-    return bake_test_run("cpp_api", argc, argv, suites, 27);
+    return bake_test_run("cpp_api", argc, argv, suites, 28);
 }


### PR DESCRIPTION
This PR fixes enum reflection for Apple Clang 14 by making sure the `__PRETTY_FUNCTION__` macro is interpreted correctly. The PR also adds jobs to CI that runs the C++ test suite against different compiler versions for both clang and gcc.