### PR TITLE
Fix a possible bug in ecs_emplace_pair

### DIFF
--- a/flecs.h
+++ b/flecs.h
@@ -8461,7 +8461,7 @@ int ecs_value_move_ctor(
     (ECS_CAST(T*, ecs_emplace_id(world, entity, ecs_id(T))))
 
 #define ecs_emplace_pair(world, entity, First, second)\
-    (ECS_CAST(First*, ecs_emplace_id(world, entity, ecs_pair_t(First, second))))
+    (ECS_CAST(First*, ecs_emplace_id(world, entity, ecs_pair_t(ecs_id(First), second))))
 
 #define ecs_get(world, entity, T)\
     (ECS_CAST(const T*, ecs_get_id(world, entity, ecs_id(T))))

--- a/include/flecs/addons/flecs_c.h
+++ b/include/flecs/addons/flecs_c.h
@@ -325,7 +325,7 @@
     (ECS_CAST(T*, ecs_emplace_id(world, entity, ecs_id(T))))
 
 #define ecs_emplace_pair(world, entity, First, second)\
-    (ECS_CAST(First*, ecs_emplace_id(world, entity, ecs_pair_t(First, second))))
+    (ECS_CAST(First*, ecs_emplace_id(world, entity, ecs_pair_t(ecs_id(First), second))))
 
 #define ecs_get(world, entity, T)\
     (ECS_CAST(const T*, ecs_get_id(world, entity, ecs_id(T))))


### PR DESCRIPTION
Hi, I've been working through writing bindings for flecs to the Odin language over the past few months. However, while I was working through flecs_c.h I noticed what I believe to be a possible bug in the `ecs_emplace_pair` macro. The macro is reproduced below:
```c
#define ecs_emplace_pair(world, entity, First, second)\
    (ECS_CAST(First*, ecs_emplace_id(world, entity, ecs_pair_t(First, second))))
```
The problem lies in that First is treated as a type in the cast, however it is treated like an entity in the pair. I believe the best way to fix this is to, like the other macros in the same file, wrap First with an `ecs_id()` in the pair. This change has been applied in my pull to both flecs_c.h and flecs.h.