### PR TITLE
Fix FreeBSD compilation

### DIFF
--- a/src/addons/http.c
+++ b/src/addons/http.c
@@ -56,6 +56,9 @@ typedef SOCKET ecs_http_socket_t;
 #include <strings.h>
 #include <signal.h>
 #include <fcntl.h>
+#ifdef __FreeBSD__
+#include <netinet/in.h>
+#endif
 typedef int ecs_http_socket_t;
 #endif
 


### PR DESCRIPTION
https://man.freebsd.org/cgi/man.cgi
https://github.com/leostratus/netinet/blob/master/in.h

Should fix compilation errors on FreeBSD:
```
  1176:53: error: use of undeclared identifier 'IPPROTO_TCP'
          sock = socket(addr->sa_family, SOCK_STREAM, IPPROTO_TCP);
                                                      ^
  /root/.xmake/cache/packages/2306/f/flecs/v3.2.4/source/src/addons/http.c:1193:34: error: use of undeclared identifier 'IPPROTO_IPV6'
              if (setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, 
                                   ^
  /root/.xmake/cache/packages/2306/f/flecs/v3.2.4/source/src/addons/http.c:1193:48: error: use of undeclared identifier 'IPV6_V6ONLY'
              if (setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, 
                                                 ^
  /root/.xmake/cache/packages/2306/f/flecs/v3.2.4/source/src/addons/http.c:1261:24: error: variable has incomplete type 'struct sockaddr_in'
      struct sockaddr_in addr;
                         ^
  /root/.xmake/cache/packages/2306/f/flecs/v3.2.4/source/src/addons/http.c:1261:12: note: forward declaration of 'struct sockaddr_in'
      struct sockaddr_in addr;
             ^
  /root/.xmake/cache/packages/2306/f/flecs/v3.2.4/source/src/addons/http.c:1267:38: error: use of undeclared identifier 'INADDR_ANY'
          addr.sin_addr.s_addr = htonl(INADDR_ANY);
                                       ^
  5 errors generated.
  gmake[2]: *** [CMakeFiles/flecs.dir/build.make:202: CMakeFiles/flecs.dir/src/addons/http.c.o] Error 1
```