### PR TITLE
Remove sep initialization in ecs_new_from_path_w_sep

### DIFF
--- a/src/hierarchy.c
+++ b/src/hierarchy.c
@@ -684,9 +684,5 @@ ecs_entity_t ecs_new_from_path_w_sep(
     const char *sep,
     const char *prefix)
 {
-    if (!sep) {
-        sep = ".";
-    }
-
     return ecs_add_path_w_sep(world, 0, parent, path, sep, prefix);
 }


### PR DESCRIPTION
This appears to be unnecessary because `ecs_add_path_w_sep` already does the same thing.