### PR TITLE
Fix the destructor not being called when a column is merged

### DIFF
--- a/src/table.c
+++ b/src/table.c
@@ -2184,7 +2184,7 @@ void flecs_merge_column(
         /* Move values into column */
         ecs_move_t move = NULL;
         if (ti) {
-            move = ti->hooks.move;
+            move = ti->hooks.move_dtor;
         }
         if (move) {
             move(dst_ptr, src_ptr, src_count, ti);

--- a/test/cpp_api/project.json
+++ b/test/cpp_api/project.json
@@ -926,7 +926,8 @@
                 "set_override_no_copy",
                 "set_override_pair_no_copy",
                 "set_override_pair_w_entity_no_copy",
-                "dtor_after_defer_set"
+                "dtor_after_defer_set",
+                "dtor_with_relation"
             ]
         }, {
             "id": "Refs",

--- a/test/cpp_api/src/ComponentLifecycle.cpp
+++ b/test/cpp_api/src/ComponentLifecycle.cpp
@@ -1758,3 +1758,33 @@ void ComponentLifecycle_dtor_after_defer_set() {
     test_int(Pod::move_invoked, 2);
     test_int(Pod::move_ctor_invoked, 0);
 }
+
+void ComponentLifecycle_dtor_with_relation() {
+    {
+        flecs::world ecs;
+
+        auto e = ecs.entity();
+        auto e2 = ecs.entity().set<Pod>({5});
+
+        e.set<Pod>({10}).add<Tag>(e2);
+
+        test_int(Pod::ctor_invoked, 4);
+        test_int(Pod::dtor_invoked, 3);
+        test_int(Pod::move_invoked, 2);
+        test_int(Pod::move_ctor_invoked, 1);
+
+        const Pod *ptr = e.get<Pod>();
+        test_assert(ptr != NULL);
+        test_int(ptr->value, 10);
+
+        test_int(Pod::ctor_invoked, 4);
+        test_int(Pod::dtor_invoked, 3);
+        test_int(Pod::move_invoked, 2);
+        test_int(Pod::move_ctor_invoked, 1);
+    }
+
+    test_int(Pod::ctor_invoked, 5);
+    test_int(Pod::dtor_invoked, 6);
+    test_int(Pod::move_invoked, 4);
+    test_int(Pod::move_ctor_invoked, 1);
+}

--- a/test/cpp_api/src/main.cpp
+++ b/test/cpp_api/src/main.cpp
@@ -889,6 +889,7 @@ void ComponentLifecycle_set_override_no_copy(void);
 void ComponentLifecycle_set_override_pair_no_copy(void);
 void ComponentLifecycle_set_override_pair_w_entity_no_copy(void);
 void ComponentLifecycle_dtor_after_defer_set(void);
+void ComponentLifecycle_dtor_with_relation(void);
 
 // Testsuite 'Refs'
 void Refs_get_ref_by_ptr(void);
@@ -4609,6 +4610,10 @@ bake_test_case ComponentLifecycle_testcases[] = {
     {
         "dtor_after_defer_set",
         ComponentLifecycle_dtor_after_defer_set
+    },
+    {
+        "dtor_with_relation",
+        ComponentLifecycle_dtor_with_relation
     }
 };
 
@@ -5786,7 +5791,7 @@ static bake_test_suite suites[] = {
         "ComponentLifecycle",
         NULL,
         NULL,
-        72,
+        73,
         ComponentLifecycle_testcases
     },
     {


### PR DESCRIPTION
Fixes an issue that happens when the world is destructed (and maybe other cases too).

In the case the column was merged into a non-empty column, the old column's data (after being moved out) was freed but never had the destructor called on it leaking memory with some types.