### PR TITLE
Add world::target

### DIFF
--- a/flecs.h
+++ b/flecs.h
@@ -19520,6 +19520,16 @@ struct world {
     template<typename T>
     flecs::entity target(flecs::entity_t first, int32_t index = 0) const;
 
+    /** Get target for a given pair from a singleton entity.
+     * This operation returns the target for a given pair. The optional
+     * index can be used to iterate through targets, in case the entity has
+     * multiple instances for the same relationship.
+     *
+     * @param first The first element of the pair for which to retrieve the target.
+     * @param index The index (0 for the first instance of the relationship).
+     */
+    flecs::entity target(flecs::entity_t first, int32_t index = 0) const;
+
     /** Create alias for component.
      *
      * @tparam T to create an alias for.
@@ -29955,6 +29965,14 @@ inline flecs::entity world::target(
 {
     return flecs::entity(m_world,
         ecs_get_target(m_world, _::cpp_type<T>::id(m_world), relationship, index));
+}
+
+inline flecs::entity world::target(
+    flecs::entity_t relationship,
+    int32_t index) const
+{
+    return flecs::entity(m_world,
+        ecs_get_target(m_world, relationship, relationship, index));
 }
 
 template <typename Func, if_t< is_callable<Func>::value > >

--- a/flecs.h
+++ b/flecs.h
@@ -19498,6 +19498,28 @@ struct world {
     template <typename T>
     flecs::entity singleton() const;
 
+    /** Get target for a given pair from a singleton entity.
+     * This operation returns the target for a given pair. The optional
+     * index can be used to iterate through targets, in case the entity has
+     * multiple instances for the same relationship.
+     *
+     * @tparam First The first element of the pair.
+     * @param index The index (0 for the first instance of the relationship).
+     */
+    template<typename First>
+    flecs::entity target(int32_t index = 0) const;
+
+    /** Get target for a given pair from a singleton entity.
+     * This operation returns the target for a given pair. The optional
+     * index can be used to iterate through targets, in case the entity has
+     * multiple instances for the same relationship.
+     *
+     * @param first The first element of the pair for which to retrieve the target.
+     * @param index The index (0 for the first instance of the relationship).
+     */
+    template<typename T>
+    flecs::entity target(flecs::entity_t first, int32_t index = 0) const;
+
     /** Create alias for component.
      *
      * @tparam T to create an alias for.
@@ -29917,6 +29939,22 @@ inline void world::children(Func&& f) const {
 template <typename T>
 inline flecs::entity world::singleton() const {
     return flecs::entity(m_world, _::cpp_type<T>::id(m_world));
+}
+
+template <typename First>
+inline flecs::entity world::target(int32_t index) const
+{
+    return flecs::entity(m_world,
+        ecs_get_target(m_world, _::cpp_type<First>::id(m_world), _::cpp_type<First>::id(m_world), index));
+}
+
+template <typename T>
+inline flecs::entity world::target(
+    flecs::entity_t relationship,
+    int32_t index) const
+{
+    return flecs::entity(m_world,
+        ecs_get_target(m_world, _::cpp_type<T>::id(m_world), relationship, index));
 }
 
 template <typename Func, if_t< is_callable<Func>::value > >

--- a/include/flecs/addons/cpp/impl/world.hpp
+++ b/include/flecs/addons/cpp/impl/world.hpp
@@ -201,6 +201,22 @@ inline flecs::entity world::singleton() const {
     return flecs::entity(m_world, _::cpp_type<T>::id(m_world));
 }
 
+template <typename First>
+inline flecs::entity world::target(int32_t index) const
+{
+    return flecs::entity(m_world,
+        ecs_get_target(m_world, _::cpp_type<First>::id(m_world), _::cpp_type<First>::id(m_world), index));
+}
+
+template <typename T>
+inline flecs::entity world::target(
+    flecs::entity_t relationship,
+    int32_t index) const
+{
+    return flecs::entity(m_world,
+        ecs_get_target(m_world, _::cpp_type<T>::id(m_world), relationship, index));
+}
+
 template <typename Func, if_t< is_callable<Func>::value > >
 inline void world::get(const Func& func) const {
     static_assert(arity<Func>::value == 1, "singleton component must be the only argument");

--- a/include/flecs/addons/cpp/impl/world.hpp
+++ b/include/flecs/addons/cpp/impl/world.hpp
@@ -217,6 +217,14 @@ inline flecs::entity world::target(
         ecs_get_target(m_world, _::cpp_type<T>::id(m_world), relationship, index));
 }
 
+inline flecs::entity world::target(
+    flecs::entity_t relationship,
+    int32_t index) const
+{
+    return flecs::entity(m_world,
+        ecs_get_target(m_world, relationship, relationship, index));
+}
+
 template <typename Func, if_t< is_callable<Func>::value > >
 inline void world::get(const Func& func) const {
     static_assert(arity<Func>::value == 1, "singleton component must be the only argument");

--- a/include/flecs/addons/cpp/world.hpp
+++ b/include/flecs/addons/cpp/world.hpp
@@ -723,6 +723,28 @@ struct world {
     template <typename T>
     flecs::entity singleton() const;
 
+    /** Get target for a given pair from a singleton entity.
+     * This operation returns the target for a given pair. The optional
+     * index can be used to iterate through targets, in case the entity has
+     * multiple instances for the same relationship.
+     *
+     * @tparam First The first element of the pair.
+     * @param index The index (0 for the first instance of the relationship).
+     */
+    template<typename First>
+    flecs::entity target(int32_t index = 0) const;
+
+    /** Get target for a given pair from a singleton entity.
+     * This operation returns the target for a given pair. The optional
+     * index can be used to iterate through targets, in case the entity has
+     * multiple instances for the same relationship.
+     *
+     * @param first The first element of the pair for which to retrieve the target.
+     * @param index The index (0 for the first instance of the relationship).
+     */
+    template<typename T>
+    flecs::entity target(flecs::entity_t first, int32_t index = 0) const;
+
     /** Create alias for component.
      *
      * @tparam T to create an alias for.

--- a/include/flecs/addons/cpp/world.hpp
+++ b/include/flecs/addons/cpp/world.hpp
@@ -745,6 +745,16 @@ struct world {
     template<typename T>
     flecs::entity target(flecs::entity_t first, int32_t index = 0) const;
 
+    /** Get target for a given pair from a singleton entity.
+     * This operation returns the target for a given pair. The optional
+     * index can be used to iterate through targets, in case the entity has
+     * multiple instances for the same relationship.
+     *
+     * @param first The first element of the pair for which to retrieve the target.
+     * @param index The index (0 for the first instance of the relationship).
+     */
+    flecs::entity target(flecs::entity_t first, int32_t index = 0) const;
+
     /** Create alias for component.
      *
      * @tparam T to create an alias for.

--- a/test/cpp_api/project.json
+++ b/test/cpp_api/project.json
@@ -1160,7 +1160,8 @@
                 "get_set_singleton_pair_R_t",
                 "add_remove_singleton_pair_R_T",
                 "add_remove_singleton_pair_R_t",
-                "add_remove_singleton_pair_r_t"
+                "add_remove_singleton_pair_r_t",
+                "get_target"
             ]
         }, {
             "id": "Misc",

--- a/test/cpp_api/src/Singleton.cpp
+++ b/test/cpp_api/src/Singleton.cpp
@@ -265,3 +265,54 @@ void Singleton_add_remove_singleton_pair_r_t() {
     world.remove(rel, tgt);
     test_assert(!(world.has(rel, tgt)));
 }
+
+void Singleton_get_target() {
+    flecs::world world;
+
+    auto Rel = world.singleton<Tag>();
+
+    auto obj1 = world.entity()
+        .add<Position>();
+
+    auto obj2 = world.entity()
+        .add<Velocity>();
+
+    auto obj3 = world.entity()
+        .add<Mass>();
+
+    flecs::entity entities[3] = {obj1, obj2, obj3};
+
+    world.add<Tag>(obj1);
+    world.add<Tag>(obj2);
+    world.add(Rel, obj3);
+
+    auto p = world.target<Tag>();
+    test_assert(p != 0);
+    test_assert(p == obj1);
+
+    p = world.target<Tag>(Rel);
+    test_assert(p != 0);
+    test_assert(p == obj1);
+
+    p = world.target(Rel);
+    test_assert(p != 0);
+    test_assert(p == obj1);
+
+    for (int i = 0; i < 3; i++) {
+        p = world.target<Tag>(i);
+        test_assert(p != 0);
+        test_assert(p == entities[i]);
+    }
+
+    for (int i = 0; i < 3; i++) {
+        p = world.target<Tag>(Rel, i);
+        test_assert(p != 0);
+        test_assert(p == entities[i]);
+    }
+
+    for (int i = 0; i < 3; i++) {
+        p = world.target(Rel, i);
+        test_assert(p != 0);
+        test_assert(p == entities[i]);
+    }
+}

--- a/test/cpp_api/src/main.cpp
+++ b/test/cpp_api/src/main.cpp
@@ -1110,6 +1110,7 @@ void Singleton_get_set_singleton_pair_R_t(void);
 void Singleton_add_remove_singleton_pair_R_T(void);
 void Singleton_add_remove_singleton_pair_R_t(void);
 void Singleton_add_remove_singleton_pair_r_t(void);
+void Singleton_get_target(void);
 
 // Testsuite 'Misc'
 void Misc_setup(void);
@@ -5536,6 +5537,10 @@ bake_test_case Singleton_testcases[] = {
     {
         "add_remove_singleton_pair_r_t",
         Singleton_add_remove_singleton_pair_r_t
+    },
+    {
+        "get_target",
+        Singleton_get_target
     }
 };
 
@@ -6225,7 +6230,7 @@ static bake_test_suite suites[] = {
         "Singleton",
         NULL,
         NULL,
-        18,
+        19,
         Singleton_testcases
     },
     {


### PR DESCRIPTION
## Changelog
- Added `world::target(int32_t index)` and `world::target(flecs::entity_t relationship, int32_t index)`

## Details
There was a [question asked on Discord](https://discord.com/channels/633826290415435777/1129888974475886672/1129888974475886672) about how to  get the target entity after doing something like the following:
```cpp
struct ActivePlayer {};
// ...

ecs.component<ActivePlayer>().add(flecs::Exclusive);

// ...

auto player = world.entity();
ecs.add<ActivePlayer>(player);
```

At the moment you can do this with (or some variation of):
```cpp
auto active_player = ecs.singleton<ActivePlayer>().target<ActivePlayer>();
```

With the change in this PR this now becomes more convenient to do, like so:
```cpp
auto active_player = ecs.target<ActivePlayer>();
```