### PR TITLE
Use `ecs_ftime_t`

### DIFF
--- a/src/addons/system/system.c
+++ b/src/addons/system/system.c
@@ -121,7 +121,7 @@ ecs_entity_t ecs_run_intern(
     }
 
     if (measure_time) {
-        system_data->time_spent += (float)ecs_time_measure(&time_start);
+        system_data->time_spent += (ecs_ftime_t)ecs_time_measure(&time_start);
     }
 
     system_data->invoke_count ++;


### PR DESCRIPTION
I have changed `ecs_float_t` to `double` on my configuration. Spares me from
```cpp
cxx/lib/flecs/src/addons/system/system.c:124:33: warning: implicit conversion from ‘float’ to ‘double’ to match other operand of binary expression [-Wdouble-promotion]
  124 |         system_data->time_spent += (float)ecs_time_measure(&time_start);
      |                                 ^~
```
(GCC)