### PR TITLE
Compiling flecs with clang-cl

### DIFF
--- a/include/flecs/os_api.h
+++ b/include/flecs/os_api.h
@@ -386,7 +386,7 @@ void ecs_os_set_api_defaults(void);
 #define ecs_offset(ptr, T, index)\
     ECS_CAST(T*, ECS_OFFSET(ptr, ECS_SIZEOF(T) * index))
 
-#if defined(ECS_TARGET_WINDOWS)
+#ifndef ECS_TARGET_POSIX
 #define ecs_os_strcat(str1, str2) strcat_s(str1, INT_MAX, str2)
 #define ecs_os_sprintf(ptr, ...) sprintf_s(ptr, INT_MAX, __VA_ARGS__)
 #define ecs_os_vsprintf(ptr, fmt, args) vsprintf_s(ptr, INT_MAX, fmt, args)
@@ -409,7 +409,7 @@ void ecs_os_set_api_defaults(void);
 #endif
 
 /* Files */
-#if defined(ECS_TARGET_WINDOWS)
+#ifndef ECS_TARGET_POSIX
 #define ecs_os_fopen(result, file, mode) fopen_s(result, file, mode)
 #else
 #define ecs_os_fopen(result, file, mode) (*(result)) = fopen(file, mode)

--- a/include/flecs/os_api.h
+++ b/include/flecs/os_api.h
@@ -386,7 +386,7 @@ void ecs_os_set_api_defaults(void);
 #define ecs_offset(ptr, T, index)\
     ECS_CAST(T*, ECS_OFFSET(ptr, ECS_SIZEOF(T) * index))
 
-#if defined(ECS_TARGET_MSVC)
+#if defined(ECS_TARGET_WINDOWS)
 #define ecs_os_strcat(str1, str2) strcat_s(str1, INT_MAX, str2)
 #define ecs_os_sprintf(ptr, ...) sprintf_s(ptr, INT_MAX, __VA_ARGS__)
 #define ecs_os_vsprintf(ptr, fmt, args) vsprintf_s(ptr, INT_MAX, fmt, args)
@@ -409,7 +409,7 @@ void ecs_os_set_api_defaults(void);
 #endif
 
 /* Files */
-#if defined(ECS_TARGET_MSVC)
+#if defined(ECS_TARGET_WINDOWS)
 #define ecs_os_fopen(result, file, mode) fopen_s(result, file, mode)
 #else
 #define ecs_os_fopen(result, file, mode) (*(result)) = fopen(file, mode)

--- a/src/addons/http.c
+++ b/src/addons/http.c
@@ -304,6 +304,7 @@ void http_sock_keep_alive(
 static
 void http_sock_nonblock(ecs_http_socket_t sock, bool enable) {
     (void)sock;
+    (void)enable;
 #ifdef ECS_TARGET_POSIX
     int flags;
     flags = fcntl(sock,F_GETFL,0);


### PR DESCRIPTION
Remaining issues: 
- `flecs/src/addons/os_api_impl/windows_impl.inl:46:33: warning: incompatible pointer types passing 'int32_t *' (aka 'int *') to parameter of type 'volatile long *' [-Wincompatible-pointer-types]`
- `flecs/src/addons/os_api_impl/windows_impl.inl:53:33: warning: incompatible pointer types passing 'int32_t *' (aka 'int *') to parameter of type 'volatile long *' [-Wincompatible-pointer-types]`
- `flecs/src/addons/os_api_impl/windows_impl.inl:230:28: warning: implicit conversion from 'LONGLONG' (aka 'long long') to 'double' may lose precision [-Wimplicit-int-float-conversion]`
- `flecs/src/addons/http.c:341:30: warning: implicit conversion changes signedness: 'uint32_t' (aka 'unsigned int') to 'socklen_t' (aka 'int') [-Wsign-conversion]`
- `flecs/src/addons/http.c:352:29: warning: implicit conversion changes signedness: 'uint32_t' (aka 'unsigned int') to 'int' [-Wsign-conversion]`
- `flecs/src/addons/http.c:1144:22: warning: comparison of integers of different signs: 'int' and 'SOCKET' (aka 'unsigned long long') [-Wsign-compare]`