### PR TITLE
[docs] Fix conflicting declaration

### DIFF
--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -191,19 +191,16 @@ const Position *p = ecs_get(world, e, Position);
 ecs_remove(world, e, Position);
 ```
 ```cpp
-// Option 1: Create entity and assign component
 auto e = world.entity();
 
 // Add a component. This creates the component in the ECS storage, but does not
 // assign it with a value.
 e.add<Velocity>();
 
-// Option 2: Create entity and assign components at the same time
 // Set the value for the Position & Velocity components. A component will be
 // added if the entity doesn't have it yet.
-auto e = ecs.entity()
-    .set<Position>({10, 20})
-    .set<Velocity>({1, 2});
+e.set<Position>({10, 20})
+ .set<Velocity>({1, 2});
 
 // Get a component
 const Position *p = e.get<Position>();

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -199,7 +199,7 @@ e.add<Velocity>();
 
 // Set the value for the Position & Velocity components. A component will be
 // added if the entity doesn't have it yet.
-auto e = ecs.entity()
+e = ecs.entity()
     .set<Position>({10, 20})
     .set<Velocity>({1, 2});
 

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -191,15 +191,17 @@ const Position *p = ecs_get(world, e, Position);
 ecs_remove(world, e, Position);
 ```
 ```cpp
+// Option 1: Create entity and assign component
 auto e = world.entity();
 
 // Add a component. This creates the component in the ECS storage, but does not
 // assign it with a value.
 e.add<Velocity>();
 
+// Option 2: Create entity and assign components at the same time
 // Set the value for the Position & Velocity components. A component will be
 // added if the entity doesn't have it yet.
-e = ecs.entity()
+auto e = ecs.entity()
     .set<Position>({10, 20})
     .set<Velocity>({1, 2});
 


### PR DESCRIPTION
Noticed this while reading the docs. I assume it's an unintentional copy-paste?

EDIT: I re-read and realized it was probably supposed to be 2 different ways of adding components, not one continuous code example. I added some comments to clarify that instead of removing the `auto` declaration.