### PR TITLE
Fix comment on iterable::each

### DIFF
--- a/include/flecs/addons/cpp/utils/iterable.hpp
+++ b/include/flecs/addons/cpp/utils/iterable.hpp
@@ -21,7 +21,7 @@ struct iterable {
      * The "each" iterator accepts a function that is invoked for each matching
      * entity. The following function signatures are valid:
      *  - func(flecs::entity e, Components& ...)
-     *  - func(flecs::iter& it, int32_t index, Components& ....)
+     *  - func(flecs::iter& it, size_t index, Components& ....)
      *  - func(Components& ...)
      * 
      * Each iterators are automatically instanced.


### PR DESCRIPTION
`each_invoker` passes a `size_t` not a `int32_t`
See: https://github.com/SanderMertens/flecs/blob/c8f946b1daa6571cc1839f779574368562ee9402/include/flecs/addons/cpp/invoker.hpp#L290-L293