### PR TITLE
Update BUILD to support .inl files in Bazel builds

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -3,7 +3,7 @@ cc_library(
     name = "flecs",
     visibility = ["//visibility:public"],
 
-    srcs = glob(["src/**/*.c", "src/**/*.h"]),
-    hdrs = glob(["include/**/*.h", "include/**/*.hpp"]),
+    srcs = glob(["src/**/*.c", "src/**/*.h", "src/**/*.inl"]),
+    hdrs = glob(["include/**/*.h", "include/**/*.hpp", "include/**/*.inl"]),
     includes = ["include"],
 )


### PR DESCRIPTION
I couldn't get building with Bazel to work due to `.inl` file not found errors. This seems like the necessary fix though I'm only just starting to get to grips with Bazel so please let me know if there's an alternative.