### PR TITLE
Fix clang compilation error

### DIFF
--- a/include/flecs/addons/cpp/utils/enum.hpp
+++ b/include/flecs/addons/cpp/utils/enum.hpp
@@ -17,7 +17,12 @@ namespace flecs {
 namespace _ {
 template <typename E, int Value>
 struct to_constant {
+#if defined(__clang__) && __clang_major__ >= 16
+    // https://reviews.llvm.org/D130058, https://reviews.llvm.org/D131307
+    static constexpr E value = __builtin_bit_cast(E, Value);
+#else
     static constexpr E value = static_cast<E>(Value);
+#endif
 };
 
 template <typename E, int Value>


### PR DESCRIPTION
Fix compilation error with the latest emscripten em++:
```
../subprojects/flecs/include/flecs/private/../addons/cpp/utils/enum.hpp:23:30: error: integer value 128 is outside the valid range of values [0, 7] for this enumeration type [-Wenum-constexpr-conversion]
  static constexpr E value = static_cast<E>(Value);
```
Searching around in github I found the solution in the magic_enum project and adapted it. 