### PR TITLE
Remove unneeded if and main_thread param from flecs_run_pipeline_ops

### DIFF
--- a/flecs.c
+++ b/flecs.c
@@ -16886,8 +16886,7 @@ int32_t flecs_run_pipeline_ops(
     ecs_stage_t* stage,
     int32_t stage_index,
     int32_t stage_count,
-    ecs_ftime_t delta_time,
-    bool main_thread);
+    ecs_ftime_t delta_time);
 
 ////////////////////////////////////////////////////////////////////////////////
 //// Worker API
@@ -16960,7 +16959,7 @@ void* flecs_worker(void *arg) {
         ecs_entity_t old_scope = ecs_set_scope((ecs_world_t*)stage, 0);
 
         ecs_dbg_3("worker %d: run", stage->id);
-        flecs_run_pipeline_ops(world, stage, stage->id, world->stage_count, world->info.delta_time, false);
+        flecs_run_pipeline_ops(world, stage, stage->id, world->stage_count, world->info.delta_time);
 
         ecs_set_scope((ecs_world_t*)stage, old_scope);
 
@@ -17756,43 +17755,38 @@ int32_t flecs_run_pipeline_ops(
     ecs_stage_t* stage,
     int32_t stage_index,
     int32_t stage_count,
-    ecs_ftime_t delta_time,
-    bool main_thread)
+    ecs_ftime_t delta_time)
 {
     ecs_pipeline_state_t* pq = world->pq;
     ecs_pipeline_op_t* op = pq->cur_op;
     int32_t i = pq->cur_i;
+    
+    ecs_assert(!stage_index || op->multi_threaded, ECS_INTERNAL_ERROR, NULL);
 
     int32_t count = ecs_vec_count(&pq->systems);
     ecs_entity_t* systems = ecs_vec_first_t(&pq->systems, ecs_entity_t);
     int32_t ran_since_merge = i - op->offset;
 
     for (; i < count; i++) {
-        /* Run system if:
-         * - this is the main thread, or if
-         * - the system is multithreaded
-         */
-        if (main_thread || op->multi_threaded) {
-            ecs_entity_t system = systems[i];
-            const EcsPoly* poly = ecs_get_pair(world, system, EcsPoly, EcsSystem);
-            ecs_assert(poly != NULL, ECS_INTERNAL_ERROR, NULL);
-            ecs_system_t* sys = ecs_poly(poly->poly, ecs_system_t);
+        ecs_entity_t system = systems[i];
+        const EcsPoly* poly = ecs_get_pair(world, system, EcsPoly, EcsSystem);
+        ecs_assert(poly != NULL, ECS_INTERNAL_ERROR, NULL);
+        ecs_system_t* sys = ecs_poly(poly->poly, ecs_system_t);
 
-            /* Keep track of the last frame for which the system has ran, so we
-            * know from where to resume the schedule in case the schedule
-            * changes during a merge. */
-            sys->last_frame = world->info.frame_count_total + 1;
+        /* Keep track of the last frame for which the system has ran, so we
+        * know from where to resume the schedule in case the schedule
+        * changes during a merge. */
+        sys->last_frame = world->info.frame_count_total + 1;
 
-            ecs_stage_t* s = NULL;
-            if (!op->no_readonly) {
-                /* If system is no_readonly it operates on the actual world, not
-                 * the stage. Only pass stage to system if it's readonly. */
-                s = stage;
-            }
-
-            ecs_run_intern(world, s, system, sys, stage_index,
-                stage_count, delta_time, 0, 0, NULL);
+        ecs_stage_t* s = NULL;
+        if (!op->no_readonly) {
+            /* If system is no_readonly it operates on the actual world, not
+                * the stage. Only pass stage to system if it's readonly. */
+            s = stage;
         }
+
+        ecs_run_intern(world, s, system, sys, stage_index,
+            stage_count, delta_time, 0, 0, NULL);
 
         world->info.systems_ran_frame++;
         ran_since_merge++;
@@ -17860,7 +17854,7 @@ void flecs_run_pipeline(
             ecs_time_measure(&st);
         }
 
-        const int32_t i = flecs_run_pipeline_ops(world, stage, stage_index, stage_count, delta_time, true);
+        const int32_t i = flecs_run_pipeline_ops(world, stage, stage_index, stage_count, delta_time);
 
         if (measure_time) {
             /* Don't include merge time in system time */

--- a/flecs.c
+++ b/flecs.c
@@ -11416,7 +11416,7 @@ ecs_page_t* flecs_sparse_get_page(
     if (page_index >= ecs_vec_count(&sparse->pages)) {
         return NULL;
     }
-    return ecs_vec_get_t(&sparse->pages, ecs_page_t, page_index);;
+    return ecs_vec_get_t(&sparse->pages, ecs_page_t, page_index);
 }
 
 static
@@ -17816,7 +17816,7 @@ void flecs_run_pipeline(
 
     ecs_assert(!stage_index, ECS_INVALID_OPERATION, NULL);
 
-    bool multi_threaded = ecs_get_stage_count(world) > 1;;
+    bool multi_threaded = ecs_get_stage_count(world) > 1;
 
     // Update the pipeline the workers will execute
     world->pq = pq;

--- a/src/addons/pipeline/pipeline.c
+++ b/src/addons/pipeline/pipeline.c
@@ -590,7 +590,7 @@ void flecs_run_pipeline(
 
     ecs_assert(!stage_index, ECS_INVALID_OPERATION, NULL);
 
-    bool multi_threaded = ecs_get_stage_count(world) > 1;;
+    bool multi_threaded = ecs_get_stage_count(world) > 1;
 
     // Update the pipeline the workers will execute
     world->pq = pq;

--- a/src/addons/pipeline/pipeline.c
+++ b/src/addons/pipeline/pipeline.c
@@ -529,43 +529,38 @@ int32_t flecs_run_pipeline_ops(
     ecs_stage_t* stage,
     int32_t stage_index,
     int32_t stage_count,
-    ecs_ftime_t delta_time,
-    bool main_thread)
+    ecs_ftime_t delta_time)
 {
     ecs_pipeline_state_t* pq = world->pq;
     ecs_pipeline_op_t* op = pq->cur_op;
     int32_t i = pq->cur_i;
+
+    ecs_assert(!stage_index || op->multi_threaded, ECS_INTERNAL_ERROR, NULL);
 
     int32_t count = ecs_vec_count(&pq->systems);
     ecs_entity_t* systems = ecs_vec_first_t(&pq->systems, ecs_entity_t);
     int32_t ran_since_merge = i - op->offset;
 
     for (; i < count; i++) {
-        /* Run system if:
-         * - this is the main thread, or if
-         * - the system is multithreaded
-         */
-        if (main_thread || op->multi_threaded) {
-            ecs_entity_t system = systems[i];
-            const EcsPoly* poly = ecs_get_pair(world, system, EcsPoly, EcsSystem);
-            ecs_assert(poly != NULL, ECS_INTERNAL_ERROR, NULL);
-            ecs_system_t* sys = ecs_poly(poly->poly, ecs_system_t);
+        ecs_entity_t system = systems[i];
+        const EcsPoly* poly = ecs_get_pair(world, system, EcsPoly, EcsSystem);
+        ecs_assert(poly != NULL, ECS_INTERNAL_ERROR, NULL);
+        ecs_system_t* sys = ecs_poly(poly->poly, ecs_system_t);
 
-            /* Keep track of the last frame for which the system has ran, so we
-            * know from where to resume the schedule in case the schedule
-            * changes during a merge. */
-            sys->last_frame = world->info.frame_count_total + 1;
+        /* Keep track of the last frame for which the system has ran, so we
+        * know from where to resume the schedule in case the schedule
+        * changes during a merge. */
+        sys->last_frame = world->info.frame_count_total + 1;
 
-            ecs_stage_t* s = NULL;
-            if (!op->no_readonly) {
-                /* If system is no_readonly it operates on the actual world, not
-                 * the stage. Only pass stage to system if it's readonly. */
-                s = stage;
-            }
-
-            ecs_run_intern(world, s, system, sys, stage_index,
-                stage_count, delta_time, 0, 0, NULL);
+        ecs_stage_t* s = NULL;
+        if (!op->no_readonly) {
+            /* If system is no_readonly it operates on the actual world, not
+                * the stage. Only pass stage to system if it's readonly. */
+            s = stage;
         }
+
+        ecs_run_intern(world, s, system, sys, stage_index,
+            stage_count, delta_time, 0, 0, NULL);
 
         world->info.systems_ran_frame++;
         ran_since_merge++;
@@ -633,7 +628,7 @@ void flecs_run_pipeline(
             ecs_time_measure(&st);
         }
 
-        const int32_t i = flecs_run_pipeline_ops(world, stage, stage_index, stage_count, delta_time, true);
+        const int32_t i = flecs_run_pipeline_ops(world, stage, stage_index, stage_count, delta_time);
 
         if (measure_time) {
             /* Don't include merge time in system time */

--- a/src/addons/pipeline/pipeline.h
+++ b/src/addons/pipeline/pipeline.h
@@ -61,8 +61,7 @@ int32_t flecs_run_pipeline_ops(
     ecs_stage_t* stage,
     int32_t stage_index,
     int32_t stage_count,
-    ecs_ftime_t delta_time,
-    bool main_thread);
+    ecs_ftime_t delta_time);
 
 ////////////////////////////////////////////////////////////////////////////////
 //// Worker API

--- a/src/addons/pipeline/worker.c
+++ b/src/addons/pipeline/worker.c
@@ -57,7 +57,7 @@ void* flecs_worker(void *arg) {
         ecs_entity_t old_scope = ecs_set_scope((ecs_world_t*)stage, 0);
 
         ecs_dbg_3("worker %d: run", stage->id);
-        flecs_run_pipeline_ops(world, stage, stage->id, world->stage_count, world->info.delta_time, false);
+        flecs_run_pipeline_ops(world, stage, stage->id, world->stage_count, world->info.delta_time);
 
         ecs_set_scope((ecs_world_t*)stage, old_scope);
 

--- a/src/datastructures/sparse.c
+++ b/src/datastructures/sparse.c
@@ -92,7 +92,7 @@ ecs_page_t* flecs_sparse_get_page(
     if (page_index >= ecs_vec_count(&sparse->pages)) {
         return NULL;
     }
-    return ecs_vec_get_t(&sparse->pages, ecs_page_t, page_index);;
+    return ecs_vec_get_t(&sparse->pages, ecs_page_t, page_index);
 }
 
 static


### PR DESCRIPTION
I was looking at changes from https://github.com/SanderMertens/flecs/pull/1003 again and realised there was some redundant code that could be cleaned up.

## Changelog
- Removed unneeded `if (main_thread || op->multi_threaded)` from `flecs_run_pipeline_ops`
  - This isn't needed since `flecs_run_pipeline` only signals workers when `op->multi_threaded` is set.
  - I turned this into an assert instead just to make sure it doesn't happen.
- Removed `bool main_thread` parameter from `flecs_run_pipeline_ops` since it is not needed.