### PR TITLE
ecs_meta_set_int(): fix unsigned bounds check

### DIFF
--- a/src/addons/meta/cursor.c
+++ b/src/addons/meta/cursor.c
@@ -873,7 +873,7 @@ int ecs_meta_set_int(
     switch(op->kind) {
     cases_T_bool(ptr, value);
     cases_T_signed(ptr, value, ecs_meta_bounds_signed);
-    cases_T_unsigned(ptr, value, ecs_meta_bounds_signed);
+    cases_T_unsigned(ptr, value, ecs_meta_bounds_unsigned);
     cases_T_float(ptr, value);
     case EcsOpOpaque: {
         const EcsOpaque *opaque = ecs_get(cursor->world, op->type, EcsOpaque);


### PR DESCRIPTION
Before this fix if you passed e.g. `-1` to set an U64 it will fail, but all values are valid for an U64. It will still error out for U32/16/8 with a value of `-1` but I think that's fair.