### PR TITLE
Query scopes

### DIFF
--- a/flecs.c
+++ b/flecs.c
@@ -40854,9 +40854,9 @@ int flecs_rule_compile_term(
         /* If the term has a 0 source, check if it's a scope open/close */
         if (term->first.id == EcsScopeOpen) {
             if (term->oper == EcsNot) {
-                ctx->scope_is_not |= 1 << ctx->scope;
+                ctx->scope_is_not |= (1ull << ctx->scope);
             } else {
-                ctx->scope_is_not &= ~(1 << ctx->scope);
+                ctx->scope_is_not &= ~(1ull << ctx->scope);
             }
         } else if (term->first.id == EcsScopeClose) {
             flecs_rule_compile_pop(ctx);

--- a/flecs.c
+++ b/flecs.c
@@ -34952,7 +34952,7 @@ int flecs_json_serialize_iter_result(
 
     /* Add "alerts": true member if table has entities with active alerts */
 #ifdef FLECS_ALERTS
-    if (ecs_id(EcsAlertsActive) != 0) {
+    if (it->table && (ecs_id(EcsAlertsActive) != 0)) {
         /* Only add field if alerts addon is imported */
         if (ecs_table_has_id(world, it->table, ecs_id(EcsAlertsActive))) {
             flecs_json_memberl(buf, "alerts");

--- a/flecs.c
+++ b/flecs.c
@@ -19878,8 +19878,9 @@ void FlecsAlertsImport(ecs_world_t *world) {
 #endif
 
     ecs_set_name_prefix(world, "Ecs");
-
     ECS_COMPONENT_DEFINE(world, EcsAlert);
+
+    ecs_set_name_prefix(world, "EcsAlert");
     ECS_COMPONENT_DEFINE(world, EcsAlertInstance);
     ECS_COMPONENT_DEFINE(world, EcsAlertsActive);
 
@@ -19905,7 +19906,7 @@ void FlecsAlertsImport(ecs_world_t *world) {
     });
 
     ECS_SYSTEM(world, MonitorAlerts, EcsPreStore, Alert, (Poly, Query));
-    ECS_SYSTEM(world, MonitorAlertInstances, EcsOnStore, AlertInstance, 
+    ECS_SYSTEM(world, MonitorAlertInstances, EcsOnStore, Instance, 
         flecs.metrics.Source, flecs.metrics.Value);
 
     ecs_system(world, {

--- a/flecs.c
+++ b/flecs.c
@@ -40854,13 +40854,13 @@ int flecs_rule_compile_term(
         /* If the term has a 0 source, check if it's a scope open/close */
         if (term->first.id == EcsScopeOpen) {
             if (term->oper == EcsNot) {
-                ctx->scope_is_not |= (1ull << ctx->scope);
+                ctx->scope_is_not |= (ecs_flags32_t)(1ull << ctx->scope);
             } else {
-                ctx->scope_is_not &= ~(1ull << ctx->scope);
+                ctx->scope_is_not &= (ecs_flags32_t)~(1ull << ctx->scope);
             }
         } else if (term->first.id == EcsScopeClose) {
             flecs_rule_compile_pop(ctx);
-            if (ctx->scope_is_not & (1 << ctx->scope)) {
+            if (ctx->scope_is_not & (ecs_flags32_t)(1ull << ctx->scope)) {
                 op.field_index = -1;
                 flecs_rule_end_not(&op, ctx, false);
             }

--- a/flecs.h
+++ b/flecs.h
@@ -245,6 +245,10 @@
  * Maximum number of query variables per query */
 #define FLECS_VARIABLE_COUNT_MAX (64)
 
+/** \def FLECS_QUERY_SCOPE_NESTING_MAX 
+ * Maximum nesting depth of query scopes */
+#define FLECS_QUERY_SCOPE_NESTING_MAX (8)
+
 /** @} */
 
 /**

--- a/flecs.h
+++ b/flecs.h
@@ -15306,6 +15306,10 @@ static const flecs::entity_t PredEq = EcsPredEq;
 static const flecs::entity_t PredMatch = EcsPredMatch;
 static const flecs::entity_t PredLookup = EcsPredLookup;
 
+/* Builtin marker entities for query scopes */
+static const flecs::entity_t ScopeOpen = EcsScopeOpen;
+static const flecs::entity_t ScopeClose = EcsScopeClose;
+
 /** @} */
 
 }
@@ -26472,6 +26476,15 @@ struct filter_builder_i : term_builder_i<Base> {
     template <typename First, typename Second>
     Base& read() {
         return this->term<First, Second>().read();
+    }
+
+    /* Scope_open/scope_close shorthand notation. */
+    Base& scope_open() {
+        return this->with(flecs::ScopeOpen).entity(0);
+    }
+
+    Base& scope_close() {
+        return this->with(flecs::ScopeClose).entity(0);
     }
 
     /* Term notation for more complex query features */

--- a/flecs.h
+++ b/flecs.h
@@ -392,7 +392,8 @@ extern "C" {
 #define EcsFilterPopulate              (1u << 9u)  /* Populate data, ignore non-matching fields */
 #define EcsFilterHasCondSet            (1u << 10u) /* Does filter have conditionally set fields */
 #define EcsFilterUnresolvedByName      (1u << 11u) /* Use by-name matching for unresolved entity identifiers */
-
+#define EcsFilterHasPred               (1u << 12u) /* Filter has equality predicates */
+#define EcsFilterHasScopes             (1u << 13u) /* Filter has query scopes */
 
 ////////////////////////////////////////////////////////////////////////////////
 //// Table flags (used by ecs_table_t::flags)
@@ -4072,6 +4073,10 @@ FLECS_API extern const ecs_entity_t EcsDefaultChildComponent;
 FLECS_API extern const ecs_entity_t EcsPredEq;
 FLECS_API extern const ecs_entity_t EcsPredMatch;
 FLECS_API extern const ecs_entity_t EcsPredLookup;
+
+/* Builtin marker entities for opening/closing query scopes */
+FLECS_API extern const ecs_entity_t EcsScopeOpen;
+FLECS_API extern const ecs_entity_t EcsScopeClose;
 
 /** Tag used to indicate query is empty */
 FLECS_API extern const ecs_entity_t EcsEmpty;

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -243,6 +243,10 @@
  * Maximum number of query variables per query */
 #define FLECS_VARIABLE_COUNT_MAX (64)
 
+/** \def FLECS_QUERY_SCOPE_NESTING_MAX 
+ * Maximum nesting depth of query scopes */
+#define FLECS_QUERY_SCOPE_NESTING_MAX (8)
+
 /** @} */
 
 #include "flecs/private/api_defines.h"

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -1367,6 +1367,10 @@ FLECS_API extern const ecs_entity_t EcsPredEq;
 FLECS_API extern const ecs_entity_t EcsPredMatch;
 FLECS_API extern const ecs_entity_t EcsPredLookup;
 
+/* Builtin marker entities for opening/closing query scopes */
+FLECS_API extern const ecs_entity_t EcsScopeOpen;
+FLECS_API extern const ecs_entity_t EcsScopeClose;
+
 /** Tag used to indicate query is empty */
 FLECS_API extern const ecs_entity_t EcsEmpty;
 

--- a/include/flecs/addons/cpp/c_types.hpp
+++ b/include/flecs/addons/cpp/c_types.hpp
@@ -145,6 +145,10 @@ static const flecs::entity_t PredEq = EcsPredEq;
 static const flecs::entity_t PredMatch = EcsPredMatch;
 static const flecs::entity_t PredLookup = EcsPredLookup;
 
+/* Builtin marker entities for query scopes */
+static const flecs::entity_t ScopeOpen = EcsScopeOpen;
+static const flecs::entity_t ScopeClose = EcsScopeClose;
+
 /** @} */
 
 }

--- a/include/flecs/addons/cpp/mixins/filter/builder_i.hpp
+++ b/include/flecs/addons/cpp/mixins/filter/builder_i.hpp
@@ -115,6 +115,15 @@ struct filter_builder_i : term_builder_i<Base> {
         return this->term<First, Second>().read();
     }
 
+    /* Scope_open/scope_close shorthand notation. */
+    Base& scope_open() {
+        return this->with(flecs::ScopeOpen).entity(0);
+    }
+
+    Base& scope_close() {
+        return this->with(flecs::ScopeClose).entity(0);
+    }
+
     /* Term notation for more complex query features */
 
     Base& term() {

--- a/include/flecs/private/api_flags.h
+++ b/include/flecs/private/api_flags.h
@@ -131,7 +131,8 @@ extern "C" {
 #define EcsFilterPopulate              (1u << 9u)  /* Populate data, ignore non-matching fields */
 #define EcsFilterHasCondSet            (1u << 10u) /* Does filter have conditionally set fields */
 #define EcsFilterUnresolvedByName      (1u << 11u) /* Use by-name matching for unresolved entity identifiers */
-
+#define EcsFilterHasPred               (1u << 12u) /* Filter has equality predicates */
+#define EcsFilterHasScopes             (1u << 13u) /* Filter has query scopes */
 
 ////////////////////////////////////////////////////////////////////////////////
 //// Table flags (used by ecs_table_t::flags)

--- a/src/addons/alerts.c
+++ b/src/addons/alerts.c
@@ -315,8 +315,9 @@ void FlecsAlertsImport(ecs_world_t *world) {
 #endif
 
     ecs_set_name_prefix(world, "Ecs");
-
     ECS_COMPONENT_DEFINE(world, EcsAlert);
+
+    ecs_set_name_prefix(world, "EcsAlert");
     ECS_COMPONENT_DEFINE(world, EcsAlertInstance);
     ECS_COMPONENT_DEFINE(world, EcsAlertsActive);
 
@@ -342,7 +343,7 @@ void FlecsAlertsImport(ecs_world_t *world) {
     });
 
     ECS_SYSTEM(world, MonitorAlerts, EcsPreStore, Alert, (Poly, Query));
-    ECS_SYSTEM(world, MonitorAlertInstances, EcsOnStore, AlertInstance, 
+    ECS_SYSTEM(world, MonitorAlertInstances, EcsOnStore, Instance, 
         flecs.metrics.Source, flecs.metrics.Value);
 
     ecs_system(world, {

--- a/src/addons/json/serialize.c
+++ b/src/addons/json/serialize.c
@@ -1769,7 +1769,7 @@ int flecs_json_serialize_iter_result(
 
     /* Add "alerts": true member if table has entities with active alerts */
 #ifdef FLECS_ALERTS
-    if (ecs_id(EcsAlertsActive) != 0) {
+    if (it->table && (ecs_id(EcsAlertsActive) != 0)) {
         /* Only add field if alerts addon is imported */
         if (ecs_table_has_id(world, it->table, ecs_id(EcsAlertsActive))) {
             flecs_json_memberl(buf, "alerts");

--- a/src/addons/rules/compile.c
+++ b/src/addons/rules/compile.c
@@ -1187,13 +1187,13 @@ int flecs_rule_compile_term(
         /* If the term has a 0 source, check if it's a scope open/close */
         if (term->first.id == EcsScopeOpen) {
             if (term->oper == EcsNot) {
-                ctx->scope_is_not |= (1ull << ctx->scope);
+                ctx->scope_is_not |= (ecs_flags32_t)(1ull << ctx->scope);
             } else {
-                ctx->scope_is_not &= ~(1ull << ctx->scope);
+                ctx->scope_is_not &= (ecs_flags32_t)~(1ull << ctx->scope);
             }
         } else if (term->first.id == EcsScopeClose) {
             flecs_rule_compile_pop(ctx);
-            if (ctx->scope_is_not & (1 << ctx->scope)) {
+            if (ctx->scope_is_not & (ecs_flags32_t)(1ull << ctx->scope)) {
                 op.field_index = -1;
                 flecs_rule_end_not(&op, ctx, false);
             }

--- a/src/addons/rules/compile.c
+++ b/src/addons/rules/compile.c
@@ -82,8 +82,13 @@ void flecs_rule_write_ctx(
 {
     bool is_written = flecs_rule_is_written(var_id, ctx->written);
     flecs_rule_write(var_id, &ctx->written);
-    if (!is_written && cond_write) {
-        flecs_rule_write(var_id, &ctx->cond_written);
+    if (!is_written) {
+        if (cond_write) {
+            flecs_rule_write(var_id, &ctx->cond_written);
+        }
+        if (ctx->scope != 0) {
+            
+        }
     }
 }
 
@@ -118,7 +123,7 @@ bool flecs_rule_var_is_anonymous(
     ecs_var_id_t var_id)
 {
     ecs_rule_var_t *var = &rule->vars[var_id];
-    return var->name && var->name[0] == '_';
+    return var->anonymous;
 }
 
 static
@@ -311,6 +316,7 @@ ecs_var_id_t flecs_rule_add_var(
     if (name) {
         flecs_name_index_init_if(var_index, NULL);
         flecs_name_index_ensure(var_index, var->id, name, 0, 0);
+        var->anonymous = name ? name[0] == '_' : false;
     }
 
     return var->id;
@@ -341,7 +347,7 @@ void flecs_rule_discover_vars(
 
     ecs_term_t *terms = rule->filter.terms;
     int32_t i, anonymous_count = 0, count = rule->filter.term_count;
-    int32_t anonymous_table_count = 0;
+    int32_t anonymous_table_count = 0, scope = 0, scoped_var_index = 0;
     bool table_this = false, entity_before_table_this = false;
 
     /* For This table lookups during discovery. This will be overwritten after
@@ -353,6 +359,28 @@ void flecs_rule_discover_vars(
         ecs_term_id_t *first = &term->first;
         ecs_term_id_t *second = &term->second;
         ecs_term_id_t *src = &term->src;
+
+        if (first->id == EcsScopeOpen) {
+            /* Keep track of which variables are first used in scope, so that we
+             * can mark them as anonymous. Terms inside a scope are collapsed 
+             * into a single result, which means that outside of the scope the
+             * value of those variables is undefined. */
+            if (!scope) {
+                scoped_var_index = ecs_vec_count(vars);
+            }
+            scope ++;
+            continue;
+        } else if (first->id == EcsScopeClose) {
+            if (!--scope) {
+                /* Any new variables declared after entering a scope should be
+                 * marked as anonymous. */
+                int32_t v;
+                for (v = scoped_var_index; v < ecs_vec_count(vars); v ++) {
+                    ecs_vec_get_t(vars, ecs_rule_var_t, v)->anonymous = true;
+                }
+            }
+            continue;
+        }
 
         ecs_var_id_t first_var_id = flecs_rule_add_var_for_term_id(
             rule, first, vars, EcsVarEntity);
@@ -543,18 +571,18 @@ ecs_rule_lbl_t flecs_rule_op_insert(
     int32_t count = ecs_vec_count(ctx->ops);
     *elem = *op;
     if (count > 1) {
-        if (ctx->lbl_union == -1) {
+        if (ctx->cur->lbl_union == -1) {
             /* Variables written by previous instruction can't be written by
              * this instruction, except when this is a union. */
             elem->written &= ~elem[-1].written;
         }
     }
 
-    if (ctx->lbl_union != -1) {
-        elem->prev = ctx->lbl_union;
-    } else if (ctx->lbl_prev != -1) {
-        elem->prev = ctx->lbl_prev;
-        ctx->lbl_prev = -1;
+    if (ctx->cur->lbl_union != -1) {
+        elem->prev = ctx->cur->lbl_union;
+    } else if (ctx->cur->lbl_prev != -1) {
+        elem->prev = ctx->cur->lbl_prev;
+        ctx->cur->lbl_prev = -1;
     } else {
         elem->prev = flecs_itolbl(count - 2);
     }
@@ -595,7 +623,7 @@ static
 void flecs_rule_begin_none(
     ecs_rule_compile_ctx_t *ctx)
 {
-    ctx->lbl_none = flecs_itolbl(ecs_vec_count(ctx->ops));
+    ctx->cur->lbl_none = flecs_itolbl(ecs_vec_count(ctx->ops));
 
     ecs_rule_op_t jmp = {0};
     jmp.kind = EcsRuleJmpCondFalse;
@@ -606,18 +634,19 @@ static
 void flecs_rule_begin_not(
     ecs_rule_compile_ctx_t *ctx)
 {
-    ctx->lbl_not = flecs_itolbl(ecs_vec_count(ctx->ops));
+    ctx->cur->lbl_not = flecs_itolbl(ecs_vec_count(ctx->ops));
 }
 
 static
 void flecs_rule_end_not(
     ecs_rule_op_t *op,
-    ecs_rule_compile_ctx_t *ctx)
+    ecs_rule_compile_ctx_t *ctx,
+    bool update_labels)
 {
-    if (ctx->lbl_none != -1) {
+    if (ctx->cur->lbl_none != -1) {
         ecs_rule_op_t setcond = {0};
         setcond.kind = EcsRuleSetCond;
-        setcond.other = ctx->lbl_none;
+        setcond.other = ctx->cur->lbl_none;
         flecs_rule_op_insert(&setcond, ctx);
     }
 
@@ -625,41 +654,45 @@ void flecs_rule_end_not(
 
     ecs_rule_op_t *ops = ecs_vec_first_t(ctx->ops, ecs_rule_op_t);
     int32_t i, count = ecs_vec_count(ctx->ops);
-    for (i = ctx->lbl_not; i < count; i ++) {
-        ecs_rule_op_t *cur = &ops[i];
-        if (flecs_rule_op_is_test[cur->kind]) {
-            cur->prev = flecs_itolbl(count - 1);
-            if (i == (count - 2)) {
-                cur->next = flecs_itolbl(ctx->lbl_not - 1);
+    if (update_labels) {
+        for (i = ctx->cur->lbl_not; i < count; i ++) {
+            ecs_rule_op_t *cur = &ops[i];
+            if (flecs_rule_op_is_test[cur->kind]) {
+                cur->prev = flecs_itolbl(count - 1);
+                if (i == (count - 2)) {
+                    cur->next = flecs_itolbl(ctx->cur->lbl_not - 1);
+                }
             }
         }
     }
 
     /* After a match was found, return to op before Not operation */
     ecs_rule_op_t *not_ptr = ecs_vec_last_t(ctx->ops, ecs_rule_op_t);
-    not_ptr->prev = flecs_itolbl(ctx->lbl_not - 1);
+    not_ptr->prev = flecs_itolbl(ctx->cur->lbl_not - 1);
 
-    if (ctx->lbl_none != -1) {
+    if (ctx->cur->lbl_none != -1) {
         /* setcond */
-        ops[count - 2].next = flecs_itolbl(ctx->lbl_none - 1);
+        ops[count - 2].next = flecs_itolbl(ctx->cur->lbl_none - 1);
         /* last actual instruction */
-        ops[count - 3].prev = flecs_itolbl(count - 4);
+        if (update_labels) {
+            ops[count - 3].prev = flecs_itolbl(count - 4);
+        }
         /* jfalse */
-        ops[ctx->lbl_none].other =
+        ops[ctx->cur->lbl_none].other =
             flecs_itolbl(count - 1); /* jump to not */
         /* not */
-        ops[count - 1].prev = flecs_itolbl(ctx->lbl_none - 1);
+        ops[count - 1].prev = flecs_itolbl(ctx->cur->lbl_none - 1);
     }
 
-    ctx->lbl_not = -1;
-    ctx->lbl_none = -1;
+    ctx->cur->lbl_not = -1;
+    ctx->cur->lbl_none = -1;
 }
 
 static
 void flecs_rule_begin_option(
     ecs_rule_compile_ctx_t *ctx)
 {
-    ctx->lbl_option = flecs_itolbl(ecs_vec_count(ctx->ops));
+    ctx->cur->lbl_option = flecs_itolbl(ecs_vec_count(ctx->ops));
 
     {
         ecs_rule_op_t new_op = {0};
@@ -677,15 +710,15 @@ void flecs_rule_end_option(
     ecs_rule_op_t *ops = ecs_vec_first_t(ctx->ops, ecs_rule_op_t);
     int32_t count = ecs_vec_count(ctx->ops);
 
-    ops[ctx->lbl_option].other = flecs_itolbl(count - 1);
+    ops[ctx->cur->lbl_option].other = flecs_itolbl(count - 1);
     ops[count - 2].next = flecs_itolbl(count);
 
     ecs_rule_op_t new_op = {0};
     new_op.kind = EcsRuleSetCond;
-    new_op.other = ctx->lbl_option;
+    new_op.other = ctx->cur->lbl_option;
     flecs_rule_op_insert(&new_op, ctx);
 
-    ctx->lbl_option = -1;
+    ctx->cur->lbl_option = -1;
 }
 
 static
@@ -713,7 +746,7 @@ void flecs_rule_begin_cond_eval(
     /* If this term uses conditionally set variables, insert instruction that
      * jumps over the term if the variables weren't set yet. */
     if (cond_mask & cond_write_state) {
-        ctx->lbl_cond_eval = flecs_itolbl(ecs_vec_count(ctx->ops));
+        ctx->cur->lbl_cond_eval = flecs_itolbl(ecs_vec_count(ctx->ops));
 
         ecs_rule_op_t jmp_op = {0};
         jmp_op.kind = EcsRuleJmpNotSet;
@@ -733,7 +766,7 @@ void flecs_rule_begin_cond_eval(
 
         flecs_rule_op_insert(&jmp_op, ctx);
     } else {
-        ctx->lbl_cond_eval = -1;
+        ctx->cur->lbl_cond_eval = -1;
     }
 }
 
@@ -742,7 +775,7 @@ void flecs_rule_end_cond_eval(
     ecs_rule_op_t *op,
     ecs_rule_compile_ctx_t *ctx)
 {
-    if (ctx->lbl_cond_eval == -1) {
+    if (ctx->cur->lbl_cond_eval == -1) {
         return;
     }
 
@@ -750,7 +783,7 @@ void flecs_rule_end_cond_eval(
 
     ecs_rule_op_t *ops = ecs_vec_first_t(ctx->ops, ecs_rule_op_t);
     int32_t count = ecs_vec_count(ctx->ops);
-    ops[ctx->lbl_cond_eval].other = flecs_itolbl(count - 1);
+    ops[ctx->cur->lbl_cond_eval].other = flecs_itolbl(count - 1);
     ops[count - 2].next = flecs_itolbl(count);
 }
 
@@ -767,7 +800,7 @@ static
 void flecs_rule_begin_or(
     ecs_rule_compile_ctx_t *ctx)
 {
-    ctx->lbl_or = flecs_itolbl(ecs_vec_count(ctx->ops) - 1);
+    ctx->cur->lbl_or = flecs_itolbl(ecs_vec_count(ctx->ops) - 1);
     flecs_rule_next_or(ctx);
 }
 
@@ -780,7 +813,7 @@ void flecs_rule_end_or(
     ecs_rule_op_t *ops = ecs_vec_first_t(ctx->ops, ecs_rule_op_t);
     int32_t i, count = ecs_vec_count(ctx->ops);
     int32_t prev_or = -2;
-    for (i = ctx->lbl_or; i < count; i ++) {
+    for (i = ctx->cur->lbl_or; i < count; i ++) {
         if (ops[i].next == FlecsRuleOrMarker) {
             if (prev_or != -2) {
                 ops[prev_or].prev = flecs_itolbl(i);
@@ -790,11 +823,11 @@ void flecs_rule_end_or(
         }
     }
 
-    ops[count - 1].prev = flecs_itolbl(ctx->lbl_or - 1);
+    ops[count - 1].prev = flecs_itolbl(ctx->cur->lbl_or - 1);
 
     /* Set prev of next instruction to before the start of the OR chain */
-    ctx->lbl_prev = flecs_itolbl(ctx->lbl_or - 1);
-    ctx->lbl_or = -1;
+    ctx->cur->lbl_prev = flecs_itolbl(ctx->cur->lbl_or - 1);
+    ctx->cur->lbl_or = -1;
 }
 
 static
@@ -803,7 +836,7 @@ void flecs_rule_begin_union(
 {
     ecs_rule_op_t op = {0};
     op.kind = EcsRuleUnion;
-    ctx->lbl_union = flecs_rule_op_insert(&op, ctx);
+    ctx->cur->lbl_union = flecs_rule_op_insert(&op, ctx);
 }
 
 static
@@ -814,7 +847,7 @@ void flecs_rule_end_union(
 
     ecs_rule_op_t op = {0};
     op.kind = EcsRuleEnd;
-    ctx->lbl_union = -1;
+    ctx->cur->lbl_union = -1;
     ecs_rule_lbl_t next = flecs_rule_op_insert(&op, ctx);
     
     ecs_rule_op_t *ops = ecs_vec_first_t(ctx->ops, ecs_rule_op_t);
@@ -1117,6 +1150,24 @@ int flecs_rule_compile_builtin_pred(
 }
 
 static
+void flecs_rule_compile_push(
+    ecs_rule_compile_ctx_t *ctx)
+{
+    ctx->cur = &ctx->ctrlflow[++ ctx->scope];
+    ctx->cur->lbl_union = -1;
+    ctx->cur->lbl_prev = -1;
+    ctx->cur->lbl_not = -1;
+    ctx->cur->lbl_none = -1;
+}
+
+static
+void flecs_rule_compile_pop(
+    ecs_rule_compile_ctx_t *ctx)
+{
+    ctx->cur = &ctx->ctrlflow[-- ctx->scope];
+}
+
+static
 int flecs_rule_compile_term(
     ecs_world_t *world,
     ecs_rule_t *rule,
@@ -1133,7 +1184,22 @@ int flecs_rule_compile_term(
     ecs_rule_op_t op = {0};
 
     if (!term->src.id && term->src.flags & EcsIsEntity) {
-        /* If the term has a 0 source, don't insert operation */
+        /* If the term has a 0 source, check if it's a scope open/close */
+        if (term->first.id == EcsScopeOpen) {
+            if (term->oper == EcsNot) {
+                ctx->scope_is_not |= 1 << ctx->scope;
+            } else {
+                ctx->scope_is_not &= ~(1 << ctx->scope);
+            }
+        } else if (term->first.id == EcsScopeClose) {
+            flecs_rule_compile_pop(ctx);
+            if (ctx->scope_is_not & (1 << ctx->scope)) {
+                op.field_index = -1;
+                flecs_rule_end_not(&op, ctx, false);
+            }
+        } else {
+            /* Nothing to be done */
+        }
         return 0;
     }
 
@@ -1284,6 +1350,16 @@ int flecs_rule_compile_term(
         flecs_rule_insert_inheritance(rule, term, &op, ctx, cond_write);
     }
 
+    /* If previous term was ScopeOpen with a Not operator, insert operation to
+     * ensure that none of the results inside the scope should match. */
+    if (!first_term && term[-1].first.id == EcsScopeOpen) {
+        if (term[-1].oper == EcsNot) {
+            flecs_rule_begin_none(ctx);
+            flecs_rule_begin_not(ctx);
+        }
+        flecs_rule_compile_push(ctx);
+    }
+
     /* Handle Not, Optional, Or operators */
     if (is_not) {
         flecs_rule_begin_not(ctx);
@@ -1348,15 +1424,15 @@ int flecs_rule_compile_term(
         /* Restore original first id in case it got replaced with a variable */
         op.first = prev_first;
         op.flags = prev_op_flags;
-        flecs_rule_end_not(&op, ctx);
+        flecs_rule_end_not(&op, ctx, true);
     } else if (term->oper == EcsOptional) {
         flecs_rule_end_option(&op, ctx);
     } else if (term->oper == EcsOr) {
-        if (ctx->lbl_union != -1) {
+        if (ctx->cur->lbl_union != -1) {
             flecs_rule_next_or(ctx);
         } else {
             if (first_term || term[-1].oper != EcsOr) {
-                if (ctx->lbl_union == -1) {
+                if (ctx->cur->lbl_union == -1) {
                     flecs_rule_begin_or(ctx);
                 }
             } else if (term->oper == EcsOr) {
@@ -1365,7 +1441,7 @@ int flecs_rule_compile_term(
         }
     } else if (term->oper == EcsAnd) {
         if (!first_term && term[-1].oper == EcsOr) {
-            if (ctx->lbl_union != -1) {
+            if (ctx->cur->lbl_union != -1) {
                 flecs_rule_end_union(ctx);
             } else {
                 flecs_rule_end_or(ctx);
@@ -1386,10 +1462,11 @@ int flecs_rule_compile(
     ecs_rule_compile_ctx_t ctx = {0};
     ecs_vec_reset_t(NULL, &stage->operations, ecs_rule_op_t);
     ctx.ops = &stage->operations;
-    ctx.lbl_union = -1;
-    ctx.lbl_prev = -1;
-    ctx.lbl_not = -1;
-    ctx.lbl_none = -1;
+    ctx.cur = ctx.ctrlflow;
+    ctx.cur->lbl_union = -1;
+    ctx.cur->lbl_prev = -1;
+    ctx.cur->lbl_not = -1;
+    ctx.cur->lbl_none = -1;
     ecs_vec_clear(ctx.ops);
 
     /* Find all variables defined in query */

--- a/src/addons/rules/compile.c
+++ b/src/addons/rules/compile.c
@@ -1547,6 +1547,19 @@ int flecs_rule_compile(
             if (!flecs_rule_var_is_anonymous(rule, var_id)) {
                 only_anonymous = false;
                 break;
+            } else {
+                /* Don't fetch component data for anonymous variables. Because
+                 * not all metadata (such as it.sources) is initialized for
+                 * anonymous variables, and because they may only be available
+                 * as table variables (each is not guaranteed to be inserted for
+                 * anonymous variables) the iterator may not have sufficient
+                 * information to resolve component data. */
+                for (int32_t t = 0; t < filter->term_count; t ++) {
+                    ecs_term_t *term = &filter->terms[t];
+                    if (term->field_index == i) {
+                        term->inout = EcsInOutNone;
+                    }
+                }
             }
         }
 

--- a/src/addons/rules/compile.c
+++ b/src/addons/rules/compile.c
@@ -1187,9 +1187,9 @@ int flecs_rule_compile_term(
         /* If the term has a 0 source, check if it's a scope open/close */
         if (term->first.id == EcsScopeOpen) {
             if (term->oper == EcsNot) {
-                ctx->scope_is_not |= 1 << ctx->scope;
+                ctx->scope_is_not |= (1ull << ctx->scope);
             } else {
-                ctx->scope_is_not &= ~(1 << ctx->scope);
+                ctx->scope_is_not &= ~(1ull << ctx->scope);
             }
         } else if (term->first.id == EcsScopeClose) {
             flecs_rule_compile_pop(ctx);

--- a/src/addons/rules/rules.h
+++ b/src/addons/rules/rules.h
@@ -24,6 +24,7 @@ typedef enum {
 
 typedef struct ecs_rule_var_t {
     int8_t kind;           /* variable kind (EcsVarEntity or EcsVarTable)*/
+    bool anonymous;        /* variable is anonymous */
     ecs_var_id_t id;       /* variable id */
     ecs_var_id_t table_id; /* id to table variable, if any */
     const char *name;      /* variable name */
@@ -175,12 +176,7 @@ typedef struct ecs_rule_op_ctx_t {
     } is;
 } ecs_rule_op_ctx_t;
 
-/* Rule compiler state */
 typedef struct {
-    ecs_vec_t *ops;
-    ecs_write_flags_t written; /* Bitmask to check which variables have been written */
-    ecs_write_flags_t cond_written; /* Track conditional writes (optional operators) */
-
     /* Labels used for control flow */
     ecs_rule_lbl_t lbl_union;
     ecs_rule_lbl_t lbl_not;
@@ -189,6 +185,20 @@ typedef struct {
     ecs_rule_lbl_t lbl_or;
     ecs_rule_lbl_t lbl_none;
     ecs_rule_lbl_t lbl_prev; /* If set, use this as default value for prev */
+} ecs_rule_compile_ctrlflow_t;
+
+/* Rule compiler state */
+typedef struct {
+    ecs_vec_t *ops;
+    ecs_write_flags_t written; /* Bitmask to check which variables have been written */
+    ecs_write_flags_t cond_written; /* Track conditional writes (optional operators) */
+
+    /* Maintain control flow per scope */
+    ecs_rule_compile_ctrlflow_t ctrlflow[FLECS_QUERY_SCOPE_NESTING_MAX];
+    ecs_rule_compile_ctrlflow_t *cur; /* Current scope */
+
+    int32_t scope; /* Nesting level of query scopes */
+    ecs_flags32_t scope_is_not; /* Whether scope is prefixed with not */
 } ecs_rule_compile_ctx_t;    
 
 /* Rule run state */

--- a/src/bootstrap.c
+++ b/src/bootstrap.c
@@ -756,6 +756,8 @@ void flecs_bootstrap(
     flecs_bootstrap_tag(world, EcsPredEq);
     flecs_bootstrap_tag(world, EcsPredMatch);
     flecs_bootstrap_tag(world, EcsPredLookup);
+    flecs_bootstrap_tag(world, EcsScopeOpen);
+    flecs_bootstrap_tag(world, EcsScopeClose);
 
     /* Builtin relationships */
     flecs_bootstrap_tag(world, EcsIsA);

--- a/src/filter.c
+++ b/src/filter.c
@@ -1236,6 +1236,11 @@ int ecs_filter_finalize(
             scope_nesting ++;
         }
         if (term->first.id == EcsScopeClose) {
+            if (i && terms[i - 1].first.id == EcsScopeOpen) {
+                flecs_filter_error(&ctx, "invalid empty scope");
+                return -1;
+            }
+
             f->flags |= EcsFilterHasScopes;
             scope_nesting --;
         }

--- a/src/world.c
+++ b/src/world.c
@@ -99,6 +99,8 @@ const ecs_entity_t EcsDefaultChildComponent =       FLECS_HI_COMPONENT_ID + 55;
 const ecs_entity_t EcsPredEq =                      FLECS_HI_COMPONENT_ID + 56;
 const ecs_entity_t EcsPredMatch =                   FLECS_HI_COMPONENT_ID + 57;
 const ecs_entity_t EcsPredLookup =                  FLECS_HI_COMPONENT_ID + 58;
+const ecs_entity_t EcsScopeOpen =                    FLECS_HI_COMPONENT_ID + 59;
+const ecs_entity_t EcsScopeClose =                   FLECS_HI_COMPONENT_ID + 60;
 
 /* Systems */
 const ecs_entity_t EcsMonitor =                     FLECS_HI_COMPONENT_ID + 61;

--- a/test/addons/project.json
+++ b/test/addons/project.json
@@ -1085,16 +1085,16 @@
         }, {
             "id": "RulesScopes",
             "testcases": [
-                "not_scope_1_term",
-                "not_scope_2_terms",
-                "not_scope_1_term_w_not",
-                "not_scope_2_terms_w_not",
-                "not_scope_1_term_w_var",
-                "not_scope_2_terms_w_var",
-                "not_scope_1_term_w_not_w_var",
-                "not_scope_2_terms_w_not_w_var",
-                "not_scope_2_terms_w_or",
-                "not_scope_3_terms_w_or"
+                "term_w_not_scope_1_term",
+                "term_w_not_scope_2_terms",
+                "term_w_not_scope_1_term_w_not",
+                "term_w_not_scope_2_terms_w_not",
+                "term_w_not_scope_1_term_w_var",
+                "term_w_not_scope_2_terms_w_var",
+                "term_w_not_scope_1_term_w_not_w_var",
+                "term_w_not_scope_2_terms_w_not_w_var",
+                "term_w_not_scope_2_terms_w_or",
+                "term_w_not_scope_3_terms_w_or"
             ]
         }, {
             "id": "SystemPeriodic",

--- a/test/addons/project.json
+++ b/test/addons/project.json
@@ -1083,6 +1083,20 @@
                 "unresolved_by_name"
             ]
         }, {
+            "id": "RulesScopes",
+            "testcases": [
+                "not_scope_1_term",
+                "not_scope_2_terms",
+                "not_scope_1_term_w_not",
+                "not_scope_2_terms_w_not",
+                "not_scope_1_term_w_var",
+                "not_scope_2_terms_w_var",
+                "not_scope_1_term_w_not_w_var",
+                "not_scope_2_terms_w_not_w_var",
+                "not_scope_2_terms_w_or",
+                "not_scope_3_terms_w_or"
+            ]
+        }, {
             "id": "SystemPeriodic",
             "testcases": [
                 "1_type_1_component",

--- a/test/addons/project.json
+++ b/test/addons/project.json
@@ -235,7 +235,8 @@
                 "query_nested_scope",
                 "query_nested_scope_spaces",
                 "query_scope_unbalanced",
-                "query_not_scope"
+                "query_not_scope",
+                "query_empty_scope"
             ]
         }, {
             "id": "Plecs",
@@ -809,7 +810,11 @@
                 "parse_2_vars_paren_w_spaces",
                 "var_count",
                 "var_name",
-                "var_is_entity"
+                "var_is_entity",
+                "no_this_anonymous_src",
+                "no_this_anonymous_src_w_pair",
+                "no_this_anonymous_component_src",
+                "no_this_anonymous_component_src_w_pair"
             ]
         }, {
             "id": "RulesOperators",

--- a/test/addons/project.json
+++ b/test/addons/project.json
@@ -228,7 +228,14 @@
                 "neq_same_var_this",
                 "eq_w_optional",
                 "neq_w_optional",
-                "match_w_optional"
+                "match_w_optional",
+                "query_scope_1_term",
+                "query_scope_1_term_spaces",
+                "query_scope_2_terms",
+                "query_nested_scope",
+                "query_nested_scope_spaces",
+                "query_scope_unbalanced",
+                "query_not_scope"
             ]
         }, {
             "id": "Plecs",

--- a/test/addons/src/Alerts.c
+++ b/test/addons/src/Alerts.c
@@ -29,7 +29,7 @@ void Alerts_one_active_alert() {
     {
         test_assert(ecs_get_alert_count(world, e2, alert) == 1);
 
-        ecs_filter_t *alerts = ecs_filter(world, { .expr = "flecs.alerts.AlertInstance" });
+        ecs_filter_t *alerts = ecs_filter(world, { .expr = "flecs.alerts.Instance" });
         ecs_iter_t it = ecs_filter_iter(world, alerts);
         test_bool(ecs_filter_next(&it), true);
         test_int(it.count, 1);
@@ -56,7 +56,7 @@ void Alerts_one_active_alert() {
     {
         test_assert(ecs_get_alert_count(world, e2, alert) == 1);
 
-        ecs_filter_t *alerts = ecs_filter(world, { .expr = "flecs.alerts.AlertInstance" });
+        ecs_filter_t *alerts = ecs_filter(world, { .expr = "flecs.alerts.Instance" });
         ecs_iter_t it = ecs_filter_iter(world, alerts);
         test_bool(ecs_filter_next(&it), true);
         test_int(it.count, 1);
@@ -123,7 +123,7 @@ void Alerts_two_active_alerts() {
         test_assert(ecs_get_alert_count(world, e2, alert_2) == 1);
         test_assert(ecs_get_alert_count(world, e2, 0) == 2);
 
-        ecs_filter_t *alerts = ecs_filter(world, { .expr = "flecs.alerts.AlertInstance" });
+        ecs_filter_t *alerts = ecs_filter(world, { .expr = "flecs.alerts.Instance" });
         ecs_iter_t it = ecs_filter_iter(world, alerts);
         test_bool(ecs_filter_next(&it), true);
         test_int(it.count, 1);
@@ -164,7 +164,7 @@ void Alerts_two_active_alerts() {
         test_assert(ecs_get_alert_count(world, e2, alert_2) == 1);
         test_assert(ecs_get_alert_count(world, e2, 0) == 2);
 
-        ecs_filter_t *alerts = ecs_filter(world, { .expr = "flecs.alerts.AlertInstance" });
+        ecs_filter_t *alerts = ecs_filter(world, { .expr = "flecs.alerts.Instance" });
         ecs_iter_t it = ecs_filter_iter(world, alerts);
         test_bool(ecs_filter_next(&it), true);
         test_int(it.count, 1);
@@ -207,7 +207,7 @@ void Alerts_two_active_alerts() {
         test_assert(ecs_get_alert_count(world, e2, alert_2) == 0);
         test_assert(ecs_get_alert_count(world, e2, 0) == 1);
 
-        ecs_filter_t *alerts = ecs_filter(world, { .expr = "flecs.alerts.AlertInstance" });
+        ecs_filter_t *alerts = ecs_filter(world, { .expr = "flecs.alerts.Instance" });
         ecs_iter_t it = ecs_filter_iter(world, alerts);
         test_bool(ecs_filter_next(&it), true);
         test_int(it.count, 1);
@@ -267,7 +267,7 @@ void Alerts_alert_message() {
     {
         test_assert(ecs_get_alert_count(world, e2, alert) == 1);
 
-        ecs_filter_t *alerts = ecs_filter(world, { .expr = "flecs.alerts.AlertInstance" });
+        ecs_filter_t *alerts = ecs_filter(world, { .expr = "flecs.alerts.Instance" });
         ecs_iter_t it = ecs_filter_iter(world, alerts);
         test_bool(ecs_filter_next(&it), true);
         test_int(it.count, 1);
@@ -319,7 +319,7 @@ void Alerts_alert_message_w_this_var() {
     {
         test_assert(ecs_get_alert_count(world, e2, alert) == 1);
 
-        ecs_filter_t *alerts = ecs_filter(world, { .expr = "flecs.alerts.AlertInstance" });
+        ecs_filter_t *alerts = ecs_filter(world, { .expr = "flecs.alerts.Instance" });
         ecs_iter_t it = ecs_filter_iter(world, alerts);
         test_bool(ecs_filter_next(&it), true);
         test_int(it.count, 1);
@@ -374,7 +374,7 @@ void Alerts_alert_message_w_var() {
     {
         test_assert(ecs_get_alert_count(world, e2, alert) == 1);
 
-        ecs_filter_t *alerts = ecs_filter(world, { .expr = "flecs.alerts.AlertInstance" });
+        ecs_filter_t *alerts = ecs_filter(world, { .expr = "flecs.alerts.Instance" });
         ecs_iter_t it = ecs_filter_iter(world, alerts);
         test_bool(ecs_filter_next(&it), true);
         test_int(it.count, 1);
@@ -430,7 +430,7 @@ void Alerts_alert_message_w_changed_var() {
     {
         test_assert(ecs_get_alert_count(world, e2, alert) == 1);
 
-        ecs_filter_t *alerts = ecs_filter(world, { .expr = "flecs.alerts.AlertInstance" });
+        ecs_filter_t *alerts = ecs_filter(world, { .expr = "flecs.alerts.Instance" });
         ecs_iter_t it = ecs_filter_iter(world, alerts);
         test_bool(ecs_filter_next(&it), true);
         test_int(it.count, 1);
@@ -459,7 +459,7 @@ void Alerts_alert_message_w_changed_var() {
     {
         test_assert(ecs_get_alert_count(world, e2, alert) == 1);
 
-        ecs_filter_t *alerts = ecs_filter(world, { .expr = "flecs.alerts.AlertInstance" });
+        ecs_filter_t *alerts = ecs_filter(world, { .expr = "flecs.alerts.Instance" });
         ecs_iter_t it = ecs_filter_iter(world, alerts);
         test_bool(ecs_filter_next(&it), true);
         test_int(it.count, 1);
@@ -523,7 +523,7 @@ void Alerts_alert_instance_has_doc_name() {
     {
         test_assert(ecs_get_alert_count(world, e2, alert) == 1);
 
-        ecs_filter_t *alerts = ecs_filter(world, { .expr = "flecs.alerts.AlertInstance" });
+        ecs_filter_t *alerts = ecs_filter(world, { .expr = "flecs.alerts.Instance" });
         ecs_iter_t it = ecs_filter_iter(world, alerts);
         test_bool(ecs_filter_next(&it), true);
         test_int(it.count, 1);

--- a/test/addons/src/Parser.c
+++ b/test/addons/src/Parser.c
@@ -4979,3 +4979,291 @@ void Parser_match_w_optional() {
 
     ecs_fini(world);
 }
+
+void Parser_query_scope_1_term() {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+
+    ecs_filter_t f = ECS_FILTER_INIT;
+    test_assert(NULL != ecs_filter_init(world, &(ecs_filter_desc_t){
+        .storage = &f,
+        .expr = "TagA, {TagB}"
+    }));
+    test_int(filter_count(&f), 4);
+
+    ecs_term_t *terms = filter_terms(&f);
+    test_first(terms[0], TagA, EcsSelf|EcsIsEntity);
+    test_src(terms[0], EcsThis, EcsSelf|EcsUp|EcsIsVariable);
+    test_int(terms[0].oper, EcsAnd);
+    test_int(terms[0].inout, EcsInOutDefault);
+
+    test_first(terms[1], EcsScopeOpen, EcsSelf|EcsIsEntity);
+    test_src(terms[1], 0, EcsIsEntity);
+    test_int(terms[1].oper, EcsAnd);
+    test_int(terms[1].inout, EcsInOutNone);
+
+    test_first(terms[2], TagB, EcsSelf|EcsIsEntity);
+    test_src(terms[2], EcsThis, EcsSelf|EcsUp|EcsIsVariable);
+    test_int(terms[2].oper, EcsAnd);
+    test_int(terms[2].inout, EcsInOutDefault);
+
+    test_first(terms[3], EcsScopeClose, EcsSelf|EcsIsEntity);
+    test_src(terms[3], 0, EcsIsEntity);
+    test_int(terms[3].oper, EcsAnd);
+    test_int(terms[3].inout, EcsInOutNone);
+
+    ecs_filter_fini(&f);
+
+    ecs_fini(world);
+}
+
+void Parser_query_scope_1_term_spaces() {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+
+    ecs_filter_t f = ECS_FILTER_INIT;
+    test_assert(NULL != ecs_filter_init(world, &(ecs_filter_desc_t){
+        .storage = &f,
+        .expr = "TagA, { TagB }"
+    }));
+    test_int(filter_count(&f), 4);
+
+    ecs_term_t *terms = filter_terms(&f);
+    test_first(terms[0], TagA, EcsSelf|EcsIsEntity);
+    test_src(terms[0], EcsThis, EcsSelf|EcsUp|EcsIsVariable);
+    test_int(terms[0].oper, EcsAnd);
+    test_int(terms[0].inout, EcsInOutDefault);
+
+    test_first(terms[1], EcsScopeOpen, EcsSelf|EcsIsEntity);
+    test_src(terms[1], 0, EcsIsEntity);
+    test_int(terms[1].oper, EcsAnd);
+    test_int(terms[1].inout, EcsInOutNone);
+
+    test_first(terms[2], TagB, EcsSelf|EcsIsEntity);
+    test_src(terms[2], EcsThis, EcsSelf|EcsUp|EcsIsVariable);
+    test_int(terms[2].oper, EcsAnd);
+    test_int(terms[2].inout, EcsInOutDefault);
+
+    test_first(terms[3], EcsScopeClose, EcsSelf|EcsIsEntity);
+    test_src(terms[3], 0, EcsIsEntity);
+    test_int(terms[3].oper, EcsAnd);
+    test_int(terms[3].inout, EcsInOutNone);
+
+    ecs_filter_fini(&f);
+
+    ecs_fini(world);
+}
+
+void Parser_query_scope_2_terms() {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+    ECS_TAG(world, TagC);
+
+    ecs_filter_t f = ECS_FILTER_INIT;
+    test_assert(NULL != ecs_filter_init(world, &(ecs_filter_desc_t){
+        .storage = &f,
+        .expr = "TagA, { TagB, TagC }"
+    }));
+    test_int(filter_count(&f), 5);
+
+    ecs_term_t *terms = filter_terms(&f);
+    test_first(terms[0], TagA, EcsSelf|EcsIsEntity);
+    test_src(terms[0], EcsThis, EcsSelf|EcsUp|EcsIsVariable);
+    test_int(terms[0].oper, EcsAnd);
+    test_int(terms[0].inout, EcsInOutDefault);
+
+    test_first(terms[1], EcsScopeOpen, EcsSelf|EcsIsEntity);
+    test_src(terms[1], 0, EcsIsEntity);
+    test_int(terms[1].oper, EcsAnd);
+    test_int(terms[1].inout, EcsInOutNone);
+
+    test_first(terms[2], TagB, EcsSelf|EcsIsEntity);
+    test_src(terms[2], EcsThis, EcsSelf|EcsUp|EcsIsVariable);
+    test_int(terms[2].oper, EcsAnd);
+    test_int(terms[2].inout, EcsInOutDefault);
+
+    test_first(terms[3], TagC, EcsSelf|EcsIsEntity);
+    test_src(terms[3], EcsThis, EcsSelf|EcsUp|EcsIsVariable);
+    test_int(terms[3].oper, EcsAnd);
+    test_int(terms[3].inout, EcsInOutDefault);
+
+    test_first(terms[4], EcsScopeClose, EcsSelf|EcsIsEntity);
+    test_src(terms[4], 0, EcsIsEntity);
+    test_int(terms[4].oper, EcsAnd);
+    test_int(terms[4].inout, EcsInOutNone);
+
+    ecs_filter_fini(&f);
+
+    ecs_fini(world);
+}
+
+void Parser_query_nested_scope() {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+    ECS_TAG(world, TagC);
+
+    ecs_filter_t f = ECS_FILTER_INIT;
+    test_assert(NULL != ecs_filter_init(world, &(ecs_filter_desc_t){
+        .storage = &f,
+        .expr = "TagA, {TagB, {TagC}}"
+    }));
+    test_int(filter_count(&f), 7);
+
+    ecs_term_t *terms = filter_terms(&f);
+    test_first(terms[0], TagA, EcsSelf|EcsIsEntity);
+    test_src(terms[0], EcsThis, EcsSelf|EcsUp|EcsIsVariable);
+    test_int(terms[0].oper, EcsAnd);
+    test_int(terms[0].inout, EcsInOutDefault);
+
+    test_first(terms[1], EcsScopeOpen, EcsSelf|EcsIsEntity);
+    test_src(terms[1], 0, EcsIsEntity);
+    test_int(terms[1].oper, EcsAnd);
+    test_int(terms[1].inout, EcsInOutNone);
+
+    test_first(terms[2], TagB, EcsSelf|EcsIsEntity);
+    test_src(terms[2], EcsThis, EcsSelf|EcsUp|EcsIsVariable);
+    test_int(terms[2].oper, EcsAnd);
+    test_int(terms[2].inout, EcsInOutDefault);
+
+    test_first(terms[3], EcsScopeOpen, EcsSelf|EcsIsEntity);
+    test_src(terms[3], 0, EcsIsEntity);
+    test_int(terms[3].oper, EcsAnd);
+    test_int(terms[3].inout, EcsInOutNone);
+
+    test_first(terms[4], TagC, EcsSelf|EcsIsEntity);
+    test_src(terms[4], EcsThis, EcsSelf|EcsUp|EcsIsVariable);
+    test_int(terms[4].oper, EcsAnd);
+    test_int(terms[4].inout, EcsInOutDefault);
+
+    test_first(terms[5], EcsScopeClose, EcsSelf|EcsIsEntity);
+    test_src(terms[5], 0, EcsIsEntity);
+    test_int(terms[5].oper, EcsAnd);
+    test_int(terms[5].inout, EcsInOutNone);
+
+    test_first(terms[6], EcsScopeClose, EcsSelf|EcsIsEntity);
+    test_src(terms[6], 0, EcsIsEntity);
+    test_int(terms[6].oper, EcsAnd);
+    test_int(terms[6].inout, EcsInOutNone);
+
+    ecs_filter_fini(&f);
+
+    ecs_fini(world);
+}
+
+void Parser_query_nested_scope_spaces() {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+    ECS_TAG(world, TagC);
+
+    ecs_filter_t f = ECS_FILTER_INIT;
+    test_assert(NULL != ecs_filter_init(world, &(ecs_filter_desc_t){
+        .storage = &f,
+        .expr = "TagA, { TagB, { TagC } }"
+    }));
+    test_int(filter_count(&f), 7);
+
+    ecs_term_t *terms = filter_terms(&f);
+    test_first(terms[0], TagA, EcsSelf|EcsIsEntity);
+    test_src(terms[0], EcsThis, EcsSelf|EcsUp|EcsIsVariable);
+    test_int(terms[0].oper, EcsAnd);
+    test_int(terms[0].inout, EcsInOutDefault);
+
+    test_first(terms[1], EcsScopeOpen, EcsSelf|EcsIsEntity);
+    test_src(terms[1], 0, EcsIsEntity);
+    test_int(terms[1].oper, EcsAnd);
+    test_int(terms[1].inout, EcsInOutNone);
+
+    test_first(terms[2], TagB, EcsSelf|EcsIsEntity);
+    test_src(terms[2], EcsThis, EcsSelf|EcsUp|EcsIsVariable);
+    test_int(terms[2].oper, EcsAnd);
+    test_int(terms[2].inout, EcsInOutDefault);
+
+    test_first(terms[3], EcsScopeOpen, EcsSelf|EcsIsEntity);
+    test_src(terms[3], 0, EcsIsEntity);
+    test_int(terms[3].oper, EcsAnd);
+    test_int(terms[3].inout, EcsInOutNone);
+
+    test_first(terms[4], TagC, EcsSelf|EcsIsEntity);
+    test_src(terms[4], EcsThis, EcsSelf|EcsUp|EcsIsVariable);
+    test_int(terms[4].oper, EcsAnd);
+    test_int(terms[4].inout, EcsInOutDefault);
+
+    test_first(terms[5], EcsScopeClose, EcsSelf|EcsIsEntity);
+    test_src(terms[5], 0, EcsIsEntity);
+    test_int(terms[5].oper, EcsAnd);
+    test_int(terms[5].inout, EcsInOutNone);
+
+    test_first(terms[6], EcsScopeClose, EcsSelf|EcsIsEntity);
+    test_src(terms[6], 0, EcsIsEntity);
+    test_int(terms[6].oper, EcsAnd);
+    test_int(terms[6].inout, EcsInOutNone);
+
+    ecs_filter_fini(&f);
+
+    ecs_fini(world);
+}
+
+void Parser_query_scope_unbalanced() {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+
+    ecs_log_set_level(-4);
+    ecs_filter_t f = ECS_FILTER_INIT;
+    test_assert(NULL == ecs_filter_init(world, &(ecs_filter_desc_t){
+        .storage = &f,
+        .expr = "TagA, { TagB"
+    }));
+
+    ecs_fini(world);
+}
+
+void Parser_query_not_scope() {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+
+    ecs_filter_t f = ECS_FILTER_INIT;
+    test_assert(NULL != ecs_filter_init(world, &(ecs_filter_desc_t){
+        .storage = &f,
+        .expr = "TagA, !{TagB}"
+    }));
+    test_int(filter_count(&f), 4);
+
+    ecs_term_t *terms = filter_terms(&f);
+    test_first(terms[0], TagA, EcsSelf|EcsIsEntity);
+    test_src(terms[0], EcsThis, EcsSelf|EcsUp|EcsIsVariable);
+    test_int(terms[0].oper, EcsAnd);
+    test_int(terms[0].inout, EcsInOutDefault);
+
+    test_first(terms[1], EcsScopeOpen, EcsSelf|EcsIsEntity);
+    test_src(terms[1], 0, EcsIsEntity);
+    test_int(terms[1].oper, EcsNot);
+    test_int(terms[1].inout, EcsInOutNone);
+
+    test_first(terms[2], TagB, EcsSelf|EcsIsEntity);
+    test_src(terms[2], EcsThis, EcsSelf|EcsUp|EcsIsVariable);
+    test_int(terms[2].oper, EcsAnd);
+    test_int(terms[2].inout, EcsInOutDefault);
+
+    test_first(terms[3], EcsScopeClose, EcsSelf|EcsIsEntity);
+    test_src(terms[3], 0, EcsIsEntity);
+    test_int(terms[3].oper, EcsAnd);
+    test_int(terms[3].inout, EcsInOutNone);
+
+    ecs_filter_fini(&f);
+
+    ecs_fini(world);
+}

--- a/test/addons/src/Parser.c
+++ b/test/addons/src/Parser.c
@@ -5267,3 +5267,19 @@ void Parser_query_not_scope() {
 
     ecs_fini(world);
 }
+
+void Parser_query_empty_scope() {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+
+    ecs_log_set_level(-4);
+    ecs_filter_t f = ECS_FILTER_INIT;
+    test_assert(NULL == ecs_filter_init(world, &(ecs_filter_desc_t){
+        .storage = &f,
+        .expr = "TagA, !{}"
+    }));
+
+    ecs_fini(world);
+}

--- a/test/addons/src/RulesScopes.c
+++ b/test/addons/src/RulesScopes.c
@@ -1,0 +1,400 @@
+#include <addons.h>
+
+void RulesScopes_not_scope_1_term() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, Root);
+    ECS_TAG(world, TagA);
+
+    ecs_entity_t parent_1 = ecs_new(world, Root);
+    ecs_add(world, parent_1, TagA);
+
+    ecs_entity_t parent_2 = ecs_new(world, Root);
+
+    ecs_rule_t *r = ecs_rule(world, {
+        .expr = "Root, !{ TagA }"
+    });
+    test_assert(r != NULL);
+
+    {
+        ecs_iter_t it = ecs_rule_iter(world, r);
+        test_bool(true, ecs_rule_next(&it));
+        test_uint(1, it.count);
+        test_uint(Root, ecs_field_id(&it, 1));
+        test_uint(0, ecs_field_src(&it, 1));
+        test_bool(true, ecs_field_is_set(&it, 1));
+        test_uint(parent_2, it.entities[0]);
+        test_bool(false, ecs_rule_next(&it));
+    }
+
+    ecs_rule_fini(r);
+
+    ecs_fini(world);
+}
+
+void RulesScopes_not_scope_2_terms() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, Root);
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+
+    ecs_entity_t parent_1 = ecs_new(world, Root);
+    ecs_add(world, parent_1, TagA);
+
+    ecs_entity_t parent_2 = ecs_new(world, Root);
+    ecs_add(world, parent_2, TagB);
+
+    ecs_entity_t parent_3 = ecs_new(world, Root);
+    ecs_add(world, parent_3, TagA);
+    ecs_add(world, parent_3, TagB);
+
+    ecs_rule_t *r = ecs_rule(world, {
+        .expr = "Root, !{ TagA, TagB }"
+    });
+    test_assert(r != NULL);
+
+    {
+        ecs_iter_t it = ecs_rule_iter(world, r);
+        test_bool(true, ecs_rule_next(&it));
+        test_uint(1, it.count);
+        test_uint(Root, ecs_field_id(&it, 1));
+        test_uint(0, ecs_field_src(&it, 1));
+        test_bool(true, ecs_field_is_set(&it, 1));
+        test_uint(parent_1, it.entities[0]);
+
+        test_bool(true, ecs_rule_next(&it));
+        test_uint(1, it.count);
+        test_uint(Root, ecs_field_id(&it, 1));
+        test_uint(0, ecs_field_src(&it, 1));
+        test_bool(true, ecs_field_is_set(&it, 1));
+        test_uint(parent_2, it.entities[0]);
+
+        test_bool(false, ecs_rule_next(&it));
+    }
+
+    ecs_rule_fini(r);
+
+    ecs_fini(world);
+}
+
+void RulesScopes_not_scope_1_term_w_not() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, Root);
+    ECS_TAG(world, TagA);
+
+    ecs_entity_t parent_1 = ecs_new(world, Root);
+    ecs_add(world, parent_1, TagA);
+
+    ecs_new(world, Root);
+
+    ecs_rule_t *r = ecs_rule(world, {
+        .expr = "Root, !{ !TagA }"
+    });
+    test_assert(r != NULL);
+
+    {
+        ecs_iter_t it = ecs_rule_iter(world, r);
+        test_bool(true, ecs_rule_next(&it));
+        test_uint(1, it.count);
+        test_uint(Root, ecs_field_id(&it, 1));
+        test_uint(0, ecs_field_src(&it, 1));
+        test_bool(true, ecs_field_is_set(&it, 1));
+        test_uint(parent_1, it.entities[0]);
+        test_bool(false, ecs_rule_next(&it));
+    }
+
+    ecs_rule_fini(r);
+
+    ecs_fini(world);
+}
+
+void RulesScopes_not_scope_2_terms_w_not() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, Root);
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+
+    ecs_entity_t parent_1 = ecs_new(world, Root);
+    ecs_add(world, parent_1, TagA);
+
+    ecs_entity_t parent_2 = ecs_new(world, Root);
+    ecs_add(world, parent_2, TagB);
+
+    ecs_entity_t parent_3 = ecs_new(world, Root);
+    ecs_add(world, parent_3, TagA);
+    ecs_add(world, parent_3, TagB);
+
+    ecs_rule_t *r = ecs_rule(world, {
+        .expr = "Root, !{ TagA, !TagB }"
+    });
+    test_assert(r != NULL);
+
+    {
+        ecs_iter_t it = ecs_rule_iter(world, r);
+        test_bool(true, ecs_rule_next(&it));
+        test_uint(1, it.count);
+        test_uint(Root, ecs_field_id(&it, 1));
+        test_uint(0, ecs_field_src(&it, 1));
+        test_bool(true, ecs_field_is_set(&it, 1));
+        test_uint(parent_2, it.entities[0]);
+
+        test_bool(true, ecs_rule_next(&it));
+        test_uint(1, it.count);
+        test_uint(Root, ecs_field_id(&it, 1));
+        test_uint(0, ecs_field_src(&it, 1));
+        test_bool(true, ecs_field_is_set(&it, 1));
+        test_uint(parent_3, it.entities[0]);
+
+        test_bool(false, ecs_rule_next(&it));
+    }
+
+    ecs_rule_fini(r);
+
+    ecs_fini(world);
+}
+
+void RulesScopes_not_scope_1_term_w_var() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, Root);
+
+    ecs_entity_t parent_1 = ecs_new(world, Root);
+    ecs_new_w_pair(world, EcsChildOf, parent_1);
+    ecs_new_w_pair(world, EcsChildOf, parent_1);
+
+    ecs_entity_t parent_2 = ecs_new(world, Root);
+    ecs_new_w_pair(world, EcsChildOf, parent_2);
+
+    ecs_entity_t parent_3 = ecs_new(world, Root);
+
+    ecs_rule_t *r = ecs_rule(world, {
+        .expr = "Root, !{ ChildOf($child, $this) }"
+    });
+    test_assert(r != NULL);
+
+    {
+        ecs_iter_t it = ecs_rule_iter(world, r);
+        test_bool(true, ecs_rule_next(&it));
+        test_uint(1, it.count);
+        test_uint(Root, ecs_field_id(&it, 1));
+        test_uint(0, ecs_field_src(&it, 1));
+        test_bool(true, ecs_field_is_set(&it, 1));
+        test_uint(parent_3, it.entities[0]);
+        test_bool(false, ecs_rule_next(&it));
+    }
+
+    ecs_rule_fini(r);
+
+    ecs_fini(world);
+}
+
+void RulesScopes_not_scope_2_terms_w_var() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, Root);
+    ECS_COMPONENT(world, Position);
+
+    ecs_entity_t parent_0 = ecs_new(world, Root);
+    {
+        ecs_entity_t child_1 = ecs_new_w_pair(world, EcsChildOf, parent_0);
+        ecs_set(world, child_1, Position, {10, 20});
+        ecs_entity_t child_2 = ecs_new_w_pair(world, EcsChildOf, parent_0);
+        ecs_set(world, child_2, Position, {10, 20});
+    }
+
+    ecs_entity_t parent_1 = ecs_new(world, Root);
+    {
+        ecs_entity_t child_1 = ecs_new_w_pair(world, EcsChildOf, parent_1);
+        ecs_set(world, child_1, Position, {10, 20});
+        ecs_new_w_pair(world, EcsChildOf, parent_1);
+    }
+
+    ecs_entity_t parent_2 = ecs_new(world, Root);
+    {
+        ecs_new_w_pair(world, EcsChildOf, parent_2);
+        ecs_new_w_pair(world, EcsChildOf, parent_2);
+    }
+
+    ecs_rule_t *r = ecs_rule(world, {
+        .expr = "Root, !{ ChildOf($child, $this), Position($child) }"
+    });
+    test_assert(r != NULL);
+
+    {
+        ecs_iter_t it = ecs_rule_iter(world, r);
+        test_bool(true, ecs_rule_next(&it));
+        test_uint(1, it.count);
+        test_uint(Root, ecs_field_id(&it, 1));
+        test_uint(0, ecs_field_src(&it, 1));
+        test_bool(true, ecs_field_is_set(&it, 1));
+        test_uint(parent_2, it.entities[0]);
+        test_bool(false, ecs_rule_next(&it));
+    }
+
+    ecs_rule_fini(r);
+
+    ecs_fini(world);
+}
+
+void RulesScopes_not_scope_1_term_w_not_w_var() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, Root);
+
+    ecs_entity_t parent_0 = ecs_new(world, Root);
+    {
+        ecs_new_w_pair(world, EcsChildOf, parent_0);
+        ecs_new_w_pair(world, EcsChildOf, parent_0);
+    }
+
+    ecs_new(world, Root);
+
+    ecs_rule_t *r = ecs_rule(world, {
+        .expr = "Root, !{ !ChildOf($child, $this) }"
+    });
+    test_assert(r != NULL);
+
+    {
+        ecs_iter_t it = ecs_rule_iter(world, r);
+        test_bool(true, ecs_rule_next(&it));
+        test_uint(1, it.count);
+        test_uint(Root, ecs_field_id(&it, 1));
+        test_uint(0, ecs_field_src(&it, 1));
+        test_bool(true, ecs_field_is_set(&it, 1));
+        test_uint(parent_0, it.entities[0]);
+
+        test_bool(false, ecs_rule_next(&it));
+    }
+
+    ecs_rule_fini(r);
+
+    ecs_fini(world);
+}
+
+void RulesScopes_not_scope_2_terms_w_not_w_var() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, Root);
+    ECS_COMPONENT(world, Position);
+
+    ecs_entity_t parent_0 = ecs_new(world, Root);
+    {
+        ecs_entity_t child_1 = ecs_new_w_pair(world, EcsChildOf, parent_0);
+        ecs_set(world, child_1, Position, {10, 20});
+        ecs_entity_t child_2 = ecs_new_w_pair(world, EcsChildOf, parent_0);
+        ecs_set(world, child_2, Position, {10, 20});
+    }
+
+    ecs_entity_t parent_1 = ecs_new(world, Root);
+    {
+        ecs_entity_t child_1 = ecs_new_w_pair(world, EcsChildOf, parent_1);
+        ecs_set(world, child_1, Position, {10, 20});
+        ecs_new_w_pair(world, EcsChildOf, parent_1);
+    }
+
+    ecs_entity_t parent_2 = ecs_new(world, Root);
+    {
+        ecs_new_w_pair(world, EcsChildOf, parent_2);
+        ecs_new_w_pair(world, EcsChildOf, parent_2);
+    }
+
+    ecs_rule_t *r = ecs_rule(world, {
+        .expr = "Root, !{ ChildOf($child, $this), !Position($child) }"
+    });
+    test_assert(r != NULL);
+
+    {
+        ecs_iter_t it = ecs_rule_iter(world, r);
+        test_bool(true, ecs_rule_next(&it));
+        test_uint(1, it.count);
+        test_uint(Root, ecs_field_id(&it, 1));
+        test_uint(0, ecs_field_src(&it, 1));
+        test_bool(true, ecs_field_is_set(&it, 1));
+        test_uint(parent_0, it.entities[0]);
+        test_bool(false, ecs_rule_next(&it));
+    }
+
+    ecs_rule_fini(r);
+
+    ecs_fini(world);
+}
+
+void RulesScopes_not_scope_2_terms_w_or() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, Root);
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+
+    ecs_entity_t e1 = ecs_new(world, Root);
+    ecs_add(world, e1, TagA);
+    ecs_entity_t e2 = ecs_new(world, Root);
+    ecs_add(world, e2, TagB);
+    ecs_entity_t e3 = ecs_new(world, Root);
+    ecs_add(world, e3, TagA);
+    ecs_add(world, e3, TagB);
+    ecs_entity_t e4 = ecs_new(world, Root);
+
+    ecs_rule_t *r = ecs_rule(world, {
+        .expr = "Root, !{ TagA || TagB }"
+    });
+    test_assert(r != NULL);
+
+    {
+        ecs_iter_t it = ecs_rule_iter(world, r);
+        test_bool(true, ecs_rule_next(&it));
+        test_uint(1, it.count);
+        test_uint(Root, ecs_field_id(&it, 1));
+        test_uint(0, ecs_field_src(&it, 1));
+        test_bool(true, ecs_field_is_set(&it, 1));
+        test_uint(e4, it.entities[0]);
+        test_bool(false, ecs_rule_next(&it));
+    }
+
+    ecs_rule_fini(r);
+
+    ecs_fini(world);
+}
+
+void RulesScopes_not_scope_3_terms_w_or() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, Root);
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+    ECS_TAG(world, TagC);
+
+    ecs_entity_t e1 = ecs_new(world, Root);
+    ecs_add(world, e1, TagA);
+    ecs_entity_t e2 = ecs_new(world, Root);
+    ecs_add(world, e2, TagB);
+    ecs_entity_t e3 = ecs_new(world, Root);
+    ecs_add(world, e3, TagA);
+    ecs_add(world, e3, TagB);
+    ecs_entity_t e4 = ecs_new(world, Root);
+    ecs_add(world, e4, TagC);
+    ecs_entity_t e5 = ecs_new(world, Root);
+
+    ecs_rule_t *r = ecs_rule(world, {
+        .expr = "Root, !{ TagA || TagB || TagC }"
+    });
+    test_assert(r != NULL);
+
+    {
+        ecs_iter_t it = ecs_rule_iter(world, r);
+        test_bool(true, ecs_rule_next(&it));
+        test_uint(1, it.count);
+        test_uint(Root, ecs_field_id(&it, 1));
+        test_uint(0, ecs_field_src(&it, 1));
+        test_bool(true, ecs_field_is_set(&it, 1));
+        test_uint(e5, it.entities[0]);
+        test_bool(false, ecs_rule_next(&it));
+    }
+
+    ecs_rule_fini(r);
+
+    ecs_fini(world);
+}

--- a/test/addons/src/RulesScopes.c
+++ b/test/addons/src/RulesScopes.c
@@ -1,6 +1,6 @@
 #include <addons.h>
 
-void RulesScopes_not_scope_1_term() {
+void RulesScopes_term_w_not_scope_1_term() {
     ecs_world_t *world = ecs_init();
 
     ECS_TAG(world, Root);
@@ -32,7 +32,7 @@ void RulesScopes_not_scope_1_term() {
     ecs_fini(world);
 }
 
-void RulesScopes_not_scope_2_terms() {
+void RulesScopes_term_w_not_scope_2_terms() {
     ecs_world_t *world = ecs_init();
 
     ECS_TAG(world, Root);
@@ -78,7 +78,7 @@ void RulesScopes_not_scope_2_terms() {
     ecs_fini(world);
 }
 
-void RulesScopes_not_scope_1_term_w_not() {
+void RulesScopes_term_w_not_scope_1_term_w_not() {
     ecs_world_t *world = ecs_init();
 
     ECS_TAG(world, Root);
@@ -110,7 +110,7 @@ void RulesScopes_not_scope_1_term_w_not() {
     ecs_fini(world);
 }
 
-void RulesScopes_not_scope_2_terms_w_not() {
+void RulesScopes_term_w_not_scope_2_terms_w_not() {
     ecs_world_t *world = ecs_init();
 
     ECS_TAG(world, Root);
@@ -156,7 +156,7 @@ void RulesScopes_not_scope_2_terms_w_not() {
     ecs_fini(world);
 }
 
-void RulesScopes_not_scope_1_term_w_var() {
+void RulesScopes_term_w_not_scope_1_term_w_var() {
     ecs_world_t *world = ecs_init();
 
     ECS_TAG(world, Root);
@@ -191,7 +191,7 @@ void RulesScopes_not_scope_1_term_w_var() {
     ecs_fini(world);
 }
 
-void RulesScopes_not_scope_2_terms_w_var() {
+void RulesScopes_term_w_not_scope_2_terms_w_var() {
     ecs_world_t *world = ecs_init();
 
     ECS_TAG(world, Root);
@@ -239,7 +239,7 @@ void RulesScopes_not_scope_2_terms_w_var() {
     ecs_fini(world);
 }
 
-void RulesScopes_not_scope_1_term_w_not_w_var() {
+void RulesScopes_term_w_not_scope_1_term_w_not_w_var() {
     ecs_world_t *world = ecs_init();
 
     ECS_TAG(world, Root);
@@ -274,7 +274,7 @@ void RulesScopes_not_scope_1_term_w_not_w_var() {
     ecs_fini(world);
 }
 
-void RulesScopes_not_scope_2_terms_w_not_w_var() {
+void RulesScopes_term_w_not_scope_2_terms_w_not_w_var() {
     ecs_world_t *world = ecs_init();
 
     ECS_TAG(world, Root);
@@ -322,7 +322,7 @@ void RulesScopes_not_scope_2_terms_w_not_w_var() {
     ecs_fini(world);
 }
 
-void RulesScopes_not_scope_2_terms_w_or() {
+void RulesScopes_term_w_not_scope_2_terms_w_or() {
     ecs_world_t *world = ecs_init();
 
     ECS_TAG(world, Root);
@@ -359,7 +359,7 @@ void RulesScopes_not_scope_2_terms_w_or() {
     ecs_fini(world);
 }
 
-void RulesScopes_not_scope_3_terms_w_or() {
+void RulesScopes_term_w_not_scope_3_terms_w_or() {
     ecs_world_t *world = ecs_init();
 
     ECS_TAG(world, Root);

--- a/test/addons/src/RulesVariables.c
+++ b/test/addons/src/RulesVariables.c
@@ -5844,3 +5844,111 @@ void RulesVariables_var_is_entity() {
 
     ecs_fini(world);
 }
+
+void RulesVariables_no_this_anonymous_src() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, TagA);
+
+    ecs_entity_t e = ecs_new_w_id(world, TagA);
+    test_assert(e != 0);
+
+    ecs_rule_t *r = ecs_rule(world, {
+        .expr = "TagA($_x)"
+    });
+    test_assert(r != NULL);
+
+    ecs_iter_t it = ecs_rule_iter(world, r);
+    test_bool(ecs_rule_next(&it), true);
+    test_uint(TagA, ecs_field_id(&it, 1));
+    test_bool(ecs_rule_next(&it), false);
+
+    ecs_rule_fini(r);
+
+    ecs_fini(world);
+}
+
+void RulesVariables_no_this_anonymous_src_w_pair() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, TagA);
+
+    ecs_entity_t parent = ecs_new_id(world);
+    ecs_entity_t e = ecs_new_w_id(world, TagA);
+    test_assert(e != 0);
+    ecs_add_pair(world, e, EcsChildOf, parent);
+
+    ecs_rule_t *r = ecs_rule(world, {
+        .expr = "TagA($_x), ChildOf($_x, $Parent)"
+    });
+    test_assert(r != NULL);
+
+    int parent_var = ecs_rule_find_var(r, "Parent");
+    test_assert(parent_var != -1);
+
+    ecs_iter_t it = ecs_rule_iter(world, r);
+    test_bool(ecs_rule_next(&it), true);
+    test_uint(0, it.count);
+    test_uint(TagA, ecs_field_id(&it, 1));
+    test_uint(ecs_pair(EcsChildOf, parent), ecs_field_id(&it, 2));
+    test_uint(parent, ecs_iter_get_var(&it, parent_var));
+    test_bool(ecs_rule_next(&it), false);
+
+    ecs_rule_fini(r);
+
+    ecs_fini(world);
+}
+
+void RulesVariables_no_this_anonymous_component_src() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_COMPONENT(world, Position);
+
+    ecs_entity_t e = ecs_new(world, Position);
+    test_assert(e != 0);
+
+    ecs_rule_t *r = ecs_rule(world, {
+        .expr = "Position($_x)"
+    });
+    test_assert(r != NULL);
+
+    ecs_iter_t it = ecs_rule_iter(world, r);
+    test_bool(ecs_rule_next(&it), true);
+    test_uint(ecs_id(Position), ecs_field_id(&it, 1));
+    test_bool(ecs_rule_next(&it), false);
+
+    ecs_rule_fini(r);
+
+    ecs_fini(world);
+}
+
+void RulesVariables_no_this_anonymous_component_src_w_pair() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_COMPONENT(world, Position);
+
+    ecs_entity_t parent = ecs_new_id(world);
+    ecs_entity_t e = ecs_new(world, Position);
+    test_assert(e != 0);
+    ecs_add_pair(world, e, EcsChildOf, parent);
+
+    ecs_rule_t *r = ecs_rule(world, {
+        .expr = "Position($_x), ChildOf($_x, $Parent)"
+    });
+    test_assert(r != NULL);
+
+    int parent_var = ecs_rule_find_var(r, "Parent");
+    test_assert(parent_var != -1);
+
+    ecs_iter_t it = ecs_rule_iter(world, r);
+    test_bool(ecs_rule_next(&it), true);
+    test_uint(0, it.count);
+    test_uint(ecs_id(Position), ecs_field_id(&it, 1));
+    test_uint(ecs_pair(EcsChildOf, parent), ecs_field_id(&it, 2));
+    test_uint(parent, ecs_iter_get_var(&it, parent_var));
+    test_bool(ecs_rule_next(&it), false);
+
+    ecs_rule_fini(r);
+
+    ecs_fini(world);
+}

--- a/test/addons/src/main.c
+++ b/test/addons/src/main.c
@@ -1055,6 +1055,18 @@ void RulesBuiltinPredicates_this_match_3_or(void);
 void RulesBuiltinPredicates_this_match_3_or_written(void);
 void RulesBuiltinPredicates_unresolved_by_name(void);
 
+// Testsuite 'RulesScopes'
+void RulesScopes_not_scope_1_term(void);
+void RulesScopes_not_scope_2_terms(void);
+void RulesScopes_not_scope_1_term_w_not(void);
+void RulesScopes_not_scope_2_terms_w_not(void);
+void RulesScopes_not_scope_1_term_w_var(void);
+void RulesScopes_not_scope_2_terms_w_var(void);
+void RulesScopes_not_scope_1_term_w_not_w_var(void);
+void RulesScopes_not_scope_2_terms_w_not_w_var(void);
+void RulesScopes_not_scope_2_terms_w_or(void);
+void RulesScopes_not_scope_3_terms_w_or(void);
+
 // Testsuite 'SystemPeriodic'
 void SystemPeriodic_1_type_1_component(void);
 void SystemPeriodic_1_type_3_component(void);
@@ -5597,6 +5609,49 @@ bake_test_case RulesBuiltinPredicates_testcases[] = {
     }
 };
 
+bake_test_case RulesScopes_testcases[] = {
+    {
+        "not_scope_1_term",
+        RulesScopes_not_scope_1_term
+    },
+    {
+        "not_scope_2_terms",
+        RulesScopes_not_scope_2_terms
+    },
+    {
+        "not_scope_1_term_w_not",
+        RulesScopes_not_scope_1_term_w_not
+    },
+    {
+        "not_scope_2_terms_w_not",
+        RulesScopes_not_scope_2_terms_w_not
+    },
+    {
+        "not_scope_1_term_w_var",
+        RulesScopes_not_scope_1_term_w_var
+    },
+    {
+        "not_scope_2_terms_w_var",
+        RulesScopes_not_scope_2_terms_w_var
+    },
+    {
+        "not_scope_1_term_w_not_w_var",
+        RulesScopes_not_scope_1_term_w_not_w_var
+    },
+    {
+        "not_scope_2_terms_w_not_w_var",
+        RulesScopes_not_scope_2_terms_w_not_w_var
+    },
+    {
+        "not_scope_2_terms_w_or",
+        RulesScopes_not_scope_2_terms_w_or
+    },
+    {
+        "not_scope_3_terms_w_or",
+        RulesScopes_not_scope_3_terms_w_or
+    }
+};
+
 bake_test_case SystemPeriodic_testcases[] = {
     {
         "1_type_1_component",
@@ -7197,6 +7252,13 @@ static bake_test_suite suites[] = {
         RulesBuiltinPredicates_testcases
     },
     {
+        "RulesScopes",
+        NULL,
+        NULL,
+        10,
+        RulesScopes_testcases
+    },
+    {
         "SystemPeriodic",
         NULL,
         NULL,
@@ -7353,5 +7415,5 @@ static bake_test_suite suites[] = {
 };
 
 int main(int argc, char *argv[]) {
-    return bake_test_run("addons", argc, argv, suites, 34);
+    return bake_test_run("addons", argc, argv, suites, 35);
 }

--- a/test/addons/src/main.c
+++ b/test/addons/src/main.c
@@ -224,6 +224,13 @@ void Parser_neq_same_var_this(void);
 void Parser_eq_w_optional(void);
 void Parser_neq_w_optional(void);
 void Parser_match_w_optional(void);
+void Parser_query_scope_1_term(void);
+void Parser_query_scope_1_term_spaces(void);
+void Parser_query_scope_2_terms(void);
+void Parser_query_nested_scope(void);
+void Parser_query_nested_scope_spaces(void);
+void Parser_query_scope_unbalanced(void);
+void Parser_query_not_scope(void);
 
 // Testsuite 'Plecs'
 void Plecs_null(void);
@@ -2322,6 +2329,34 @@ bake_test_case Parser_testcases[] = {
     {
         "match_w_optional",
         Parser_match_w_optional
+    },
+    {
+        "query_scope_1_term",
+        Parser_query_scope_1_term
+    },
+    {
+        "query_scope_1_term_spaces",
+        Parser_query_scope_1_term_spaces
+    },
+    {
+        "query_scope_2_terms",
+        Parser_query_scope_2_terms
+    },
+    {
+        "query_nested_scope",
+        Parser_query_nested_scope
+    },
+    {
+        "query_nested_scope_spaces",
+        Parser_query_nested_scope_spaces
+    },
+    {
+        "query_scope_unbalanced",
+        Parser_query_scope_unbalanced
+    },
+    {
+        "query_not_scope",
+        Parser_query_not_scope
     }
 };
 
@@ -7081,7 +7116,7 @@ static bake_test_suite suites[] = {
         "Parser",
         NULL,
         NULL,
-        215,
+        222,
         Parser_testcases
     },
     {

--- a/test/addons/src/main.c
+++ b/test/addons/src/main.c
@@ -1056,16 +1056,16 @@ void RulesBuiltinPredicates_this_match_3_or_written(void);
 void RulesBuiltinPredicates_unresolved_by_name(void);
 
 // Testsuite 'RulesScopes'
-void RulesScopes_not_scope_1_term(void);
-void RulesScopes_not_scope_2_terms(void);
-void RulesScopes_not_scope_1_term_w_not(void);
-void RulesScopes_not_scope_2_terms_w_not(void);
-void RulesScopes_not_scope_1_term_w_var(void);
-void RulesScopes_not_scope_2_terms_w_var(void);
-void RulesScopes_not_scope_1_term_w_not_w_var(void);
-void RulesScopes_not_scope_2_terms_w_not_w_var(void);
-void RulesScopes_not_scope_2_terms_w_or(void);
-void RulesScopes_not_scope_3_terms_w_or(void);
+void RulesScopes_term_w_not_scope_1_term(void);
+void RulesScopes_term_w_not_scope_2_terms(void);
+void RulesScopes_term_w_not_scope_1_term_w_not(void);
+void RulesScopes_term_w_not_scope_2_terms_w_not(void);
+void RulesScopes_term_w_not_scope_1_term_w_var(void);
+void RulesScopes_term_w_not_scope_2_terms_w_var(void);
+void RulesScopes_term_w_not_scope_1_term_w_not_w_var(void);
+void RulesScopes_term_w_not_scope_2_terms_w_not_w_var(void);
+void RulesScopes_term_w_not_scope_2_terms_w_or(void);
+void RulesScopes_term_w_not_scope_3_terms_w_or(void);
 
 // Testsuite 'SystemPeriodic'
 void SystemPeriodic_1_type_1_component(void);
@@ -5611,44 +5611,44 @@ bake_test_case RulesBuiltinPredicates_testcases[] = {
 
 bake_test_case RulesScopes_testcases[] = {
     {
-        "not_scope_1_term",
-        RulesScopes_not_scope_1_term
+        "term_w_not_scope_1_term",
+        RulesScopes_term_w_not_scope_1_term
     },
     {
-        "not_scope_2_terms",
-        RulesScopes_not_scope_2_terms
+        "term_w_not_scope_2_terms",
+        RulesScopes_term_w_not_scope_2_terms
     },
     {
-        "not_scope_1_term_w_not",
-        RulesScopes_not_scope_1_term_w_not
+        "term_w_not_scope_1_term_w_not",
+        RulesScopes_term_w_not_scope_1_term_w_not
     },
     {
-        "not_scope_2_terms_w_not",
-        RulesScopes_not_scope_2_terms_w_not
+        "term_w_not_scope_2_terms_w_not",
+        RulesScopes_term_w_not_scope_2_terms_w_not
     },
     {
-        "not_scope_1_term_w_var",
-        RulesScopes_not_scope_1_term_w_var
+        "term_w_not_scope_1_term_w_var",
+        RulesScopes_term_w_not_scope_1_term_w_var
     },
     {
-        "not_scope_2_terms_w_var",
-        RulesScopes_not_scope_2_terms_w_var
+        "term_w_not_scope_2_terms_w_var",
+        RulesScopes_term_w_not_scope_2_terms_w_var
     },
     {
-        "not_scope_1_term_w_not_w_var",
-        RulesScopes_not_scope_1_term_w_not_w_var
+        "term_w_not_scope_1_term_w_not_w_var",
+        RulesScopes_term_w_not_scope_1_term_w_not_w_var
     },
     {
-        "not_scope_2_terms_w_not_w_var",
-        RulesScopes_not_scope_2_terms_w_not_w_var
+        "term_w_not_scope_2_terms_w_not_w_var",
+        RulesScopes_term_w_not_scope_2_terms_w_not_w_var
     },
     {
-        "not_scope_2_terms_w_or",
-        RulesScopes_not_scope_2_terms_w_or
+        "term_w_not_scope_2_terms_w_or",
+        RulesScopes_term_w_not_scope_2_terms_w_or
     },
     {
-        "not_scope_3_terms_w_or",
-        RulesScopes_not_scope_3_terms_w_or
+        "term_w_not_scope_3_terms_w_or",
+        RulesScopes_term_w_not_scope_3_terms_w_or
     }
 };
 

--- a/test/addons/src/main.c
+++ b/test/addons/src/main.c
@@ -231,6 +231,7 @@ void Parser_query_nested_scope(void);
 void Parser_query_nested_scope_spaces(void);
 void Parser_query_scope_unbalanced(void);
 void Parser_query_not_scope(void);
+void Parser_query_empty_scope(void);
 
 // Testsuite 'Plecs'
 void Plecs_null(void);
@@ -793,6 +794,10 @@ void RulesVariables_parse_2_vars_paren_w_spaces(void);
 void RulesVariables_var_count(void);
 void RulesVariables_var_name(void);
 void RulesVariables_var_is_entity(void);
+void RulesVariables_no_this_anonymous_src(void);
+void RulesVariables_no_this_anonymous_src_w_pair(void);
+void RulesVariables_no_this_anonymous_component_src(void);
+void RulesVariables_no_this_anonymous_component_src_w_pair(void);
 
 // Testsuite 'RulesOperators'
 void RulesOperators_2_and_not(void);
@@ -2369,6 +2374,10 @@ bake_test_case Parser_testcases[] = {
     {
         "query_not_scope",
         Parser_query_not_scope
+    },
+    {
+        "query_empty_scope",
+        Parser_query_empty_scope
     }
 };
 
@@ -4587,6 +4596,22 @@ bake_test_case RulesVariables_testcases[] = {
     {
         "var_is_entity",
         RulesVariables_var_is_entity
+    },
+    {
+        "no_this_anonymous_src",
+        RulesVariables_no_this_anonymous_src
+    },
+    {
+        "no_this_anonymous_src_w_pair",
+        RulesVariables_no_this_anonymous_src_w_pair
+    },
+    {
+        "no_this_anonymous_component_src",
+        RulesVariables_no_this_anonymous_component_src
+    },
+    {
+        "no_this_anonymous_component_src_w_pair",
+        RulesVariables_no_this_anonymous_component_src_w_pair
     }
 };
 
@@ -7171,7 +7196,7 @@ static bake_test_suite suites[] = {
         "Parser",
         NULL,
         NULL,
-        222,
+        223,
         Parser_testcases
     },
     {
@@ -7213,7 +7238,7 @@ static bake_test_suite suites[] = {
         "RulesVariables",
         NULL,
         NULL,
-        93,
+        97,
         RulesVariables_testcases
     },
     {

--- a/test/api/project.json
+++ b/test/api/project.json
@@ -1402,7 +1402,8 @@
                 "one_term_w_first_var_entity_src",
                 "one_term_w_pair_w_0_entity",
                 "not_term",
-                "wildcard_term"
+                "wildcard_term",
+                "scopes"
             ]
         }, {
             "id": "Query",

--- a/test/api/src/FilterStr.c
+++ b/test/api/src/FilterStr.c
@@ -476,3 +476,25 @@ void FilterStr_wildcard_term() {
 
     ecs_fini(world);
 }
+
+void FilterStr_scopes() {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, TagA);
+    ECS_TAG(world, TagB);
+    ECS_TAG(world, TagC);
+
+    ecs_filter_t f = ECS_FILTER_INIT;
+    test_assert(NULL != ecs_filter_init(world, &(ecs_filter_desc_t){
+        .storage = &f,
+        .expr = "TagA, {TagB, {TagC}}"
+    }));
+
+    char *str = ecs_filter_str(world, &f);
+    test_str(str, "TagA, {TagB, {TagC}}");
+    ecs_os_free(str);
+
+    ecs_filter_fini(&f);
+
+    ecs_fini(world);
+}

--- a/test/api/src/main.c
+++ b/test/api/src/main.c
@@ -1342,6 +1342,7 @@ void FilterStr_one_term_w_first_var_entity_src(void);
 void FilterStr_one_term_w_pair_w_0_entity(void);
 void FilterStr_not_term(void);
 void FilterStr_wildcard_term(void);
+void FilterStr_scopes(void);
 
 // Testsuite 'Query'
 void Query_simple_query_existing_table(void);
@@ -7716,6 +7717,10 @@ bake_test_case FilterStr_testcases[] = {
     {
         "wildcard_term",
         FilterStr_wildcard_term
+    },
+    {
+        "scopes",
+        FilterStr_scopes
     }
 };
 
@@ -12619,7 +12624,7 @@ static bake_test_suite suites[] = {
         "FilterStr",
         NULL,
         NULL,
-        22,
+        23,
         FilterStr_testcases
     },
     {

--- a/test/cpp_api/project.json
+++ b/test/cpp_api/project.json
@@ -796,7 +796,8 @@
                 "named_rule",
                 "named_scoped_rule",
                 "is_valid",
-                "unresolved_by_name"
+                "unresolved_by_name",
+                "scope"
             ]
         }, {
             "id": "SystemBuilder",

--- a/test/cpp_api/src/RuleBuilder.cpp
+++ b/test/cpp_api/src/RuleBuilder.cpp
@@ -725,3 +725,43 @@ void RuleBuilder_unresolved_by_name() {
 
     test_true(q.iter().is_true());
 }
+
+void RuleBuilder_scope() {
+    flecs::world ecs;
+
+    flecs::entity Root = ecs.entity();
+    flecs::entity TagA = ecs.entity();
+    flecs::entity TagB = ecs.entity();
+
+    ecs.entity()
+        .add(Root)
+        .add(TagA)
+        .add(TagB);
+
+    auto e2 = ecs.entity()
+        .add(Root)
+        .add(TagA);
+
+    ecs.entity()
+        .add(Root)
+        .add(TagB);
+
+    ecs.entity()
+        .add(Root);
+
+    auto r = ecs.rule_builder()
+        .with(Root)
+        .scope_open().not_()
+            .with(TagA)
+            .without(TagB)
+        .scope_close()
+        .build();
+
+    int32_t count = 0;
+    r.each([&](flecs::entity e) {
+        test_assert(e != e2);
+        count ++;
+    });
+
+    test_int(count, 3);
+}

--- a/test/cpp_api/src/main.cpp
+++ b/test/cpp_api/src/main.cpp
@@ -767,6 +767,7 @@ void RuleBuilder_named_rule(void);
 void RuleBuilder_named_scoped_rule(void);
 void RuleBuilder_is_valid(void);
 void RuleBuilder_unresolved_by_name(void);
+void RuleBuilder_scope(void);
 
 // Testsuite 'SystemBuilder'
 void SystemBuilder_builder_assign_same_type(void);
@@ -4195,6 +4196,10 @@ bake_test_case RuleBuilder_testcases[] = {
     {
         "unresolved_by_name",
         RuleBuilder_unresolved_by_name
+    },
+    {
+        "scope",
+        RuleBuilder_scope
     }
 };
 
@@ -6028,7 +6033,7 @@ static bake_test_suite suites[] = {
         "RuleBuilder",
         NULL,
         NULL,
-        27,
+        28,
         RuleBuilder_testcases
     },
     {

--- a/test/meta/project.json
+++ b/test/meta/project.json
@@ -738,6 +738,7 @@
                 "serialize_iterator_invalid_value",
                 "serialize_iterator_recycled_pair_id",
                 "serialize_iterator_w_alert",
+                "serialize_iterator_no_this_alert_imported",
                 "serialize_paged_iterator",
                 "serialize_paged_iterator_w_optional_component",
                 "serialize_paged_iterator_w_optional_tag",

--- a/test/meta/src/SerializeToJson.c
+++ b/test/meta/src/SerializeToJson.c
@@ -4248,6 +4248,47 @@ void SerializeToJson_serialize_iterator_w_alert() {
     ecs_fini(world);
 }
 
+void SerializeToJson_serialize_iterator_no_this_alert_imported() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_IMPORT(world, FlecsAlerts);
+
+    ECS_COMPONENT(world, Position);
+
+    ecs_struct_init(world, &(ecs_struct_desc_t){
+        .entity = ecs_id(Position),
+        .members = {
+            {"x", ecs_id(ecs_i32_t)},
+            {"y", ecs_id(ecs_i32_t)}
+        }
+    });
+
+    ecs_entity_t e1 = ecs_new_entity(world, "Foo");
+    ecs_set(world, e1, Position, {10, 20});
+
+    ecs_rule_t *q = ecs_rule(world, {
+        .expr = "Position($x)"
+    });
+    ecs_iter_t it = ecs_rule_iter(world, q);
+
+    char *json = ecs_iter_to_json(world, &it, NULL);
+    test_str(json, 
+    "{"
+        "\"ids\":[[\"Position\"]], "
+        "\"vars\":[\"x\"], "
+        "\"results\":[{"
+            "\"ids\":[[\"Position\"]], "
+            "\"sources\":[\"Foo\"], "
+            "\"vars\":[\"Foo\"], "
+            "\"values\":["
+                "{\"x\":10, \"y\":20}"
+            "]"
+        "}]"
+    "}");
+
+    ecs_fini(world);
+}
+
 void SerializeToJson_serialize_paged_iterator() {
     ecs_world_t *world = ecs_init();
 
@@ -4665,4 +4706,8 @@ void SerializeToJson_serialize_anonymous_entities_w_offset() {
     ecs_rule_fini(r);
 
     ecs_fini(world);
+}
+
+void SerializeToJson_serialize_iterator_w_alert_no_this() {
+    // Implement testcase
 }

--- a/test/meta/src/main.c
+++ b/test/meta/src/main.c
@@ -707,6 +707,7 @@ void SerializeToJson_serialize_iterator_variable_ids_2_entities(void);
 void SerializeToJson_serialize_iterator_invalid_value(void);
 void SerializeToJson_serialize_iterator_recycled_pair_id(void);
 void SerializeToJson_serialize_iterator_w_alert(void);
+void SerializeToJson_serialize_iterator_no_this_alert_imported(void);
 void SerializeToJson_serialize_paged_iterator(void);
 void SerializeToJson_serialize_paged_iterator_w_optional_component(void);
 void SerializeToJson_serialize_paged_iterator_w_optional_tag(void);
@@ -3651,6 +3652,10 @@ bake_test_case SerializeToJson_testcases[] = {
         SerializeToJson_serialize_iterator_w_alert
     },
     {
+        "serialize_iterator_no_this_alert_imported",
+        SerializeToJson_serialize_iterator_no_this_alert_imported
+    },
+    {
         "serialize_paged_iterator",
         SerializeToJson_serialize_paged_iterator
     },
@@ -4579,7 +4584,7 @@ static bake_test_suite suites[] = {
         "SerializeToJson",
         NULL,
         NULL,
-        133,
+        134,
         SerializeToJson_testcases
     },
     {


### PR DESCRIPTION
This PR implements query scopes, which allows for grouping a set of terms in a query in a "scope", to which query operators can be applied. A query scope is created using curly brackets in the query DSL. An example:

```
Position, !{Velocity || Speed}
```

Some limitations still apply to how query scopes can be used, see the query manual for details.

This PR also includes the following changes:
- Fix issue in rule engine with anonymous source variables and component terms
- Fix issue with JSON serialization of query without `$this` source while alert module is imported
- Fix naming inconsistency between alerts/metrics addon