### PR TITLE
Fix missing include

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -1,5 +1,6 @@
 #include "private_api.h"
 #include <time.h>
+#include <stdio.h>
 
 #ifndef FLECS_NDEBUG
 static int64_t flecs_s_min[] = { 


### PR DESCRIPTION
Fix missing include. I use a very strict build environment, which is probably why this was caught.
I suspect most users would not even be able to observe this.