### PR TITLE
Remove entities support from ecs_field functions

### DIFF
--- a/flecs.c
+++ b/flecs.c
@@ -59455,68 +59455,53 @@ bool flecs_iter_next_instanced(
 void* ecs_field_w_size(
     const ecs_iter_t *it,
     size_t size,
-    int32_t term)
+    int32_t index)
 {
     ecs_check(it->flags & EcsIterIsValid, ECS_INVALID_PARAMETER, NULL);
-    ecs_check(it->ptrs != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_check(!size || ecs_field_size(it, term) == size || 
-        (!ecs_field_size(it, term) && (!it->ptrs[term - 1])), 
+    ecs_assert(index >= 1, ECS_INVALID_PARAMETER, NULL);
+
+    ecs_check(!size || ecs_field_size(it, index) == size ||
+        (!ecs_field_size(it, index) && (!it->ptrs[index - 1])),
             ECS_INVALID_PARAMETER, NULL);
     (void)size;
 
-    if (!term) {
-        return it->entities;
-    }
-
-    return it->ptrs[term - 1];
+    return it->ptrs[index - 1];
 error:
     return NULL;
 }
 
 bool ecs_field_is_readonly(
     const ecs_iter_t *it,
-    int32_t term_index)
+    int32_t index)
 {
     ecs_check(it->flags & EcsIterIsValid, ECS_INVALID_PARAMETER, NULL);
-    ecs_check(term_index > 0, ECS_INVALID_PARAMETER, NULL);
+    ecs_assert(index >= 1, ECS_INVALID_PARAMETER, NULL);
+    ecs_term_t *term = &it->terms[index - 1];
 
-    ecs_term_t *term = &it->terms[term_index - 1];
-    ecs_check(term != NULL, ECS_INVALID_PARAMETER, NULL);
-    
     if (term->inout == EcsIn) {
         return true;
-    } else {
+    } else if (term->inout == EcsInOutDefault) {
+        if (!ecs_term_match_this(term)) {
+            return true;
+        }
+
         ecs_term_id_t *src = &term->src;
-
-        if (term->inout == EcsInOutDefault) {
-            if (!(ecs_term_match_this(term))) {
-                return true;
-            }
-
-            if (!(src->flags & EcsSelf)) {
-                return true;
-            }
+        if (!(src->flags & EcsSelf)) {
+            return true;
         }
     }
-
 error:
     return false;
 }
 
 bool ecs_field_is_writeonly(
     const ecs_iter_t *it,
-    int32_t term_index)
+    int32_t index)
 {
     ecs_check(it->flags & EcsIterIsValid, ECS_INVALID_PARAMETER, NULL);
-    ecs_check(term_index > 0, ECS_INVALID_PARAMETER, NULL);
-
-    ecs_term_t *term = &it->terms[term_index - 1];
-    ecs_check(term != NULL, ECS_INVALID_PARAMETER, NULL);
-    
-    if (term->inout == EcsOut) {
-        return true;
-    }
-
+    ecs_assert(index >= 1, ECS_INVALID_PARAMETER, NULL);
+    ecs_term_t *term = &it->terms[index - 1];
+    return term->inout == EcsOut;
 error:
     return false;
 }
@@ -59526,7 +59511,7 @@ bool ecs_field_is_set(
     int32_t index)
 {
     ecs_check(it->flags & EcsIterIsValid, ECS_INVALID_PARAMETER, NULL);
-
+    ecs_assert(index >= 1, ECS_INVALID_PARAMETER, NULL);
     int32_t column = it->columns[index - 1];
     if (!column) {
         return false;
@@ -59539,7 +59524,6 @@ bool ecs_field_is_set(
             return true;
         }
     }
-
     return true;
 error:
     return false;
@@ -59549,8 +59533,7 @@ bool ecs_field_is_self(
     const ecs_iter_t *it,
     int32_t index)
 {
-    ecs_assert(it != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(index >= 0, ECS_INVALID_PARAMETER, NULL);
+    ecs_assert(index >= 1, ECS_INVALID_PARAMETER, NULL);
     return it->sources == NULL || it->sources[index - 1] == 0;
 }
 
@@ -59558,8 +59541,7 @@ ecs_id_t ecs_field_id(
     const ecs_iter_t *it,
     int32_t index)
 {
-    ecs_assert(it != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(index >= 0, ECS_INVALID_PARAMETER, NULL);
+    ecs_assert(index >= 1, ECS_INVALID_PARAMETER, NULL);
     return it->ids[index - 1];
 }
 
@@ -59567,23 +59549,20 @@ int32_t ecs_field_column_index(
     const ecs_iter_t *it,
     int32_t index)
 {
-    ecs_assert(it != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(index >= 0, ECS_INVALID_PARAMETER, NULL);
-
+    ecs_assert(index >= 1, ECS_INVALID_PARAMETER, NULL);
     int32_t result = it->columns[index - 1];
     if (result <= 0) {
         return -1;
+    } else {
+        return result - 1;
     }
-
-    return result - 1;
 }
 
 ecs_entity_t ecs_field_src(
     const ecs_iter_t *it,
     int32_t index)
 {
-    ecs_assert(it != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(index >= 0, ECS_INVALID_PARAMETER, NULL);
+    ecs_assert(index >= 1, ECS_INVALID_PARAMETER, NULL);
     if (it->sources) {
         return it->sources[index - 1];
     } else {
@@ -59595,14 +59574,8 @@ size_t ecs_field_size(
     const ecs_iter_t *it,
     int32_t index)
 {
-    ecs_assert(it != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(index >= 0, ECS_INVALID_PARAMETER, NULL);
-
-    if (index == 0) {
-        return sizeof(ecs_entity_t);
-    } else {
-        return (size_t)it->sizes[index - 1];
-    }
+    ecs_assert(index >= 1, ECS_INVALID_PARAMETER, NULL);
+    return (size_t)it->sizes[index - 1];
 }
 
 char* ecs_iter_str(

--- a/flecs.h
+++ b/flecs.h
@@ -20900,6 +20900,14 @@ public:
         return get_unchecked_field(index);
     }
 
+    /** Get readonly access to entity ids.
+     *
+     * @return The entity ids.
+     */
+    flecs::column<const flecs::entity_t> entities() const {
+        return flecs::column<const flecs::entity_t>(m_iter->entities, static_cast<size_t>(m_iter->count), false);
+    }
+
     /** Obtain the total number of tables the iterator will iterate over. */
     int32_t table_count() const {
         return m_iter->table_count;

--- a/include/flecs/addons/cpp/iter.hpp
+++ b/include/flecs/addons/cpp/iter.hpp
@@ -374,6 +374,14 @@ public:
         return get_unchecked_field(index);
     }
 
+    /** Get readonly access to entity ids.
+     *
+     * @return The entity ids.
+     */
+    flecs::column<const flecs::entity_t> entities() const {
+        return flecs::column<const flecs::entity_t>(m_iter->entities, static_cast<size_t>(m_iter->count), false);
+    }
+
     /** Obtain the total number of tables the iterator will iterate over. */
     int32_t table_count() const {
         return m_iter->table_count;

--- a/test/addons/src/util.c
+++ b/test/addons/src/util.c
@@ -26,24 +26,15 @@ void probe_system_w_ctx(
         test_assert(e != 0);
     }
 
-    if (it->entities) {
-        ecs_entity_t *e = ecs_field(it, ecs_entity_t, 0);
-        if (e) {
-            test_assert(e != NULL);
-            test_assert(it->entities != NULL);
-            test_assert(it->entities == e);
-            
-            for (i = 0; i < it->count; i ++) {
-                if (i + ctx->count < 256) {
-                    ctx->e[i + ctx->count] = e[i];
-                } else {
-                    /* can't store more than that, tests shouldn't rely on
-                     * getting back more than 256 results */
-                }
-            }
-            ctx->count += it->count;
+    for (i = 0; i < it->count; i ++) {
+        if (i + ctx->count < 256) {
+            ctx->e[i + ctx->count] = it->entities[i];
+        } else {
+            /* can't store more than that, tests shouldn't rely on
+                * getting back more than 256 results */
         }
     }
+    ctx->count += it->count;
 
     ctx->invoked ++;
 }

--- a/test/api/src/util.c
+++ b/test/api/src/util.c
@@ -26,24 +26,15 @@ void probe_system_w_ctx(
         test_assert(e != 0);
     }
 
-    if (it->entities) {
-        ecs_entity_t *e = ecs_field(it, ecs_entity_t, 0);
-        if (e) {
-            test_assert(e != NULL);
-            test_assert(it->entities != NULL);
-            test_assert(it->entities == e);
-            
-            for (i = 0; i < it->count; i ++) {
-                if (i + ctx->count < 256) {
-                    ctx->e[i + ctx->count] = e[i];
-                } else {
-                    /* can't store more than that, tests shouldn't rely on
-                     * getting back more than 256 results */
-                }
-            }
-            ctx->count += it->count;
+    for (i = 0; i < it->count; i ++) {
+        if (i + ctx->count < 256) {
+            ctx->e[i + ctx->count] = it->entities[i];
+        } else {
+            /* can't store more than that, tests shouldn't rely on
+                * getting back more than 256 results */
         }
     }
+    ctx->count += it->count;
 
     ctx->invoked ++;
 }

--- a/test/cpp_api/src/Query.cpp
+++ b/test/cpp_api/src/Query.cpp
@@ -2229,3 +2229,21 @@ void Query_worker_iter_captured_query() {
         test_int(count, 1);
     }();
 }
+
+void Query_iter_entities() {
+    flecs::world ecs;
+
+    auto e1 = ecs.entity().set<Position>({10, 20});
+    auto e2 = ecs.entity().set<Position>({10, 20});
+    auto e3 = ecs.entity().set<Position>({10, 20});
+
+    ecs.query<Position>()
+        .iter([&](flecs::iter& it) {
+            test_int(it.count(), 3);
+
+            auto entities = it.entities();
+            test_assert(entities[0] == e1);
+            test_assert(entities[1] == e2);
+            test_assert(entities[2] == e3);
+        });
+}

--- a/test/cpp_api/src/main.cpp
+++ b/test/cpp_api/src/main.cpp
@@ -561,6 +561,7 @@ void Query_instanced_nested_query_w_world(void);
 void Query_captured_query(void);
 void Query_page_iter_captured_query(void);
 void Query_worker_iter_captured_query(void);
+void Query_iter_entities(void);
 
 // Testsuite 'QueryBuilder'
 void QueryBuilder_builder_assign_same_type(void);
@@ -3407,6 +3408,10 @@ bake_test_case Query_testcases[] = {
     {
         "worker_iter_captured_query",
         Query_worker_iter_captured_query
+    },
+    {
+        "iter_entities",
+        Query_iter_entities
     }
 };
 
@@ -6112,7 +6117,7 @@ static bake_test_suite suites[] = {
         "Query",
         NULL,
         NULL,
-        78,
+        79,
         Query_testcases
     },
     {


### PR DESCRIPTION
## Changelog
- Removes support for index 0 from:
  - `ecs_field_w_size`
  - `ecs_field_size`
- Ensure all the following functions assert that `index >= 1`
  - `ecs_field_w_size`
  - `ecs_field_is_readonly`
  - `ecs_field_is_writeonly`
  - `ecs_field_is_set`
  - `ecs_field_is_self`
  - `ecs_field_id`
  - `ecs_field_column_index`
  - `ecs_field_src`
  - `ecs_field_size`
- Added `flecs::column<const flecs::entity_t> flecs::iter::entities()` to allow access to the iterators `entities` with the C++ API.
- Added `Query_iter_entities` to test the `flecs::iter::entities()` function.

## Details
I was attempting to write a filter like the following snippet and while doing so discovered that the `flecs::iter` was asserting when trying to access the field for the entities.
```cpp
std::vector<flecs::entity_t> allEntities;
ecs.filter_builder<>()
  .with<SomeTag>()
  .build()
  .iter([&allEntities](flecs::iter& it)
    {
      auto entities = it.field<const flecs::entity_t>(0);
      allEntities.insert(allEntities.end(), &entities[0], &entities[it.count()]);
    });

// Sort the entity ids to ensure the order is stable
std::sort(allEntities.begin(), allEntities.end());

for (auto eId : allEntities)
{
  // ...
}
```
Note that there is a way to work around this by accessing the underlying `ecs_iter_t*`
```cpp
auto iter = it.c_ptr();
allEntities.insert(allEntities.end(), &iter->entities[0], &iter->entities[it.count()]);
```

<br/>

The specific assert I was seeing was the id retrieved from `ecs_field_id` didn't match the id from `_::cpp_type<T>::id(m_iter->world)` causing this assert to fail https://github.com/SanderMertens/flecs/blob/798f7353cdb7659c9795ef458d4b7de3ef45bfd9/include/flecs/addons/cpp/iter.hpp#L421-L426

When looking into this I also found that `ecs_field_id` was doing out-of-bounds access since it was doing `index - 1` and the assert was allowing `index >= 0` which would cause it to do `return it->ids[-1];`
https://github.com/SanderMertens/flecs/blob/798f7353cdb7659c9795ef458d4b7de3ef45bfd9/src/iter.c#L450-L457

From there I decided to check the other `ecs_field_*` functions to make sure they acted correctly with `index == 0` and there were a few more that needed changing to handle this case correctly.