### PR TITLE
Fix phase error in custom_phases_no_builtin cpp example

### DIFF
--- a/examples/cpp/systems/custom_phases_no_builtin/src/main.cpp
+++ b/examples/cpp/systems/custom_phases_no_builtin/src/main.cpp
@@ -30,7 +30,7 @@ int main(int argc, char *argv[]) {
         .iter(Sys);
 
     ecs.system("GameSystem")
-        .kind(flecs::OnUpdate)
+        .kind(Update)
         .iter(Sys);
 
     // Run pipeline


### PR DESCRIPTION
The expected output for this example is: 

system GameSystem
system PhysicsSystem
system CollisionSystem

However the current output is:

system PhysicsSystem
system CollisionSystem
system GameSystem

From looking at the C version of this example, GameSystem is supposed to be of kind Update and not flecs::OnUpdate. Swapping out that one line allows the expected and actual output to match.