### PR TITLE
Don't return malformed JSON from REST API if serialization failed

### DIFF
--- a/flecs.c
+++ b/flecs.c
@@ -37211,7 +37211,12 @@ bool flecs_rest_reply_entity(
 
     ecs_entity_to_json_desc_t desc = ECS_ENTITY_TO_JSON_INIT;
     flecs_rest_parse_json_ser_entity_params(&desc, req);
-    ecs_entity_to_json_buf(world, e, &reply->body, &desc);
+    if (ecs_entity_to_json_buf(world, e, &reply->body, &desc) != 0) {
+        ecs_strbuf_reset(&reply->body);
+        reply->code = 500;
+        reply->status = "Internal server error";
+        return true;
+    }
     return true;
 }
 
@@ -37222,7 +37227,12 @@ bool flecs_rest_reply_world(
     ecs_http_reply_t *reply)
 {
     (void)req;
-    ecs_world_to_json_buf(world, &reply->body, NULL);
+    if (ecs_world_to_json_buf(world, &reply->body, NULL) != 0) {
+        ecs_strbuf_reset(&reply->body);
+        reply->code = 500;
+        reply->status = "Internal server error";
+        return true;
+    }
     return true;
 }
 

--- a/src/addons/rest.c
+++ b/src/addons/rest.c
@@ -221,7 +221,12 @@ bool flecs_rest_reply_entity(
 
     ecs_entity_to_json_desc_t desc = ECS_ENTITY_TO_JSON_INIT;
     flecs_rest_parse_json_ser_entity_params(&desc, req);
-    ecs_entity_to_json_buf(world, e, &reply->body, &desc);
+    if (ecs_entity_to_json_buf(world, e, &reply->body, &desc) != 0) {
+        ecs_strbuf_reset(&reply->body);
+        reply->code = 500;
+        reply->status = "Internal server error";
+        return true;
+    }
     return true;
 }
 
@@ -232,7 +237,12 @@ bool flecs_rest_reply_world(
     ecs_http_reply_t *reply)
 {
     (void)req;
-    ecs_world_to_json_buf(world, &reply->body, NULL);
+    if (ecs_world_to_json_buf(world, &reply->body, NULL) != 0) {
+        ecs_strbuf_reset(&reply->body);
+        reply->code = 500;
+        reply->status = "Internal server error";
+        return true;
+    }
     return true;
 }
 


### PR DESCRIPTION
Previously when generating a reply for the entity and world REST API endpoints, the code ignored any errors, this meant it would send partial JSON data to the client with a 200 OK HTTP response.

This change instead checks if serialization was successful and if not will clear the body of the response and return a 500 Internal server error instead.
