### PR TITLE
Multi-threaded custom pipelines

### DIFF
--- a/flecs.c
+++ b/flecs.c
@@ -18013,14 +18013,7 @@ void ecs_set_pipeline(
     ecs_check( ecs_get(world, pipeline, EcsPipeline) != NULL, 
         ECS_INVALID_PARAMETER, "not a pipeline");
 
-    int32_t thread_count = ecs_get_stage_count(world);
-    if (thread_count > 1) {
-        ecs_set_threads(world, 1);
-    }
     world->pipeline = pipeline;
-    if (thread_count > 1) {
-        ecs_set_threads(world, thread_count);
-    }
 error:
     return;
 }

--- a/flecs.c
+++ b/flecs.c
@@ -949,6 +949,8 @@ typedef struct ecs_cmd_entry_t {
     int32_t last;                    /* If -1, a delete command was inserted */
 } ecs_cmd_entry_t;
 
+typedef struct ecs_pipeline_state_t ecs_pipeline_state_t;
+
 /** A stage is a context that allows for safely using the API from multiple 
  * threads. Stage pointers can be passed to the world argument of API 
  * operations, which causes the operation to be ran on the stage instead of the
@@ -993,7 +995,7 @@ struct ecs_stage_t {
 
 #ifdef FLECS_PIPELINE
     /* The pipeline for the worker thread to execute using this stage */
-    void* pq; // TODO: This should be ecs_pipeline_state_t but its not defined yet
+    ecs_pipeline_state_t* pq;
 #endif
 };
 
@@ -16844,7 +16846,7 @@ typedef struct ecs_pipeline_op_t {
     bool no_readonly;           /* Whether systems are staged or not */
 } ecs_pipeline_op_t;
 
-typedef struct ecs_pipeline_state_t {
+struct ecs_pipeline_state_t {
     ecs_query_t *query;         /* Pipeline query */
     ecs_vec_t ops;              /* Pipeline schedule */
     ecs_vec_t systems;          /* Vector with system ids */
@@ -16862,7 +16864,7 @@ typedef struct ecs_pipeline_state_t {
     int32_t cur_i;              /* Index in current result */
     int32_t ran_since_merge;    /* Index in current op */
     bool no_readonly;           /* Is pipeline in readonly mode */
-} ecs_pipeline_state_t;
+};
 
 typedef struct EcsPipeline {
     /* Stable ptr so threads can safely access while entity/components move */

--- a/flecs.c
+++ b/flecs.c
@@ -17874,9 +17874,6 @@ void flecs_run_pipeline(
 
         const int32_t i = flecs_run_pipeline_ops(world, stage, stage_index, stage_count, delta_time, true);
 
-        // TODO: What if one of the worker threads has more 'work' to do and so takes longer?
-        // This time interval on the main-thread will not be equivelent to the amount of time the system
-        // actually took to execute.
         if (measure_time) {
             /* Don't include merge time in system time */
             world->info.system_time_total += (ecs_ftime_t)ecs_time_measure(&st);

--- a/flecs.c
+++ b/flecs.c
@@ -990,6 +990,11 @@ struct ecs_stage_t {
     /* Caches for rule creation */
     ecs_vec_t variables;
     ecs_vec_t operations;
+
+#ifdef FLECS_PIPELINE
+    /* The pipeline for the worker thread to execute using this stage */
+    void* pq; // TODO: This should be ecs_pipeline_state_t but its not defined yet
+#endif
 };
 
 /* Component monitor */
@@ -16878,26 +16883,17 @@ void flecs_run_pipeline(
     ecs_pipeline_state_t *pq,
     ecs_ftime_t delta_time);
 
+int32_t flecs_run_pipeline_ops(
+    ecs_world_t* world,
+    ecs_stage_t* stage,
+    int32_t stage_index,
+    int32_t stage_count,
+    ecs_ftime_t delta_time,
+    bool main_thread);
+
 ////////////////////////////////////////////////////////////////////////////////
 //// Worker API
 ////////////////////////////////////////////////////////////////////////////////
-
-bool flecs_worker_begin(
-    ecs_world_t *world,
-    ecs_stage_t *stage,
-    ecs_pipeline_state_t *pq,
-    bool start_of_frame);
-
-void flecs_worker_end(
-    ecs_world_t *world,
-    ecs_stage_t *stage);
-
-bool flecs_worker_sync(
-    ecs_world_t *world,
-    ecs_stage_t *stage,
-    ecs_pipeline_state_t *pq,
-    ecs_pipeline_op_t **cur_op,
-    int32_t *cur_i);
 
 void flecs_workers_progress(
     ecs_world_t *world,
@@ -16910,20 +16906,40 @@ void flecs_create_worker_threads(
 bool flecs_join_worker_threads(
     ecs_world_t *world);
 
+void flecs_signal_workers(
+    ecs_world_t *world);
+
+void flecs_wait_for_sync(
+    ecs_world_t *world);
+
 #endif
 
+/* Synchronize workers */
+static
+void flecs_sync_worker(
+    ecs_world_t* world)
+{
+    int32_t stage_count = ecs_get_stage_count(world);
+    if (stage_count <= 1) {
+        return;
+    }
 
-typedef struct ecs_worker_state_t {
-    ecs_stage_t *stage;
-    ecs_pipeline_state_t *pq;
-} ecs_worker_state_t;
+    /* Signal that thread is waiting */
+    ecs_os_mutex_lock(world->sync_mutex);
+    if (++world->workers_waiting == (stage_count - 1)) {
+        /* Only signal main thread when all threads are waiting */
+        ecs_os_cond_signal(world->sync_cond);
+    }
+
+    /* Wait until main thread signals that thread can continue */
+    ecs_os_cond_wait(world->worker_cond, world->sync_mutex);
+    ecs_os_mutex_unlock(world->sync_mutex);
+}
 
 /* Worker thread */
 static
 void* flecs_worker(void *arg) {
-    ecs_worker_state_t *state = arg;
-    ecs_stage_t *stage = state->stage;
-    ecs_pipeline_state_t *pq = state->pq;
+    ecs_stage_t *stage = arg;
     ecs_world_t *world = stage->world;
 
     ecs_poly_assert(world, ecs_world_t);
@@ -16946,10 +16962,11 @@ void* flecs_worker(void *arg) {
         ecs_entity_t old_scope = ecs_set_scope((ecs_world_t*)stage, 0);
 
         ecs_dbg_3("worker %d: run", stage->id);
- 
-        flecs_run_pipeline((ecs_world_t*)stage, pq, world->info.delta_time);
+        flecs_run_pipeline_ops(world, stage, stage->id, world->stage_count, world->info.delta_time, false);
 
         ecs_set_scope((ecs_world_t*)stage, old_scope);
+
+        flecs_sync_worker(world);
     }
 
     ecs_dbg_2("worker %d: finalizing", stage->id);
@@ -16960,24 +16977,7 @@ void* flecs_worker(void *arg) {
 
     ecs_dbg_2("worker %d: stop", stage->id);
 
-    ecs_os_free(state);
-
     return NULL;
-}
-
-static
-bool flecs_is_multithreaded(
-    ecs_world_t *world)
-{
-    ecs_poly_assert(world, ecs_world_t);
-    return ecs_get_stage_count(world) > 1;
-}
-
-static
-bool flecs_is_main_thread(
-    ecs_stage_t *stage)
-{
-    return !stage->id;
 }
 
 /* Start threads */
@@ -16992,27 +16992,16 @@ void flecs_create_worker_threads(
         ecs_assert(stage != NULL, ECS_INTERNAL_ERROR, NULL);
         ecs_poly_assert(stage, ecs_stage_t);
 
-        ecs_entity_t pipeline = world->pipeline;
-        ecs_assert(pipeline != 0, ECS_INVALID_OPERATION, NULL);
-        const EcsPipeline *pqc = ecs_get(world, pipeline, EcsPipeline);
-        ecs_assert(pqc != NULL, ECS_INVALID_OPERATION, NULL);
-        ecs_pipeline_state_t *pq = pqc->state;
-        ecs_assert(pq != NULL, ECS_INTERNAL_ERROR, NULL);
-
-        ecs_worker_state_t *state = ecs_os_calloc_t(ecs_worker_state_t);
-        state->stage = stage;
-        state->pq = pq;
-
         ecs_assert(stage->thread == 0, ECS_INTERNAL_ERROR, NULL);
         if (ecs_using_task_threads(world))
         {
             /* workers are using tasks in an external task manager provided to the OS API */
-            stage->thread = ecs_os_task_new(flecs_worker, state);
+            stage->thread = ecs_os_task_new(flecs_worker, stage);
         }
         else
         {
             /* workers are using long-running os threads */
-            stage->thread = ecs_os_thread_new(flecs_worker, state);
+            stage->thread = ecs_os_thread_new(flecs_worker, stage);
         }
         ecs_assert(stage->thread != 0, ECS_OPERATION_FAILED, NULL);
     }
@@ -17056,7 +17045,6 @@ void flecs_wait_for_workers(
 }
 
 /* Wait until all threads are waiting on sync point */
-static
 void flecs_wait_for_sync(
     ecs_world_t *world)
 {
@@ -17082,30 +17070,7 @@ void flecs_wait_for_sync(
     ecs_dbg_3("#[bold]pipeline: workers synced");
 }
 
-/* Synchronize workers */
-static
-void flecs_sync_worker(
-    ecs_world_t *world)
-{
-    int32_t stage_count = ecs_get_stage_count(world);
-    if (stage_count <= 1) {
-        return;
-    }
-
-    /* Signal that thread is waiting */
-    ecs_os_mutex_lock(world->sync_mutex);
-    if (++ world->workers_waiting == (stage_count - 1)) {
-        /* Only signal main thread when all threads are waiting */
-        ecs_os_cond_signal(world->sync_cond);
-    }
-
-    /* Wait until main thread signals that thread can continue */
-    ecs_os_cond_wait(world->worker_cond, world->sync_mutex);
-    ecs_os_mutex_unlock(world->sync_mutex);
-}
-
 /* Signal workers that they can start/resume work */
-static
 void flecs_signal_workers(
     ecs_world_t *world)
 {
@@ -17189,97 +17154,6 @@ bool ecs_stop_threads(
 }
 
 /* -- Private functions -- */
-bool flecs_worker_begin(
-    ecs_world_t *world,
-    ecs_stage_t *stage,
-    ecs_pipeline_state_t *pq,
-    bool start_of_frame)
-{
-    ecs_poly_assert(world, ecs_world_t);
-    ecs_poly_assert(stage, ecs_stage_t);
-    bool main_thread = flecs_is_main_thread(stage);
-    bool multi_threaded = flecs_is_multithreaded(world);
-
-    if (main_thread) {
-        if (ecs_stage_is_readonly(world)) {
-            ecs_assert(!pq->no_readonly, ECS_INTERNAL_ERROR, NULL);
-            ecs_readonly_end(world);
-            pq->no_readonly = false;
-        }
-
-        flecs_pipeline_update(world, pq, start_of_frame);
-    }
-
-    ecs_pipeline_op_t *cur_op = pq->cur_op;
-    if (main_thread && (cur_op != NULL)) {
-        pq->no_readonly = cur_op->no_readonly;
-        if (!cur_op->no_readonly) {
-            ecs_readonly_begin(world);
-        }
-
-        ECS_BIT_COND(world->flags, EcsWorldMultiThreaded, 
-            cur_op->multi_threaded);
-        ecs_assert(world->workers_waiting == 0, 
-            ECS_INTERNAL_ERROR, NULL);
-    }
-
-    if (main_thread && multi_threaded) {
-        flecs_signal_workers(world);
-    }
-
-    return pq->cur_op != NULL;
-}
-
-void flecs_worker_end(
-    ecs_world_t *world,
-    ecs_stage_t *stage)
-{
-    ecs_poly_assert(world, ecs_world_t);
-    ecs_poly_assert(stage, ecs_stage_t);
-
-    if (flecs_is_multithreaded(world)) {
-        if (flecs_is_main_thread(stage)) {
-            flecs_wait_for_sync(world);
-        } else {
-            flecs_sync_worker(world);
-        }
-    }
-
-    if (flecs_is_main_thread(stage)) {
-        if (ecs_stage_is_readonly(world)) {
-            ecs_readonly_end(world);
-        }
-    }
-}
-
-bool flecs_worker_sync(
-    ecs_world_t *world,
-    ecs_stage_t *stage,
-    ecs_pipeline_state_t *pq,
-    ecs_pipeline_op_t **cur_op,
-    int32_t *cur_i)
-{
-    ecs_assert(pq != NULL, ECS_INTERNAL_ERROR, NULL);
-    ecs_assert(pq->cur_op != NULL, ECS_INTERNAL_ERROR, NULL);
-    bool main_thread = flecs_is_main_thread(stage);
-
-    /* Synchronize workers */
-    flecs_worker_end(world, stage);
-
-    /* Store the current state of the schedule after we synchronized the
-     * threads, to avoid race conditions. */
-    if (main_thread) {
-        pq->cur_op = *cur_op;
-        pq->cur_i = *cur_i;
-    }
-
-    /* Prepare state for running the next part of the schedule */
-    bool result = flecs_worker_begin(world, stage, pq, false);
-    *cur_op = pq->cur_op;
-    *cur_i = pq->cur_i;
-    return result;
-}
-
 void flecs_workers_progress(
     ecs_world_t *world,
     ecs_pipeline_state_t *pq,
@@ -17863,10 +17737,79 @@ void ecs_run_pipeline(
         pipeline = world->pipeline;
     }
 
-    EcsPipeline *pq = (EcsPipeline*)ecs_get(world, pipeline, EcsPipeline);
-    flecs_pipeline_update(world, pq->state, true);
-    flecs_run_pipeline((ecs_world_t*)flecs_stage_from_world(&world), 
-        pq->state, delta_time);
+    /* create any worker task threads request */
+    if (ecs_using_task_threads(world))
+    {
+        flecs_create_worker_threads(world);
+    }
+
+    EcsPipeline *p = (EcsPipeline*)ecs_get(world, pipeline, EcsPipeline);
+    flecs_workers_progress(world, p->state, delta_time);
+
+    if (ecs_using_task_threads(world))
+    {
+        /* task threads were temporary and may now be joined */
+        flecs_join_worker_threads(world);
+    }
+}
+
+int32_t flecs_run_pipeline_ops(
+    ecs_world_t* world,
+    ecs_stage_t* stage,
+    int32_t stage_index,
+    int32_t stage_count,
+    ecs_ftime_t delta_time,
+    bool main_thread)
+{
+    ecs_pipeline_state_t* pq = stage->pq;
+    ecs_pipeline_op_t* op = pq->cur_op;
+    int32_t i = pq->cur_i;
+
+    int32_t count = ecs_vec_count(&pq->systems);
+    ecs_entity_t* systems = ecs_vec_first_t(&pq->systems, ecs_entity_t);
+    int32_t ran_since_merge = i - op->offset;
+
+    if (i == count) {
+        return i;
+    }
+
+    for (; i < count; i++) {
+        /* Run system if:
+         * - this is the main thread, or if
+         * - the system is multithreaded
+         */
+        if (main_thread || op->multi_threaded) {
+            ecs_entity_t system = systems[i];
+            const EcsPoly* poly = ecs_get_pair(world, system, EcsPoly, EcsSystem);
+            ecs_assert(poly != NULL, ECS_INTERNAL_ERROR, NULL);
+            ecs_system_t* sys = ecs_poly(poly->poly, ecs_system_t);
+
+            /* Keep track of the last frame for which the system has ran, so we
+            * know from where to resume the schedule in case the schedule
+            * changes during a merge. */
+            sys->last_frame = world->info.frame_count_total + 1;
+
+            ecs_stage_t* s = NULL;
+            if (!op->no_readonly) {
+                /* If system is no_readonly it operates on the actual world, not
+                 * the stage. Only pass stage to system if it's readonly. */
+                s = stage;
+            }
+
+            ecs_run_intern(world, s, system, sys, stage_index,
+                stage_count, delta_time, 0, 0, NULL);
+        }
+
+        world->info.systems_ran_frame++;
+        ran_since_merge++;
+
+        if (ran_since_merge == op->count) {
+            /* Merge */
+            break;
+        }
+    }
+
+    return i;
 }
 
 void flecs_run_pipeline(
@@ -17883,82 +17826,74 @@ void flecs_run_pipeline(
     int32_t stage_index = ecs_get_stage_id(stage->thread_ctx);
     int32_t stage_count = ecs_get_stage_count(world);
 
-    if (!flecs_worker_begin(world, stage, pq, true)) {
-        return;
+    ecs_assert(!stage_index, ECS_INVALID_OPERATION, NULL);
+
+    bool multi_threaded = ecs_get_stage_count(world) > 1;;
+
+    // Update the pipeline the workers will execute
+    int32_t stages = ecs_get_stage_count(world);
+    for (int32_t i = 0; i < stages; i++) {
+        ecs_stage_t* other_stage = (ecs_stage_t*)ecs_get_stage(world, i);
+        other_stage->pq = pq;
     }
 
-    ecs_time_t st = {0};
-    bool main_thread = !stage_index;
-    bool measure_time = main_thread && (world->flags & EcsWorldMeasureSystemTime);
-    ecs_pipeline_op_t *op = ecs_vec_first_t(&pq->ops, ecs_pipeline_op_t);
-    int32_t i = 0;
+    // Update the pipeline before waking the workers.
+    flecs_pipeline_update(world, pq, true);
 
-    do {
-        int32_t count = ecs_vec_count(&pq->systems);
-        ecs_entity_t *systems = ecs_vec_first_t(&pq->systems, ecs_entity_t);
-        int32_t ran_since_merge = i - op->offset;
-
-        if (i == count) {
-            break;
+    // If there are no operations to execute in the pipeline bail early,
+    // no need to wake the workers since they have nothing to do.
+    while (pq->cur_op != NULL) {
+        if (pq->cur_i == ecs_vec_count(&pq->systems)) {
+            flecs_pipeline_update(world, pq, false);
+            continue;
         }
 
+        bool no_readonly = pq->cur_op->no_readonly;
+        bool op_multi_threaded = multi_threaded && pq->cur_op->multi_threaded;
+
+        pq->no_readonly = no_readonly;
+
+        if (!no_readonly) {
+            ecs_readonly_begin(world);
+        }
+
+        ECS_BIT_COND(world->flags, EcsWorldMultiThreaded, op_multi_threaded);
+        ecs_assert(world->workers_waiting == 0, ECS_INTERNAL_ERROR, NULL);
+
+        if (op_multi_threaded) {
+            flecs_signal_workers(world);
+        }
+
+        ecs_time_t st = { 0 };
+        bool measure_time = world->flags & EcsWorldMeasureSystemTime;
         if (measure_time) {
             ecs_time_measure(&st);
         }
 
-        for (; i < count; i ++) {
-            /* Run system if:
-             * - this is the main thread, or if
-             * - the system is multithreaded 
-             */
-            if (main_thread || op->multi_threaded) {
-                ecs_entity_t system = systems[i];
-                const EcsPoly *poly = ecs_get_pair(world, system, EcsPoly, EcsSystem);
-                ecs_assert(poly != NULL, ECS_INTERNAL_ERROR, NULL);
-                ecs_system_t *sys = ecs_poly(poly->poly, ecs_system_t);
+        const int32_t i = flecs_run_pipeline_ops(world, stage, stage_index, stage_count, delta_time, true);
 
-                /* Keep track of the last frame for which the system has ran, so we
-                * know from where to resume the schedule in case the schedule 
-                * changes during a merge. */
-                sys->last_frame = world->info.frame_count_total + 1;
-
-                ecs_stage_t *s = NULL;
-                if (!op->no_readonly) {
-                    /* If system is no_readonly it operates on the actual world, not
-                     * the stage. Only pass stage to system if it's readonly. */
-                    s = stage;
-                }
-
-                ecs_run_intern(world, s, system, sys, stage_index, 
-                    stage_count, delta_time, 0, 0, NULL);
-            }
-
-            world->info.systems_ran_frame ++;
-            ran_since_merge ++;
-
-            if (ran_since_merge == op->count) {
-                /* Merge */
-                break;
-            }
-        }
-
+        // TODO: What if one of the worker threads has more 'work' to do and so takes longer?
+        // This time interval on the main-thread will not be equivelent to the amount of time the system
+        // actually took to execute.
         if (measure_time) {
             /* Don't include merge time in system time */
-            world->info.system_time_total += 
-                (ecs_ftime_t)ecs_time_measure(&st);
+            world->info.system_time_total += (ecs_ftime_t)ecs_time_measure(&st);
         }
 
-        /* Synchronize workers, rebuild pipeline if necessary. Pass current op
-         * and system index to function, so we know where to resume from. */
-    } while (flecs_worker_sync(world, stage, pq, &op, &i));
+        if (op_multi_threaded) {
+            flecs_wait_for_sync(world);
+        }
 
-    if (measure_time) {
-        world->info.system_time_total += (ecs_ftime_t)ecs_time_measure(&st);
+        if (!no_readonly) {
+            ecs_readonly_end(world);
+        }
+
+        /* Store the current state of the schedule after we synchronized the
+         * threads, to avoid race conditions. */
+        pq->cur_i = i;
+
+        flecs_pipeline_update(world, pq, false);
     }
-
-    flecs_worker_end(world, stage);
-
-    return;
 }
 
 static

--- a/flecs.h
+++ b/flecs.h
@@ -10550,9 +10550,6 @@ void ecs_reset_clock(
  * default pipeline (either the builtin pipeline or the pipeline set with 
  * set_pipeline()). An application may run additional pipelines.
  *
- * Note: calling this function from an application currently only works in
- * single threaded applications with a single stage.
- *
  * @param world The world.
  * @param pipeline The pipeline to run.
  */

--- a/include/flecs/addons/pipeline.h
+++ b/include/flecs/addons/pipeline.h
@@ -160,9 +160,6 @@ void ecs_reset_clock(
  * default pipeline (either the builtin pipeline or the pipeline set with 
  * set_pipeline()). An application may run additional pipelines.
  *
- * Note: calling this function from an application currently only works in
- * single threaded applications with a single stage.
- *
  * @param world The world.
  * @param pipeline The pipeline to run.
  */

--- a/src/addons/pipeline/pipeline.c
+++ b/src/addons/pipeline/pipeline.c
@@ -532,17 +532,13 @@ int32_t flecs_run_pipeline_ops(
     ecs_ftime_t delta_time,
     bool main_thread)
 {
-    ecs_pipeline_state_t* pq = stage->pq;
+    ecs_pipeline_state_t* pq = world->pq;
     ecs_pipeline_op_t* op = pq->cur_op;
     int32_t i = pq->cur_i;
 
     int32_t count = ecs_vec_count(&pq->systems);
     ecs_entity_t* systems = ecs_vec_first_t(&pq->systems, ecs_entity_t);
     int32_t ran_since_merge = i - op->offset;
-
-    if (i == count) {
-        return i;
-    }
 
     for (; i < count; i++) {
         /* Run system if:
@@ -602,11 +598,7 @@ void flecs_run_pipeline(
     bool multi_threaded = ecs_get_stage_count(world) > 1;;
 
     // Update the pipeline the workers will execute
-    int32_t stages = ecs_get_stage_count(world);
-    for (int32_t i = 0; i < stages; i++) {
-        ecs_stage_t* other_stage = (ecs_stage_t*)ecs_get_stage(world, i);
-        other_stage->pq = pq;
-    }
+    world->pq = pq;
 
     // Update the pipeline before waking the workers.
     flecs_pipeline_update(world, pq, true);

--- a/src/addons/pipeline/pipeline.c
+++ b/src/addons/pipeline/pipeline.c
@@ -782,14 +782,7 @@ void ecs_set_pipeline(
     ecs_check( ecs_get(world, pipeline, EcsPipeline) != NULL, 
         ECS_INVALID_PARAMETER, "not a pipeline");
 
-    int32_t thread_count = ecs_get_stage_count(world);
-    if (thread_count > 1) {
-        ecs_set_threads(world, 1);
-    }
     world->pipeline = pipeline;
-    if (thread_count > 1) {
-        ecs_set_threads(world, thread_count);
-    }
 error:
     return;
 }

--- a/src/addons/pipeline/pipeline.c
+++ b/src/addons/pipeline/pipeline.c
@@ -643,9 +643,6 @@ void flecs_run_pipeline(
 
         const int32_t i = flecs_run_pipeline_ops(world, stage, stage_index, stage_count, delta_time, true);
 
-        // TODO: What if one of the worker threads has more 'work' to do and so takes longer?
-        // This time interval on the main-thread will not be equivelent to the amount of time the system
-        // actually took to execute.
         if (measure_time) {
             /* Don't include merge time in system time */
             world->info.system_time_total += (ecs_ftime_t)ecs_time_measure(&st);

--- a/src/addons/pipeline/pipeline.c
+++ b/src/addons/pipeline/pipeline.c
@@ -508,10 +508,79 @@ void ecs_run_pipeline(
         pipeline = world->pipeline;
     }
 
-    EcsPipeline *pq = (EcsPipeline*)ecs_get(world, pipeline, EcsPipeline);
-    flecs_pipeline_update(world, pq->state, true);
-    flecs_run_pipeline((ecs_world_t*)flecs_stage_from_world(&world), 
-        pq->state, delta_time);
+    /* create any worker task threads request */
+    if (ecs_using_task_threads(world))
+    {
+        flecs_create_worker_threads(world);
+    }
+
+    EcsPipeline *p = (EcsPipeline*)ecs_get(world, pipeline, EcsPipeline);
+    flecs_workers_progress(world, p->state, delta_time);
+
+    if (ecs_using_task_threads(world))
+    {
+        /* task threads were temporary and may now be joined */
+        flecs_join_worker_threads(world);
+    }
+}
+
+int32_t flecs_run_pipeline_ops(
+    ecs_world_t* world,
+    ecs_stage_t* stage,
+    int32_t stage_index,
+    int32_t stage_count,
+    ecs_ftime_t delta_time,
+    bool main_thread)
+{
+    ecs_pipeline_state_t* pq = stage->pq;
+    ecs_pipeline_op_t* op = pq->cur_op;
+    int32_t i = pq->cur_i;
+
+    int32_t count = ecs_vec_count(&pq->systems);
+    ecs_entity_t* systems = ecs_vec_first_t(&pq->systems, ecs_entity_t);
+    int32_t ran_since_merge = i - op->offset;
+
+    if (i == count) {
+        return i;
+    }
+
+    for (; i < count; i++) {
+        /* Run system if:
+         * - this is the main thread, or if
+         * - the system is multithreaded
+         */
+        if (main_thread || op->multi_threaded) {
+            ecs_entity_t system = systems[i];
+            const EcsPoly* poly = ecs_get_pair(world, system, EcsPoly, EcsSystem);
+            ecs_assert(poly != NULL, ECS_INTERNAL_ERROR, NULL);
+            ecs_system_t* sys = ecs_poly(poly->poly, ecs_system_t);
+
+            /* Keep track of the last frame for which the system has ran, so we
+            * know from where to resume the schedule in case the schedule
+            * changes during a merge. */
+            sys->last_frame = world->info.frame_count_total + 1;
+
+            ecs_stage_t* s = NULL;
+            if (!op->no_readonly) {
+                /* If system is no_readonly it operates on the actual world, not
+                 * the stage. Only pass stage to system if it's readonly. */
+                s = stage;
+            }
+
+            ecs_run_intern(world, s, system, sys, stage_index,
+                stage_count, delta_time, 0, 0, NULL);
+        }
+
+        world->info.systems_ran_frame++;
+        ran_since_merge++;
+
+        if (ran_since_merge == op->count) {
+            /* Merge */
+            break;
+        }
+    }
+
+    return i;
 }
 
 void flecs_run_pipeline(
@@ -528,82 +597,74 @@ void flecs_run_pipeline(
     int32_t stage_index = ecs_get_stage_id(stage->thread_ctx);
     int32_t stage_count = ecs_get_stage_count(world);
 
-    if (!flecs_worker_begin(world, stage, pq, true)) {
-        return;
+    ecs_assert(!stage_index, ECS_INVALID_OPERATION, NULL);
+
+    bool multi_threaded = ecs_get_stage_count(world) > 1;;
+
+    // Update the pipeline the workers will execute
+    int32_t stages = ecs_get_stage_count(world);
+    for (int32_t i = 0; i < stages; i++) {
+        ecs_stage_t* other_stage = (ecs_stage_t*)ecs_get_stage(world, i);
+        other_stage->pq = pq;
     }
 
-    ecs_time_t st = {0};
-    bool main_thread = !stage_index;
-    bool measure_time = main_thread && (world->flags & EcsWorldMeasureSystemTime);
-    ecs_pipeline_op_t *op = ecs_vec_first_t(&pq->ops, ecs_pipeline_op_t);
-    int32_t i = 0;
+    // Update the pipeline before waking the workers.
+    flecs_pipeline_update(world, pq, true);
 
-    do {
-        int32_t count = ecs_vec_count(&pq->systems);
-        ecs_entity_t *systems = ecs_vec_first_t(&pq->systems, ecs_entity_t);
-        int32_t ran_since_merge = i - op->offset;
-
-        if (i == count) {
-            break;
+    // If there are no operations to execute in the pipeline bail early,
+    // no need to wake the workers since they have nothing to do.
+    while (pq->cur_op != NULL) {
+        if (pq->cur_i == ecs_vec_count(&pq->systems)) {
+            flecs_pipeline_update(world, pq, false);
+            continue;
         }
 
+        bool no_readonly = pq->cur_op->no_readonly;
+        bool op_multi_threaded = multi_threaded && pq->cur_op->multi_threaded;
+
+        pq->no_readonly = no_readonly;
+
+        if (!no_readonly) {
+            ecs_readonly_begin(world);
+        }
+
+        ECS_BIT_COND(world->flags, EcsWorldMultiThreaded, op_multi_threaded);
+        ecs_assert(world->workers_waiting == 0, ECS_INTERNAL_ERROR, NULL);
+
+        if (op_multi_threaded) {
+            flecs_signal_workers(world);
+        }
+
+        ecs_time_t st = { 0 };
+        bool measure_time = world->flags & EcsWorldMeasureSystemTime;
         if (measure_time) {
             ecs_time_measure(&st);
         }
 
-        for (; i < count; i ++) {
-            /* Run system if:
-             * - this is the main thread, or if
-             * - the system is multithreaded 
-             */
-            if (main_thread || op->multi_threaded) {
-                ecs_entity_t system = systems[i];
-                const EcsPoly *poly = ecs_get_pair(world, system, EcsPoly, EcsSystem);
-                ecs_assert(poly != NULL, ECS_INTERNAL_ERROR, NULL);
-                ecs_system_t *sys = ecs_poly(poly->poly, ecs_system_t);
+        const int32_t i = flecs_run_pipeline_ops(world, stage, stage_index, stage_count, delta_time, true);
 
-                /* Keep track of the last frame for which the system has ran, so we
-                * know from where to resume the schedule in case the schedule 
-                * changes during a merge. */
-                sys->last_frame = world->info.frame_count_total + 1;
-
-                ecs_stage_t *s = NULL;
-                if (!op->no_readonly) {
-                    /* If system is no_readonly it operates on the actual world, not
-                     * the stage. Only pass stage to system if it's readonly. */
-                    s = stage;
-                }
-
-                ecs_run_intern(world, s, system, sys, stage_index, 
-                    stage_count, delta_time, 0, 0, NULL);
-            }
-
-            world->info.systems_ran_frame ++;
-            ran_since_merge ++;
-
-            if (ran_since_merge == op->count) {
-                /* Merge */
-                break;
-            }
-        }
-
+        // TODO: What if one of the worker threads has more 'work' to do and so takes longer?
+        // This time interval on the main-thread will not be equivelent to the amount of time the system
+        // actually took to execute.
         if (measure_time) {
             /* Don't include merge time in system time */
-            world->info.system_time_total += 
-                (ecs_ftime_t)ecs_time_measure(&st);
+            world->info.system_time_total += (ecs_ftime_t)ecs_time_measure(&st);
         }
 
-        /* Synchronize workers, rebuild pipeline if necessary. Pass current op
-         * and system index to function, so we know where to resume from. */
-    } while (flecs_worker_sync(world, stage, pq, &op, &i));
+        if (op_multi_threaded) {
+            flecs_wait_for_sync(world);
+        }
 
-    if (measure_time) {
-        world->info.system_time_total += (ecs_ftime_t)ecs_time_measure(&st);
+        if (!no_readonly) {
+            ecs_readonly_end(world);
+        }
+
+        /* Store the current state of the schedule after we synchronized the
+         * threads, to avoid race conditions. */
+        pq->cur_i = i;
+
+        flecs_pipeline_update(world, pq, false);
     }
-
-    flecs_worker_end(world, stage);
-
-    return;
 }
 
 static

--- a/src/addons/pipeline/pipeline.h
+++ b/src/addons/pipeline/pipeline.h
@@ -17,7 +17,7 @@ typedef struct ecs_pipeline_op_t {
     bool no_readonly;           /* Whether systems are staged or not */
 } ecs_pipeline_op_t;
 
-typedef struct ecs_pipeline_state_t {
+struct ecs_pipeline_state_t {
     ecs_query_t *query;         /* Pipeline query */
     ecs_vec_t ops;              /* Pipeline schedule */
     ecs_vec_t systems;          /* Vector with system ids */
@@ -35,7 +35,7 @@ typedef struct ecs_pipeline_state_t {
     int32_t cur_i;              /* Index in current result */
     int32_t ran_since_merge;    /* Index in current op */
     bool no_readonly;           /* Is pipeline in readonly mode */
-} ecs_pipeline_state_t;
+};
 
 typedef struct EcsPipeline {
     /* Stable ptr so threads can safely access while entity/components move */

--- a/src/addons/pipeline/pipeline.h
+++ b/src/addons/pipeline/pipeline.h
@@ -56,26 +56,17 @@ void flecs_run_pipeline(
     ecs_pipeline_state_t *pq,
     ecs_ftime_t delta_time);
 
+int32_t flecs_run_pipeline_ops(
+    ecs_world_t* world,
+    ecs_stage_t* stage,
+    int32_t stage_index,
+    int32_t stage_count,
+    ecs_ftime_t delta_time,
+    bool main_thread);
+
 ////////////////////////////////////////////////////////////////////////////////
 //// Worker API
 ////////////////////////////////////////////////////////////////////////////////
-
-bool flecs_worker_begin(
-    ecs_world_t *world,
-    ecs_stage_t *stage,
-    ecs_pipeline_state_t *pq,
-    bool start_of_frame);
-
-void flecs_worker_end(
-    ecs_world_t *world,
-    ecs_stage_t *stage);
-
-bool flecs_worker_sync(
-    ecs_world_t *world,
-    ecs_stage_t *stage,
-    ecs_pipeline_state_t *pq,
-    ecs_pipeline_op_t **cur_op,
-    int32_t *cur_i);
 
 void flecs_workers_progress(
     ecs_world_t *world,
@@ -86,6 +77,12 @@ void flecs_create_worker_threads(
     ecs_world_t *world);
 
 bool flecs_join_worker_threads(
+    ecs_world_t *world);
+
+void flecs_signal_workers(
+    ecs_world_t *world);
+
+void flecs_wait_for_sync(
     ecs_world_t *world);
 
 #endif

--- a/src/addons/pipeline/worker.c
+++ b/src/addons/pipeline/worker.c
@@ -9,17 +9,32 @@
 #ifdef FLECS_PIPELINE
 #include "pipeline.h"
 
-typedef struct ecs_worker_state_t {
-    ecs_stage_t *stage;
-    ecs_pipeline_state_t *pq;
-} ecs_worker_state_t;
+/* Synchronize workers */
+static
+void flecs_sync_worker(
+    ecs_world_t* world)
+{
+    int32_t stage_count = ecs_get_stage_count(world);
+    if (stage_count <= 1) {
+        return;
+    }
+
+    /* Signal that thread is waiting */
+    ecs_os_mutex_lock(world->sync_mutex);
+    if (++world->workers_waiting == (stage_count - 1)) {
+        /* Only signal main thread when all threads are waiting */
+        ecs_os_cond_signal(world->sync_cond);
+    }
+
+    /* Wait until main thread signals that thread can continue */
+    ecs_os_cond_wait(world->worker_cond, world->sync_mutex);
+    ecs_os_mutex_unlock(world->sync_mutex);
+}
 
 /* Worker thread */
 static
 void* flecs_worker(void *arg) {
-    ecs_worker_state_t *state = arg;
-    ecs_stage_t *stage = state->stage;
-    ecs_pipeline_state_t *pq = state->pq;
+    ecs_stage_t *stage = arg;
     ecs_world_t *world = stage->world;
 
     ecs_poly_assert(world, ecs_world_t);
@@ -42,10 +57,11 @@ void* flecs_worker(void *arg) {
         ecs_entity_t old_scope = ecs_set_scope((ecs_world_t*)stage, 0);
 
         ecs_dbg_3("worker %d: run", stage->id);
- 
-        flecs_run_pipeline((ecs_world_t*)stage, pq, world->info.delta_time);
+        flecs_run_pipeline_ops(world, stage, stage->id, world->stage_count, world->info.delta_time, false);
 
         ecs_set_scope((ecs_world_t*)stage, old_scope);
+
+        flecs_sync_worker(world);
     }
 
     ecs_dbg_2("worker %d: finalizing", stage->id);
@@ -56,24 +72,7 @@ void* flecs_worker(void *arg) {
 
     ecs_dbg_2("worker %d: stop", stage->id);
 
-    ecs_os_free(state);
-
     return NULL;
-}
-
-static
-bool flecs_is_multithreaded(
-    ecs_world_t *world)
-{
-    ecs_poly_assert(world, ecs_world_t);
-    return ecs_get_stage_count(world) > 1;
-}
-
-static
-bool flecs_is_main_thread(
-    ecs_stage_t *stage)
-{
-    return !stage->id;
 }
 
 /* Start threads */
@@ -88,27 +87,16 @@ void flecs_create_worker_threads(
         ecs_assert(stage != NULL, ECS_INTERNAL_ERROR, NULL);
         ecs_poly_assert(stage, ecs_stage_t);
 
-        ecs_entity_t pipeline = world->pipeline;
-        ecs_assert(pipeline != 0, ECS_INVALID_OPERATION, NULL);
-        const EcsPipeline *pqc = ecs_get(world, pipeline, EcsPipeline);
-        ecs_assert(pqc != NULL, ECS_INVALID_OPERATION, NULL);
-        ecs_pipeline_state_t *pq = pqc->state;
-        ecs_assert(pq != NULL, ECS_INTERNAL_ERROR, NULL);
-
-        ecs_worker_state_t *state = ecs_os_calloc_t(ecs_worker_state_t);
-        state->stage = stage;
-        state->pq = pq;
-
         ecs_assert(stage->thread == 0, ECS_INTERNAL_ERROR, NULL);
         if (ecs_using_task_threads(world))
         {
             /* workers are using tasks in an external task manager provided to the OS API */
-            stage->thread = ecs_os_task_new(flecs_worker, state);
+            stage->thread = ecs_os_task_new(flecs_worker, stage);
         }
         else
         {
             /* workers are using long-running os threads */
-            stage->thread = ecs_os_thread_new(flecs_worker, state);
+            stage->thread = ecs_os_thread_new(flecs_worker, stage);
         }
         ecs_assert(stage->thread != 0, ECS_OPERATION_FAILED, NULL);
     }
@@ -152,7 +140,6 @@ void flecs_wait_for_workers(
 }
 
 /* Wait until all threads are waiting on sync point */
-static
 void flecs_wait_for_sync(
     ecs_world_t *world)
 {
@@ -178,30 +165,7 @@ void flecs_wait_for_sync(
     ecs_dbg_3("#[bold]pipeline: workers synced");
 }
 
-/* Synchronize workers */
-static
-void flecs_sync_worker(
-    ecs_world_t *world)
-{
-    int32_t stage_count = ecs_get_stage_count(world);
-    if (stage_count <= 1) {
-        return;
-    }
-
-    /* Signal that thread is waiting */
-    ecs_os_mutex_lock(world->sync_mutex);
-    if (++ world->workers_waiting == (stage_count - 1)) {
-        /* Only signal main thread when all threads are waiting */
-        ecs_os_cond_signal(world->sync_cond);
-    }
-
-    /* Wait until main thread signals that thread can continue */
-    ecs_os_cond_wait(world->worker_cond, world->sync_mutex);
-    ecs_os_mutex_unlock(world->sync_mutex);
-}
-
 /* Signal workers that they can start/resume work */
-static
 void flecs_signal_workers(
     ecs_world_t *world)
 {
@@ -285,97 +249,6 @@ bool ecs_stop_threads(
 }
 
 /* -- Private functions -- */
-bool flecs_worker_begin(
-    ecs_world_t *world,
-    ecs_stage_t *stage,
-    ecs_pipeline_state_t *pq,
-    bool start_of_frame)
-{
-    ecs_poly_assert(world, ecs_world_t);
-    ecs_poly_assert(stage, ecs_stage_t);
-    bool main_thread = flecs_is_main_thread(stage);
-    bool multi_threaded = flecs_is_multithreaded(world);
-
-    if (main_thread) {
-        if (ecs_stage_is_readonly(world)) {
-            ecs_assert(!pq->no_readonly, ECS_INTERNAL_ERROR, NULL);
-            ecs_readonly_end(world);
-            pq->no_readonly = false;
-        }
-
-        flecs_pipeline_update(world, pq, start_of_frame);
-    }
-
-    ecs_pipeline_op_t *cur_op = pq->cur_op;
-    if (main_thread && (cur_op != NULL)) {
-        pq->no_readonly = cur_op->no_readonly;
-        if (!cur_op->no_readonly) {
-            ecs_readonly_begin(world);
-        }
-
-        ECS_BIT_COND(world->flags, EcsWorldMultiThreaded, 
-            cur_op->multi_threaded);
-        ecs_assert(world->workers_waiting == 0, 
-            ECS_INTERNAL_ERROR, NULL);
-    }
-
-    if (main_thread && multi_threaded) {
-        flecs_signal_workers(world);
-    }
-
-    return pq->cur_op != NULL;
-}
-
-void flecs_worker_end(
-    ecs_world_t *world,
-    ecs_stage_t *stage)
-{
-    ecs_poly_assert(world, ecs_world_t);
-    ecs_poly_assert(stage, ecs_stage_t);
-
-    if (flecs_is_multithreaded(world)) {
-        if (flecs_is_main_thread(stage)) {
-            flecs_wait_for_sync(world);
-        } else {
-            flecs_sync_worker(world);
-        }
-    }
-
-    if (flecs_is_main_thread(stage)) {
-        if (ecs_stage_is_readonly(world)) {
-            ecs_readonly_end(world);
-        }
-    }
-}
-
-bool flecs_worker_sync(
-    ecs_world_t *world,
-    ecs_stage_t *stage,
-    ecs_pipeline_state_t *pq,
-    ecs_pipeline_op_t **cur_op,
-    int32_t *cur_i)
-{
-    ecs_assert(pq != NULL, ECS_INTERNAL_ERROR, NULL);
-    ecs_assert(pq->cur_op != NULL, ECS_INTERNAL_ERROR, NULL);
-    bool main_thread = flecs_is_main_thread(stage);
-
-    /* Synchronize workers */
-    flecs_worker_end(world, stage);
-
-    /* Store the current state of the schedule after we synchronized the
-     * threads, to avoid race conditions. */
-    if (main_thread) {
-        pq->cur_op = *cur_op;
-        pq->cur_i = *cur_i;
-    }
-
-    /* Prepare state for running the next part of the schedule */
-    bool result = flecs_worker_begin(world, stage, pq, false);
-    *cur_op = pq->cur_op;
-    *cur_i = pq->cur_i;
-    return result;
-}
-
 void flecs_workers_progress(
     ecs_world_t *world,
     ecs_pipeline_state_t *pq,

--- a/src/private_types.h
+++ b/src/private_types.h
@@ -480,6 +480,8 @@ typedef struct ecs_cmd_entry_t {
     int32_t last;                    /* If -1, a delete command was inserted */
 } ecs_cmd_entry_t;
 
+typedef struct ecs_pipeline_state_t ecs_pipeline_state_t;
+
 /** A stage is a context that allows for safely using the API from multiple 
  * threads. Stage pointers can be passed to the world argument of API 
  * operations, which causes the operation to be ran on the stage instead of the
@@ -524,7 +526,7 @@ struct ecs_stage_t {
 
 #ifdef FLECS_PIPELINE
     /* The pipeline for the worker thread to execute using this stage */
-    void* pq; // TODO: This should be ecs_pipeline_state_t but its not defined yet
+    ecs_pipeline_state_t* pq;
 #endif
 };
 

--- a/src/private_types.h
+++ b/src/private_types.h
@@ -480,8 +480,6 @@ typedef struct ecs_cmd_entry_t {
     int32_t last;                    /* If -1, a delete command was inserted */
 } ecs_cmd_entry_t;
 
-typedef struct ecs_pipeline_state_t ecs_pipeline_state_t;
-
 /** A stage is a context that allows for safely using the API from multiple 
  * threads. Stage pointers can be passed to the world argument of API 
  * operations, which causes the operation to be ran on the stage instead of the
@@ -523,11 +521,6 @@ struct ecs_stage_t {
     /* Caches for rule creation */
     ecs_vec_t variables;
     ecs_vec_t operations;
-
-#ifdef FLECS_PIPELINE
-    /* The pipeline for the worker thread to execute using this stage */
-    ecs_pipeline_state_t* pq;
-#endif
 };
 
 /* Component monitor */
@@ -579,6 +572,8 @@ typedef struct ecs_action_elem_t {
     ecs_fini_action_t action;
     void *ctx;
 } ecs_action_elem_t;
+
+typedef struct ecs_pipeline_state_t ecs_pipeline_state_t;
 
 /** The world stores and manages all ECS data. An application can have more than
  * one world, but data is not shared between worlds. */
@@ -637,7 +632,8 @@ struct ecs_world_t {
     ecs_os_mutex_t sync_mutex;       /* Mutex for job_cond */
     int32_t workers_running;         /* Number of threads running */
     int32_t workers_waiting;         /* Number of workers waiting on sync */
-    bool workers_use_task_api;   /* Workers are short-lived tasks, not long-running threads */
+    ecs_pipeline_state_t* pq;        /* Pointer to the pipeline for the workers to execute */
+    bool workers_use_task_api;       /* Workers are short-lived tasks, not long-running threads */
 
     /* -- Time management -- */
     ecs_time_t world_start_time;     /* Timestamp of simulation start */

--- a/src/private_types.h
+++ b/src/private_types.h
@@ -521,6 +521,11 @@ struct ecs_stage_t {
     /* Caches for rule creation */
     ecs_vec_t variables;
     ecs_vec_t operations;
+
+#ifdef FLECS_PIPELINE
+    /* The pipeline for the worker thread to execute using this stage */
+    void* pq; // TODO: This should be ecs_pipeline_state_t but its not defined yet
+#endif
 };
 
 /* Component monitor */

--- a/test/addons/project.json
+++ b/test/addons/project.json
@@ -556,8 +556,10 @@
                 "2_pipelines_1_system",
                 "builtin_pipeline_w_self_system_term",
                 "custom_pipeline_w_self_system_term",
-		"switch_from_threads_to_tasks",
-		"switch_from_tasks_to_threads"
+                "switch_from_threads_to_tasks",
+                "switch_from_tasks_to_threads",
+                "run_pipeline_multithreaded",
+                "run_pipeline_multithreaded_tasks"
             ]
         }, {
             "id": "SystemMisc",

--- a/test/addons/src/main.c
+++ b/test/addons/src/main.c
@@ -547,6 +547,8 @@ void Pipeline_builtin_pipeline_w_self_system_term(void);
 void Pipeline_custom_pipeline_w_self_system_term(void);
 void Pipeline_switch_from_threads_to_tasks(void);
 void Pipeline_switch_from_tasks_to_threads(void);
+void Pipeline_run_pipeline_multithreaded(void);
+void Pipeline_run_pipeline_multithreaded_tasks(void);
 
 // Testsuite 'SystemMisc'
 void SystemMisc_invalid_not_without_id(void);
@@ -3656,6 +3658,14 @@ bake_test_case Pipeline_testcases[] = {
     {
         "switch_from_tasks_to_threads",
         Pipeline_switch_from_tasks_to_threads
+    },
+    {
+        "run_pipeline_multithreaded",
+        Pipeline_run_pipeline_multithreaded
+    },
+    {
+        "run_pipeline_multithreaded_tasks",
+        Pipeline_run_pipeline_multithreaded_tasks
     }
 };
 
@@ -7382,7 +7392,7 @@ static bake_test_suite suites[] = {
         "Pipeline",
         NULL,
         NULL,
-        78,
+        80,
         Pipeline_testcases
     },
     {

--- a/test/cpp_api/project.json
+++ b/test/cpp_api/project.json
@@ -586,7 +586,8 @@
                 "instanced_nested_query_w_world",
                 "captured_query",
                 "page_iter_captured_query",
-                "worker_iter_captured_query"
+                "worker_iter_captured_query",
+                "iter_entities"
             ]
         }, {
             "id": "QueryBuilder",


### PR DESCRIPTION
## Changelog
- **Feature:** Added the ability for `ecs_run_pipeline` to execute multi-threaded systems on the worker threads.
  - Added pipeline test cases: `run_pipeline_multithreaded` and `run_pipeline_multithreaded_tasks`.
- **Performance:**
  - Improved the performance of workers by reducing the number of times the main thread needs to synchronize with the worker threads.
  - Worker threads are no longer restarted when using `ecs_set_pipeline`
- **Bug:** Fixed a bug where if an empty pipeline was run it would cause `ecs_progress` to block forever ([Report on Discord](https://discord.com/channels/633826290415435777/1125769038337933352/1125774526786056223))

## TODO
- [ ] Resolve how `system_time_total` is calculated

## Notes
- I discovered during this work that the way `system_time_total` is measured with multi-threaded systems is not accurate as it only measures the work the main thread does, but this may not be accurate as a worker thread could have more or less work. It would be straightforward with the changes in this branch to instead measure the system time including thread synchronization. This would make `system_time_total` the wall time of the system.

## Details
**Multi-threaded `ecs_run_pipeline`**
- Modified `ecs_run_pipeline` to call `flecs_workers_progress` and to more closely mirror `ecs_progress` with support for task threads.
- Removed `ecs_worker_state_t` and instead pass `ecs_pipeline_state_t*` via the `ecs_stage_t` allowing for it to be dynamically updated.
- Moved the main body of code for executing pipeline operations from `flecs_run_pipeline` into a new function `flecs_run_pipeline_ops`.
- Moved `flecs_worker` to now call `flecs_run_pipeline_ops` so it only operates on a specific pipeline operation, making the synchronization with the main thread clearer.
- Modified `flecs_run_pipeline` to now only be the main-thread operations handling updating the pipeline, updating the pipeline operation, waking works, synchronizing workers and also calls `flecs_run_pipeline_ops` to execute the pipeline operation for the main thread.
- Removed `flecs_worker_begin`, `flecs_worker_end`, `flecs_worker_sync`,`flecs_is_multithreaded` and `flecs_is_main_thread` as they were no longer needed anymore.
- Exposed `flecs_signal_workers` and `flecs_wait_for_sync` from `worker.c` to `pipeline.c` in `pipeline.h`.
- Remove calls to `ecs_set_threads` from `ecs_set_pipeline` now that the workers can operate on any pipeline dynamically so there is no need to restart them.

**Some info on how this changes worker synchronization.**
I ran both `master` and the branch for this PR with log level 3 enabled in a release build to compare how the workers operate.

Here in the following diff, you can see the functional difference.
```diff
diff --git "a/master.txt" "b/multithreaded-custom-piepline.txt"
index 5b1a059..22b34e4 100644
--- "a/master.txt"
+++ "b/multithreaded-custom-piepline.txt"
@@ -2665,42 +2665,40 @@ info: | | pipeline: waiting for worker sync
 info: | | pipeline: workers synced
 info: | merge
 info: | readonly
-info: | | pipeline: signal workers
 info: | | worker 0: ecs_run_intern - SysB
 info: | | worker 0: ecs_run_intern - SysC
-info: | | pipeline: waiting for worker sync
-info: | | pipeline: workers synced
 info: | merge
 info: | readonly
 info: | | pipeline: signal workers
 info: | | worker 0: ecs_run_intern - SysD
 info: | | worker 0: ecs_run_intern - SysE
+info: | | worker 1: run
 info: | | worker 1: ecs_run_intern - SysD
 info: | | worker 1: ecs_run_intern - SysE
+info: | | worker 2: run
 info: | | worker 2: ecs_run_intern - SysD
 info: | | worker 2: ecs_run_intern - SysE
+info: | | worker 3: run
 info: | | worker 3: ecs_run_intern - SysD
 info: | | worker 3: ecs_run_intern - SysE
+info: | | worker 4: run
 info: | | worker 4: ecs_run_intern - SysD
 info: | | worker 4: ecs_run_intern - SysE
+info: | | worker 5: run
 info: | | worker 5: ecs_run_intern - SysD
 info: | | worker 5: ecs_run_intern - SysE
+info: | | worker 6: run
 info: | | worker 6: ecs_run_intern - SysD
 info: | | worker 6: ecs_run_intern - SysE
+info: | | worker 7: run
 info: | | worker 7: ecs_run_intern - SysD
 info: | | worker 7: ecs_run_intern - SysE
 info: | | pipeline: waiting for worker sync
 info: | | pipeline: workers synced
 info: | merge
 info: | readonly
-info: | | pipeline: signal workers
 info: | | worker 0: ecs_run_intern - SysF
-info: | | pipeline: waiting for worker sync
-info: | | pipeline: workers synced
 info: | merge
-info: | pipeline: signal workers
-info: | pipeline: waiting for worker sync
-info: | pipeline: workers synced
 info: shutting down world
 info: | cleanup root entities
 info: | run fini actions
```

In this diff, you can see a few changes.
1. When running `SysB` and `SysC`, and then also lower down for `SysF` the worker threads are no longer signalled since the operation is not marked as `multi_threaded`. This means we can avoid needing to synchronize on the worker threads when not needed.
2. When running `SysD` and `SysE` there are new log messages for `worker %d: run`, this is because the workers now go back to their main loop after executing one operation, rather than synchronizing internally in `flecs_run_pipeline`.
3. At the end of the pipeline execution after the final merge (`info: | merge`), we no longer wake the worker threads an additional time. This is possible since the workers are staying in their main loop when waiting for the next operation to execute. This effectively removes an unneeded sync point.


**Notes about log collection:**
- Had to tweak `flecs_log_msg` to lock while writing to make the logging to be more stable
- Tweaked the worker log message in `ecs_run_intern` so its clearer what it is when viewed next to the `worker %d: run` message:
```diff
-ecs_dbg_3("worker %d: %s", stage_index, path);
+ecs_dbg_3("worker %d: ecs_run_intern - %s", stage_index, path);
```
- I manually sorted some log lines by their worker id and that only differs due to multithreading so that the diff is clearer.
  eg.
  ```log
  info: worker 2: start
  ```
  ```log
  info: | | worker 2: ecs_run_intern - SysA
  ```
  ```log
  info: | | worker 1: finalizing
  info: | | worker 1: stop
  ```

I've attached the full logs in case someone wants to look at them.
[master.txt](https://github.com/SanderMertens/flecs/files/12062792/master.txt)
[multithreaded-custom-piepline.txt](https://github.com/SanderMertens/flecs/files/12062793/multithreaded-custom-piepline.txt)

<hr>

**Deadlock when using `ecs_run_pipeline` with worker threads enabled** ([Report on Discord](https://discord.com/channels/633826290415435777/1125769038337933352/1125774526786056223))
_Fixed a bug in `flecs_worker_begin` where if an empty pipeline was run it would cause `ecs_progress` to block forever_ 
- The problem was caused by `flecs_worker_begin` signalling the workers to start but then `flecs_run_pipeline` would immediately return if there are no operations to perform, meaning the worker threads were never synchronized before exiting. https://github.com/SanderMertens/flecs/blob/d24a9e1df5a896ffcf3f35f024573e027002c351/src/addons/pipeline/pipeline.c#L531-L533

<hr>

**Removed unneeded worker signal and sync at end of pipeline**
While working on this I noticed that when a pipeline is run across the worker threads (eg. `ecs_progress`) at the end of the pipeline when no more operations exist `flecs_worker_sync` would call `flecs_worker_begin` which would then signal the workers, only for the loop to exit and then `flecs_worker_end` to immediately be called.