### PR TITLE
Remove unnecessary backslash in ECS_MODULE macro

### DIFF
--- a/include/flecs/addons/module.h
+++ b/include/flecs/addons/module.h
@@ -105,7 +105,7 @@ ecs_entity_t ecs_module_init(
 
 #define ECS_MODULE(world, id)\
     ecs_entity_t ecs_id(id) = 0; ECS_MODULE_DEFINE(world, id)\
-    (void)ecs_id(id);\
+    (void)ecs_id(id);
 
 /** Wrapper around ecs_import.
  * This macro provides a convenient way to load a module with the world. It can


### PR DESCRIPTION
I ran into this by chance when trying to parse `#define`s from the header file directly. Seems to be the only place an extra `\` character is at the end of a macro, so likely unintentional.