### PR TITLE
Member range alerts

### DIFF
--- a/flecs.c
+++ b/flecs.c
@@ -19531,11 +19531,11 @@ ecs_entity_t flecs_alert_out_of_range_kind(
     case EcsU8: value = *(uint8_t*)value_ptr; break;
     case EcsU16: value = *(uint16_t*)value_ptr; break;
     case EcsU32: value = *(uint32_t*)value_ptr; break;
-    case EcsU64: value = *(uint64_t*)value_ptr; break;
+    case EcsU64: value = (double)*(uint64_t*)value_ptr; break;
     case EcsI8: value = *(int8_t*)value_ptr; break;
     case EcsI16: value = *(int16_t*)value_ptr; break;
     case EcsI32: value = *(int32_t*)value_ptr; break;
-    case EcsI64: value = *(int64_t*)value_ptr; break;
+    case EcsI64: value = (double)*(int64_t*)value_ptr; break;
     case EcsF32: value = (double)*(float*)value_ptr; break;
     case EcsF64: value = *(double*)value_ptr; break;
     default: return 0;
@@ -19693,10 +19693,11 @@ void MonitorAlertInstances(ecs_iter_t *it) {
             const void *member_data = ecs_get_id(world, e, member_id);
             if (!member_data) {
                 range_match = false;
+            } else {
+                member_data = ECS_OFFSET(member_data, alert->offset);
+                range_match = flecs_alert_out_of_range_kind(
+                    &alert[i], ranges, member_data) != 0;
             }
-            member_data = ECS_OFFSET(member_data, alert->offset);
-            range_match = flecs_alert_out_of_range_kind(
-                &alert[i], ranges, member_data) != 0;
         }
 
         /* Check if alert instance still matches rule */
@@ -34702,7 +34703,6 @@ int ecs_entity_to_json_buf(
             while (ecs_map_next(&it)) {
                 flecs_json_next(buf);
                 flecs_json_object_push(buf);
-                ecs_entity_t a = ecs_map_key(&it);
                 ecs_entity_t ai = ecs_map_value(&it);
                 char *alert_name = ecs_get_fullpath(world, ai);
                 flecs_json_memberl(buf, "alert");
@@ -34710,7 +34710,7 @@ int ecs_entity_to_json_buf(
                 ecs_os_free(alert_name);
 
                 ecs_entity_t severity_id = ecs_get_target(
-                    world, a, ecs_id(EcsAlert), 0);
+                    world, ai, ecs_id(EcsAlert), 0);
                 const char *severity = ecs_get_name(world, severity_id);
 
                 const EcsAlertInstance *alert = ecs_get(

--- a/flecs.c
+++ b/flecs.c
@@ -19696,7 +19696,7 @@ void MonitorAlertInstances(ecs_iter_t *it) {
             } else {
                 member_data = ECS_OFFSET(member_data, alert->offset);
                 range_match = flecs_alert_out_of_range_kind(
-                    &alert[i], ranges, member_data) != 0;
+                    alert, ranges, member_data) != 0;
             }
         }
 

--- a/flecs.c
+++ b/flecs.c
@@ -19367,6 +19367,14 @@ typedef struct EcsAlert {
     ecs_map_t instances;        /* Active instances for metric */
     ecs_ftime_t retain_period;  /* How long to retain the alert */
     ecs_vec_t severity_filters; /* Severity filters */
+    
+    /* Member range monitoring */
+    ecs_id_t id;                /* (Component) id that contains to monitor member */
+    ecs_entity_t member;        /* Member to monitor */
+    uint16_t offset;            /* Offset of member in component */
+    uint16_t size;              /* Size of component */
+    ecs_primitive_kind_t kind;  /* Primitive type kind */
+    ecs_ref_t ranges;           /* Reference to ranges component */
 } EcsAlert;
 
 typedef struct EcsAlertTimeout {
@@ -19378,7 +19386,7 @@ ECS_COMPONENT_DECLARE(EcsAlertTimeout);
 
 static
 ECS_CTOR(EcsAlert, ptr, {
-    ptr->message = NULL;
+    ecs_os_zeromem(ptr);
     ecs_map_init(&ptr->instances, NULL);
     ecs_vec_init_t(NULL, &ptr->severity_filters, ecs_alert_severity_filter_t, 0);
 })
@@ -19405,6 +19413,12 @@ ECS_MOVE(EcsAlert, dst, src, {
     src->severity_filters = (ecs_vec_t){0};
 
     dst->retain_period = src->retain_period;
+    dst->id = src->id;
+    dst->member = src->member;
+    dst->offset = src->offset;
+    dst->size = src->size;
+    dst->kind = src->kind;
+    dst->ranges = src->ranges;
 })
 
 static
@@ -19506,6 +19520,42 @@ ecs_entity_t flecs_alert_get_severity(
 }
 
 static
+ecs_entity_t flecs_alert_out_of_range_kind(
+    EcsAlert *alert,
+    const EcsMemberRanges *ranges,
+    const void *value_ptr)
+{
+    double value;
+
+    switch(alert->kind) {
+    case EcsU8: value = *(uint8_t*)value_ptr; break;
+    case EcsU16: value = *(uint16_t*)value_ptr; break;
+    case EcsU32: value = *(uint32_t*)value_ptr; break;
+    case EcsU64: value = *(uint64_t*)value_ptr; break;
+    case EcsI8: value = *(int8_t*)value_ptr; break;
+    case EcsI16: value = *(int16_t*)value_ptr; break;
+    case EcsI32: value = *(int32_t*)value_ptr; break;
+    case EcsI64: value = *(int64_t*)value_ptr; break;
+    case EcsF32: value = *(float*)value_ptr; break;
+    case EcsF64: value = *(double*)value_ptr; break;
+    default: return 0;
+    }
+
+    bool has_error = ranges->error.min != ranges->error.max;
+    bool has_warning = ranges->warning.min != ranges->warning.max;
+
+    if (has_error && (value < ranges->error.min || value > ranges->error.max)) {
+        return EcsAlertError;
+    } else if (has_warning && 
+        (value < ranges->warning.min || value > ranges->warning.max)) 
+    {
+        return EcsAlertWarning;
+    } else {
+        return 0;
+    }
+}
+
+static
 void MonitorAlerts(ecs_iter_t *it) {
     ecs_world_t *world = it->real_world;
     EcsAlert *alert = ecs_field(it, EcsAlert, 1);
@@ -19519,6 +19569,12 @@ void MonitorAlerts(ecs_iter_t *it) {
         ecs_rule_t *rule = poly[i].poly;
         ecs_poly_assert(rule, ecs_rule_t);
 
+        ecs_id_t member_id = alert[i].id;
+        const EcsMemberRanges *ranges = NULL;
+        if (member_id) {
+            ranges = ecs_ref_get(world, &alert[i].ranges, EcsMemberRanges);
+        }
+
         ecs_iter_t rit = ecs_rule_iter(world, rule);
         rit.flags |= EcsIterNoData;
         rit.flags |= EcsIterIsInstanced;
@@ -19530,9 +19586,33 @@ void MonitorAlerts(ecs_iter_t *it) {
                 severity = default_severity;
             }
 
+            const void *member_data = NULL;
+            if (ranges) {
+                member_data = ecs_table_get_id(
+                    world, rit.table, member_id, rit.offset);
+                if (!member_data) {
+                    continue;
+                }
+                member_data = ECS_OFFSET(member_data, alert[i].offset);
+            }
+
             int32_t j, alert_src_count = rit.count;
             for (j = 0; j < alert_src_count; j ++) {
+                ecs_entity_t src_severity = severity;
                 ecs_entity_t e = rit.entities[j];
+                if (member_data) {
+                    ecs_entity_t range_severity = flecs_alert_out_of_range_kind(
+                        &alert[i], ranges, member_data);
+                    member_data = ECS_OFFSET(member_data, alert[i].size);
+                    if (!range_severity) {
+                        continue;
+                    }
+                    if (range_severity < src_severity) {
+                        /* Range severity should not exceed alert severity */
+                        src_severity = range_severity;
+                    }
+                }
+
                 ecs_entity_t *aptr = ecs_map_ensure(&alert[i].instances, e);
                 ecs_assert(aptr != NULL, ECS_INTERNAL_ERROR, NULL);
                 if (!aptr[0]) {
@@ -19541,7 +19621,7 @@ void MonitorAlerts(ecs_iter_t *it) {
                     ecs_set(world, ai, EcsAlertInstance, { .message = NULL });
                     ecs_set(world, ai, EcsMetricSource, { .entity = e });
                     ecs_set(world, ai, EcsMetricValue, { .value = 0 });
-                    ecs_add_pair(world, ai, ecs_id(EcsAlert), severity);
+                    ecs_add_pair(world, ai, ecs_id(EcsAlert), src_severity);
                     if (alert[i].retain_period != 0) {
                         ecs_set(world, ai, EcsAlertTimeout, {
                             .inactive_time = 0,
@@ -19555,12 +19635,12 @@ void MonitorAlerts(ecs_iter_t *it) {
                     aptr[0] = ai;
                 } else {
                     /* Make sure alert severity is up to date */
-                    if (ecs_vec_count(&alert[i].severity_filters)) {
+                    if (ecs_vec_count(&alert[i].severity_filters) || member_data) {
                         ecs_entity_t cur_severity = ecs_get_target(
                             world, aptr[0], ecs_id(EcsAlert), 0);
-                        if (cur_severity != severity) {
+                        if (cur_severity != src_severity) {
                             ecs_add_pair(world, aptr[0], ecs_id(EcsAlert), 
-                                severity);
+                                src_severity);
                         }
                     }
                 }
@@ -19594,6 +19674,12 @@ void MonitorAlertInstances(ecs_iter_t *it) {
     ecs_rule_t *rule = poly->poly;
     ecs_poly_assert(rule, ecs_rule_t);
 
+    ecs_id_t member_id = alert->id;
+    const EcsMemberRanges *ranges = NULL;
+    if (member_id) {
+        ranges = ecs_ref_get(world, &alert->ranges, EcsMemberRanges);
+    }
+
     ecs_vars_t vars = {0};
     ecs_vars_init(world, &vars);
 
@@ -19601,14 +19687,28 @@ void MonitorAlertInstances(ecs_iter_t *it) {
     for (i = 0; i < count; i ++) {
         ecs_entity_t ai = it->entities[i];
         ecs_entity_t e = source[i].entity;
+        bool range_match = true;
+
+        if (ranges) {
+            const void *member_data = ecs_get_id(world, e, member_id);
+            if (!member_data) {
+                range_match = false;
+            }
+            member_data = ECS_OFFSET(member_data, alert->offset);
+            range_match = flecs_alert_out_of_range_kind(
+                &alert[i], ranges, member_data) != 0;
+        }
 
         /* Check if alert instance still matches rule */
-        ecs_iter_t rit = ecs_rule_iter(world, rule);
-        rit.flags |= EcsIterNoData;
-        rit.flags |= EcsIterIsInstanced;
-        ecs_iter_set_var(&rit, 0, e);
+        ecs_iter_t rit;
+        if (range_match) {
+            rit = ecs_rule_iter(world, rule);
+            rit.flags |= EcsIterNoData;
+            rit.flags |= EcsIterIsInstanced;
+            ecs_iter_set_var(&rit, 0, e);
+        }
 
-        if (ecs_rule_next(&rit)) {
+        if (range_match && ecs_rule_next(&rit)) {
             /* Only increase alert duration if the alert was active */
             value[i].value += (double)it->delta_system_time;
 
@@ -19690,6 +19790,7 @@ ecs_entity_t ecs_alert_init(
 
     ecs_rule_t *rule = ecs_rule_init(world, &private_desc);
     if (!rule) {
+        ecs_err("failed to create alert filter");
         return 0;
     }
 
@@ -19726,6 +19827,63 @@ ecs_entity_t ecs_alert_init(
                 }
             }
         }
+    }
+
+    /* Fetch data for member monitoring */
+    if (desc->member) {
+        alert->member = desc->member;
+        if (!desc->id) {
+            alert->id = ecs_get_parent(world, desc->member);
+            if (!alert->id) {
+                ecs_err("ecs_alert_desc_t::member is not a member");
+                goto error;
+            }
+            ecs_check(alert->id != 0, ECS_INVALID_PARAMETER, NULL);
+        } else {
+            alert->id = desc->id;
+        }
+
+        ecs_id_record_t *idr = flecs_id_record_ensure(world, alert->id);
+        ecs_assert(idr != NULL, ECS_INTERNAL_ERROR, NULL);
+        if (!idr->type_info) {
+            ecs_err("ecs_alert_desc_t::id must be a component");
+            goto error;
+        }
+
+        ecs_entity_t type = idr->type_info->component;
+        if (type != ecs_get_parent(world, desc->member)) {
+            char *type_name = ecs_get_fullpath(world, type);
+            ecs_err("member '%s' is not a member of '%s'", 
+                ecs_get_name(world, desc->member), type_name);
+            ecs_os_free(type_name);
+            goto error;
+        }
+
+        const EcsMember *member = ecs_get(world, alert->member, EcsMember);
+        if (!member) {
+            ecs_err("ecs_alert_desc_t::member is not a member");
+            goto error;
+        }
+        if (!member->type) {
+            ecs_err("ecs_alert_desc_t::member must have a type");
+            goto error;
+        }
+        
+        const EcsPrimitive *pr = ecs_get(world, member->type, EcsPrimitive);
+        if (!pr) {
+            ecs_err("ecs_alert_desc_t::member must be of a primitive type");
+            goto error;
+        }
+
+        if (!ecs_has(world, desc->member, EcsMemberRanges)) {
+            ecs_err("ecs_alert_desc_t::member must have warning/error ranges");
+            goto error;
+        }
+
+        alert->offset = member->offset;
+        alert->size = idr->type_info->size;
+        alert->kind = pr->kind;
+        alert->ranges = ecs_ref_init(world, desc->member, EcsMemberRanges);
     }
 
     ecs_modified(world, result, EcsAlert);

--- a/flecs.c
+++ b/flecs.c
@@ -19371,8 +19371,8 @@ typedef struct EcsAlert {
     /* Member range monitoring */
     ecs_id_t id;                /* (Component) id that contains to monitor member */
     ecs_entity_t member;        /* Member to monitor */
-    uint16_t offset;            /* Offset of member in component */
-    uint16_t size;              /* Size of component */
+    int32_t offset;             /* Offset of member in component */
+    int32_t size;               /* Size of component */
     ecs_primitive_kind_t kind;  /* Primitive type kind */
     ecs_ref_t ranges;           /* Reference to ranges component */
 } EcsAlert;
@@ -19536,7 +19536,7 @@ ecs_entity_t flecs_alert_out_of_range_kind(
     case EcsI16: value = *(int16_t*)value_ptr; break;
     case EcsI32: value = *(int32_t*)value_ptr; break;
     case EcsI64: value = *(int64_t*)value_ptr; break;
-    case EcsF32: value = *(float*)value_ptr; break;
+    case EcsF32: value = (double)*(float*)value_ptr; break;
     case EcsF64: value = *(double*)value_ptr; break;
     default: return 0;
     }

--- a/flecs.h
+++ b/flecs.h
@@ -11653,6 +11653,10 @@ typedef struct ecs_alert_desc_t {
     /** (Component) id of member to monitor. If left to 0 this will be set to
      * the parent entity of the member (optional). */
     ecs_id_t id;
+
+    /** Variable from which to fetch the member (optional). When left to NULL
+     * 'id' will be obtained from $this. */
+    const char *var;
 } ecs_alert_desc_t;
 
 /** Create a new alert.
@@ -29485,12 +29489,19 @@ public:
 
     /** Set member to create an alert for out of range values */
     template <typename T>
-    Base& member(const char *m) {
+    Base& member(const char *m, const char *v = nullptr) {
         flecs::entity_t id = _::cpp_type<T>::id(world_v());
         flecs::entity_t mid = ecs_lookup_path_w_sep(
             world_v(), id, m, "::", "::", false);
         ecs_assert(m != 0, ECS_INVALID_PARAMETER, NULL);
+        m_desc->var = v;
         return this->member(mid);
+    }
+
+    /** Set source variable for member (optional, defaults to $this) */
+    Base& var(const char *v) {
+        m_desc->var = v;
+        return *this;
     }
 
 protected:

--- a/flecs.h
+++ b/flecs.h
@@ -29470,6 +29470,29 @@ public:
             w.pair<T>(constant), var);
     }
 
+    /** Set member to create an alert for out of range values */
+    Base& member(flecs::entity_t member) {
+        m_desc->member = member;
+        return *this;
+    }
+
+    /** Set (component) id for member (optional). If .member() is set and id
+     * is not set, the id will default to the member parent. */
+    Base& id(flecs::id_t id) {
+        m_desc->id = id;
+        return *this;
+    }
+
+    /** Set member to create an alert for out of range values */
+    template <typename T>
+    Base& member(const char *member) {
+        flecs::entity_t id = _::cpp_type<T>::id(world_v());
+        flecs::entity_t m = ecs_lookup_path_w_sep(
+            world_v(), id, member, "::", "::", false);
+        ecs_assert(m != 0, ECS_INVALID_PARAMETER, NULL);
+        return this->member(m);
+    }
+
 protected:
     virtual flecs::world_t* world_v() = 0;
 

--- a/flecs.h
+++ b/flecs.h
@@ -11633,6 +11633,12 @@ typedef struct ecs_alert_desc_t {
      * EcsAlertCritical. Defaults to EcsAlertError. */
     ecs_entity_t severity;
 
+    /** Severity filters can be used to assign different severities to the same
+     * alert. This prevents having to create multiple alerts, and allows 
+     * entities to transition between severities without resetting the 
+     * alert duration (optional). */
+    ecs_alert_severity_filter_t severity_filters[ECS_ALERT_MAX_SEVERITY_FILTERS];
+
     /** The retain period specifies how long an alert must be inactive before it
      * is cleared. This makes it easier to track noisy alerts. While an alert is
      * inactive its duration won't increase. 
@@ -11640,11 +11646,13 @@ typedef struct ecs_alert_desc_t {
      * longer matches the alert query. */
     ecs_ftime_t retain_period;
 
-    /** Severity filters can be used to assign different severities to the same
-     * alert. This prevents having to create multiple alerts, and allows 
-     * entities to transition between severities without resetting the 
-     * alert duration. */
-    ecs_alert_severity_filter_t severity_filters[ECS_ALERT_MAX_SEVERITY_FILTERS];
+    /** Alert when member value is out of range. Uses the warning/error ranges
+     * assigned to the member in the MemberRanges component (optional). */
+    ecs_entity_t member;
+
+    /** (Component) id of member to monitor. If left to 0 this will be set to
+     * the parent entity of the member (optional). */
+    ecs_id_t id;
 } ecs_alert_desc_t;
 
 /** Create a new alert.

--- a/flecs.h
+++ b/flecs.h
@@ -29471,8 +29471,8 @@ public:
     }
 
     /** Set member to create an alert for out of range values */
-    Base& member(flecs::entity_t member) {
-        m_desc->member = member;
+    Base& member(flecs::entity_t m) {
+        m_desc->member = m;
         return *this;
     }
 
@@ -29485,12 +29485,12 @@ public:
 
     /** Set member to create an alert for out of range values */
     template <typename T>
-    Base& member(const char *member) {
+    Base& member(const char *m) {
         flecs::entity_t id = _::cpp_type<T>::id(world_v());
-        flecs::entity_t m = ecs_lookup_path_w_sep(
-            world_v(), id, member, "::", "::", false);
+        flecs::entity_t mid = ecs_lookup_path_w_sep(
+            world_v(), id, m, "::", "::", false);
         ecs_assert(m != 0, ECS_INVALID_PARAMETER, NULL);
-        return this->member(m);
+        return this->member(mid);
     }
 
 protected:

--- a/include/flecs/addons/alerts.h
+++ b/include/flecs/addons/alerts.h
@@ -119,6 +119,10 @@ typedef struct ecs_alert_desc_t {
     /** (Component) id of member to monitor. If left to 0 this will be set to
      * the parent entity of the member (optional). */
     ecs_id_t id;
+
+    /** Variable from which to fetch the member (optional). When left to NULL
+     * 'id' will be obtained from $this. */
+    const char *var;
 } ecs_alert_desc_t;
 
 /** Create a new alert.

--- a/include/flecs/addons/alerts.h
+++ b/include/flecs/addons/alerts.h
@@ -99,6 +99,12 @@ typedef struct ecs_alert_desc_t {
      * EcsAlertCritical. Defaults to EcsAlertError. */
     ecs_entity_t severity;
 
+    /** Severity filters can be used to assign different severities to the same
+     * alert. This prevents having to create multiple alerts, and allows 
+     * entities to transition between severities without resetting the 
+     * alert duration (optional). */
+    ecs_alert_severity_filter_t severity_filters[ECS_ALERT_MAX_SEVERITY_FILTERS];
+
     /** The retain period specifies how long an alert must be inactive before it
      * is cleared. This makes it easier to track noisy alerts. While an alert is
      * inactive its duration won't increase. 
@@ -106,11 +112,13 @@ typedef struct ecs_alert_desc_t {
      * longer matches the alert query. */
     ecs_ftime_t retain_period;
 
-    /** Severity filters can be used to assign different severities to the same
-     * alert. This prevents having to create multiple alerts, and allows 
-     * entities to transition between severities without resetting the 
-     * alert duration. */
-    ecs_alert_severity_filter_t severity_filters[ECS_ALERT_MAX_SEVERITY_FILTERS];
+    /** Alert when member value is out of range. Uses the warning/error ranges
+     * assigned to the member in the MemberRanges component (optional). */
+    ecs_entity_t member;
+
+    /** (Component) id of member to monitor. If left to 0 this will be set to
+     * the parent entity of the member (optional). */
+    ecs_id_t id;
 } ecs_alert_desc_t;
 
 /** Create a new alert.

--- a/include/flecs/addons/cpp/mixins/alerts/builder_i.hpp
+++ b/include/flecs/addons/cpp/mixins/alerts/builder_i.hpp
@@ -132,12 +132,19 @@ public:
 
     /** Set member to create an alert for out of range values */
     template <typename T>
-    Base& member(const char *m) {
+    Base& member(const char *m, const char *v = nullptr) {
         flecs::entity_t id = _::cpp_type<T>::id(world_v());
         flecs::entity_t mid = ecs_lookup_path_w_sep(
             world_v(), id, m, "::", "::", false);
         ecs_assert(m != 0, ECS_INVALID_PARAMETER, NULL);
+        m_desc->var = v;
         return this->member(mid);
+    }
+
+    /** Set source variable for member (optional, defaults to $this) */
+    Base& var(const char *v) {
+        m_desc->var = v;
+        return *this;
     }
 
 protected:

--- a/include/flecs/addons/cpp/mixins/alerts/builder_i.hpp
+++ b/include/flecs/addons/cpp/mixins/alerts/builder_i.hpp
@@ -118,8 +118,8 @@ public:
     }
 
     /** Set member to create an alert for out of range values */
-    Base& member(flecs::entity_t member) {
-        m_desc->member = member;
+    Base& member(flecs::entity_t m) {
+        m_desc->member = m;
         return *this;
     }
 
@@ -132,12 +132,12 @@ public:
 
     /** Set member to create an alert for out of range values */
     template <typename T>
-    Base& member(const char *member) {
+    Base& member(const char *m) {
         flecs::entity_t id = _::cpp_type<T>::id(world_v());
-        flecs::entity_t m = ecs_lookup_path_w_sep(
-            world_v(), id, member, "::", "::", false);
+        flecs::entity_t mid = ecs_lookup_path_w_sep(
+            world_v(), id, m, "::", "::", false);
         ecs_assert(m != 0, ECS_INVALID_PARAMETER, NULL);
-        return this->member(m);
+        return this->member(mid);
     }
 
 protected:

--- a/include/flecs/addons/cpp/mixins/alerts/builder_i.hpp
+++ b/include/flecs/addons/cpp/mixins/alerts/builder_i.hpp
@@ -117,6 +117,29 @@ public:
             w.pair<T>(constant), var);
     }
 
+    /** Set member to create an alert for out of range values */
+    Base& member(flecs::entity_t member) {
+        m_desc->member = member;
+        return *this;
+    }
+
+    /** Set (component) id for member (optional). If .member() is set and id
+     * is not set, the id will default to the member parent. */
+    Base& id(flecs::id_t id) {
+        m_desc->id = id;
+        return *this;
+    }
+
+    /** Set member to create an alert for out of range values */
+    template <typename T>
+    Base& member(const char *member) {
+        flecs::entity_t id = _::cpp_type<T>::id(world_v());
+        flecs::entity_t m = ecs_lookup_path_w_sep(
+            world_v(), id, member, "::", "::", false);
+        ecs_assert(m != 0, ECS_INVALID_PARAMETER, NULL);
+        return this->member(m);
+    }
+
 protected:
     virtual flecs::world_t* world_v() = 0;
 

--- a/src/addons/alerts.c
+++ b/src/addons/alerts.c
@@ -343,7 +343,7 @@ void MonitorAlertInstances(ecs_iter_t *it) {
             } else {
                 member_data = ECS_OFFSET(member_data, alert->offset);
                 range_match = flecs_alert_out_of_range_kind(
-                    &alert[i], ranges, member_data) != 0;
+                    alert, ranges, member_data) != 0;
             }
         }
 

--- a/src/addons/alerts.c
+++ b/src/addons/alerts.c
@@ -178,11 +178,11 @@ ecs_entity_t flecs_alert_out_of_range_kind(
     case EcsU8: value = *(uint8_t*)value_ptr; break;
     case EcsU16: value = *(uint16_t*)value_ptr; break;
     case EcsU32: value = *(uint32_t*)value_ptr; break;
-    case EcsU64: value = *(uint64_t*)value_ptr; break;
+    case EcsU64: value = (double)*(uint64_t*)value_ptr; break;
     case EcsI8: value = *(int8_t*)value_ptr; break;
     case EcsI16: value = *(int16_t*)value_ptr; break;
     case EcsI32: value = *(int32_t*)value_ptr; break;
-    case EcsI64: value = *(int64_t*)value_ptr; break;
+    case EcsI64: value = (double)*(int64_t*)value_ptr; break;
     case EcsF32: value = (double)*(float*)value_ptr; break;
     case EcsF64: value = *(double*)value_ptr; break;
     default: return 0;
@@ -340,10 +340,11 @@ void MonitorAlertInstances(ecs_iter_t *it) {
             const void *member_data = ecs_get_id(world, e, member_id);
             if (!member_data) {
                 range_match = false;
+            } else {
+                member_data = ECS_OFFSET(member_data, alert->offset);
+                range_match = flecs_alert_out_of_range_kind(
+                    &alert[i], ranges, member_data) != 0;
             }
-            member_data = ECS_OFFSET(member_data, alert->offset);
-            range_match = flecs_alert_out_of_range_kind(
-                &alert[i], ranges, member_data) != 0;
         }
 
         /* Check if alert instance still matches rule */

--- a/src/addons/alerts.c
+++ b/src/addons/alerts.c
@@ -18,8 +18,8 @@ typedef struct EcsAlert {
     /* Member range monitoring */
     ecs_id_t id;                /* (Component) id that contains to monitor member */
     ecs_entity_t member;        /* Member to monitor */
-    uint16_t offset;            /* Offset of member in component */
-    uint16_t size;              /* Size of component */
+    int32_t offset;             /* Offset of member in component */
+    int32_t size;               /* Size of component */
     ecs_primitive_kind_t kind;  /* Primitive type kind */
     ecs_ref_t ranges;           /* Reference to ranges component */
 } EcsAlert;
@@ -183,7 +183,7 @@ ecs_entity_t flecs_alert_out_of_range_kind(
     case EcsI16: value = *(int16_t*)value_ptr; break;
     case EcsI32: value = *(int32_t*)value_ptr; break;
     case EcsI64: value = *(int64_t*)value_ptr; break;
-    case EcsF32: value = *(float*)value_ptr; break;
+    case EcsF32: value = (double)*(float*)value_ptr; break;
     case EcsF64: value = *(double*)value_ptr; break;
     default: return 0;
     }

--- a/src/addons/alerts.c
+++ b/src/addons/alerts.c
@@ -22,6 +22,7 @@ typedef struct EcsAlert {
     int32_t size;               /* Size of component */
     ecs_primitive_kind_t kind;  /* Primitive type kind */
     ecs_ref_t ranges;           /* Reference to ranges component */
+    int32_t var_id;             /* Variable from which to obtain data (0 = $this) */
 } EcsAlert;
 
 typedef struct EcsAlertTimeout {
@@ -66,6 +67,7 @@ ECS_MOVE(EcsAlert, dst, src, {
     dst->size = src->size;
     dst->kind = src->kind;
     dst->ranges = src->ranges;
+    dst->var_id = src->var_id;
 })
 
 static
@@ -234,9 +236,20 @@ void MonitorAlerts(ecs_iter_t *it) {
             }
 
             const void *member_data = NULL;
+            ecs_entity_t member_src = 0;
             if (ranges) {
-                member_data = ecs_table_get_id(
-                    world, rit.table, member_id, rit.offset);
+                if (alert[i].var_id) {
+                    member_src = ecs_iter_get_var(&rit, alert[i].var_id);
+                    if (!member_src || member_src == EcsWildcard) {
+                        continue;
+                    }
+                }
+                if (!member_src) {
+                    member_data = ecs_table_get_id(
+                        world, rit.table, member_id, rit.offset);
+                } else {
+                    member_data = ecs_get_id(world, member_src, member_id);
+                }
                 if (!member_data) {
                     continue;
                 }
@@ -250,7 +263,9 @@ void MonitorAlerts(ecs_iter_t *it) {
                 if (member_data) {
                     ecs_entity_t range_severity = flecs_alert_out_of_range_kind(
                         &alert[i], ranges, member_data);
-                    member_data = ECS_OFFSET(member_data, alert[i].size);
+                    if (!member_src) {
+                        member_data = ECS_OFFSET(member_data, alert[i].size);
+                    }
                     if (!range_severity) {
                         continue;
                     }
@@ -334,78 +349,99 @@ void MonitorAlertInstances(ecs_iter_t *it) {
     for (i = 0; i < count; i ++) {
         ecs_entity_t ai = it->entities[i];
         ecs_entity_t e = source[i].entity;
-        bool range_match = true;
 
-        if (ranges) {
-            const void *member_data = ecs_get_id(world, e, member_id);
-            if (!member_data) {
-                range_match = false;
-            } else {
-                member_data = ECS_OFFSET(member_data, alert->offset);
-                range_match = flecs_alert_out_of_range_kind(
-                    alert, ranges, member_data) != 0;
-            }
+        /* If source of alert is no longer alive, delete alert instance even if
+         * the alert has a retain period. */
+        if (!ecs_is_alive(world, e)) {
+            ecs_delete(world, ai);
+            continue;
         }
 
         /* Check if alert instance still matches rule */
-        ecs_iter_t rit;
-        if (range_match) {
-            rit = ecs_rule_iter(world, rule);
-            rit.flags |= EcsIterNoData;
-            rit.flags |= EcsIterIsInstanced;
-            ecs_iter_set_var(&rit, 0, e);
+        ecs_iter_t rit = ecs_rule_iter(world, rule);
+        rit.flags |= EcsIterNoData;
+        rit.flags |= EcsIterIsInstanced;
+        ecs_iter_set_var(&rit, 0, e);
+
+        if (ecs_rule_next(&rit)) {
+            bool match = true;
+
+            /* If alert is monitoring member range, test value against range */
+            if (ranges) {
+                ecs_entity_t member_src = e;
+                if (alert->var_id) {
+                    member_src = ecs_iter_get_var(&rit, alert->var_id);
+                }
+
+                const void *member_data = ecs_get_id(
+                    world, member_src, member_id);
+                if (!member_data) {
+                    match = false;
+                } else {
+                    member_data = ECS_OFFSET(member_data, alert->offset);
+                    if (flecs_alert_out_of_range_kind(
+                        alert, ranges, member_data) == 0) 
+                    {
+                        match = false;
+                    }
+                }
+            }
+
+            if (match) {
+                /* Only increase alert duration if the alert was active */
+                value[i].value += (double)it->delta_system_time;
+
+                bool generate_message = alert->message;
+                if (generate_message) {
+                    if (alert_instance[i].message) {
+                        /* If a message was already generated, only regenerate if
+                        * rule has multiple variables. Variable values could have 
+                        * changed, this ensures the message remains up to date. */
+                        generate_message = rit.variable_count > 1;
+                    }
+                }
+
+                if (generate_message) {
+                    if (alert_instance[i].message) {
+                        ecs_os_free(alert_instance[i].message);
+                    }
+
+                    ecs_iter_to_vars(&rit, &vars, 0);
+                    alert_instance[i].message = ecs_interpolate_string(
+                        world, alert->message, &vars);
+                }
+
+                if (timeout) {
+                    if (timeout[i].inactive_time != 0) {
+                        /* The alert just became active. Remove Disabled tag */
+                        flecs_alerts_add_alert_to_src(world, e, parent, ai);
+                        ecs_remove_id(world, ai, EcsDisabled);
+                    }
+                    timeout[i].inactive_time = 0;
+                }
+
+                /* Alert instance still matches rule, keep it alive */
+                ecs_iter_fini(&rit);
+                continue;
+            }
+
+            ecs_iter_fini(&rit);
         }
 
-        if (range_match && ecs_rule_next(&rit)) {
-            /* Only increase alert duration if the alert was active */
-            value[i].value += (double)it->delta_system_time;
+        /* Alert instance is no longer active */
 
-            bool generate_message = alert->message;
-            if (generate_message) {
-                if (alert_instance[i].message) {
-                    /* If a message was already generated, only regenerate if
-                     * rule has multiple variables. Variable values could have 
-                     * changed, this ensures the message remains up to date. */
-                    generate_message = rit.variable_count > 1;
-                }
+        if (timeout) {
+            if (timeout[i].inactive_time == 0) {
+                /* The alert just became inactive. Add Disabled tag */
+                flecs_alerts_remove_alert_from_src(world, e, parent);
+                ecs_add_id(world, ai, EcsDisabled);
             }
-
-            if (generate_message) {
-                if (alert_instance[i].message) {
-                    ecs_os_free(alert_instance[i].message);
-                }
-
-                ecs_iter_to_vars(&rit, &vars, 0);
-                alert_instance[i].message = ecs_interpolate_string(
-                    world, alert->message, &vars);
-            }
-
-            if (timeout) {
-                if (timeout[i].inactive_time != 0) {
-                    /* The alert just became active. Remove Disabled tag */
-                    flecs_alerts_add_alert_to_src(world, e, parent, ai);
-                    ecs_remove_id(world, ai, EcsDisabled);
-                }
-                timeout[i].inactive_time = 0;
-            }
-
-            /* Alert instance still matches rule, keep it alive */
-            ecs_iter_fini(&rit);
-            continue;
-        } else {
-            if (timeout) {
-                if (timeout[i].inactive_time == 0) {
-                    /* The alert just became inactive. Add Disabled tag */
-                    flecs_alerts_remove_alert_from_src(world, e, parent);
-                    ecs_add_id(world, ai, EcsDisabled);
-                }
-                ecs_ftime_t t = timeout[i].inactive_time;
-                timeout[i].inactive_time += it->delta_system_time;
-                if (t < timeout[i].expire_time) {
-                    /* Alert instance no longer matches rule, but is still
-                     * within the timeout period. Keep it alive. */
-                    continue;
-                }
+            ecs_ftime_t t = timeout[i].inactive_time;
+            timeout[i].inactive_time += it->delta_system_time;
+            if (t < timeout[i].expire_time) {
+                /* Alert instance no longer matches rule, but is still
+                    * within the timeout period. Keep it alive. */
+                continue;
             }
         }
 
@@ -528,10 +564,20 @@ ecs_entity_t ecs_alert_init(
             goto error;
         }
 
+        int32_t var_id = 0;
+        if (desc->var) {
+            var_id = ecs_rule_find_var(rule, desc->var);
+            if (var_id == -1) {
+                ecs_err("unresolved variable '%s' in alert member", desc->var);
+                goto error;
+            }
+        }
+
         alert->offset = member->offset;
         alert->size = idr->type_info->size;
         alert->kind = pr->kind;
         alert->ranges = ecs_ref_init(world, desc->member, EcsMemberRanges);
+        alert->var_id = var_id;
     }
 
     ecs_modified(world, result, EcsAlert);

--- a/src/addons/json/serialize.c
+++ b/src/addons/json/serialize.c
@@ -1022,7 +1022,6 @@ int ecs_entity_to_json_buf(
             while (ecs_map_next(&it)) {
                 flecs_json_next(buf);
                 flecs_json_object_push(buf);
-                ecs_entity_t a = ecs_map_key(&it);
                 ecs_entity_t ai = ecs_map_value(&it);
                 char *alert_name = ecs_get_fullpath(world, ai);
                 flecs_json_memberl(buf, "alert");
@@ -1030,7 +1029,7 @@ int ecs_entity_to_json_buf(
                 ecs_os_free(alert_name);
 
                 ecs_entity_t severity_id = ecs_get_target(
-                    world, a, ecs_id(EcsAlert), 0);
+                    world, ai, ecs_id(EcsAlert), 0);
                 const char *severity = ecs_get_name(world, severity_id);
 
                 const EcsAlertInstance *alert = ecs_get(

--- a/test/addons/project.json
+++ b/test/addons/project.json
@@ -1586,7 +1586,8 @@
                 "member_range_invalid_member_child",
                 "member_range_invalid_type",
                 "member_range_invalid_member_type",
-                "member_range_no_range"
+                "member_range_no_range",
+                "member_range_alert_two_instances"
             ]
         }]
     }

--- a/test/addons/project.json
+++ b/test/addons/project.json
@@ -1587,7 +1587,10 @@
                 "member_range_invalid_type",
                 "member_range_invalid_member_type",
                 "member_range_no_range",
-                "member_range_alert_two_instances"
+                "member_range_alert_two_instances",
+                "member_range_from_var",
+                "member_range_from_var_after_remove",
+                "retained_alert_w_dead_source"
             ]
         }]
     }

--- a/test/addons/project.json
+++ b/test/addons/project.json
@@ -1574,7 +1574,19 @@
                 "severity_filter",
                 "two_severity_filters",
                 "severity_filter_w_var",
-                "severity_filter_w_var_change_var"
+                "severity_filter_w_var_change_var",
+                "member_range_warning",
+                "member_range_error",
+                "member_range_warning_error",
+                "member_range_error_w_warning_severity",
+                "member_range_error_w_severity_filter",
+                "member_range_warning_w_severity_filter",
+                "member_range_pair_id",
+                "member_range_invalid_member",
+                "member_range_invalid_member_child",
+                "member_range_invalid_type",
+                "member_range_invalid_member_type",
+                "member_range_no_range"
             ]
         }]
     }

--- a/test/addons/src/main.c
+++ b/test/addons/src/main.c
@@ -1515,6 +1515,9 @@ void Alerts_member_range_invalid_type(void);
 void Alerts_member_range_invalid_member_type(void);
 void Alerts_member_range_no_range(void);
 void Alerts_member_range_alert_two_instances(void);
+void Alerts_member_range_from_var(void);
+void Alerts_member_range_from_var_after_remove(void);
+void Alerts_retained_alert_w_dead_source(void);
 
 bake_test_case Parser_testcases[] = {
     {
@@ -7338,6 +7341,18 @@ bake_test_case Alerts_testcases[] = {
     {
         "member_range_alert_two_instances",
         Alerts_member_range_alert_two_instances
+    },
+    {
+        "member_range_from_var",
+        Alerts_member_range_from_var
+    },
+    {
+        "member_range_from_var_after_remove",
+        Alerts_member_range_from_var_after_remove
+    },
+    {
+        "retained_alert_w_dead_source",
+        Alerts_retained_alert_w_dead_source
     }
 };
 
@@ -7584,7 +7599,7 @@ static bake_test_suite suites[] = {
         "Alerts",
         NULL,
         NULL,
-        32,
+        35,
         Alerts_testcases
     }
 };

--- a/test/addons/src/main.c
+++ b/test/addons/src/main.c
@@ -1502,6 +1502,18 @@ void Alerts_severity_filter(void);
 void Alerts_two_severity_filters(void);
 void Alerts_severity_filter_w_var(void);
 void Alerts_severity_filter_w_var_change_var(void);
+void Alerts_member_range_warning(void);
+void Alerts_member_range_error(void);
+void Alerts_member_range_warning_error(void);
+void Alerts_member_range_error_w_warning_severity(void);
+void Alerts_member_range_error_w_severity_filter(void);
+void Alerts_member_range_warning_w_severity_filter(void);
+void Alerts_member_range_pair_id(void);
+void Alerts_member_range_invalid_member(void);
+void Alerts_member_range_invalid_member_child(void);
+void Alerts_member_range_invalid_type(void);
+void Alerts_member_range_invalid_member_type(void);
+void Alerts_member_range_no_range(void);
 
 bake_test_case Parser_testcases[] = {
     {
@@ -7273,6 +7285,54 @@ bake_test_case Alerts_testcases[] = {
     {
         "severity_filter_w_var_change_var",
         Alerts_severity_filter_w_var_change_var
+    },
+    {
+        "member_range_warning",
+        Alerts_member_range_warning
+    },
+    {
+        "member_range_error",
+        Alerts_member_range_error
+    },
+    {
+        "member_range_warning_error",
+        Alerts_member_range_warning_error
+    },
+    {
+        "member_range_error_w_warning_severity",
+        Alerts_member_range_error_w_warning_severity
+    },
+    {
+        "member_range_error_w_severity_filter",
+        Alerts_member_range_error_w_severity_filter
+    },
+    {
+        "member_range_warning_w_severity_filter",
+        Alerts_member_range_warning_w_severity_filter
+    },
+    {
+        "member_range_pair_id",
+        Alerts_member_range_pair_id
+    },
+    {
+        "member_range_invalid_member",
+        Alerts_member_range_invalid_member
+    },
+    {
+        "member_range_invalid_member_child",
+        Alerts_member_range_invalid_member_child
+    },
+    {
+        "member_range_invalid_type",
+        Alerts_member_range_invalid_type
+    },
+    {
+        "member_range_invalid_member_type",
+        Alerts_member_range_invalid_member_type
+    },
+    {
+        "member_range_no_range",
+        Alerts_member_range_no_range
     }
 };
 
@@ -7519,7 +7579,7 @@ static bake_test_suite suites[] = {
         "Alerts",
         NULL,
         NULL,
-        19,
+        31,
         Alerts_testcases
     }
 };

--- a/test/addons/src/main.c
+++ b/test/addons/src/main.c
@@ -1514,6 +1514,7 @@ void Alerts_member_range_invalid_member_child(void);
 void Alerts_member_range_invalid_type(void);
 void Alerts_member_range_invalid_member_type(void);
 void Alerts_member_range_no_range(void);
+void Alerts_member_range_alert_two_instances(void);
 
 bake_test_case Parser_testcases[] = {
     {
@@ -7333,6 +7334,10 @@ bake_test_case Alerts_testcases[] = {
     {
         "member_range_no_range",
         Alerts_member_range_no_range
+    },
+    {
+        "member_range_alert_two_instances",
+        Alerts_member_range_alert_two_instances
     }
 };
 
@@ -7579,7 +7584,7 @@ static bake_test_suite suites[] = {
         "Alerts",
         NULL,
         NULL,
-        31,
+        32,
         Alerts_testcases
     }
 };

--- a/test/cpp_api/project.json
+++ b/test/cpp_api/project.json
@@ -1208,7 +1208,8 @@
                 "alert_w_severity_filter_severity_type_w_var",
                 "alert_w_severity_filter_severity_type_id_type_w_var",
                 "alert_w_severity_filter_severity_type_enum_constant_w_var",
-                "alert_for_member_range"
+                "alert_for_member_range",
+                "alert_w_member_range_from_var"
             ]
         }, {
             "id": "Meta",

--- a/test/cpp_api/project.json
+++ b/test/cpp_api/project.json
@@ -1207,7 +1207,8 @@
                 "alert_w_severity_filter_w_var",
                 "alert_w_severity_filter_severity_type_w_var",
                 "alert_w_severity_filter_severity_type_id_type_w_var",
-                "alert_w_severity_filter_severity_type_enum_constant_w_var"
+                "alert_w_severity_filter_severity_type_enum_constant_w_var",
+                "alert_for_member_range"
             ]
         }, {
             "id": "Meta",

--- a/test/cpp_api/src/Misc.cpp
+++ b/test/cpp_api/src/Misc.cpp
@@ -1831,3 +1831,61 @@ void Misc_alert_for_member_range() {
         test_assert(ai == 0);
     }
 }
+
+void Misc_alert_w_member_range_from_var() {
+    flecs::world ecs;
+
+    ecs.import<flecs::alerts>();
+
+    ecs.component<Mass>()
+        .member<float>("value")
+            .error_range(0, 100);
+
+    flecs::entity a = ecs.alert("high_parent_mass")
+        .with(flecs::ChildOf).second("$parent")
+        .with<Mass>().src("$parent")
+        .message("$this has high mass")
+        .member<Mass>("value", "parent")
+        .build();
+    test_assert(a != 0);
+    test_str(a.name().c_str(), "high_parent_mass");
+
+    auto p = ecs.entity().set<Mass>({25});
+    auto e1 = ecs.entity("e1").child_of(p);
+
+    ecs.progress(1.0);
+
+    test_assert(!e1.has<flecs::alerts::AlertsActive>());
+
+    p.set<Mass>({150});
+
+    ecs.progress(1.0);
+
+    test_assert(e1.has<flecs::alerts::AlertsActive>());
+    test_int(e1.alert_count(), 1);
+    test_int(e1.alert_count(a), 1);
+
+    {
+        flecs::entity ai = ecs.filter_builder()
+            .with<flecs::alerts::Instance>()
+            .build()
+            .first();
+        test_assert(ai != 0);
+        test_assert(ai.has<flecs::alerts::Instance>());
+        test_assert(ai.has<flecs::metrics::Source>());
+        test_assert(ai.get<flecs::metrics::Source>()->entity == e1);
+        test_assert(ai.parent() == a);
+    }
+
+    p.set<Mass>({0});
+
+    ecs.progress(1.0);
+
+    {
+        flecs::entity ai = ecs.filter_builder()
+            .with<flecs::alerts::Instance>()
+            .build()
+            .first();
+        test_assert(ai == 0);
+    }
+}

--- a/test/cpp_api/src/main.cpp
+++ b/test/cpp_api/src/main.cpp
@@ -1154,6 +1154,7 @@ void Misc_alert_w_severity_filter_w_var(void);
 void Misc_alert_w_severity_filter_severity_type_w_var(void);
 void Misc_alert_w_severity_filter_severity_type_id_type_w_var(void);
 void Misc_alert_w_severity_filter_severity_type_enum_constant_w_var(void);
+void Misc_alert_for_member_range(void);
 
 // Testsuite 'Meta'
 void Meta_struct(void);
@@ -5698,6 +5699,10 @@ bake_test_case Misc_testcases[] = {
     {
         "alert_w_severity_filter_severity_type_enum_constant_w_var",
         Misc_alert_w_severity_filter_severity_type_enum_constant_w_var
+    },
+    {
+        "alert_for_member_range",
+        Misc_alert_for_member_range
     }
 };
 
@@ -6207,7 +6212,7 @@ static bake_test_suite suites[] = {
         "Misc",
         Misc_setup,
         NULL,
-        44,
+        45,
         Misc_testcases
     },
     {

--- a/test/cpp_api/src/main.cpp
+++ b/test/cpp_api/src/main.cpp
@@ -1155,6 +1155,7 @@ void Misc_alert_w_severity_filter_severity_type_w_var(void);
 void Misc_alert_w_severity_filter_severity_type_id_type_w_var(void);
 void Misc_alert_w_severity_filter_severity_type_enum_constant_w_var(void);
 void Misc_alert_for_member_range(void);
+void Misc_alert_w_member_range_from_var(void);
 
 // Testsuite 'Meta'
 void Meta_struct(void);
@@ -5703,6 +5704,10 @@ bake_test_case Misc_testcases[] = {
     {
         "alert_for_member_range",
         Misc_alert_for_member_range
+    },
+    {
+        "alert_w_member_range_from_var",
+        Misc_alert_w_member_range_from_var
     }
 };
 
@@ -6212,7 +6217,7 @@ static bake_test_suite suites[] = {
         "Misc",
         Misc_setup,
         NULL,
-        45,
+        46,
         Misc_testcases
     },
     {

--- a/test/meta/project.json
+++ b/test/meta/project.json
@@ -709,6 +709,7 @@
                 "serialize_entity_from_core",
                 "serialize_entity_w_1_alert",
                 "serialize_entity_w_2_alerts",
+                "serialize_entity_w_severity_filter_alert",
                 "serialize_iterator_1_comps_empty",
                 "serialize_iterator_1_comps_2_ents_same_table",
                 "serialize_iterator_1_tag_2_ents_same_table",

--- a/test/meta/src/SerializeToJson.c
+++ b/test/meta/src/SerializeToJson.c
@@ -2373,6 +2373,55 @@ void SerializeToJson_serialize_entity_w_2_alerts() {
     ecs_fini(world);
 }
 
+void SerializeToJson_serialize_entity_w_severity_filter_alert() {
+    ecs_world_t *world = ecs_init();
+
+    ECS_IMPORT(world, FlecsAlerts);
+
+    ECS_COMPONENT(world, Position);
+    ECS_COMPONENT(world, Velocity);
+    ECS_TAG(world, Tag);
+
+    ecs_entity_t alert = ecs_alert(world, {
+        .entity = ecs_new_entity(world, "position_without_velocity"),
+        .filter.expr = "Position, !Velocity",
+        .message = "$this has Position but not Velocity",
+        .severity_filters[0] = {
+            .severity = EcsAlertWarning,
+            .with = Tag
+        }
+    });
+
+    ecs_entity_t e1 = ecs_new_entity(world, "e1");
+    ecs_set(world, e1, Position, {10, 20});
+    ecs_add(world, e1, Tag);
+
+    ecs_progress(world, 1.0); /* Evaluate alert logic */
+
+    /* Give alert instance name so we don't have to test unstable entity ids */
+    ecs_entity_t ai = ecs_get_alert(world, e1, alert);
+    test_assert(ai != 0);
+    ecs_set_name(world, ai, "e1_alert");
+
+    ecs_entity_to_json_desc_t desc = ECS_ENTITY_TO_JSON_INIT;
+    desc.serialize_alerts = true;
+    char *json = ecs_entity_to_json(world, e1, &desc);
+    test_assert(json != NULL);
+
+    test_str(json, "{"
+        "\"path\":\"e1\", "
+        "\"ids\":[[\"Position\"], [\"Tag\"]], "
+        "\"alerts\":[{"
+            "\"alert\":\"position_without_velocity.e1_alert\", "
+            "\"message\":\"e1 has Position but not Velocity\", "
+            "\"severity\":\"Warning\""
+        "}]"
+    "}");
+    ecs_os_free(json);
+
+    ecs_fini(world);
+}
+
 void SerializeToJson_serialize_iterator_1_comps_empty() {
     ecs_world_t *world = ecs_init();
 

--- a/test/meta/src/main.c
+++ b/test/meta/src/main.c
@@ -678,6 +678,7 @@ void SerializeToJson_serialize_entity_w_union_property(void);
 void SerializeToJson_serialize_entity_from_core(void);
 void SerializeToJson_serialize_entity_w_1_alert(void);
 void SerializeToJson_serialize_entity_w_2_alerts(void);
+void SerializeToJson_serialize_entity_w_severity_filter_alert(void);
 void SerializeToJson_serialize_iterator_1_comps_empty(void);
 void SerializeToJson_serialize_iterator_1_comps_2_ents_same_table(void);
 void SerializeToJson_serialize_iterator_1_tag_2_ents_same_table(void);
@@ -3564,6 +3565,10 @@ bake_test_case SerializeToJson_testcases[] = {
         SerializeToJson_serialize_entity_w_2_alerts
     },
     {
+        "serialize_entity_w_severity_filter_alert",
+        SerializeToJson_serialize_entity_w_severity_filter_alert
+    },
+    {
         "serialize_iterator_1_comps_empty",
         SerializeToJson_serialize_iterator_1_comps_empty
     },
@@ -4724,7 +4729,7 @@ static bake_test_suite suites[] = {
         "SerializeToJson",
         NULL,
         NULL,
-        134,
+        135,
         SerializeToJson_testcases
     },
     {


### PR DESCRIPTION
This PR adds the ability to generate alerts from members with values that are out of range. For example:

```cpp
ecs.component<CpuUtilization>()
    .member<float>("value")
        .warning_range(0, 70)
        .error_range(0, 80);

ecs.alert("high_cpu")
    .with<CpuUtilization>()
    .message("$this has high CPU utilization")
    .member<CpuUtilization>("value")
    .build();

ecs.entity().set<CpuUtilization>({ 75 }); // throws alert with severity Warning
ecs.entity().set<CpuUtilization>({ 85 }); // throws alert with severity Error
```