### PR TITLE
Add world::run_pipeline<T>(ecs_ftime_t) overload

### DIFF
--- a/flecs.h
+++ b/flecs.h
@@ -20134,6 +20134,13 @@ bool progress(ecs_ftime_t delta_time = 0.0) const;
  */
 void run_pipeline(const flecs::entity_t pip, ecs_ftime_t delta_time = 0.0) const;
 
+/** Run pipeline.
+ * @tparam Pipeline Type associated with pipeline.
+ * @see ecs_run_pipeline
+ */
+template <typename Pipeline, if_not_t< is_enum<Pipeline>::value > = 0>
+void run_pipeline(ecs_ftime_t delta_time = 0.0) const;
+
 /** Set timescale.
  * @see ecs_set_time_scale
  */
@@ -28363,6 +28370,11 @@ inline bool world::progress(ecs_ftime_t delta_time) const {
 
 inline void world::run_pipeline(const flecs::entity_t pip, ecs_ftime_t delta_time) const {
     return ecs_run_pipeline(m_world, pip, delta_time);
+}
+
+template <typename Pipeline, if_not_t< is_enum<Pipeline>::value >>
+inline void world::run_pipeline(ecs_ftime_t delta_time) const {
+    return ecs_run_pipeline(m_world, _::cpp_type<Pipeline>::id(m_world), delta_time);
 }
 
 inline void world::set_time_scale(ecs_ftime_t mul) const {

--- a/include/flecs/addons/cpp/mixins/pipeline/impl.hpp
+++ b/include/flecs/addons/cpp/mixins/pipeline/impl.hpp
@@ -56,6 +56,11 @@ inline void world::run_pipeline(const flecs::entity_t pip, ecs_ftime_t delta_tim
     return ecs_run_pipeline(m_world, pip, delta_time);
 }
 
+template <typename Pipeline, if_not_t< is_enum<Pipeline>::value >>
+inline void world::run_pipeline(ecs_ftime_t delta_time) const {
+    return ecs_run_pipeline(m_world, _::cpp_type<Pipeline>::id(m_world), delta_time);
+}
+
 inline void world::set_time_scale(ecs_ftime_t mul) const {
     ecs_set_time_scale(m_world, mul);
 }  

--- a/include/flecs/addons/cpp/mixins/pipeline/mixin.inl
+++ b/include/flecs/addons/cpp/mixins/pipeline/mixin.inl
@@ -48,6 +48,13 @@ bool progress(ecs_ftime_t delta_time = 0.0) const;
  */
 void run_pipeline(const flecs::entity_t pip, ecs_ftime_t delta_time = 0.0) const;
 
+/** Run pipeline.
+ * @tparam Pipeline Type associated with pipeline.
+ * @see ecs_run_pipeline
+ */
+template <typename Pipeline, if_not_t< is_enum<Pipeline>::value > = 0>
+void run_pipeline(ecs_ftime_t delta_time = 0.0) const;
+
 /** Set timescale.
  * @see ecs_set_time_scale
  */


### PR DESCRIPTION
## Changelog
- Add `world::run_pipeline<T>(ecs_ftime_t)` overload

## Details
Was working with custom pipelines and noticed that this convenience overload was missing.

With this change instead of writing
```cpp
ecs.run_pipeline(ecs.id<CustomPipeline>().entity());
```
You can now just do
```cpp
ecs.run_pipeline<CustomPipeline>();
```