### PR TITLE
Match comment on is_monitor with other multi-line comments

### DIFF
--- a/include/flecs.h
+++ b/include/flecs.h
@@ -599,8 +599,8 @@ struct ecs_observer_t {
     int32_t term_index;         /**< Index of the term in parent observer (single term observers only) */
 
     bool is_monitor;            /**< If true, the observer only triggers when the
-                                 **< filter did not match with the entity before
-                                 **< the event happened. */
+                                 * filter did not match with the entity before
+                                 * the event happened. */
 
     bool is_multi;              /**< If true, the observer triggers on more than one term */
 


### PR DESCRIPTION
I found `is_monitor` is the only place that, for some reason, uses `**<` on subsequent lines of a multi-line comment. I changed it to match the others.