### PR TITLE
`flecs::entity_t` vs `flecs::entity`

### DIFF
--- a/docs/Queries.md
+++ b/docs/Queries.md
@@ -2493,7 +2493,7 @@ Queries may specify zero for component id to sort on entity ids:
 
 ```cpp
 auto q = world.query_builder<Position>()
-  .order_by(0, [](flecs::entity e1, const void *d1, flecs::entity e2, const void *d2) {
+  .order_by(0, [](flecs::entity_t e1, const void *d1, flecs::entity_t e2, const void *d2) {
     return (e1 > e2) - (e1 < e2);
   })
   .build();


### PR DESCRIPTION
On my machine using MSVC I had to change the parameter types to `flecs::entity_t` here in order for it to compile.
I am not certain if the C++ API functor signature should be changed, if these documentations should be updated, or if I set it up incorrectly.

```
error C2664: 'Base &flecs::query_builder_i<Base>::order_by(flecs::entity_t,int (__cdecl *)(flecs::entity_t,const void *,flecs::entity_t,const void *))': cannot convert argument 2 from 'M::Pipeline::{ctor}::<lambda_1>' to 'int (__cdecl *)(flecs::entity_t,const void 
*,flecs::entity_t,const void *)'
```