### PR TITLE
Add a way to get the filter from a rule, swap str method to rule specific one

### DIFF
--- a/flecs.h
+++ b/flecs.h
@@ -27734,9 +27734,12 @@ struct rule_base {
         obj.m_rule = nullptr;
     }
 
-    flecs::string str() {
-        const ecs_filter_t *f = ecs_rule_get_filter(m_rule);
-        char *result = ecs_filter_str(m_world, f);
+    flecs::filter_base filter() const {
+        return filter_base(m_world, ecs_rule_get_filter(m_rule));
+    }
+
+    flecs::string str() const {
+        char *result = ecs_rule_str(m_rule);
         return flecs::string(result);
     }
 

--- a/flecs.h
+++ b/flecs.h
@@ -27749,7 +27749,7 @@ struct rule_base {
 
 
     /** Converts this rule to a string that can be used to aid debugging
-     * the behavior rule.
+     * the behavior of the rule.
      * @see ecs_rule_str
      */
     flecs::string rule_str() const {

--- a/flecs.h
+++ b/flecs.h
@@ -27738,7 +27738,21 @@ struct rule_base {
         return filter_base(m_world, ecs_rule_get_filter(m_rule));
     }
 
+    /** Converts this rule to a string expression
+     * @see ecs_filter_str
+     */
     flecs::string str() const {
+        const ecs_filter_t *f = ecs_rule_get_filter(m_rule);
+        char *result = ecs_filter_str(m_world, f);
+        return flecs::string(result);
+    }
+
+
+    /** Converts this rule to a string that can be used to aid debugging
+     * the behavior rule.
+     * @see ecs_rule_str
+     */
+    flecs::string rule_str() const {
         char *result = ecs_rule_str(m_rule);
         return flecs::string(result);
     }

--- a/include/flecs/addons/cpp/mixins/rule/impl.hpp
+++ b/include/flecs/addons/cpp/mixins/rule/impl.hpp
@@ -76,7 +76,7 @@ struct rule_base {
 
 
     /** Converts this rule to a string that can be used to aid debugging
-     * the behavior rule.
+     * the behavior of the rule.
      * @see ecs_rule_str
      */
     flecs::string rule_str() const {

--- a/include/flecs/addons/cpp/mixins/rule/impl.hpp
+++ b/include/flecs/addons/cpp/mixins/rule/impl.hpp
@@ -65,7 +65,21 @@ struct rule_base {
         return filter_base(m_world, ecs_rule_get_filter(m_rule));
     }
 
+    /** Converts this rule to a string expression
+     * @see ecs_filter_str
+     */
     flecs::string str() const {
+        const ecs_filter_t *f = ecs_rule_get_filter(m_rule);
+        char *result = ecs_filter_str(m_world, f);
+        return flecs::string(result);
+    }
+
+
+    /** Converts this rule to a string that can be used to aid debugging
+     * the behavior rule.
+     * @see ecs_rule_str
+     */
+    flecs::string rule_str() const {
         char *result = ecs_rule_str(m_rule);
         return flecs::string(result);
     }

--- a/include/flecs/addons/cpp/mixins/rule/impl.hpp
+++ b/include/flecs/addons/cpp/mixins/rule/impl.hpp
@@ -61,9 +61,12 @@ struct rule_base {
         obj.m_rule = nullptr;
     }
 
-    flecs::string str() {
-        const ecs_filter_t *f = ecs_rule_get_filter(m_rule);
-        char *result = ecs_filter_str(m_world, f);
+    flecs::filter_base filter() const {
+        return filter_base(m_world, ecs_rule_get_filter(m_rule));
+    }
+
+    flecs::string str() const {
+        char *result = ecs_rule_str(m_rule);
         return flecs::string(result);
     }
 


### PR DESCRIPTION
Noticed the `str` method for rules wasn't `const` so went to fix that and noticed in the process that it was calling the filter string method instead of the new one for rules so I've also changed it to that whilst also adding a method to get the filter so the old string result can still be fetched.

This is a breaking change however from the previous behavior though due to the output being very different so it might be better to add a different method to return the rule string?