### PR TITLE
Add missing ecs_rule_var_name and ecs_rule_var_is_entity

### DIFF
--- a/src/addons/rules/compile.c
+++ b/src/addons/rules/compile.c
@@ -179,6 +179,12 @@ ecs_var_id_t flecs_rule_find_var_id(
     return flecs_rule_find_var_id(rule, name, EcsVarTable);
 }
 
+int32_t ecs_rule_var_count(
+    const ecs_rule_t *rule)
+{
+    return rule->var_pub_count;
+}
+
 int32_t ecs_rule_find_var(
     const ecs_rule_t *rule,
     const char *name)
@@ -200,10 +206,18 @@ int32_t ecs_rule_find_var(
     return (int32_t)var_id;
 }
 
-int32_t ecs_rule_var_count(
-    const ecs_rule_t *rule)
+const char* ecs_rule_var_name(
+    const ecs_rule_t *rule,
+    int32_t var_id)
 {
-    return rule->var_pub_count;
+    return rule->vars[var_id].name;
+}
+
+bool ecs_rule_var_is_entity(
+    const ecs_rule_t *rule,
+    int32_t var_id)
+{
+    return rule->vars[var_id].kind == EcsVarEntity;
 }
 
 static


### PR DESCRIPTION
- I did not touch the main `flecs.c`.
- May want to add tests like you did for `ecs_rule_var_count`.
- I took the liberty of moving `ecs_rule_var_count` so all functions appear in the same order as in `rules.h`.
- Code taken from [rules.c of commit `5043840`](https://github.com/SanderMertens/flecs/blob/50438400bfae1dcc2aba343c6eba98b04bad485e/src/addons/rules.c#L2914C47-L2928).
- Simply changed `EcsRuleVarKindEntity` to `EcsVarEntity`.
- Compiled, tested in my project, solved the issue with missing functions I had.

Welcome back, Inspector Gadget.
![image](https://user-images.githubusercontent.com/272586/236869838-23937bc5-7b64-4de2-a397-3b6b18496bd8.png)