### PR TITLE
Stricter warnings

### DIFF
--- a/cmake/target_default_compile_warnings.cmake
+++ b/cmake/target_default_compile_warnings.cmake
@@ -4,34 +4,35 @@ function(target_default_compile_warnings_c THIS)
             OR CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
 
         target_compile_options(${THIS} PRIVATE
-                #$<$<CONFIG:RELEASE>:-Werror>
                 $<$<CONFIG:Debug>:-Wshadow>
                 $<$<CONFIG:Debug>:-Wunused>
-                -Wall -Wextra
+                -Wall -Wextra -Werror
                 -Wcast-align
                 -Wpedantic
                 -Wconversion
                 -Wsign-conversion
-                -Wdouble-promotion)
+                -Wdouble-promotion
+                -Wno-missing-prototypes
+                -Wno-missing-variable-declarations)
 
     elseif (CMAKE_C_COMPILER_ID STREQUAL "GNU")
 
         target_compile_options(${THIS} PRIVATE
-                #$<$<CONFIG:RELEASE>:-Werror>
                 $<$<CONFIG:Debug>:-Wshadow>
                 $<$<CONFIG:Debug>:-Wunused>
-                -Wall -Wextra
+                -Wall -Wextra -Werror
                 -Wcast-align
                 -Wpedantic
                 -Wconversion
                 -Wsign-conversion
-                -Wdouble-promotion)
+                -Wdouble-promotion
+                -Wno-missing-prototypes
+                -Wno-missing-variable-declarations)
 
     elseif (CMAKE_C_COMPILER_ID STREQUAL "MSVC")
 
         target_compile_options(${THIS} PRIVATE
-                #$<$<CONFIG:RELEASE>:/WX>
-                /W3
+                /W3 /WX
                 /w14242 /w14254 /w14263
                 /w14265 /w14287 /we4289
                 /w14296 /w14311 /w14545

--- a/examples/c/entities/hooks/src/main.c
+++ b/examples/c/entities/hooks/src/main.c
@@ -84,7 +84,7 @@ int main(int argc, char *argv[]) {
 
     ecs_trace("ecs_set(world, e, String, {\"Hello World\"})");
     ecs_log_push();
-        ecs_set(world, e, String, {(char*)"Hello World"});
+        ecs_set(world, e, String, {ECS_CONST_CAST(char*, "Hello World")});
     ecs_log_pop();
 
     // This operation changes the entity's archetype, which invokes a move

--- a/examples/c/rules/basics/src/main.c
+++ b/examples/c/rules/basics/src/main.c
@@ -43,10 +43,10 @@ int main(int argc, char *argv[]) {
             // By replacing * with _Food, both terms are constrained to use the
             // same entity.
             { .first.id = Eats, .second = { 
-                .name = (char*)"Food", .flags = EcsIsVariable },
+                .name = "Food", .flags = EcsIsVariable },
             },
             { .first.id = Healthy, .src = {
-                .name = (char*)"Food", .flags = EcsIsVariable }
+                .name = "Food", .flags = EcsIsVariable }
             }
         }
     });

--- a/examples/c/rules/cyclic_variables/src/main.c
+++ b/examples/c/rules/cyclic_variables/src/main.c
@@ -38,13 +38,13 @@ int main(int argc, char *argv[]) {
         .terms = {
             { 
                 .first.id = Likes, 
-                .src = { .name = (char*)"X", .flags = EcsIsVariable },
-                .second = { .name = (char*)"Y", .flags = EcsIsVariable }
+                .src = { .name = "X", .flags = EcsIsVariable },
+                .second = { .name = "Y", .flags = EcsIsVariable }
             },
             { 
                 .first.id = Likes, 
-                .src = { .name = (char*)"Y", .flags = EcsIsVariable },
-                .second = { .name = (char*)"X", .flags = EcsIsVariable }
+                .src = { .name = "Y", .flags = EcsIsVariable },
+                .second = { .name = "X", .flags = EcsIsVariable }
             }
         }
     });

--- a/examples/c/rules/facts/src/main.c
+++ b/examples/c/rules/facts/src/main.c
@@ -51,13 +51,13 @@ int main(int argc, char *argv[]) {
         .terms = {
             { 
                 .first.id = Likes, 
-                .src = { .name = (char*)"X", .flags = EcsIsVariable },
-                .second = { .name = (char*)"Y", .flags = EcsIsVariable }
+                .src = { .name = "X", .flags = EcsIsVariable },
+                .second = { .name = "Y", .flags = EcsIsVariable }
             },
             { 
                 .first.id = Likes, 
-                .src = { .name = (char*)"Y", .flags = EcsIsVariable },
-                .second = { .name = (char*)"X", .flags = EcsIsVariable }
+                .src = { .name = "Y", .flags = EcsIsVariable },
+                .second = { .name = "X", .flags = EcsIsVariable }
             }
         }
     });

--- a/examples/c/rules/setting_variables/src/main.c
+++ b/examples/c/rules/setting_variables/src/main.c
@@ -73,12 +73,12 @@ int main(int argc, char *argv[]) {
             { .first.id = RangedUnit },
             {
                 .first.id = Platoon, 
-                .second = { .name = (char*)"Platoon", .flags = EcsIsVariable },
+                .second = { .name = "Platoon", .flags = EcsIsVariable },
             },
             { 
                 .first.id = Player, 
-                .src = { .name = (char*)"Platoon", .flags = EcsIsVariable },
-                .second = { .name = (char*)"Player", .flags = EcsIsVariable },
+                .src = { .name = "Platoon", .flags = EcsIsVariable },
+                .second = { .name = "Player", .flags = EcsIsVariable },
             }
         }
     });

--- a/examples/c/rules/transitive_queries/src/main.c
+++ b/examples/c/rules/transitive_queries/src/main.c
@@ -102,11 +102,11 @@ int main(int argc, char *argv[]) {
             { .id = Person },
             { 
                 .first.id = LocatedIn, 
-                .second = { .name = (char*)"Location", .flags = EcsIsVariable },
+                .second = { .name = "Location", .flags = EcsIsVariable },
             },
             {
                 .first.id = Country, 
-                .src = { .name = (char*)"Location", .flags = EcsIsVariable },
+                .src = { .name = "Location", .flags = EcsIsVariable },
             },
         }
     });

--- a/flecs.c
+++ b/flecs.c
@@ -5426,11 +5426,11 @@ ecs_poly_t* ecs_poly_get_(
     return NULL;
 }
 
+#ifndef FLECS_NDEBUG
 #define assert_object(cond, file, line, type_name)\
     ecs_assert_((cond), ECS_INVALID_PARAMETER, #cond, file, line, type_name);\
     assert(cond)
 
-#ifndef FLECS_NDEBUG
 void* ecs_poly_assert_(
     const ecs_poly_t *poly,
     int32_t type,
@@ -27444,7 +27444,13 @@ int ecs_meta_set_float(
     void *ptr = flecs_meta_cursor_get_ptr(cursor->world, scope);
 
     switch(op->kind) {
-    cases_T_bool(ptr, value);
+    case EcsOpBool:
+        if (ECS_EQZERO(value)) {
+            set_T(bool, ptr, false);
+        } else {
+            set_T(bool, ptr, true);
+        }
+        break;
     cases_T_signed(ptr, value, ecs_meta_bounds_float);
     cases_T_unsigned(ptr, value, ecs_meta_bounds_float);
     cases_T_float(ptr, value);

--- a/flecs.c
+++ b/flecs.c
@@ -16973,7 +16973,8 @@ void* flecs_worker(void *arg) {
         ecs_entity_t old_scope = ecs_set_scope((ecs_world_t*)stage, 0);
 
         ecs_dbg_3("worker %d: run", stage->id);
-        flecs_run_pipeline_ops(world, stage, stage->id, world->stage_count, world->info.delta_time);
+        flecs_run_pipeline_ops(world, stage, stage->id, world->stage_count, 
+            world->info.delta_time);
 
         ecs_set_scope((ecs_world_t*)stage, old_scope);
 
@@ -17004,13 +17005,11 @@ void flecs_create_worker_threads(
         ecs_poly_assert(stage, ecs_stage_t);
 
         ecs_assert(stage->thread == 0, ECS_INTERNAL_ERROR, NULL);
-        if (ecs_using_task_threads(world))
-        {
-            /* workers are using tasks in an external task manager provided to the OS API */
+        if (ecs_using_task_threads(world)) {
+            /* workers are using tasks in an external task manager provided to 
+             * the OS API */
             stage->thread = ecs_os_task_new(flecs_worker, stage);
-        }
-        else
-        {
+        } else {
             /* workers are using long-running os threads */
             stage->thread = ecs_os_thread_new(flecs_worker, stage);
         }
@@ -17027,8 +17026,7 @@ void flecs_start_workers(
 
     ecs_assert(ecs_get_stage_count(world) == threads, ECS_INTERNAL_ERROR, NULL);
 
-    if (!ecs_using_task_threads(world))
-    {
+    if (!ecs_using_task_threads(world)) {
         flecs_create_worker_threads(world);
     }
 }
@@ -17129,13 +17127,10 @@ bool flecs_join_worker_threads(
 
     /* Join all threads with main */
     for (i = 1; i < count; i ++) {
-        if (ecs_using_task_threads(world))
-        {
+        if (ecs_using_task_threads(world)) {
             /* Join using the override provided */
             ecs_os_task_join(stages[i].thread);
-        }
-        else
-        {
+        } else {
             ecs_os_thread_join(stages[i].thread);
         }
         stages[i].thread = 0;
@@ -17189,7 +17184,10 @@ void flecs_set_threads_internal(
     int32_t threads,
     bool use_task_api)
 {
-    ecs_assert(threads <= 1 || (use_task_api ? ecs_os_has_task_support() : ecs_os_has_threading()), ECS_MISSING_OS_API, NULL);
+    ecs_assert(threads <= 1 || (use_task_api 
+        ? ecs_os_has_task_support() 
+        : ecs_os_has_threading()), 
+            ECS_MISSING_OS_API, NULL);
     
     int32_t stage_count = ecs_get_stage_count(world);
     bool worker_method_changed = (use_task_api != world->workers_use_task_api);
@@ -17754,8 +17752,7 @@ void ecs_run_pipeline(
     }
 
     /* create any worker task threads request */
-    if (ecs_using_task_threads(world))
-    {
+    if (ecs_using_task_threads(world)) {
         flecs_create_worker_threads(world);
     }
 
@@ -17763,8 +17760,7 @@ void ecs_run_pipeline(
         ECS_CONST_CAST(EcsPipeline*, ecs_get(world, pipeline, EcsPipeline));
     flecs_workers_progress(world, p->state, delta_time);
 
-    if (ecs_using_task_threads(world))
-    {
+    if (ecs_using_task_threads(world)) {
         /* task threads were temporary and may now be joined */
         flecs_join_worker_threads(world);
     }
@@ -17874,7 +17870,8 @@ void flecs_run_pipeline(
             ecs_time_measure(&st);
         }
 
-        const int32_t i = flecs_run_pipeline_ops(world, stage, stage_index, stage_count, delta_time);
+        const int32_t i = flecs_run_pipeline_ops(
+            world, stage, stage_index, stage_count, delta_time);
 
         if (measure_time) {
             /* Don't include merge time in system time */
@@ -17965,8 +17962,7 @@ bool ecs_progress(
     }
 
     /* create any worker task threads request */
-    if (ecs_using_task_threads(world))
-    {
+    if (ecs_using_task_threads(world)) {
         flecs_create_worker_threads(world);
     }
 
@@ -17979,8 +17975,7 @@ bool ecs_progress(
 
     ecs_frame_end(world);
 
-    if (ecs_using_task_threads(world))
-    {
+    if (ecs_using_task_threads(world)) {
         /* task threads were temporary and may now be joined */
         flecs_join_worker_threads(world);
     }

--- a/flecs.c
+++ b/flecs.c
@@ -651,22 +651,22 @@ typedef struct ecs_table__t {
  * entity has a set of components not previously observed before. When a new
  * table is created, it is automatically matched with existing queries */
 struct ecs_table_t {
-    uint64_t id;                     /* Table id in sparse set */
-    ecs_flags32_t flags;             /* Flags for testing table properties */
-    uint16_t storage_count;          /* Number of components (excluding tags) */
-    ecs_type_t type;                 /* Identifies table type in type_index */
+    uint64_t id;                       /* Table id in sparse set */
+    ecs_flags32_t flags;               /* Flags for testing table properties */
+    uint16_t storage_count;            /* Number of components (excluding tags) */
+    ecs_type_t type;                   /* Identifies table type in type_index */
 
-    ecs_graph_node_t node;           /* Graph node */
-    ecs_data_t data;                 /* Component storage */
-    ecs_type_info_t **type_info;     /* Cached type info */
-    int32_t *dirty_state;            /* Keep track of changes in columns */
+    ecs_graph_node_t node;             /* Graph node */
+    ecs_data_t data;                   /* Component storage */
+    const ecs_type_info_t **type_info; /* Cached type info */
+    int32_t *dirty_state;              /* Keep track of changes in columns */
 
-    ecs_table_t *storage_table;      /* Table without tags */
-    ecs_id_t *storage_ids;           /* Component ids (prevent indirection) */
-    int32_t *storage_map;            /* Map type <-> data type
-                                      *  - 0..count(T):        type -> data_type
-                                      *  - count(T)..count(S): data_type -> type
-                                      */
+    ecs_table_t *storage_table;        /* Table without tags */
+    ecs_id_t *storage_ids;             /* Component ids (prevent indirection) */
+    int32_t *storage_map;              /* Map type <-> data type
+                                        *  - 0..count(T):        type -> data_type
+                                        *  - count(T)..count(S): data_type -> type
+                                        */
 
     ecs_table__t *_;                 /* Infrequently accessed table metadata */
 };
@@ -977,7 +977,7 @@ struct ecs_stage_t {
     ecs_entity_t scope;              /* Entity of current scope */
     ecs_entity_t with;               /* Id to add by default to new entities */
     ecs_entity_t base;               /* Currently instantiated top-level base */
-    ecs_entity_t *lookup_path;       /* Search path used by lookup operations */
+    const ecs_entity_t *lookup_path; /* Search path used by lookup operations */
 
     /* Properties */
     bool auto_merge;                 /* Should this stage automatically merge? */
@@ -1185,11 +1185,11 @@ bool flecs_table_cache_all_iter(
     ecs_table_cache_t *cache,
     ecs_table_cache_iter_t *out);
 
-ecs_table_cache_hdr_t* _flecs_table_cache_next(
+ecs_table_cache_hdr_t* flecs_table_cache_next_(
     ecs_table_cache_iter_t *it);
 
 #define flecs_table_cache_next(it, T)\
-    (ECS_CAST(T*, _flecs_table_cache_next(it)))
+    (ECS_CAST(T*, flecs_table_cache_next_(it)))
 
 #endif
 
@@ -1326,7 +1326,7 @@ ecs_table_record_t* flecs_table_record_get(
     ecs_id_t id);
 
 /* Find table record for id record */
-const ecs_table_record_t* flecs_id_record_get_table(
+ecs_table_record_t* flecs_id_record_get_table(
     const ecs_id_record_t *idr,
     const ecs_table_t *table);
 
@@ -1712,22 +1712,22 @@ void flecs_table_diff_build_noalloc(
 #include <stddef.h>
 
 /* Initialize poly */
-void* _ecs_poly_init(
+void* ecs_poly_init_(
     ecs_poly_t *object,
     int32_t kind,
     ecs_size_t size,
     ecs_mixins_t *mixins);
 
 #define ecs_poly_init(object, type)\
-    _ecs_poly_init(object, type##_magic, sizeof(type), &type##_mixins)
+    ecs_poly_init_(object, type##_magic, sizeof(type), &type##_mixins)
 
 /* Deinitialize object for specified type */
-void _ecs_poly_fini(
+void ecs_poly_fini_(
     ecs_poly_t *object,
     int32_t kind);
 
 #define ecs_poly_fini(object, type)\
-    _ecs_poly_fini(object, type##_magic)
+    ecs_poly_fini_(object, type##_magic)
 
 /* Utility functions for creating an object on the heap */
 #define ecs_poly_new(type)\
@@ -1738,49 +1738,49 @@ void _ecs_poly_fini(
     ecs_os_free(obj)
 
 /* Get or create poly component for an entity */
-EcsPoly* _ecs_poly_bind(
+EcsPoly* ecs_poly_bind_(
     ecs_world_t *world,
     ecs_entity_t entity,
     ecs_entity_t tag);
 
 #define ecs_poly_bind(world, entity, T) \
-    _ecs_poly_bind(world, entity, T##_tag)
+    ecs_poly_bind_(world, entity, T##_tag)
 
-void _ecs_poly_modified(
+void ecs_poly_modified_(
     ecs_world_t *world,
     ecs_entity_t entity,
     ecs_entity_t tag);
 
 #define ecs_poly_modified(world, entity, T) \
-    _ecs_poly_modified(world, entity, T##_tag)
+    ecs_poly_modified_(world, entity, T##_tag)
 
 /* Get poly component for an entity */
-const EcsPoly* _ecs_poly_bind_get(
+const EcsPoly* ecs_poly_bind_get_(
     const ecs_world_t *world,
     ecs_entity_t entity,
     ecs_entity_t tag);
 
 #define ecs_poly_bind_get(world, entity, T) \
-    _ecs_poly_bind_get(world, entity, T##_tag)
+    ecs_poly_bind_get_(world, entity, T##_tag)
 
-ecs_poly_t* _ecs_poly_get(
+ecs_poly_t* ecs_poly_get_(
     const ecs_world_t *world,
     ecs_entity_t entity,
     ecs_entity_t tag);
 
 #define ecs_poly_get(world, entity, T) \
-    ((T*)_ecs_poly_get(world, entity, T##_tag))
+    ((T*)ecs_poly_get_(world, entity, T##_tag))
 
 /* Utilities for testing/asserting an object type */
 #ifndef FLECS_NDEBUG
-void* _ecs_poly_assert(
+void* ecs_poly_assert_(
     const ecs_poly_t *object,
     int32_t type,
     const char *file,
     int32_t line);
 
 #define ecs_poly_assert(object, type)\
-    _ecs_poly_assert(object, type##_magic, __FILE__, __LINE__)
+    ecs_poly_assert_(object, type##_magic, __FILE__, __LINE__)
 
 #define ecs_poly(object, T) ((T*)ecs_poly_assert(object, T))
 #else
@@ -2134,7 +2134,7 @@ void flecs_bootstrap(
     ecs_add_id(world, name, EcsFinal);\
     ecs_add_pair(world, name, EcsChildOf, ecs_get_scope(world));\
     ecs_set(world, name, EcsComponent, {.size = 0});\
-    ecs_set_name(world, name, (char*)&#name[ecs_os_strlen(world->info.name_prefix)]);\
+    ecs_set_name(world, name, (const char*)&#name[ecs_os_strlen(world->info.name_prefix)]);\
     ecs_set_symbol(world, name, #name)
 
 /* Bootstrap functions for other parts in the code */
@@ -2283,7 +2283,7 @@ void flecs_filter_apply_iter_flags(
 #define flecs_signed_ecs_size_t__ true
 #define flecs_signed_ecs_entity_t__ false
 
-uint64_t _flecs_ito(
+uint64_t flecs_ito_(
     size_t dst_size,
     bool dst_signed,
     bool lt_zero,
@@ -2292,7 +2292,7 @@ uint64_t _flecs_ito(
 
 #ifndef FLECS_NDEBUG
 #define flecs_ito(T, value)\
-    (T)_flecs_ito(\
+    (T)flecs_ito_(\
         sizeof(T),\
         flecs_signed_##T##__,\
         (value) < 0,\
@@ -2300,7 +2300,7 @@ uint64_t _flecs_ito(
         FLECS_CONVERSION_ERR(T, (value)))
 
 #define flecs_uto(T, value)\
-    (T)_flecs_ito(\
+    (T)flecs_ito_(\
         sizeof(T),\
         flecs_signed_##T##__,\
         false,\
@@ -2391,14 +2391,6 @@ uint64_t flecs_string_hash(
 void flecs_table_hashmap_init(
     ecs_world_t *world,
     ecs_hashmap_t *hm);
-
-#define assert_func(cond) _assert_func(cond, #cond, __FILE__, __LINE__, __func__)
-void _assert_func(
-    bool cond,
-    const char *cond_str,
-    const char *file,
-    int32_t line,
-    const char *func);
 
 void flecs_dump_backtrace(
     FILE *stream);
@@ -2637,7 +2629,7 @@ void flecs_table_init_type_info(
         const ecs_type_info_t *ti = idr->type_info;
         ecs_assert(ti != NULL, ECS_INTERNAL_ERROR, NULL);
         table->flags |= flecs_type_info_flags(ti);
-        table->type_info[i] = (ecs_type_info_t*)ti;
+        table->type_info[i] = ti;
     }
 }
 
@@ -2721,7 +2713,7 @@ void flecs_table_init_data(
         ecs_vec_t *columns = flecs_wcalloc_n(world, ecs_vec_t, count);
         storage->columns = columns;
 #ifdef FLECS_DEBUG
-        ecs_type_info_t **ti = table->type_info;
+        const ecs_type_info_t **ti = table->type_info;
         for (i = 0; i < count; i ++) {
             ecs_vec_init(NULL, &columns[i], ti[i]->size, 0);
         }
@@ -3199,7 +3191,7 @@ void flecs_table_invoke_hook(
     ecs_id_t id,
     int32_t row,
     int32_t count,
-    ecs_type_info_t *ti)
+    const ecs_type_info_t *ti)
 {
     ecs_assert(ti != NULL, ECS_INTERNAL_ERROR, NULL);
     void *ptr = ecs_vec_get(column, ti->size, row);
@@ -3210,7 +3202,7 @@ void flecs_table_invoke_hook(
 /* Construct components */
 static
 void flecs_table_invoke_ctor(
-    ecs_type_info_t *ti,
+    const ecs_type_info_t *ti,
     ecs_vec_t *column,
     int32_t row,
     int32_t count)
@@ -3226,7 +3218,7 @@ void flecs_table_invoke_ctor(
 /* Destruct components */
 static
 void flecs_table_invoke_dtor(
-    ecs_type_info_t *ti,
+    const ecs_type_info_t *ti,
     ecs_vec_t *column,
     int32_t row,
     int32_t count)
@@ -3245,7 +3237,7 @@ static
 void flecs_table_invoke_add_hooks(
     ecs_world_t *world,
     ecs_table_t *table,
-    ecs_type_info_t *ti,
+    const ecs_type_info_t *ti,
     ecs_vec_t *column,
     ecs_entity_t *entities,
     ecs_id_t id,
@@ -3271,7 +3263,7 @@ static
 void flecs_table_invoke_remove_hooks(
     ecs_world_t *world,
     ecs_table_t *table,
-    ecs_type_info_t *ti,
+    const ecs_type_info_t *ti,
     ecs_vec_t *column,
     ecs_entity_t *entities,
     ecs_id_t id,
@@ -3328,7 +3320,7 @@ void flecs_table_dtor_all(
         /* Run on_remove callbacks first before destructing components */
         for (c = 0; c < ids_count; c++) {
             ecs_vec_t *column = &data->columns[c];
-            ecs_type_info_t *ti = table->type_info[c];
+            const ecs_type_info_t *ti = table->type_info[c];
             ecs_iter_action_t on_remove = ti->hooks.on_remove;
             if (on_remove) {
                 flecs_table_invoke_hook(world, table, on_remove, EcsOnRemove, 
@@ -3584,7 +3576,7 @@ void flecs_table_free(
     if (storage_table == table) {
         if (table->type_info) {
             flecs_wfree_n(world, ecs_type_info_t*, table->storage_count, 
-                table->type_info);
+                ECS_CONST_CAST(ecs_type_info_t**, table->type_info));
         }
     } else if (storage_table) {
         flecs_table_release(world, storage_table);
@@ -3886,7 +3878,7 @@ static
 void* flecs_table_grow_column(
     ecs_world_t *world,
     ecs_vec_t *column,
-    ecs_type_info_t *ti,
+    const ecs_type_info_t *ti,
     int32_t to_add,
     int32_t dst_size,
     bool construct)
@@ -3994,10 +3986,10 @@ int32_t flecs_table_grow_data(
 
     /* Add elements to each column array */
     ecs_vec_t *columns = data->columns;
-    ecs_type_info_t **type_info = table->type_info;
+    const ecs_type_info_t **type_info = table->type_info;
     for (i = 0; i < column_count; i ++) {
         ecs_vec_t *column = &columns[i];
-        ecs_type_info_t *ti = type_info[i];
+        const ecs_type_info_t *ti = type_info[i];
         flecs_table_grow_column(world, column, ti, to_add, size, true);
         ecs_assert(columns[i].size == size, ECS_INTERNAL_ERROR, NULL);
         flecs_table_invoke_add_hooks(world, table, ti, column, e, table->type.array[i], 
@@ -4037,14 +4029,14 @@ int32_t flecs_table_grow_data(
 static
 void flecs_table_fast_append(
     ecs_world_t *world,
-    ecs_type_info_t **type_info,
+    const ecs_type_info_t **type_info,
     ecs_vec_t *columns,
     int32_t count)
 {
     /* Add elements to each column array */
     int32_t i;
     for (i = 0; i < count; i ++) {
-        ecs_type_info_t *ti = type_info[i];
+        const ecs_type_info_t *ti = type_info[i];
         ecs_vec_t *column = &columns[i];
         ecs_vec_append(&world->allocator, column, ti->size);
     }
@@ -4089,7 +4081,7 @@ int32_t flecs_table_append(
     flecs_table_mark_table_dirty(world, table, 0);
     ecs_assert(count >= 0, ECS_INTERNAL_ERROR, NULL);
 
-    ecs_type_info_t **type_info = table->type_info;
+    const ecs_type_info_t **type_info = table->type_info;
 
     /* Fast path: no switch columns, no lifecycle actions */
     if (!(table->flags & EcsTableIsComplex)) {
@@ -4111,7 +4103,7 @@ int32_t flecs_table_append(
     int32_t i;
     for (i = 0; i < column_count; i ++) {
         ecs_vec_t *column = &columns[i];
-        ecs_type_info_t *ti = type_info[i];  
+        const ecs_type_info_t *ti = type_info[i];
         flecs_table_grow_column(world, column, ti, 1, size, construct);
 
         ecs_iter_action_t on_add_hook;
@@ -4172,14 +4164,14 @@ void flecs_table_fast_delete_last(
 /* Delete operation for tables that don't have any complex logic */
 static
 void flecs_table_fast_delete(
-    ecs_type_info_t **type_info,
+    const ecs_type_info_t **type_info,
     ecs_vec_t *columns,
     int32_t column_count,
     int32_t index) 
 {
     int i;
     for (i = 0; i < column_count; i ++) {
-        ecs_type_info_t *ti = type_info[i];
+        const ecs_type_info_t *ti = type_info[i];
         ecs_vec_t *column = &columns[i];
         ecs_vec_remove(column, ti->size, index);
     }
@@ -4241,7 +4233,7 @@ void flecs_table_delete(
     }
 
     /* Destruct component data */
-    ecs_type_info_t **type_info = table->type_info;
+    const ecs_type_info_t **type_info = table->type_info;
     ecs_vec_t *columns = data->columns;
     int32_t column_count = table->storage_count;
     int32_t i;
@@ -4266,8 +4258,8 @@ void flecs_table_delete(
         /* If table has component destructors, invoke */
         if (destruct && (table->flags & EcsTableHasDtors)) {            
             for (i = 0; i < column_count; i ++) {
-                flecs_table_invoke_remove_hooks(world, table, type_info[i], &columns[i], 
-                    &entity_to_delete, ids[i], index, 1, true);
+                flecs_table_invoke_remove_hooks(world, table, type_info[i], 
+                    &columns[i], &entity_to_delete, ids[i], index, 1, true);
             }
         }
 
@@ -4279,7 +4271,7 @@ void flecs_table_delete(
         if ((table->flags & (EcsTableHasDtors | EcsTableHasMove))) {
             for (i = 0; i < column_count; i ++) {
                 ecs_vec_t *column = &columns[i];
-                ecs_type_info_t *ti = type_info[i];
+                const ecs_type_info_t *ti = type_info[i];
                 ecs_size_t size = ti->size;
                 void *dst = ecs_vec_get(column, size, index);
                 void *src = ecs_vec_last(column, size);
@@ -4338,7 +4330,7 @@ void flecs_table_fast_move(
     ecs_vec_t *src_columns = src_table->data.columns;
     ecs_vec_t *dst_columns = dst_table->data.columns;
 
-    ecs_type_info_t **dst_type_info = dst_table->type_info;
+    const ecs_type_info_t **dst_type_info = dst_table->type_info;
 
     for (; (i_new < dst_column_count) && (i_old < src_column_count);) {
         ecs_id_t dst_id = dst_ids[i_new];
@@ -4347,7 +4339,7 @@ void flecs_table_fast_move(
         if (dst_id == src_id) {
             ecs_vec_t *dst_column = &dst_columns[i_new];
             ecs_vec_t *src_column = &src_columns[i_old];
-            ecs_type_info_t *ti = dst_type_info[i_new];
+            const ecs_type_info_t *ti = dst_type_info[i_new];
             int32_t size = ti->size;
             void *dst = ecs_vec_get(dst_column, size, dst_index);
             void *src = ecs_vec_get(src_column, size, src_index);
@@ -4402,8 +4394,8 @@ void flecs_table_move(
      * care of cleaning up resources. */
     bool use_move_dtor = ecs_table_count(src_table) == (src_index + 1);
 
-    ecs_type_info_t **dst_type_info = dst_table->type_info;
-    ecs_type_info_t **src_type_info = src_table->type_info;
+    const ecs_type_info_t **dst_type_info = dst_table->type_info;
+    const ecs_type_info_t **src_type_info = src_table->type_info;
 
     int32_t i_new = 0, dst_column_count = dst_table->storage_count;
     int32_t i_old = 0, src_column_count = src_table->storage_count;
@@ -4420,7 +4412,7 @@ void flecs_table_move(
         if (dst_id == src_id) {
             ecs_vec_t *dst_column = &dst_columns[i_new];
             ecs_vec_t *src_column = &src_columns[i_old];
-            ecs_type_info_t *ti = dst_type_info[i_new];
+            const ecs_type_info_t *ti = dst_type_info[i_new];
             int32_t size = ti->size;
 
             ecs_assert(size != 0, ECS_INTERNAL_ERROR, NULL);
@@ -4537,10 +4529,10 @@ bool flecs_table_shrink(
     ecs_vec_reclaim_t(&world->allocator, &data->records, ecs_record_t*);
 
     int32_t i, count = table->storage_count;
-    ecs_type_info_t **type_info = table->type_info;
+    const ecs_type_info_t **type_info = table->type_info;
     for (i = 0; i < count; i ++) {
         ecs_vec_t *column = &data->columns[i];
-        ecs_type_info_t *ti = type_info[i];
+        const ecs_type_info_t *ti = type_info[i];
         ecs_vec_reclaim(&world->allocator, column, ti->size);
     }
 
@@ -4648,13 +4640,13 @@ void flecs_table_swap(
         return;
     }
 
-    ecs_type_info_t **type_info = table->type_info;
+    const ecs_type_info_t **type_info = table->type_info;
 
     /* Find the maximum size of column elements
      * and allocate a temporary buffer for swapping */
     int32_t i, temp_buffer_size = ECS_SIZEOF(uint64_t), column_count = table->storage_count;
     for (i = 0; i < column_count; i++) {
-        ecs_type_info_t* ti = type_info[i];
+        const ecs_type_info_t* ti = type_info[i];
         temp_buffer_size = ECS_MAX(temp_buffer_size, ti->size);
     }
 
@@ -4662,7 +4654,7 @@ void flecs_table_swap(
 
     /* Swap columns */
     for (i = 0; i < column_count; i ++) {
-        ecs_type_info_t *ti = type_info[i];
+        const ecs_type_info_t *ti = type_info[i];
         int32_t size = ti->size;
         ecs_assert(size != 0, ECS_INTERNAL_ERROR, NULL);
 
@@ -4687,7 +4679,7 @@ void flecs_table_merge_column(
     ecs_vec_t *src,
     int32_t size,
     int32_t column_size,
-    ecs_type_info_t *ti)
+    const ecs_type_info_t *ti)
 {
     int32_t dst_count = dst->count;
 
@@ -4749,8 +4741,8 @@ void flecs_table_merge_data(
     ecs_id_t *dst_ids = dst_table->storage_ids;
     ecs_id_t *src_ids = src_table->storage_ids;
 
-    ecs_type_info_t **dst_type_info = dst_table->type_info;
-    ecs_type_info_t **src_type_info = src_table->type_info;
+    const ecs_type_info_t **dst_type_info = dst_table->type_info;
+    const ecs_type_info_t **src_type_info = src_table->type_info;
 
     ecs_vec_t *src = src_data->columns;
     ecs_vec_t *dst = dst_data->columns;
@@ -4776,7 +4768,7 @@ void flecs_table_merge_data(
     for (; (i_new < dst_column_count) && (i_old < src_column_count); ) {
         ecs_id_t dst_id = dst_ids[i_new];
         ecs_id_t src_id = src_ids[i_old];
-        ecs_type_info_t *dst_ti = dst_type_info[i_new];
+        const ecs_type_info_t *dst_ti = dst_type_info[i_new];
         int32_t size = dst_ti->size;
         ecs_assert(size != 0, ECS_INTERNAL_ERROR, NULL);
 
@@ -4798,7 +4790,7 @@ void flecs_table_merge_data(
         } else if (dst_id > src_id) {
             /* Old column does not occur in new table, destruct */
             ecs_vec_t *column = &src[i_old];
-            ecs_type_info_t *ti = src_type_info[i_old];
+            const ecs_type_info_t *ti = src_type_info[i_old];
             flecs_table_invoke_dtor(ti, column, 0, src_count);
             ecs_vec_fini(a, column, ti->size);
             i_old ++;
@@ -4811,7 +4803,7 @@ void flecs_table_merge_data(
     /* Initialize remaining columns */
     for (; i_new < dst_column_count; i_new ++) {
         ecs_vec_t *column = &dst[i_new];
-        ecs_type_info_t *ti = dst_type_info[i_new];
+        const ecs_type_info_t *ti = dst_type_info[i_new];
         int32_t size = ti->size;
         ecs_assert(size != 0, ECS_INTERNAL_ERROR, NULL);
         ecs_vec_set_size(a, column, size, column_size);
@@ -4822,7 +4814,7 @@ void flecs_table_merge_data(
     /* Destruct remaining columns */
     for (; i_old < src_column_count; i_old ++) {
         ecs_vec_t *column = &src[i_old];
-        ecs_type_info_t *ti = src_type_info[i_old];
+        const ecs_type_info_t *ti = src_type_info[i_old];
         flecs_table_invoke_dtor(ti, column, 0, src_count);
         ecs_vec_fini(a, column, ti->size);
     }    
@@ -5136,7 +5128,7 @@ int32_t ecs_table_get_index(
         return -1;
     }
 
-    const ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
+    ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
     if (!tr) {
         return -1;
     }
@@ -5217,7 +5209,7 @@ void* ecs_record_get_column(
     ecs_table_t *table = r->table;
 
     ecs_check(column < table->storage_count, ECS_INVALID_PARAMETER, NULL);
-    ecs_type_info_t *ti = table->type_info[column];
+    const ecs_type_info_t *ti = table->type_info[column];
     ecs_vec_t *c = &table->data.columns[column];
     ecs_assert(c != NULL, ECS_INTERNAL_ERROR, NULL);
 
@@ -5344,7 +5336,7 @@ void* assert_mixin(
     return ECS_OFFSET(hdr, offset);
 }
 
-void* _ecs_poly_init(
+void* ecs_poly_init_(
     ecs_poly_t *poly,
     int32_t type,
     ecs_size_t size,
@@ -5362,7 +5354,7 @@ void* _ecs_poly_init(
     return poly;
 }
 
-void _ecs_poly_fini(
+void ecs_poly_fini_(
     ecs_poly_t *poly,
     int32_t type)
 {
@@ -5377,7 +5369,7 @@ void _ecs_poly_fini(
     hdr->magic = 0;
 }
 
-EcsPoly* _ecs_poly_bind(
+EcsPoly* ecs_poly_bind_(
     ecs_world_t *world,
     ecs_entity_t entity,
     ecs_entity_t tag)
@@ -5406,7 +5398,7 @@ EcsPoly* _ecs_poly_bind(
     return result;
 }
 
-void _ecs_poly_modified(
+void ecs_poly_modified_(
     ecs_world_t *world,
     ecs_entity_t entity,
     ecs_entity_t tag)
@@ -5414,7 +5406,7 @@ void _ecs_poly_modified(
     ecs_modified_pair(world, entity, ecs_id(EcsPoly), tag);
 }
 
-const EcsPoly* _ecs_poly_bind_get(
+const EcsPoly* ecs_poly_bind_get_(
     const ecs_world_t *world,
     ecs_entity_t entity,
     ecs_entity_t tag)
@@ -5422,12 +5414,12 @@ const EcsPoly* _ecs_poly_bind_get(
     return ecs_get_pair(world, entity, EcsPoly, tag);
 }
 
-ecs_poly_t* _ecs_poly_get(
+ecs_poly_t* ecs_poly_get_(
     const ecs_world_t *world,
     ecs_entity_t entity,
     ecs_entity_t tag)
 {
-    const EcsPoly *p = _ecs_poly_bind_get(world, entity, tag);
+    const EcsPoly *p = ecs_poly_bind_get_(world, entity, tag);
     if (p) {
         return p->poly;
     }
@@ -5435,11 +5427,11 @@ ecs_poly_t* _ecs_poly_get(
 }
 
 #define assert_object(cond, file, line, type_name)\
-    _ecs_assert((cond), ECS_INVALID_PARAMETER, #cond, file, line, type_name);\
+    ecs_assert_((cond), ECS_INVALID_PARAMETER, #cond, file, line, type_name);\
     assert(cond)
 
 #ifndef FLECS_NDEBUG
-void* _ecs_poly_assert(
+void* ecs_poly_assert_(
     const ecs_poly_t *poly,
     int32_t type,
     const char *file,
@@ -5451,11 +5443,11 @@ void* _ecs_poly_assert(
     const char *type_name = hdr->mixins->type_name;
     assert_object(hdr->magic == ECS_OBJECT_MAGIC, file, line, type_name);
     assert_object(hdr->type == type, file, line, type_name);
-    return (ecs_poly_t*)poly;
+    return ECS_CONST_CAST(ecs_poly_t*, poly);
 }
 #endif
 
-bool _ecs_poly_is(
+bool ecs_poly_is_(
     const ecs_poly_t *poly,
     int32_t type)
 {
@@ -5481,7 +5473,7 @@ ecs_observable_t* ecs_get_observable(
 const ecs_world_t* ecs_get_world(
     const ecs_poly_t *poly)
 {
-    if (((ecs_header_t*)poly)->type == ecs_world_t_magic) {
+    if (((const ecs_header_t*)poly)->type == ecs_world_t_magic) {
         return poly;
     }
     return *(ecs_world_t**)assert_mixin(poly, EcsMixinWorld);
@@ -5526,7 +5518,7 @@ const ecs_entity_t* flecs_bulk_new(
     ecs_table_diff_t *diff);
 
 typedef struct {
-    ecs_type_info_t *ti;
+    const ecs_type_info_t *ti;
     void *ptr;
 } flecs_component_ptr_t;
 
@@ -5537,7 +5529,7 @@ flecs_component_ptr_t flecs_get_component_w_index(
     int32_t row)
 {
     ecs_check(column_index < table->storage_count, ECS_NOT_A_COMPONENT, NULL);
-    ecs_type_info_t *ti = table->type_info[column_index];
+    const ecs_type_info_t *ti = table->type_info[column_index];
     ecs_vec_t *column = &table->data.columns[column_index];
     return (flecs_component_ptr_t){
         .ti = ti,
@@ -5608,7 +5600,7 @@ void* flecs_get_base_component(
 
     /* Table should always be in the table index for (IsA, *), otherwise the
      * HasBase flag should not have been set */
-    const ecs_table_record_t *tr_isa = flecs_id_record_get_table(
+    ecs_table_record_t *tr_isa = flecs_id_record_get_table(
         world->idr_isa_wildcard, table);
     ecs_check(tr_isa != NULL, ECS_INTERNAL_ERROR, NULL);
 
@@ -5998,8 +5990,7 @@ void flecs_set_union(
                 continue;
             }
 
-            const ecs_table_record_t *tr = flecs_id_record_get_table(
-                idr, table);
+            ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
             ecs_assert(tr != NULL, ECS_INTERNAL_ERROR, NULL);
             ecs_assert(table->_ != NULL, ECS_INTERNAL_ERROR, NULL);
             int32_t column = tr->column - table->_->sw_offset;
@@ -6394,7 +6385,7 @@ const ecs_entity_t* flecs_bulk_new(
                 "ids cannot be wildcards");
 
             int32_t index = tr->column;
-            ecs_type_info_t *ti = table->type_info[index];
+            const ecs_type_info_t *ti = table->type_info[index];
             ecs_vec_t *column = &table->data.columns[index];
             int32_t size = ti->size;
             ecs_assert(size != 0, ECS_INTERNAL_ERROR, NULL);
@@ -6553,7 +6544,7 @@ void flecs_invoke_hook(
     it.real_world = world;
     it.table = table;
     it.ptrs[0] = ptr;
-    it.sizes = (ecs_size_t*)&ti->size;
+    it.sizes = ECS_CONST_CAST(ecs_size_t*, &ti->size);
     it.ids[0] = id;
     it.event = event;
     it.event_id = id;
@@ -6719,7 +6710,8 @@ ecs_entity_t ecs_new_id(
      * make sure we have the actual world. Cast away const since this is one of
      * the few functions that may modify the world while it is in readonly mode,
      * since it is thread safe (uses atomic inc when in threading mode) */
-    ecs_world_t *unsafe_world = (ecs_world_t*)ecs_get_world(world);
+    ecs_world_t *unsafe_world = 
+        ECS_CONST_CAST(ecs_world_t*, ecs_get_world(world));
 
     ecs_entity_t entity;
     if (stage->async || (unsafe_world->flags & EcsWorldMultiThreaded)) {
@@ -6756,7 +6748,8 @@ ecs_entity_t ecs_new_low_id(
      * make sure we have the actual world. Cast away const since this is one of
      * the few functions that may modify the world while it is in readonly mode,
      * but only if single threaded. */
-    ecs_world_t *unsafe_world = (ecs_world_t*)ecs_get_world(world);
+    ecs_world_t *unsafe_world = 
+        ECS_CONST_CAST(ecs_world_t*, ecs_get_world(world));
     if (unsafe_world->flags & EcsWorldReadonly) {
         /* Can't issue new comp id while iterating when in multithreaded mode */
         ecs_check(ecs_get_stage_count(world) <= 1,
@@ -7350,7 +7343,7 @@ const ecs_entity_t* ecs_bulk_init(
             i ++;
         }
 
-        ids.array = (ecs_id_t*)desc->ids;
+        ids.array = ECS_CONST_CAST(ecs_id_t*, desc->ids);
         ids.count = i;
 
         ecs_table_diff_t table_diff;
@@ -8671,7 +8664,8 @@ ecs_entity_t ecs_set_id(
     }
 
     /* Safe to cast away const: function won't modify if move arg is false */
-    flecs_copy_ptr_w_id(world, stage, entity, id, size, (void*)ptr);
+    flecs_copy_ptr_w_id(world, stage, entity, id, size, 
+        ECS_CONST_CAST(void*, ptr));
     return entity;
 error:
     return 0;
@@ -8783,7 +8777,7 @@ bool ecs_has_id(
     ecs_id_record_t *idr = flecs_id_record_get(world, id);
     int32_t column;
     if (idr) {
-        const ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
+        ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
         if (tr) {
             return true;
         }
@@ -8887,7 +8881,7 @@ ecs_entity_t ecs_get_target(
     return ecs_pair_second(world, table->type.array[tr->column + index]);
 look_in_base:
     if (table->flags & EcsTableHasIsA) {
-        const ecs_table_record_t *isa_tr = flecs_id_record_get_table(
+        ecs_table_record_t *isa_tr = flecs_id_record_get_table(
             world->idr_isa_wildcard, table);
         ecs_assert(isa_tr != NULL, ECS_INTERNAL_ERROR, NULL);
 
@@ -9404,7 +9398,7 @@ void ecs_ensure(
     ecs_check(entity != 0, ECS_INVALID_PARAMETER, NULL);
 
     /* Const cast is safe, function checks for threading */
-    world = (ecs_world_t*)ecs_get_world(world);
+    world = ECS_CONST_CAST(ecs_world_t*, ecs_get_world(world));
 
     /* The entity index can be mutated while in staged/readonly mode, as long as
      * the world is not multithreaded. */
@@ -10024,12 +10018,12 @@ void flecs_cmd_batch_for_entity(
             /* Add is batched, but keep Modified */
             cmd->kind = EcsOpModified;
 
-            /* fallthrough */
+            /* fall through */
         case EcsOpAdd:
             table = flecs_find_table_add(world, table, id, diff);
             world->info.cmd.batched_command_count ++;
             break;
-        case EcsOpModified: {
+        case EcsOpModified:
             if (start_table) {
                 /* If a modified was inserted for an existing component, the value
                  * of the component could have been changed. If this is the case,
@@ -10042,7 +10036,7 @@ void flecs_cmd_batch_for_entity(
                 flecs_component_ptr_t ptr = flecs_get_component_ptr(
                     world, start_table, row, cmd->id);
                 if (ptr.ptr) {
-                    ecs_type_info_t *ti = ptr.ti;
+                    const ecs_type_info_t *ti = ptr.ti;
                     ecs_iter_action_t on_set;
                     if ((on_set = ti->hooks.on_set)) {
                         flecs_invoke_hook(world, start_table, 1, row, &entity,
@@ -10051,7 +10045,6 @@ void flecs_cmd_batch_for_entity(
                 }
             }
             break;
-        }
         case EcsOpSet:
         case EcsOpMut:
             table = flecs_find_table_add(world, table, id, diff);
@@ -10076,7 +10069,14 @@ void flecs_cmd_batch_for_entity(
             table = &world->store.root;
             world->info.cmd.batched_command_count ++;
             break;
-        default:
+        case EcsOpClone:
+        case EcsOpBulkNew:
+        case EcsOpPath:
+        case EcsOpDelete:
+        case EcsOpOnDeleteAction:
+        case EcsOpEnable:
+        case EcsOpDisable:
+        case EcsOpSkip:
             break;
         }
 
@@ -10121,7 +10121,20 @@ void flecs_cmd_batch_for_entity(
                 }
                 break;
             }
-            default:
+        case EcsOpClone:
+        case EcsOpBulkNew:
+        case EcsOpAdd:
+        case EcsOpRemove:
+        case EcsOpEmplace:
+        case EcsOpModified:
+        case EcsOpAddModified:
+        case EcsOpPath:
+        case EcsOpDelete:
+        case EcsOpClear:
+        case EcsOpOnDeleteAction:
+        case EcsOpEnable:
+        case EcsOpDisable:
+        case EcsOpSkip:
                 break;
             }
         } while ((cur = next_for_entity));
@@ -10764,7 +10777,7 @@ void* flecs_defer_set(
         ecs_record_t *r = flecs_entities_get(world, entity);
         table = r->table;
         if (r && table && (storage_table = table->storage_table)) {
-            const ecs_table_record_t *tr = flecs_id_record_get_table(
+            ecs_table_record_t *tr = flecs_id_record_get_table(
                 idr, storage_table);
             if (tr) {
                 /* Entity has the component */
@@ -10958,7 +10971,7 @@ void ecs_set_stage_count(
         ECS_INTERNAL_ERROR, NULL);
 
     bool auto_merge = true;
-    ecs_entity_t *lookup_path = NULL;
+    const ecs_entity_t *lookup_path = NULL;
     ecs_entity_t scope = 0;
     ecs_entity_t with = 0;
     if (world->stage_count >= 1) {
@@ -11030,7 +11043,7 @@ int32_t ecs_get_stage_id(
     ecs_check(world != NULL, ECS_INVALID_PARAMETER, NULL);
 
     if (ecs_poly_is(world, ecs_stage_t)) {
-        ecs_stage_t *stage = (ecs_stage_t*)world;
+        ecs_stage_t *stage = ECS_CONST_CAST(ecs_stage_t*, world);
 
         /* Index 0 is reserved for main stage */
         return stage->id;
@@ -11151,7 +11164,7 @@ bool ecs_stage_is_readonly(
     const ecs_world_t *world = ecs_get_world(stage);
 
     if (ecs_poly_is(stage, ecs_stage_t)) {
-        if (((ecs_stage_t*)stage)->async) {
+        if (((const ecs_stage_t*)stage)->async) {
             return false;
         }
     }
@@ -12349,7 +12362,7 @@ uint64_t flecs_switch_get(
 ecs_vec_t* flecs_switch_values(
     const ecs_switch_t *sw)
 {
-    return (ecs_vec_t*)&sw->values;
+    return ECS_CONST_CAST(ecs_vec_t*, &sw->values);
 }
 
 int32_t flecs_switch_case_count(
@@ -12826,7 +12839,7 @@ void flecs_name_index_init(
     ecs_hashmap_t *hm,
     ecs_allocator_t *allocator) 
 {
-    _flecs_hashmap_init(hm, 
+    flecs_hashmap_init_(hm, 
         ECS_SIZEOF(ecs_hashed_string_t), ECS_SIZEOF(uint64_t), 
         flecs_name_index_hash, 
         flecs_name_index_compare,
@@ -12900,7 +12913,7 @@ ecs_hashed_string_t flecs_get_hashed_string(
     }
 
     return (ecs_hashed_string_t) {
-        .value = (char*)name,
+        .value = ECS_CONST_CAST(char*, name),
         .length = length,
         .hash = hash
     };
@@ -12989,7 +13002,7 @@ void flecs_name_index_update_name(
         if (ids[i] == e) {
             ecs_hashed_string_t *key = ecs_vec_get_t(
                 &b->keys, ecs_hashed_string_t, i);
-            key->value = (char*)name;
+            key->value = ECS_CONST_CAST(char*, name);
             ecs_assert(ecs_os_strlen(name) == key->length,
                 ECS_INTERNAL_ERROR, NULL);
             ecs_assert(flecs_hash(name, key->length) == key->hash,
@@ -13039,7 +13052,7 @@ error:
 
 /* quick example:
    string s="fjsakfdsjkf";
-   uint64_t hash=wyhash(s.c_str(), s.size(), 0, _wyp);
+   uint64_t hash=wyhash(s.c_str(), s.size(), 0, wyp_);
 */
 
 
@@ -13066,15 +13079,15 @@ error:
 
 //likely and unlikely macros
 #if defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__clang__)
-  #define _likely_(x)  __builtin_expect(x,1)
-  #define _unlikely_(x)  __builtin_expect(x,0)
+  #define likely_(x)  __builtin_expect(x,1)
+  #define unlikely_(x)  __builtin_expect(x,0)
 #else
-  #define _likely_(x) (x)
-  #define _unlikely_(x) (x)
+  #define likely_(x) (x)
+  #define unlikely_(x) (x)
 #endif
 
 //128bit multiply function
-static inline void _wymum(uint64_t *A, uint64_t *B){
+static inline void wymum_(uint64_t *A, uint64_t *B){
 #if(WYHASH_32BIT_MUM)
   uint64_t hh=(*A>>32)*(*B>>32), hl=(*A>>32)*(uint32_t)*B, lh=(uint32_t)*A*(*B>>32), ll=(uint64_t)(uint32_t)*A*(uint32_t)*B;
   #if(WYHASH_CONDOM>1)
@@ -13110,7 +13123,7 @@ static inline void _wymum(uint64_t *A, uint64_t *B){
 }
 
 //multiply and xor mix function, aka MUM
-static inline uint64_t _wymix(uint64_t A, uint64_t B){ _wymum(&A,&B); return A^B; }
+static inline uint64_t wymix_(uint64_t A, uint64_t B){ wymum_(&A,&B); return A^B; }
 
 //endian macros
 #ifndef WYHASH_LITTLE_ENDIAN
@@ -13126,61 +13139,61 @@ static inline uint64_t _wymix(uint64_t A, uint64_t B){ _wymum(&A,&B); return A^B
 
 //read functions
 #if (WYHASH_LITTLE_ENDIAN)
-static inline uint64_t _wyr8(const uint8_t *p) { uint64_t v; memcpy(&v, p, 8); return v;}
-static inline uint64_t _wyr4(const uint8_t *p) { uint32_t v; memcpy(&v, p, 4); return v;}
+static inline uint64_t wyr8_(const uint8_t *p) { uint64_t v; memcpy(&v, p, 8); return v;}
+static inline uint64_t wyr4_(const uint8_t *p) { uint32_t v; memcpy(&v, p, 4); return v;}
 #elif defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__clang__)
-static inline uint64_t _wyr8(const uint8_t *p) { uint64_t v; memcpy(&v, p, 8); return __builtin_bswap64(v);}
-static inline uint64_t _wyr4(const uint8_t *p) { uint32_t v; memcpy(&v, p, 4); return __builtin_bswap32(v);}
+static inline uint64_t wyr8_(const uint8_t *p) { uint64_t v; memcpy(&v, p, 8); return __builtin_bswap64(v);}
+static inline uint64_t wyr4_(const uint8_t *p) { uint32_t v; memcpy(&v, p, 4); return __builtin_bswap32(v);}
 #elif defined(_MSC_VER)
-static inline uint64_t _wyr8(const uint8_t *p) { uint64_t v; memcpy(&v, p, 8); return _byteswap_uint64(v);}
-static inline uint64_t _wyr4(const uint8_t *p) { uint32_t v; memcpy(&v, p, 4); return _byteswap_ulong(v);}
+static inline uint64_t wyr8_(const uint8_t *p) { uint64_t v; memcpy(&v, p, 8); return _byteswap_uint64(v);}
+static inline uint64_t wyr4_(const uint8_t *p) { uint32_t v; memcpy(&v, p, 4); return _byteswap_ulong(v);}
 #else
-static inline uint64_t _wyr8(const uint8_t *p) {
+static inline uint64_t wyr8_(const uint8_t *p) {
   uint64_t v; memcpy(&v, p, 8);
   return (((v >> 56) & 0xff)| ((v >> 40) & 0xff00)| ((v >> 24) & 0xff0000)| ((v >>  8) & 0xff000000)| ((v <<  8) & 0xff00000000)| ((v << 24) & 0xff0000000000)| ((v << 40) & 0xff000000000000)| ((v << 56) & 0xff00000000000000));
 }
-static inline uint64_t _wyr4(const uint8_t *p) {
+static inline uint64_t wyr4_(const uint8_t *p) {
   uint32_t v; memcpy(&v, p, 4);
   return (((v >> 24) & 0xff)| ((v >>  8) & 0xff00)| ((v <<  8) & 0xff0000)| ((v << 24) & 0xff000000));
 }
 #endif
-static inline uint64_t _wyr3(const uint8_t *p, size_t k) { return (((uint64_t)p[0])<<16)|(((uint64_t)p[k>>1])<<8)|p[k-1];}
+static inline uint64_t wyr3_(const uint8_t *p, size_t k) { return (((uint64_t)p[0])<<16)|(((uint64_t)p[k>>1])<<8)|p[k-1];}
 
 //wyhash main function
 static inline uint64_t wyhash(const void *key, size_t len, uint64_t seed, const uint64_t *secret){
-  const uint8_t *p=(const uint8_t *)key; seed^=_wymix(seed^secret[0],secret[1]);	uint64_t	a,	b;
-  if(_likely_(len<=16)){
-    if(_likely_(len>=4)){ a=(_wyr4(p)<<32)|_wyr4(p+((len>>3)<<2)); b=(_wyr4(p+len-4)<<32)|_wyr4(p+len-4-((len>>3)<<2)); }
-    else if(_likely_(len>0)){ a=_wyr3(p,len); b=0;}
+  const uint8_t *p=(const uint8_t *)key; seed^=wymix_(seed^secret[0],secret[1]);	uint64_t	a,	b;
+  if(likely_(len<=16)){
+    if(likely_(len>=4)){ a=(wyr4_(p)<<32)|wyr4_(p+((len>>3)<<2)); b=(wyr4_(p+len-4)<<32)|wyr4_(p+len-4-((len>>3)<<2)); }
+    else if(likely_(len>0)){ a=wyr3_(p,len); b=0;}
     else a=b=0;
   }
   else{
     size_t i=len; 
-    if(_unlikely_(i>48)){
+    if(unlikely_(i>48)){
       uint64_t see1=seed, see2=seed;
       do{
-        seed=_wymix(_wyr8(p)^secret[1],_wyr8(p+8)^seed);
-        see1=_wymix(_wyr8(p+16)^secret[2],_wyr8(p+24)^see1);
-        see2=_wymix(_wyr8(p+32)^secret[3],_wyr8(p+40)^see2);
+        seed=wymix_(wyr8_(p)^secret[1],wyr8_(p+8)^seed);
+        see1=wymix_(wyr8_(p+16)^secret[2],wyr8_(p+24)^see1);
+        see2=wymix_(wyr8_(p+32)^secret[3],wyr8_(p+40)^see2);
         p+=48; i-=48;
-      }while(_likely_(i>48));
+      }while(likely_(i>48));
       seed^=see1^see2;
     }
-    while(_unlikely_(i>16)){  seed=_wymix(_wyr8(p)^secret[1],_wyr8(p+8)^seed);  i-=16; p+=16;  }
-    a=_wyr8(p+i-16);  b=_wyr8(p+i-8);
+    while(unlikely_(i>16)){  seed=wymix_(wyr8_(p)^secret[1],wyr8_(p+8)^seed);  i-=16; p+=16;  }
+    a=wyr8_(p+i-16);  b=wyr8_(p+i-8);
   }
-  a^=secret[1]; b^=seed;  _wymum(&a,&b);
-  return  _wymix(a^secret[0]^len,b^secret[1]);
+  a^=secret[1]; b^=seed;  wymum_(&a,&b);
+  return  wymix_(a^secret[0]^len,b^secret[1]);
 }
 
 //the default secret parameters
-static const uint64_t _wyp[4] = {0xa0761d6478bd642full, 0xe7037ed1a0b428dbull, 0x8ebc6af09c88c6e3ull, 0x589965cc75374cc3ull};
+static const uint64_t wyp_[4] = {0xa0761d6478bd642full, 0xe7037ed1a0b428dbull, 0x8ebc6af09c88c6e3ull, 0x589965cc75374cc3ull};
 
 uint64_t flecs_hash(
     const void *data,
     ecs_size_t length)
 {
-    return wyhash(data, flecs_ito(size_t, length), 0, _wyp);
+    return wyhash(data, flecs_ito(size_t, length), 0, wyp_);
 }
 
 /**
@@ -13554,7 +13567,7 @@ void flecs_strbuf_grow(
 static
 void flecs_strbuf_grow_str(
     ecs_strbuf_t *b,
-    char *str,
+    const char *str,
     char *alloc_str,
     int32_t size)
 {
@@ -13567,7 +13580,7 @@ void flecs_strbuf_grow_str(
     e->super.buffer_embedded = false;
     e->super.pos = size ? size : (int32_t)ecs_os_strlen(str);
     e->super.next = NULL;
-    e->super.buf = str;
+    e->super.buf = ECS_CONST_CAST(char*, str);
     e->alloc_str = alloc_str;
 }
 
@@ -13877,7 +13890,7 @@ bool ecs_strbuf_appendstr_zerocpy_const(
     ecs_assert(str != NULL, ECS_INVALID_PARAMETER, NULL);
     /* Removes const modifier, but logic prevents changing / delete string */
     flecs_strbuf_init(b);
-    flecs_strbuf_grow_str(b, (char*)str, NULL, 0);
+    flecs_strbuf_grow_str(b, str, NULL, 0);
     return true;
 }
 
@@ -13890,7 +13903,7 @@ bool ecs_strbuf_appendstr_zerocpyn_const(
     ecs_assert(str != NULL, ECS_INVALID_PARAMETER, NULL);
     /* Removes const modifier, but logic prevents changing / delete string */
     flecs_strbuf_init(b);
-    flecs_strbuf_grow_str(b, (char*)str, NULL, n);
+    flecs_strbuf_grow_str(b, str, NULL, n);
     return true;
 }
 
@@ -14214,7 +14227,7 @@ void ecs_vec_clear(
 
 ecs_vec_t ecs_vec_copy(
     ecs_allocator_t *allocator,
-    ecs_vec_t *v,
+    const ecs_vec_t *v,
     ecs_size_t size)
 {
     ecs_dbg_assert(size == v->elem_size, ECS_INVALID_PARAMETER, NULL);
@@ -14704,7 +14717,7 @@ ecs_map_val_t* ecs_map_get(
     return flecs_map_bucket_get(flecs_map_get_bucket(map, key), key);
 }
 
-void* _ecs_map_get_deref(
+void* ecs_map_get_deref_(
     const ecs_map_t *map,
     ecs_map_key_t key)
 {
@@ -15161,7 +15174,7 @@ int32_t flecs_hashmap_find_key(
     return -1;
 }
 
-void _flecs_hashmap_init(
+void flecs_hashmap_init_(
     ecs_hashmap_t *map,
     ecs_size_t key_size,
     ecs_size_t value_size,
@@ -15202,7 +15215,7 @@ void flecs_hashmap_copy(
 {
     ecs_assert(dst != src, ECS_INVALID_PARAMETER, NULL);
 
-    _flecs_hashmap_init(dst, src->key_size, src->value_size, src->hash, 
+    flecs_hashmap_init_(dst, src->key_size, src->value_size, src->hash, 
         src->compare, src->impl.allocator);
     ecs_map_copy(&dst->impl, &src->impl);
 
@@ -15218,7 +15231,7 @@ void flecs_hashmap_copy(
     }
 }
 
-void* _flecs_hashmap_get(
+void* flecs_hashmap_get_(
     const ecs_hashmap_t *map,
     ecs_size_t key_size,
     const void *key,
@@ -15242,7 +15255,7 @@ void* _flecs_hashmap_get(
     return ecs_vec_get(&bucket->values, value_size, index);
 }
 
-flecs_hashmap_result_t _flecs_hashmap_ensure(
+flecs_hashmap_result_t flecs_hashmap_ensure_(
     ecs_hashmap_t *map,
     ecs_size_t key_size,
     const void *key,
@@ -15287,14 +15300,14 @@ flecs_hashmap_result_t _flecs_hashmap_ensure(
     };
 }
 
-void _flecs_hashmap_set(
+void flecs_hashmap_set_(
     ecs_hashmap_t *map,
     ecs_size_t key_size,
     void *key,
     ecs_size_t value_size,
     const void *value)
 {
-    void *value_ptr = _flecs_hashmap_ensure(map, key_size, key, value_size).value;
+    void *value_ptr = flecs_hashmap_ensure_(map, key_size, key, value_size).value;
     ecs_assert(value_ptr != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_os_memcpy(value_ptr, value, value_size);
 }
@@ -15326,7 +15339,7 @@ void flecs_hm_bucket_remove(
     }
 }
 
-void _flecs_hashmap_remove_w_hash(
+void flecs_hashmap_remove_w_hash_(
     ecs_hashmap_t *map,
     ecs_size_t key_size,
     const void *key,
@@ -15351,7 +15364,7 @@ void _flecs_hashmap_remove_w_hash(
     flecs_hm_bucket_remove(map, bucket, hash, index);
 }
 
-void _flecs_hashmap_remove(
+void flecs_hashmap_remove_(
     ecs_hashmap_t *map,
     ecs_size_t key_size,
     const void *key,
@@ -15361,7 +15374,7 @@ void _flecs_hashmap_remove(
     ecs_assert(map->value_size == value_size, ECS_INVALID_PARAMETER, NULL);
 
     uint64_t hash = map->hash(key);
-    _flecs_hashmap_remove_w_hash(map, key_size, key, value_size, hash);
+    flecs_hashmap_remove_w_hash_(map, key_size, key, value_size, hash);
 }
 
 flecs_hashmap_iter_t flecs_hashmap_iter(
@@ -15372,7 +15385,7 @@ flecs_hashmap_iter_t flecs_hashmap_iter(
     };
 }
 
-void* _flecs_hashmap_next(
+void* flecs_hashmap_next_(
     flecs_hashmap_iter_t *it,
     ecs_size_t key_size,
     void *key_out,
@@ -15894,10 +15907,10 @@ int32_t flecs_get_flattened_target(
         return -1;
     }
 
-    const ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
+    ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
     if (tr) {
         *src_out = ecs_record_get_entity(r);
-        *tr_out = (ecs_table_record_t*)tr;
+        *tr_out = tr;
         return tr->column;
     }
 
@@ -16335,7 +16348,7 @@ void flecs_colorize_buf(
     }
 }
 
-void _ecs_printv(
+void ecs_printv_(
     int level,
     const char *file,
     int32_t line,
@@ -16364,7 +16377,7 @@ void _ecs_printv(
     }
 }
 
-void _ecs_print(
+void ecs_print_(
     int level,
     const char *file,
     int32_t line,
@@ -16373,11 +16386,11 @@ void _ecs_print(
 {
     va_list args;
     va_start(args, fmt);
-    _ecs_printv(level, file, line, fmt, args);
+    ecs_printv_(level, file, line, fmt, args);
     va_end(args);    
 }
 
-void _ecs_logv(
+void ecs_logv_(
     int level,
     const char *file,
     int32_t line,
@@ -16388,10 +16401,10 @@ void _ecs_logv(
         return;
     }
 
-    _ecs_printv(level, file, line, fmt, args);
+    ecs_printv_(level, file, line, fmt, args);
 }
 
-void _ecs_log(
+void ecs_log_(
     int level,
     const char *file,
     int32_t line,
@@ -16404,12 +16417,12 @@ void _ecs_log(
 
     va_list args;
     va_start(args, fmt);
-    _ecs_printv(level, file, line, fmt, args);
+    ecs_printv_(level, file, line, fmt, args);
     va_end(args);    
 }
 
 
-void _ecs_log_push(
+void ecs_log_push_(
     int32_t level) 
 {
     if (level <= ecs_os_api.log_level_) {
@@ -16417,7 +16430,7 @@ void _ecs_log_push(
     }
 }
 
-void _ecs_log_pop(
+void ecs_log_pop_(
     int32_t level)
 {
     if (level <= ecs_os_api.log_level_) {
@@ -16426,7 +16439,7 @@ void _ecs_log_pop(
     }
 }
 
-void _ecs_parser_errorv(
+void ecs_parser_errorv_(
     const char *name,
     const char *expr, 
     int64_t column_arg,
@@ -16491,7 +16504,7 @@ void _ecs_parser_errorv(
     }
 }
 
-void _ecs_parser_error(
+void ecs_parser_error_(
     const char *name,
     const char *expr, 
     int64_t column,
@@ -16501,12 +16514,12 @@ void _ecs_parser_error(
     if (ecs_os_api.log_level_  >= -2) {
         va_list args;
         va_start(args, fmt);
-        _ecs_parser_errorv(name, expr, column, fmt, args);
+        ecs_parser_errorv_(name, expr, column, fmt, args);
         va_end(args);
     }
 }
 
-void _ecs_abort(
+void ecs_abort_(
     int32_t err,
     const char *file,
     int32_t line,
@@ -16518,15 +16531,15 @@ void _ecs_abort(
         va_start(args, fmt);
         char *msg = ecs_vasprintf(fmt, args);
         va_end(args);
-        _ecs_fatal(file, line, "%s (%s)", msg, ecs_strerror(err));
+        ecs_fatal_(file, line, "%s (%s)", msg, ecs_strerror(err));
         ecs_os_free(msg);
     } else {
-        _ecs_fatal(file, line, "%s", ecs_strerror(err));
+        ecs_fatal_(file, line, "%s", ecs_strerror(err));
     }
     ecs_os_api.log_last_error_ = err;
 }
 
-bool _ecs_assert(
+bool ecs_assert_(
     bool condition,
     int32_t err,
     const char *cond_str,
@@ -16541,11 +16554,11 @@ bool _ecs_assert(
             va_start(args, fmt);
             char *msg = ecs_vasprintf(fmt, args);
             va_end(args);            
-            _ecs_fatal(file, line, "assert: %s %s (%s)", 
+            ecs_fatal_(file, line, "assert: %s %s (%s)", 
                 cond_str, msg, ecs_strerror(err));
             ecs_os_free(msg);
         } else {
-            _ecs_fatal(file, line, "assert: %s %s", 
+            ecs_fatal_(file, line, "assert: %s %s", 
                 cond_str, ecs_strerror(err));
         }
         ecs_os_api.log_last_error_ = err;
@@ -16554,12 +16567,12 @@ bool _ecs_assert(
     return condition;
 }
 
-void _ecs_deprecated(
+void ecs_deprecated_(
     const char *file,
     int32_t line,
     const char *msg)
 {
-    _ecs_err(file, line, "%s", msg);
+    ecs_err_(file, line, "%s", msg);
 }
 
 bool ecs_should_log(int32_t level) {
@@ -16630,7 +16643,7 @@ const char* ecs_strerror(
 
 /* Empty bodies for when logging is disabled */
 
-void _ecs_log(
+void ecs_log_(
     int32_t level,
     const char *file,
     int32_t line,
@@ -16643,7 +16656,7 @@ void _ecs_log(
     (void)fmt;
 }
 
-void _ecs_parser_error(
+void ecs_parser_error_(
     const char *name,
     const char *expr, 
     int64_t column,
@@ -16656,7 +16669,7 @@ void _ecs_parser_error(
     (void)fmt;
 }
 
-void _ecs_parser_errorv(
+void ecs_parser_errorv_(
     const char *name,
     const char *expr, 
     int64_t column,
@@ -16670,7 +16683,7 @@ void _ecs_parser_errorv(
     (void)args;
 }
 
-void _ecs_abort(
+void ecs_abort_(
     int32_t error_code,
     const char *file,
     int32_t line,
@@ -16683,7 +16696,7 @@ void _ecs_abort(
     (void)fmt;
 }
 
-bool _ecs_assert(
+bool ecs_assert_(
     bool condition,
     int32_t error_code,
     const char *condition_str,
@@ -16910,6 +16923,7 @@ void flecs_wait_for_sync(
     ecs_world_t *world);
 
 #endif
+
 
 /* Synchronize workers */
 static
@@ -17407,7 +17421,9 @@ bool flecs_pipeline_check_term(
                 flecs_pipeline_set_write_state(write_state, id);
             }
             break;
-        default:
+        case EcsInOutDefault:
+        case EcsInOutNone:
+        case EcsIn:
             break;
         }
 
@@ -17419,7 +17435,10 @@ bool flecs_pipeline_check_term(
                  * the main store so it must be merged first */
                 return true;
             }
-        default:
+            /* fall through */
+        case EcsInOutDefault:
+        case EcsInOutNone:
+        case EcsOut:
             break;
         }
     }
@@ -17740,7 +17759,8 @@ void ecs_run_pipeline(
         flecs_create_worker_threads(world);
     }
 
-    EcsPipeline *p = (EcsPipeline*)ecs_get(world, pipeline, EcsPipeline);
+    EcsPipeline *p = 
+        ECS_CONST_CAST(EcsPipeline*, ecs_get(world, pipeline, EcsPipeline));
     flecs_workers_progress(world, p->state, delta_time);
 
     if (ecs_using_task_threads(world))
@@ -17760,7 +17780,7 @@ int32_t flecs_run_pipeline_ops(
     ecs_pipeline_state_t* pq = world->pq;
     ecs_pipeline_op_t* op = pq->cur_op;
     int32_t i = pq->cur_i;
-    
+
     ecs_assert(!stage_index || op->multi_threaded, ECS_INTERNAL_ERROR, NULL);
 
     int32_t count = ecs_vec_count(&pq->systems);
@@ -18060,9 +18080,9 @@ void FlecsPipelineFini(
 
 #define flecs_bootstrap_phase(world, phase, depends_on)\
     flecs_bootstrap_tag(world, phase);\
-    _flecs_bootstrap_phase(world, phase, depends_on)
+    flecs_bootstrap_phase_(world, phase, depends_on)
 static
-void _flecs_bootstrap_phase(
+void flecs_bootstrap_phase_(
     ecs_world_t *world,
     ecs_entity_t phase,
     ecs_entity_t depends_on)
@@ -19492,24 +19512,31 @@ ecs_entity_t flecs_alert_out_of_range_kind(
     const EcsMemberRanges *ranges,
     const void *value_ptr)
 {
-    double value;
+    double value = 0;
 
     switch(alert->kind) {
-    case EcsU8: value = *(uint8_t*)value_ptr; break;
-    case EcsU16: value = *(uint16_t*)value_ptr; break;
-    case EcsU32: value = *(uint32_t*)value_ptr; break;
-    case EcsU64: value = (double)*(uint64_t*)value_ptr; break;
-    case EcsI8: value = *(int8_t*)value_ptr; break;
-    case EcsI16: value = *(int16_t*)value_ptr; break;
-    case EcsI32: value = *(int32_t*)value_ptr; break;
-    case EcsI64: value = (double)*(int64_t*)value_ptr; break;
-    case EcsF32: value = (double)*(float*)value_ptr; break;
-    case EcsF64: value = *(double*)value_ptr; break;
-    default: return 0;
+    case EcsU8: value = *(const uint8_t*)value_ptr; break;
+    case EcsU16: value = *(const uint16_t*)value_ptr; break;
+    case EcsU32: value = *(const uint32_t*)value_ptr; break;
+    case EcsU64: value = (double)*(const uint64_t*)value_ptr; break;
+    case EcsI8: value = *(const int8_t*)value_ptr; break;
+    case EcsI16: value = *(const int16_t*)value_ptr; break;
+    case EcsI32: value = *(const int32_t*)value_ptr; break;
+    case EcsI64: value = (double)*(const int64_t*)value_ptr; break;
+    case EcsF32: value = (double)*(const float*)value_ptr; break;
+    case EcsF64: value = *(const double*)value_ptr; break;
+    case EcsBool:
+    case EcsChar:
+    case EcsByte:
+    case EcsUPtr:
+    case EcsIPtr:
+    case EcsString:
+    case EcsEntity:
+        return 0;
     }
 
-    bool has_error = ranges->error.min != ranges->error.max;
-    bool has_warning = ranges->warning.min != ranges->warning.max;
+    bool has_error = ECS_NEQ(ranges->error.min, ranges->error.max);
+    bool has_warning = ECS_NEQ(ranges->warning.min, ranges->warning.max);
 
     if (has_error && (value < ranges->error.min || value > ranges->error.max)) {
         return EcsAlertError;
@@ -19602,7 +19629,7 @@ void MonitorAlerts(ecs_iter_t *it) {
                     ecs_set(world, ai, EcsMetricSource, { .entity = e });
                     ecs_set(world, ai, EcsMetricValue, { .value = 0 });
                     ecs_add_pair(world, ai, ecs_id(EcsAlert), src_severity);
-                    if (alert[i].retain_period != 0) {
+                    if (ECS_NEQZERO(alert[i].retain_period)) {
                         ecs_set(world, ai, EcsAlertTimeout, {
                             .inactive_time = 0,
                             .expire_time = alert[i].retain_period
@@ -19730,7 +19757,7 @@ void MonitorAlertInstances(ecs_iter_t *it) {
                 }
 
                 if (timeout) {
-                    if (timeout[i].inactive_time != 0) {
+                    if (ECS_NEQZERO(timeout[i].inactive_time)) {
                         /* The alert just became active. Remove Disabled tag */
                         flecs_alerts_add_alert_to_src(world, e, parent, ai);
                         ecs_remove_id(world, ai, EcsDisabled);
@@ -19749,7 +19776,7 @@ void MonitorAlertInstances(ecs_iter_t *it) {
         /* Alert instance is no longer active */
 
         if (timeout) {
-            if (timeout[i].inactive_time == 0) {
+            if (ECS_EQZERO(timeout[i].inactive_time)) {
                 /* The alert just became inactive. Add Disabled tag */
                 flecs_alerts_remove_alert_from_src(world, e, parent);
                 ecs_add_id(world, ai, EcsDisabled);
@@ -20073,17 +20100,32 @@ void FlecsAlertsImport(ecs_world_t *world) {
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
-#include <winsock2.h>
-#include <windows.h>
+#include <WinSock2.h>
+#include <Windows.h>
+
+typedef struct ecs_win_thread_t {
+    HANDLE thread;
+    ecs_os_thread_callback_t callback;
+    void *arg;
+} ecs_win_thread_t;
+
+static
+DWORD flecs_win_thread(void *ptr) {
+    ecs_win_thread_t *thread = ptr;
+    thread->callback(thread->arg);
+    return 0;
+}
 
 static
 ecs_os_thread_t win_thread_new(
     ecs_os_thread_callback_t callback, 
     void *arg)
 {
-    HANDLE *thread = ecs_os_malloc_t(HANDLE);
-    *thread = CreateThread(
-        NULL, 0, (LPTHREAD_START_ROUTINE)callback, arg, 0, NULL);
+    ecs_win_thread_t *thread = ecs_os_malloc_t(ecs_win_thread_t);
+    thread->arg= arg;
+    thread->callback = callback;
+    thread->thread = CreateThread(
+        NULL, 0, (LPTHREAD_START_ROUTINE)flecs_win_thread, thread, 0, NULL);
     return (ecs_os_thread_t)(uintptr_t)thread;
 }
 
@@ -20091,8 +20133,8 @@ static
 void* win_thread_join(
     ecs_os_thread_t thr)
 {
-    HANDLE *thread = (HANDLE*)(uintptr_t)thr;
-    DWORD r = WaitForSingleObject(*thread, INFINITE);
+    ecs_win_thread_t *thread = (ecs_win_thread_t*)(uintptr_t)thr;
+    DWORD r = WaitForSingleObject(thread->thread, INFINITE);
     if (r == WAIT_FAILED) {
         ecs_err("win_thread_join: WaitForSingleObject failed");
     }
@@ -20110,14 +20152,14 @@ static
 int32_t win_ainc(
     int32_t *count) 
 {
-    return InterlockedIncrement(count);
+    return InterlockedIncrement((volatile long*)count);
 }
 
 static
 int32_t win_adec(
     int32_t *count) 
 {
-    return InterlockedDecrement(count);
+    return InterlockedDecrement((volatile long*)count);
 }
 
 static
@@ -20251,20 +20293,21 @@ void win_enable_high_timer_resolution(bool enable)
         return;
     }
 
-    LONG (__stdcall *pNtSetTimerResolution)(
-        ULONG desired, BOOLEAN set, ULONG * current);
+    union {
+        LONG (__stdcall *f)(
+            ULONG desired, BOOLEAN set, ULONG * current);
+        FARPROC p;
+    } func;
 
-    pNtSetTimerResolution = (LONG(__stdcall*)(ULONG, BOOLEAN, ULONG*))
-        GetProcAddress(hntdll, "NtSetTimerResolution");
-
-    if(!pNtSetTimerResolution) {
+    func.p = GetProcAddress(hntdll, "NtSetTimerResolution");
+    if(!func.p) {
         return;
     }
 
     ULONG current, resolution = 10000; /* 1 ms */
 
     if (!enable && win_current_resolution) {
-        pNtSetTimerResolution(win_current_resolution, 0, &current);
+        func.f(win_current_resolution, 0, &current);
         win_current_resolution = 0;
         return;
     } else if (!enable) {
@@ -20276,13 +20319,13 @@ void win_enable_high_timer_resolution(bool enable)
     }
 
     if (win_current_resolution) {
-        pNtSetTimerResolution(win_current_resolution, 0, &current);
+        func.f(win_current_resolution, 0, &current);
     }
 
-    if (pNtSetTimerResolution(resolution, 1, &current)) {
+    if (func.f(resolution, 1, &current)) {
         /* Try setting a lower resolution */
         resolution *= 2;
-        if(pNtSetTimerResolution(resolution, 1, &current)) return;
+        if(func.f(resolution, 1, &current)) return;
     }
 
     win_current_resolution = resolution;
@@ -20294,7 +20337,7 @@ uint64_t win_time_now(void) {
 
     LARGE_INTEGER qpc_t;
     QueryPerformanceCounter(&qpc_t);
-    now = (uint64_t)(qpc_t.QuadPart / win_time_freq);
+    now = (uint64_t)((double)qpc_t.QuadPart / win_time_freq);
 
     return now;
 }
@@ -21259,7 +21302,7 @@ static
 char* plecs_trim_annot(
     char *annot)
 {
-    annot = (char*)ecs_parse_ws(annot);
+    annot = ECS_CONST_CAST(char*, ecs_parse_ws(annot));
     int32_t len = ecs_os_strlen(annot) - 1;
     while (isspace(annot[len]) && (len > 0)) {
         annot[len] = '\0';
@@ -22844,14 +22887,14 @@ ecs_entity_t ecs_script_init(
 
     if (script != desc->str) {
         /* Safe cast, only happens when script is loaded from file */
-        ecs_os_free((char*)script);
+        ecs_os_free(ECS_CONST_CAST(char*, script));
     }
 
     return e;
 error:
     if (script != desc->str) {
         /* Safe cast, only happens when script is loaded from file */
-        ecs_os_free((char*)script);
+        ecs_os_free(ECS_CONST_CAST(char*, script));
     }
     if (!desc->entity) {
         ecs_delete(world, e);
@@ -23110,8 +23153,8 @@ ecs_entity_t ecs_import_from_library(
 {
     ecs_check(library_name != NULL, ECS_INVALID_PARAMETER, NULL);
 
-    char *import_func = (char*)module_name; /* safe */
-    char *module = (char*)module_name;
+    char *import_func = ECS_CONST_CAST(char*, module_name);
+    char *module = ECS_CONST_CAST(char*, module_name);
 
     if (!ecs_os_has_modules() || !ecs_os_has_dl()) {
         ecs_err(
@@ -23277,14 +23320,14 @@ ECS_TAG_DECLARE(EcsCounterId);
 ECS_TAG_DECLARE(EcsGauge);
 
 /* Internal components */
-ECS_COMPONENT_DECLARE(EcsMetricMember);
-ECS_COMPONENT_DECLARE(EcsMetricId);
-ECS_COMPONENT_DECLARE(EcsMetricOneOf);
-ECS_COMPONENT_DECLARE(EcsMetricCountIds);
-ECS_COMPONENT_DECLARE(EcsMetricCountTargets);
-ECS_COMPONENT_DECLARE(EcsMetricMemberInstance);
-ECS_COMPONENT_DECLARE(EcsMetricIdInstance);
-ECS_COMPONENT_DECLARE(EcsMetricOneOfInstance);
+static ECS_COMPONENT_DECLARE(EcsMetricMember);
+static ECS_COMPONENT_DECLARE(EcsMetricId);
+static ECS_COMPONENT_DECLARE(EcsMetricOneOf);
+static ECS_COMPONENT_DECLARE(EcsMetricCountIds);
+static ECS_COMPONENT_DECLARE(EcsMetricCountTargets);
+static ECS_COMPONENT_DECLARE(EcsMetricMemberInstance);
+static ECS_COMPONENT_DECLARE(EcsMetricIdInstance);
+static ECS_COMPONENT_DECLARE(EcsMetricOneOfInstance);
 
 /** Context for metric */
 typedef struct {
@@ -24207,7 +24250,16 @@ bool flecs_type_is_number(
     case EcsF32:
     case EcsF64:
         return true;
+
+    case EcsBool:
+    case EcsByte:
+    case EcsUPtr:
+    case EcsIPtr:
+    case EcsString:
+    case EcsEntity:
+        return false;
     default:
+        ecs_abort(ECS_INVALID_PARAMETER, NULL);
         return false;
     }
 }
@@ -24350,11 +24402,11 @@ bool flecs_member_range_overlaps(
     const ecs_member_value_range_t *range,
     const ecs_member_value_range_t *with)
 {
-    if (with->min == with->max) {
+    if (ECS_EQ(with->min, with->max)) {
         return false;
     }
 
-    if (range->min == range->max) {
+    if (ECS_EQ(range->min, range->max)) {
         return false;
     }
 
@@ -24407,7 +24459,7 @@ ecs_entity_t ecs_struct_init(
         const ecs_member_value_range_t *range = &m_desc->range;
         const ecs_member_value_range_t *error = &m_desc->error_range;
         const ecs_member_value_range_t *warning = &m_desc->warning_range;
-        if (range->min != range->max) {
+        if (ECS_NEQ(range->min, range->max)) {
             ranges = ecs_get_mut(world, m, EcsMemberRanges);
             if (range->min > range->max) {
                 char *member_name = ecs_get_fullpath(world, m);
@@ -24419,7 +24471,7 @@ ecs_entity_t ecs_struct_init(
             ranges->value.min = range->min;
             ranges->value.max = range->max;
         }
-        if (error->min != error->max) {
+        if (ECS_NEQ(error->min, error->max)) {
             if (error->min > error->max) {
                 char *member_name = ecs_get_fullpath(world, m);
                 ecs_err("member '%s' has an invalid error range [%d..%d]",
@@ -24441,7 +24493,7 @@ ecs_entity_t ecs_struct_init(
             ranges->error.max = error->max;
         }
 
-        if (warning->min != warning->max) {
+        if (ECS_NEQ(warning->min, warning->max)) {
             if (warning->min > warning->max) {
                 char *member_name = ecs_get_fullpath(world, m);
                 ecs_err("member '%s' has an invalid warning range [%d..%d]",
@@ -24577,7 +24629,7 @@ ecs_entity_t ecs_unit_prefix_init(
     }
 
     ecs_set(world, t, EcsUnitPrefix, {
-        .symbol = (char*)desc->symbol,
+        .symbol = ECS_CONST_CAST(char*, desc->symbol),
         .translation = desc->translation
     });
 
@@ -24664,7 +24716,7 @@ int flecs_meta_serialize_primitive(
     }
 
     ecs_meta_type_op_t *op = flecs_meta_ops_add(ops, flecs_meta_primitive_to_op_kind(ptr->kind));
-    op->offset = offset,
+    op->offset = offset;
     op->type = type;
     op->size = flecs_meta_type_size(world, type);
     return 0;
@@ -24680,7 +24732,7 @@ int flecs_meta_serialize_enum(
     (void)world;
     
     ecs_meta_type_op_t *op = flecs_meta_ops_add(ops, EcsOpEnum);
-    op->offset = offset,
+    op->offset = offset;
     op->type = type;
     op->size = ECS_SIZEOF(ecs_i32_t);
     return 0;
@@ -24696,7 +24748,7 @@ int flecs_meta_serialize_bitmask(
     (void)world;
     
     ecs_meta_type_op_t *op = flecs_meta_ops_add(ops, EcsOpBitmask);
-    op->offset = offset,
+    op->offset = offset;
     op->type = type;
     op->size = ECS_SIZEOF(ecs_u32_t);
     return 0;
@@ -24864,16 +24916,11 @@ int flecs_meta_serialize_component(
         return -1;
     }
 
-    switch(ptr->kind) {
-    case EcsArrayType:
+    if (ptr->kind == EcsArrayType) {
         return flecs_meta_serialize_array_component(world, type, ops);
-        break;
-    default:
+    } else {
         return flecs_meta_serialize_type(world, type, 0, ops);
-        break;
     }
-
-    return 0;
 }
 
 void ecs_meta_type_serialized_init(
@@ -24912,7 +24959,7 @@ void ecs_meta_type_serialized_init(
 
 static ECS_COPY(ecs_string_t, dst, src, {
     ecs_os_free(*(ecs_string_t*)dst);
-    *(ecs_string_t*)dst = ecs_os_strdup(*(ecs_string_t*)src);
+    *(ecs_string_t*)dst = ecs_os_strdup(*(const ecs_string_t*)src);
 })
 
 static ECS_MOVE(ecs_string_t, dst, src, {
@@ -24980,7 +25027,7 @@ static void flecs_struct_dtor(
     ecs_member_t *members = ecs_vec_first_t(&ptr->members, ecs_member_t);
     int32_t i, count = ecs_vec_count(&ptr->members);
     for (i = 0; i < count; i ++) {
-        ecs_os_free((char*)members[i].name);
+        ecs_os_free(ECS_CONST_CAST(char*, members[i].name));
     }
     ecs_vec_fini_t(NULL, &ptr->members, ecs_member_t);
 }
@@ -25015,7 +25062,7 @@ static void flecs_constants_dtor(
     ecs_map_iter_t it = ecs_map_iter(constants);
     while (ecs_map_next(&it)) {
         ecs_enum_constant_t *c = ecs_map_ptr(&it);
-        ecs_os_free((char*)c->name);
+        ecs_os_free(ECS_CONST_CAST(char*, c->name));
         ecs_os_free(c);
     }
     ecs_map_fini(constants);
@@ -25023,7 +25070,7 @@ static void flecs_constants_dtor(
 
 static void flecs_constants_copy(
     ecs_map_t *dst,
-    ecs_map_t *src)
+    const ecs_map_t *src)
 {
     ecs_map_copy(dst, src);
 
@@ -25237,7 +25284,7 @@ void flecs_set_struct_member(
         member->count = 1;
     }
 
-    ecs_os_strset((char**)&member->name, name);
+    ecs_os_strset(ECS_CONST_CAST(char**, &member->name), name);
 
     if (ranges) {
         member->range = ranges->value;
@@ -25448,7 +25495,7 @@ int flecs_add_constant_to_enum(
     while (ecs_map_next(&it)) {
         ecs_enum_constant_t *c = ecs_map_ptr(&it);
         if (c->constant == e) {
-            ecs_os_free((char*)c->name);
+            ecs_os_free(ECS_CONST_CAST(char*, c->name));
             ecs_map_remove_free(&ptr->constants, ecs_map_key(&it));
         }
     }
@@ -25522,7 +25569,7 @@ int flecs_add_constant_to_bitmask(
     while (ecs_map_next(&it)) {
         ecs_bitmask_constant_t *c = ecs_map_ptr(&it);
         if (c->constant == e) {
-            ecs_os_free((char*)c->name);
+            ecs_os_free(ECS_CONST_CAST(char*, c->name));
             ecs_map_remove_free(&ptr->constants, ecs_map_key(&it));
         }
     }
@@ -26229,126 +26276,126 @@ void FlecsMetaImport(
     ecs_entity_t type_kind = ecs_enum_init(world, &(ecs_enum_desc_t){
         .entity = ecs_entity(world, { .name = "TypeKind" }),
         .constants = {
-            {.name = "PrimitiveType"},
-            {.name = "BitmaskType"},
-            {.name = "EnumType"},
-            {.name = "StructType"},
-            {.name = "ArrayType"},
-            {.name = "VectorType"},
-            {.name = "OpaqueType"}
+            { .name = "PrimitiveType" },
+            { .name = "BitmaskType" },
+            { .name = "EnumType" },
+            { .name = "StructType" },
+            { .name = "ArrayType" },
+            { .name = "VectorType" },
+            { .name = "OpaqueType" }
         }
     });
 
     ecs_struct_init(world, &(ecs_struct_desc_t){
         .entity = ecs_id(EcsMetaType),
         .members = {
-            {.name = (char*)"kind", .type = type_kind}
+            { .name = "kind", .type = type_kind }
         }
     });
 
     ecs_entity_t primitive_kind = ecs_enum_init(world, &(ecs_enum_desc_t){
         .entity = ecs_entity(world, { .name = "PrimitiveKind" }),
         .constants = {
-            {.name = "Bool", 1}, 
-            {.name = "Char"}, 
-            {.name = "Byte"}, 
-            {.name = "U8"}, 
-            {.name = "U16"}, 
-            {.name = "U32"}, 
-            {.name = "U64"},
-            {.name = "I8"}, 
-            {.name = "I16"}, 
-            {.name = "I32"}, 
-            {.name = "I64"}, 
-            {.name = "F32"}, 
-            {.name = "F64"}, 
-            {.name = "UPtr"},
-            {.name = "IPtr"}, 
-            {.name = "String"}, 
-            {.name = "Entity"}
+            { .name = "Bool", 1 }, 
+            { .name = "Char" }, 
+            { .name = "Byte" }, 
+            { .name = "U8" }, 
+            { .name = "U16" }, 
+            { .name = "U32" }, 
+            { .name = "U64 "},
+            { .name = "I8" }, 
+            { .name = "I16" }, 
+            { .name = "I32" }, 
+            { .name = "I64" }, 
+            { .name = "F32" }, 
+            { .name = "F64" }, 
+            { .name = "UPtr "},
+            { .name = "IPtr" }, 
+            { .name = "String" }, 
+            { .name = "Entity" }
         }
     });
 
     ecs_struct_init(world, &(ecs_struct_desc_t){
         .entity = ecs_id(EcsPrimitive),
         .members = {
-            {.name = (char*)"kind", .type = primitive_kind}
+            { .name = "kind", .type = primitive_kind }
         }
     });
 
     ecs_struct_init(world, &(ecs_struct_desc_t){
         .entity = ecs_id(EcsMember),
         .members = {
-            {.name = (char*)"type", .type = ecs_id(ecs_entity_t)},
-            {.name = (char*)"count", .type = ecs_id(ecs_i32_t)},
-            {.name = (char*)"unit", .type = ecs_id(ecs_entity_t)},
-            {.name = (char*)"offset", .type = ecs_id(ecs_i32_t)}
+            { .name = "type", .type = ecs_id(ecs_entity_t) },
+            { .name = "count", .type = ecs_id(ecs_i32_t) },
+            { .name = "unit", .type = ecs_id(ecs_entity_t) },
+            { .name = "offset", .type = ecs_id(ecs_i32_t) }
         }
     });
 
     ecs_entity_t vr = ecs_struct_init(world, &(ecs_struct_desc_t){
         .entity = ecs_entity(world, { .name = "value_range" }),
         .members = {
-            {.name = (char*)"min", .type = ecs_id(ecs_f64_t)},
-            {.name = (char*)"max", .type = ecs_id(ecs_f64_t)}
+            { .name = "min", .type = ecs_id(ecs_f64_t) },
+            { .name = "max", .type = ecs_id(ecs_f64_t) }
         }
     });
 
     ecs_struct_init(world, &(ecs_struct_desc_t){
         .entity = ecs_id(EcsMemberRanges),
         .members = {
-            { .name = (char*)"value", .type = vr},
-            { .name = (char*)"warning", .type = vr},
-            { .name = (char*)"error", .type = vr}
+            { .name = "value", .type = vr },
+            { .name = "warning", .type = vr },
+            { .name = "error", .type = vr }
         }
     });
 
     ecs_struct_init(world, &(ecs_struct_desc_t){
         .entity = ecs_id(EcsArray),
         .members = {
-            {.name = (char*)"type", .type = ecs_id(ecs_entity_t)},
-            {.name = (char*)"count", .type = ecs_id(ecs_i32_t)},
+            { .name = "type", .type = ecs_id(ecs_entity_t) },
+            { .name = "count", .type = ecs_id(ecs_i32_t) },
         }
     });
 
     ecs_struct_init(world, &(ecs_struct_desc_t){
         .entity = ecs_id(EcsVector),
         .members = {
-            {.name = (char*)"type", .type = ecs_id(ecs_entity_t)}
+            { .name = "type", .type = ecs_id(ecs_entity_t) }
         }
     });
 
     ecs_struct_init(world, &(ecs_struct_desc_t){
         .entity = ecs_id(EcsOpaque),
         .members = {
-            { .name = (char*)"as_type", .type = ecs_id(ecs_entity_t) }
+            { .name = "as_type", .type = ecs_id(ecs_entity_t) }
         }
     });
 
     ecs_entity_t ut = ecs_struct_init(world, &(ecs_struct_desc_t){
         .entity = ecs_entity(world, { .name = "unit_translation" }),
         .members = {
-            {.name = (char*)"factor", .type = ecs_id(ecs_i32_t)},
-            {.name = (char*)"power", .type = ecs_id(ecs_i32_t)}
+            { .name = "factor", .type = ecs_id(ecs_i32_t) },
+            { .name = "power", .type = ecs_id(ecs_i32_t) }
         }
     });
 
     ecs_struct_init(world, &(ecs_struct_desc_t){
         .entity = ecs_id(EcsUnit),
         .members = {
-            {.name = (char*)"symbol", .type = ecs_id(ecs_string_t)},
-            {.name = (char*)"prefix", .type = ecs_id(ecs_entity_t)},
-            {.name = (char*)"base", .type = ecs_id(ecs_entity_t)},
-            {.name = (char*)"over", .type = ecs_id(ecs_entity_t)},
-            {.name = (char*)"translation", .type = ut}
+            { .name = "symbol", .type = ecs_id(ecs_string_t) },
+            { .name = "prefix", .type = ecs_id(ecs_entity_t) },
+            { .name = "base", .type = ecs_id(ecs_entity_t) },
+            { .name = "over", .type = ecs_id(ecs_entity_t) },
+            { .name = "translation", .type = ut }
         }
     });
 
     ecs_struct_init(world, &(ecs_struct_desc_t){
         .entity = ecs_id(EcsUnitPrefix),
         .members = {
-            {.name = (char*)"symbol", .type = ecs_id(ecs_string_t)},
-            {.name = (char*)"translation", .type = ut}
+            { .name = "symbol", .type = ecs_id(ecs_string_t) },
+            { .name = "translation", .type = ut }
         }
     });
 }
@@ -26395,6 +26442,7 @@ const char* flecs_meta_op_kind_str(
     case EcsOpIPtr: return "IPtr";
     case EcsOpString: return "String";
     case EcsOpEntity: return "Entity";
+    case EcsOpScope: return "Scope";
     default: return "<< invalid kind >>";
     }
 }
@@ -26405,7 +26453,7 @@ ecs_meta_scope_t* flecs_meta_cursor_get_scope(
     const ecs_meta_cursor_t *cursor)
 {
     ecs_check(cursor != NULL, ECS_INVALID_PARAMETER, NULL);
-    return (ecs_meta_scope_t*)&cursor->scope[cursor->depth];
+    return ECS_CONST_CAST(ecs_meta_scope_t*, &cursor->scope[cursor->depth]);
 error:
     return NULL;
 }
@@ -26896,7 +26944,11 @@ int ecs_meta_push(
             next_scope->ops = &next_scope->ops[1];
             next_scope->op_count --;
             break;
-
+        
+        case EcsPrimitiveType:
+        case EcsEnumType:
+        case EcsBitmaskType:
+        case EcsOpaqueType:
         default:
             break;
         }
@@ -26906,12 +26958,35 @@ int ecs_meta_push(
         break;
     }
 
-    default: {
+    case EcsOpPop:
+    case EcsOpScope:
+    case EcsOpEnum:
+    case EcsOpBitmask:
+    case EcsOpPrimitive:
+    case EcsOpBool:
+    case EcsOpChar:
+    case EcsOpByte:
+    case EcsOpU8:
+    case EcsOpU16:
+    case EcsOpU32:
+    case EcsOpU64:
+    case EcsOpI8:
+    case EcsOpI16:
+    case EcsOpI32:
+    case EcsOpI64:
+    case EcsOpF32:
+    case EcsOpF64:
+    case EcsOpUPtr:
+    case EcsOpIPtr:
+    case EcsOpString:
+    case EcsOpEntity: {
         char *path = ecs_get_fullpath(world, scope->type);
         ecs_err("invalid push for type '%s'", path);
         ecs_os_free(path);
         goto error;
     }
+    default:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid operation");
     }
 
     if (scope->is_collection && !scope->opaque) {
@@ -27040,7 +27115,7 @@ const char* ecs_meta_get_member(
 }
 
 /* Utilities for type conversions and bounds checking */
-struct {
+static struct {
     int64_t min, max;
 } ecs_meta_bounds_signed[EcsMetaTypeOpKindLast + 1] = {
     [EcsOpBool]    = {false,      true},
@@ -27064,7 +27139,7 @@ struct {
     [EcsOpBitmask] = {0,          INT32_MAX}
 };
 
-struct {
+static struct {
     uint64_t min, max;
 } ecs_meta_bounds_unsigned[EcsMetaTypeOpKindLast + 1] = {
     [EcsOpBool]    = {false,      true},
@@ -27085,7 +27160,7 @@ struct {
     [EcsOpBitmask] = {0,          UINT32_MAX}
 };
 
-struct {
+static struct {
     double min, max;
 } ecs_meta_bounds_float[EcsMetaTypeOpKindLast + 1] = {
     [EcsOpBool]    = {false,      true},
@@ -27190,12 +27265,24 @@ int ecs_meta_set_bool(
         }
     }
     /* fall through */
-    default:
+    case EcsOpArray:
+    case EcsOpVector:
+    case EcsOpPush:
+    case EcsOpPop:
+    case EcsOpScope:
+    case EcsOpPrimitive:
+    case EcsOpF32:
+    case EcsOpF64:
+    case EcsOpString:
         flecs_meta_conversion_error(cursor, op, "bool");
         return -1;
+    default:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid operation");
     }
 
     return 0;
+error:
+    return -1;
 }
 
 int ecs_meta_set_char(
@@ -27224,12 +27311,32 @@ int ecs_meta_set_char(
         }
     }
     /* fall through */
-    default:
+    case EcsOpArray:
+    case EcsOpVector:
+    case EcsOpPush:
+    case EcsOpPop:
+    case EcsOpScope:
+    case EcsOpBitmask:
+    case EcsOpPrimitive:
+    case EcsOpByte:
+    case EcsOpU8:
+    case EcsOpU16:
+    case EcsOpU32:
+    case EcsOpU64:
+    case EcsOpF32:
+    case EcsOpF64:
+    case EcsOpUPtr:
+    case EcsOpString:
+    case EcsOpEntity:
         flecs_meta_conversion_error(cursor, op, "char");
         return -1;
+    default:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid operation");
     }
 
     return 0;
+error:
+    return -1;
 }
 
 int ecs_meta_set_int(
@@ -27263,14 +27370,24 @@ int ecs_meta_set_int(
         }
     }
     /* fall through */
-    default: {
+    case EcsOpArray:
+    case EcsOpVector:
+    case EcsOpPush:
+    case EcsOpPop:
+    case EcsOpScope:
+    case EcsOpPrimitive:
+    case EcsOpString: {
         if(!value) return ecs_meta_set_null(cursor);
         flecs_meta_conversion_error(cursor, op, "int");
         return -1;
     }
+    default:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid operation");
     }
 
     return 0;
+error:
+    return -1;
 }
 
 int ecs_meta_set_uint(
@@ -27304,13 +27421,23 @@ int ecs_meta_set_uint(
         }
     }
     /* fall through */
-    default:
+    case EcsOpArray:
+    case EcsOpVector:
+    case EcsOpPush:
+    case EcsOpPop:
+    case EcsOpScope:
+    case EcsOpPrimitive:
+    case EcsOpString:
         if(!value) return ecs_meta_set_null(cursor);
         flecs_meta_conversion_error(cursor, op, "uint");
         return -1;
+    default:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid operation");
     }
 
     return 0;
+error:
+    return -1;
 }
 
 int ecs_meta_set_float(
@@ -27342,17 +27469,28 @@ int ecs_meta_set_float(
             break;
         } else if (opaque->assign_entity && (value >= 0)) {
             opaque->assign_entity(
-                ptr, (ecs_world_t*)cursor->world, (ecs_entity_t)value);
+                ptr, ECS_CONST_CAST(ecs_world_t*, cursor->world), 
+                    (ecs_entity_t)value);
             break;
         }
     }
     /* fall through */
-    default:
+    case EcsOpArray:
+    case EcsOpVector:
+    case EcsOpPush:
+    case EcsOpPop:
+    case EcsOpScope:
+    case EcsOpPrimitive:
+    case EcsOpString:
         flecs_meta_conversion_error(cursor, op, "float");
         return -1;
+    default:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid operation");
     }
 
     return 0;
+error:
+    return -1;
 }
 
 int ecs_meta_set_value(
@@ -27525,7 +27663,7 @@ int ecs_meta_set_string(
             }
         } else {
             ecs_err("invalid value for boolean '%s'", value);
-            return -1;
+            goto error;
         }
         break;
     case EcsOpI8:
@@ -27572,7 +27710,7 @@ int ecs_meta_set_string(
             char *path = ecs_get_fullpath(cursor->world, op->type);
             ecs_err("unresolved enum constant '%s' for type '%s'", value, path);
             ecs_os_free(path);
-            return -1;
+            goto error;
         }
 
         const ecs_i32_t *v = ecs_get_pair_object(
@@ -27581,7 +27719,7 @@ int ecs_meta_set_string(
             char *path = ecs_get_fullpath(cursor->world, op->type);
             ecs_err("'%s' is not an enum constant for type '%s'", value, path);
             ecs_os_free(path);
-            return -1;
+            goto error;
         }
 
         set_T(ecs_i32_t, ptr, v[0]);
@@ -27589,20 +27727,20 @@ int ecs_meta_set_string(
     }
     case EcsOpBitmask:
         if (flecs_meta_parse_bitmask(cursor, op, ptr, value) != 0) {
-            return -1;
+            goto error;
         }
         break;
     case EcsOpEntity: {
         ecs_entity_t e = 0;
         if (flecs_meta_cursor_lookup(cursor, value, &e)) {
-            return -1;
+            goto error;
         }
         set_T(ecs_entity_t, ptr, e);
         break;
     }
     case EcsOpPop:
         ecs_err("excess element '%s' in scope", value);
-        return -1;
+        goto error;
     case EcsOpOpaque: {
         const EcsOpaque *opaque = ecs_get(cursor->world, op->type, EcsOpaque);
         ecs_assert(opaque != NULL, ECS_INVALID_OPERATION, NULL);
@@ -27615,20 +27753,30 @@ int ecs_meta_set_string(
         } else if (opaque->assign_entity) {
             ecs_entity_t e = 0;
             if (flecs_meta_cursor_lookup(cursor, value, &e)) {
-                return -1;
+                goto error;
             }
-            opaque->assign_entity(ptr, (ecs_world_t*)cursor->world, e);
+            opaque->assign_entity(ptr, 
+                ECS_CONST_CAST(ecs_world_t*, cursor->world), e);
             break;
         }
     }
     /* fall through */
-    default:
+    case EcsOpArray:
+    case EcsOpVector:
+    case EcsOpPush:
+    case EcsOpScope:
+    case EcsOpPrimitive:
         ecs_err("unsupported conversion from string '%s' to '%s'",
             value, flecs_meta_op_kind_str(op->kind));
-        return -1;
+        goto error;
+    default:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid operation");
+        break;
     }
 
     return 0;
+error:
+    return -1;
 }
 
 int ecs_meta_set_string_literal(
@@ -27642,7 +27790,7 @@ int ecs_meta_set_string_literal(
     ecs_size_t len = ecs_os_strlen(value);
     if (value[0] != '\"' || value[len - 1] != '\"') {
         ecs_err("invalid string literal '%s'", value);
-        return -1;
+        goto error;
     }
 
     switch(op->kind) {
@@ -27650,10 +27798,31 @@ int ecs_meta_set_string_literal(
         set_T(ecs_char_t, ptr, value[1]);
         break;
 
-    default:
-    case EcsOpEntity:
-    case EcsOpString:
+    case EcsOpArray:
+    case EcsOpVector:
     case EcsOpOpaque:
+    case EcsOpPush:
+    case EcsOpPop:
+    case EcsOpScope:
+    case EcsOpEnum:
+    case EcsOpBitmask:
+    case EcsOpPrimitive:
+    case EcsOpBool:
+    case EcsOpByte:
+    case EcsOpU8:
+    case EcsOpU16:
+    case EcsOpU32:
+    case EcsOpU64:
+    case EcsOpI8:
+    case EcsOpI16:
+    case EcsOpI32:
+    case EcsOpI64:
+    case EcsOpF32:
+    case EcsOpF64:
+    case EcsOpUPtr:
+    case EcsOpIPtr:
+    case EcsOpString:
+    case EcsOpEntity:
         len -= 2;
 
         char *result = ecs_os_malloc(len + 1);
@@ -27667,9 +27836,14 @@ int ecs_meta_set_string_literal(
 
         ecs_os_free(result);
         break;
+    default:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid operation");
+        break;
     }
 
     return 0;
+error:
+    return -1;
 }
 
 int ecs_meta_set_entity(
@@ -27687,17 +27861,46 @@ int ecs_meta_set_entity(
     case EcsOpOpaque: {
         const EcsOpaque *opaque = ecs_get(cursor->world, op->type, EcsOpaque);
         if (opaque && opaque->assign_entity) {
-            opaque->assign_entity(ptr, (ecs_world_t*)cursor->world, value);
+            opaque->assign_entity(ptr, 
+                ECS_CONST_CAST(ecs_world_t*, cursor->world), value);
             break;
         }
     }
     /* fall through */
-    default:
+    case EcsOpArray:
+    case EcsOpVector:
+    case EcsOpPush:
+    case EcsOpPop:
+    case EcsOpScope:
+    case EcsOpEnum:
+    case EcsOpBitmask:
+    case EcsOpPrimitive:
+    case EcsOpBool:
+    case EcsOpChar:
+    case EcsOpByte:
+    case EcsOpU8:
+    case EcsOpU16:
+    case EcsOpU32:
+    case EcsOpU64:
+    case EcsOpI8:
+    case EcsOpI16:
+    case EcsOpI32:
+    case EcsOpI64:
+    case EcsOpF32:
+    case EcsOpF64:
+    case EcsOpUPtr:
+    case EcsOpIPtr:
+    case EcsOpString:
         flecs_meta_conversion_error(cursor, op, "entity");
-        return -1;
+        goto error;
+    default:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid operation");
+        break;
     }
 
     return 0;
+error:
+    return -1;
 }
 
 int ecs_meta_set_null(
@@ -27719,12 +27922,40 @@ int ecs_meta_set_null(
         }
     }
     /* fall through */
-    default:
+    case EcsOpArray:
+    case EcsOpVector:
+    case EcsOpPush:
+    case EcsOpPop:
+    case EcsOpScope:
+    case EcsOpEnum:
+    case EcsOpBitmask:
+    case EcsOpPrimitive:
+    case EcsOpBool:
+    case EcsOpChar:
+    case EcsOpByte:
+    case EcsOpU8:
+    case EcsOpU16:
+    case EcsOpU32:
+    case EcsOpU64:
+    case EcsOpI8:
+    case EcsOpI16:
+    case EcsOpI32:
+    case EcsOpI64:
+    case EcsOpF32:
+    case EcsOpF64:
+    case EcsOpUPtr:
+    case EcsOpIPtr:
+    case EcsOpEntity:
         flecs_meta_conversion_error(cursor, op, "null");
-        return -1;
+        goto error;
+    default:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid operation");
+        break;
     }
 
     return 0;
+error:
+    return -1;
 }
 
 bool ecs_meta_get_bool(
@@ -27747,14 +27978,24 @@ bool ecs_meta_get_bool(
     case EcsOpU64:  return *(ecs_u64_t*)ptr != 0;
     case EcsOpIPtr: return *(ecs_iptr_t*)ptr != 0;
     case EcsOpUPtr: return *(ecs_uptr_t*)ptr != 0;
-    case EcsOpF32:  return *(ecs_f32_t*)ptr != 0;
-    case EcsOpF64:  return *(ecs_f64_t*)ptr != 0;
+    case EcsOpF32:  return ECS_NEQZERO(*(ecs_f32_t*)ptr);
+    case EcsOpF64:  return ECS_NEQZERO(*(ecs_f64_t*)ptr);
     case EcsOpString: return *(const char**)ptr != NULL;
     case EcsOpEnum: return *(ecs_i32_t*)ptr != 0;
     case EcsOpBitmask: return *(ecs_u32_t*)ptr != 0;
     case EcsOpEntity: return *(ecs_entity_t*)ptr != 0;
-    default: ecs_throw(ECS_INVALID_PARAMETER,
-                "invalid element for bool");
+    case EcsOpArray:
+    case EcsOpVector:
+    case EcsOpOpaque:
+    case EcsOpPush:
+    case EcsOpPop:
+    case EcsOpScope:
+    case EcsOpPrimitive:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid element for bool");
+        break;
+    default:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid operation");
+        break;
     }
 
 error:
@@ -27768,9 +28009,35 @@ char ecs_meta_get_char(
     ecs_meta_type_op_t *op = flecs_meta_cursor_get_op(scope);
     void *ptr = flecs_meta_cursor_get_ptr(cursor->world, scope);
     switch(op->kind) {
-    case EcsOpChar: return *(ecs_char_t*)ptr != 0;
-    default: ecs_throw(ECS_INVALID_PARAMETER,
-                "invalid element for char");
+    case EcsOpChar: 
+        return *(ecs_char_t*)ptr != 0;
+    case EcsOpArray:
+    case EcsOpVector:
+    case EcsOpOpaque:
+    case EcsOpPush:
+    case EcsOpPop:
+    case EcsOpScope:
+    case EcsOpEnum:
+    case EcsOpBitmask:
+    case EcsOpPrimitive:
+    case EcsOpBool:
+    case EcsOpByte:
+    case EcsOpU8:
+    case EcsOpU16:
+    case EcsOpU32:
+    case EcsOpU64:
+    case EcsOpI8:
+    case EcsOpI16:
+    case EcsOpI32:
+    case EcsOpI64:
+    case EcsOpF32:
+    case EcsOpF64:
+    case EcsOpUPtr:
+    case EcsOpIPtr:
+    case EcsOpString:
+    case EcsOpEntity:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid element for char");
+        break;
     }
 
 error:
@@ -27784,31 +28051,41 @@ int64_t ecs_meta_get_int(
     ecs_meta_type_op_t *op = flecs_meta_cursor_get_op(scope);
     void *ptr = flecs_meta_cursor_get_ptr(cursor->world, scope);
     switch(op->kind) {
-    case EcsOpBool: return *(ecs_bool_t*)ptr;
-    case EcsOpI8:   return *(ecs_i8_t*)ptr;
-    case EcsOpU8:   return *(ecs_u8_t*)ptr;
-    case EcsOpChar: return *(ecs_char_t*)ptr;
-    case EcsOpByte: return *(ecs_u8_t*)ptr;
-    case EcsOpI16:  return *(ecs_i16_t*)ptr;
-    case EcsOpU16:  return *(ecs_u16_t*)ptr;
-    case EcsOpI32:  return *(ecs_i32_t*)ptr;
-    case EcsOpU32:  return *(ecs_u32_t*)ptr;
-    case EcsOpI64:  return *(ecs_i64_t*)ptr;
-    case EcsOpU64:  return flecs_uto(int64_t, *(ecs_u64_t*)ptr);
-    case EcsOpIPtr: return *(ecs_iptr_t*)ptr;
-    case EcsOpUPtr: return flecs_uto(int64_t, *(ecs_uptr_t*)ptr);
-    case EcsOpF32:  return (int64_t)*(ecs_f32_t*)ptr;
-    case EcsOpF64:  return (int64_t)*(ecs_f64_t*)ptr;
+    case EcsOpBool: return *(const ecs_bool_t*)ptr;
+    case EcsOpI8:   return *(const ecs_i8_t*)ptr;
+    case EcsOpU8:   return *(const ecs_u8_t*)ptr;
+    case EcsOpChar: return *(const ecs_char_t*)ptr;
+    case EcsOpByte: return *(const ecs_u8_t*)ptr;
+    case EcsOpI16:  return *(const ecs_i16_t*)ptr;
+    case EcsOpU16:  return *(const ecs_u16_t*)ptr;
+    case EcsOpI32:  return *(const ecs_i32_t*)ptr;
+    case EcsOpU32:  return *(const ecs_u32_t*)ptr;
+    case EcsOpI64:  return *(const ecs_i64_t*)ptr;
+    case EcsOpU64:  return flecs_uto(int64_t, *(const ecs_u64_t*)ptr);
+    case EcsOpIPtr: return *(const ecs_iptr_t*)ptr;
+    case EcsOpUPtr: return flecs_uto(int64_t, *(const ecs_uptr_t*)ptr);
+    case EcsOpF32:  return (int64_t)*(const ecs_f32_t*)ptr;
+    case EcsOpF64:  return (int64_t)*(const ecs_f64_t*)ptr;
     case EcsOpString: return atoi(*(const char**)ptr);
-    case EcsOpEnum: return *(ecs_i32_t*)ptr;
-    case EcsOpBitmask: return *(ecs_u32_t*)ptr;
+    case EcsOpEnum: return *(const ecs_i32_t*)ptr;
+    case EcsOpBitmask: return *(const ecs_u32_t*)ptr;
     case EcsOpEntity:
         ecs_throw(ECS_INVALID_PARAMETER,
             "invalid conversion from entity to int");
         break;
-    default: ecs_throw(ECS_INVALID_PARAMETER, "invalid element for int");
+    case EcsOpArray:
+    case EcsOpVector:
+    case EcsOpOpaque:
+    case EcsOpPush:
+    case EcsOpPop:
+    case EcsOpScope:
+    case EcsOpPrimitive:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid element for int");
+        break;
+    default:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid operation");
+        break;
     }
-
 error:
     return 0;
 }
@@ -27821,25 +28098,36 @@ uint64_t ecs_meta_get_uint(
     void *ptr = flecs_meta_cursor_get_ptr(cursor->world, scope);
     switch(op->kind) {
     case EcsOpBool: return *(ecs_bool_t*)ptr;
-    case EcsOpI8:   return flecs_ito(uint64_t, *(ecs_i8_t*)ptr);
+    case EcsOpI8:   return flecs_ito(uint64_t, *(const ecs_i8_t*)ptr);
     case EcsOpU8:   return *(ecs_u8_t*)ptr;
-    case EcsOpChar: return flecs_ito(uint64_t, *(ecs_char_t*)ptr);
-    case EcsOpByte: return flecs_ito(uint64_t, *(ecs_u8_t*)ptr);
-    case EcsOpI16:  return flecs_ito(uint64_t, *(ecs_i16_t*)ptr);
+    case EcsOpChar: return flecs_ito(uint64_t, *(const ecs_char_t*)ptr);
+    case EcsOpByte: return flecs_ito(uint64_t, *(const ecs_u8_t*)ptr);
+    case EcsOpI16:  return flecs_ito(uint64_t, *(const ecs_i16_t*)ptr);
     case EcsOpU16:  return *(ecs_u16_t*)ptr;
-    case EcsOpI32:  return flecs_ito(uint64_t, *(ecs_i32_t*)ptr);
+    case EcsOpI32:  return flecs_ito(uint64_t, *(const ecs_i32_t*)ptr);
     case EcsOpU32:  return *(ecs_u32_t*)ptr;
-    case EcsOpI64:  return flecs_ito(uint64_t, *(ecs_i64_t*)ptr);
+    case EcsOpI64:  return flecs_ito(uint64_t, *(const ecs_i64_t*)ptr);
     case EcsOpU64:  return *(ecs_u64_t*)ptr;
-    case EcsOpIPtr: return flecs_ito(uint64_t, *(ecs_i64_t*)ptr);
+    case EcsOpIPtr: return flecs_ito(uint64_t, *(const ecs_i64_t*)ptr);
     case EcsOpUPtr: return *(ecs_uptr_t*)ptr;
-    case EcsOpF32:  return flecs_ito(uint64_t, *(ecs_f32_t*)ptr);
-    case EcsOpF64:  return flecs_ito(uint64_t, *(ecs_f64_t*)ptr);
+    case EcsOpF32:  return flecs_ito(uint64_t, *(const ecs_f32_t*)ptr);
+    case EcsOpF64:  return flecs_ito(uint64_t, *(const ecs_f64_t*)ptr);
     case EcsOpString: return flecs_ito(uint64_t, atoi(*(const char**)ptr));
-    case EcsOpEnum: return flecs_ito(uint64_t, *(ecs_i32_t*)ptr);
-    case EcsOpBitmask: return *(ecs_u32_t*)ptr;
-    case EcsOpEntity: return *(ecs_entity_t*)ptr;
-    default: ecs_throw(ECS_INVALID_PARAMETER, "invalid element for uint");
+    case EcsOpEnum: return flecs_ito(uint64_t, *(const ecs_i32_t*)ptr);
+    case EcsOpBitmask: return *(const ecs_u32_t*)ptr;
+    case EcsOpEntity: return *(const ecs_entity_t*)ptr;
+    case EcsOpArray:
+    case EcsOpVector:
+    case EcsOpOpaque:
+    case EcsOpPush:
+    case EcsOpPop:
+    case EcsOpScope:
+    case EcsOpPrimitive:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid element for uint");
+        break;
+    default:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid operation");
+        break;
     }
 error:
     return 0;
@@ -27851,29 +28139,40 @@ double flecs_meta_to_float(
     const void *ptr)
 {
     switch(kind) {
-    case EcsOpBool: return *(ecs_bool_t*)ptr;
-    case EcsOpI8:   return *(ecs_i8_t*)ptr;
-    case EcsOpU8:   return *(ecs_u8_t*)ptr;
-    case EcsOpChar: return *(ecs_char_t*)ptr;
-    case EcsOpByte: return *(ecs_u8_t*)ptr;
-    case EcsOpI16:  return *(ecs_i16_t*)ptr;
-    case EcsOpU16:  return *(ecs_u16_t*)ptr;
-    case EcsOpI32:  return *(ecs_i32_t*)ptr;
-    case EcsOpU32:  return *(ecs_u32_t*)ptr;
-    case EcsOpI64:  return (double)*(ecs_i64_t*)ptr;
-    case EcsOpU64:  return (double)*(ecs_u64_t*)ptr;
-    case EcsOpIPtr: return (double)*(ecs_iptr_t*)ptr;
-    case EcsOpUPtr: return (double)*(ecs_uptr_t*)ptr;
-    case EcsOpF32:  return (double)*(ecs_f32_t*)ptr;
-    case EcsOpF64:  return *(ecs_f64_t*)ptr;
-    case EcsOpString: return atof(*(const char**)ptr);
-    case EcsOpEnum: return *(ecs_i32_t*)ptr;
-    case EcsOpBitmask: return *(ecs_u32_t*)ptr;
+    case EcsOpBool: return *(const ecs_bool_t*)ptr;
+    case EcsOpI8:   return *(const ecs_i8_t*)ptr;
+    case EcsOpU8:   return *(const ecs_u8_t*)ptr;
+    case EcsOpChar: return *(const ecs_char_t*)ptr;
+    case EcsOpByte: return *(const ecs_u8_t*)ptr;
+    case EcsOpI16:  return *(const ecs_i16_t*)ptr;
+    case EcsOpU16:  return *(const ecs_u16_t*)ptr;
+    case EcsOpI32:  return *(const ecs_i32_t*)ptr;
+    case EcsOpU32:  return *(const ecs_u32_t*)ptr;
+    case EcsOpI64:  return (double)*(const ecs_i64_t*)ptr;
+    case EcsOpU64:  return (double)*(const ecs_u64_t*)ptr;
+    case EcsOpIPtr: return (double)*(const ecs_iptr_t*)ptr;
+    case EcsOpUPtr: return (double)*(const ecs_uptr_t*)ptr;
+    case EcsOpF32:  return (double)*(const ecs_f32_t*)ptr;
+    case EcsOpF64:  return *(const ecs_f64_t*)ptr;
+    case EcsOpString: return atof(*ECS_CONST_CAST(const char**, ptr));
+    case EcsOpEnum: return *(const ecs_i32_t*)ptr;
+    case EcsOpBitmask: return *(const ecs_u32_t*)ptr;
     case EcsOpEntity:
         ecs_throw(ECS_INVALID_PARAMETER,
             "invalid conversion from entity to float");
         break;
-    default: ecs_throw(ECS_INVALID_PARAMETER, "invalid element for float");
+    case EcsOpArray:
+    case EcsOpVector:
+    case EcsOpOpaque:
+    case EcsOpPush:
+    case EcsOpPop:
+    case EcsOpScope:
+    case EcsOpPrimitive:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid element for float");
+        break;
+    default:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid operation");
+        break;
     }
 error:
     return 0;
@@ -27896,7 +28195,34 @@ const char* ecs_meta_get_string(
     void *ptr = flecs_meta_cursor_get_ptr(cursor->world, scope);
     switch(op->kind) {
     case EcsOpString: return *(const char**)ptr;
-    default: ecs_throw(ECS_INVALID_PARAMETER, "invalid element for string");
+    case EcsOpArray:
+    case EcsOpVector:
+    case EcsOpOpaque:
+    case EcsOpPush:
+    case EcsOpPop:
+    case EcsOpScope:
+    case EcsOpEnum:
+    case EcsOpBitmask:
+    case EcsOpPrimitive:
+    case EcsOpChar:
+    case EcsOpBool:
+    case EcsOpByte:
+    case EcsOpU8:
+    case EcsOpU16:
+    case EcsOpU32:
+    case EcsOpU64:
+    case EcsOpI8:
+    case EcsOpI16:
+    case EcsOpI32:
+    case EcsOpI64:
+    case EcsOpF32:
+    case EcsOpF64:
+    case EcsOpUPtr:
+    case EcsOpIPtr:
+    case EcsOpEntity:
+    default:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid element for string");
+        break;
     }
 error:
     return 0;
@@ -27910,7 +28236,33 @@ ecs_entity_t ecs_meta_get_entity(
     void *ptr = flecs_meta_cursor_get_ptr(cursor->world, scope);
     switch(op->kind) {
     case EcsOpEntity: return *(ecs_entity_t*)ptr;
-    default: ecs_throw(ECS_INVALID_PARAMETER, "invalid element for entity");
+    case EcsOpArray:
+    case EcsOpVector:
+    case EcsOpOpaque:
+    case EcsOpPush:
+    case EcsOpPop:
+    case EcsOpScope:
+    case EcsOpEnum:
+    case EcsOpBitmask:
+    case EcsOpPrimitive:
+    case EcsOpChar:
+    case EcsOpBool:
+    case EcsOpByte:
+    case EcsOpU8:
+    case EcsOpU16:
+    case EcsOpU32:
+    case EcsOpU64:
+    case EcsOpI8:
+    case EcsOpI16:
+    case EcsOpI32:
+    case EcsOpI64:
+    case EcsOpF32:
+    case EcsOpF64:
+    case EcsOpUPtr:
+    case EcsOpIPtr:
+    case EcsOpString:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid element for entity");
+        break;
     }
 error:
     return 0;
@@ -27976,7 +28328,7 @@ int flecs_expr_ser_primitive(
 {
     switch(kind) {
     case EcsBool:
-        if (*(bool*)base) {
+        if (*(const bool*)base) {
             ecs_strbuf_appendlit(str, "true");
         } else {
             ecs_strbuf_appendlit(str, "false");
@@ -27984,9 +28336,9 @@ int flecs_expr_ser_primitive(
         break;
     case EcsChar: {
         char chbuf[3];
-        char ch = *(char*)base;
+        char ch = *(const char*)base;
         if (ch) {
-            ecs_chresc(chbuf, *(char*)base, '"');
+            ecs_chresc(chbuf, *(const char*)base, '"');
             if (is_expr) ecs_strbuf_appendch(str, '"');
             ecs_strbuf_appendstr(str, chbuf);
             if (is_expr) ecs_strbuf_appendch(str, '"');
@@ -27996,46 +28348,46 @@ int flecs_expr_ser_primitive(
         break;
     }
     case EcsByte:
-        ecs_strbuf_appendint(str, flecs_uto(int64_t, *(uint8_t*)base));
+        ecs_strbuf_appendint(str, flecs_uto(int64_t, *(const uint8_t*)base));
         break;
     case EcsU8:
-        ecs_strbuf_appendint(str, flecs_uto(int64_t, *(uint8_t*)base));
+        ecs_strbuf_appendint(str, flecs_uto(int64_t, *(const uint8_t*)base));
         break;
     case EcsU16:
-        ecs_strbuf_appendint(str, flecs_uto(int64_t, *(uint16_t*)base));
+        ecs_strbuf_appendint(str, flecs_uto(int64_t, *(const uint16_t*)base));
         break;
     case EcsU32:
-        ecs_strbuf_appendint(str, flecs_uto(int64_t, *(uint32_t*)base));
+        ecs_strbuf_appendint(str, flecs_uto(int64_t, *(const uint32_t*)base));
         break;
     case EcsU64:
-        ecs_strbuf_append(str, "%llu", *(uint64_t*)base);
+        ecs_strbuf_append(str, "%llu", *(const uint64_t*)base);
         break;
     case EcsI8:
-        ecs_strbuf_appendint(str, flecs_ito(int64_t, *(int8_t*)base));
+        ecs_strbuf_appendint(str, flecs_ito(int64_t, *(const int8_t*)base));
         break;
     case EcsI16:
-        ecs_strbuf_appendint(str, flecs_ito(int64_t, *(int16_t*)base));
+        ecs_strbuf_appendint(str, flecs_ito(int64_t, *(const int16_t*)base));
         break;
     case EcsI32:
-        ecs_strbuf_appendint(str, flecs_ito(int64_t, *(int32_t*)base));
+        ecs_strbuf_appendint(str, flecs_ito(int64_t, *(const int32_t*)base));
         break;
     case EcsI64:
-        ecs_strbuf_appendint(str, *(int64_t*)base);
+        ecs_strbuf_appendint(str, *(const int64_t*)base);
         break;
     case EcsF32:
-        ecs_strbuf_appendflt(str, (double)*(float*)base, 0);
+        ecs_strbuf_appendflt(str, (double)*(const float*)base, 0);
         break;
     case EcsF64:
-        ecs_strbuf_appendflt(str, *(double*)base, 0);
+        ecs_strbuf_appendflt(str, *(const double*)base, 0);
         break;
     case EcsIPtr:
-        ecs_strbuf_appendint(str, flecs_ito(int64_t, *(intptr_t*)base));
+        ecs_strbuf_appendint(str, flecs_ito(int64_t, *(const intptr_t*)base));
         break;
     case EcsUPtr:
-        ecs_strbuf_append(str, "%u", *(uintptr_t*)base);
+        ecs_strbuf_append(str, "%u", *(const uintptr_t*)base);
         break;
     case EcsString: {
-        char *value = *(char**)base;
+        const char *value = *ECS_CONST_CAST(const char**, base);
         if (value) {
             if (!is_expr) {
                 ecs_strbuf_appendstr(str, value);
@@ -28060,7 +28412,7 @@ int flecs_expr_ser_primitive(
         break;
     }
     case EcsEntity: {
-        ecs_entity_t e = *(ecs_entity_t*)base;
+        ecs_entity_t e = *(const ecs_entity_t*)base;
         if (!e) {
             ecs_strbuf_appendch(str, '0');
         } else {
@@ -28087,7 +28439,7 @@ int flecs_expr_ser_enum(
     const EcsEnum *enum_type = ecs_get(world, op->type, EcsEnum);
     ecs_check(enum_type != NULL, ECS_INVALID_PARAMETER, NULL);
 
-    int32_t val = *(int32_t*)base;
+    int32_t val = *(const int32_t*)base;
     
     /* Enumeration constants are stored in a map that is keyed on the
      * enumeration value. */
@@ -28117,7 +28469,7 @@ int flecs_expr_ser_bitmask(
 {
     const EcsBitmask *bitmask_type = ecs_get(world, op->type, EcsBitmask);
     ecs_check(bitmask_type != NULL, ECS_INVALID_PARAMETER, NULL);
-    uint32_t value = *(uint32_t*)ptr;
+    uint32_t value = *(const uint32_t*)ptr;
 
     ecs_strbuf_list_push(str, "", "|");
 
@@ -28279,7 +28631,26 @@ int flecs_expr_ser_type_op(
             goto error;
         }
         break;
-    default:
+    case EcsOpScope:
+    case EcsOpPrimitive:
+    case EcsOpBool:
+    case EcsOpChar:
+    case EcsOpByte:
+    case EcsOpU8:
+    case EcsOpU16:
+    case EcsOpU32:
+    case EcsOpU64:
+    case EcsOpI8:
+    case EcsOpI16:
+    case EcsOpI32:
+    case EcsOpI64:
+    case EcsOpF32:
+    case EcsOpF64:
+    case EcsOpUPtr:
+    case EcsOpIPtr:
+    case EcsOpEntity:
+    case EcsOpString:
+    case EcsOpOpaque:
         if (flecs_expr_ser_primitive(world, flecs_expr_op_to_primitive_kind(op->kind), 
             ECS_OFFSET(ptr, op->offset), str, is_expr))
         {
@@ -28288,6 +28659,8 @@ int flecs_expr_ser_type_op(
             goto error;
         }
         break;
+    default:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid operation");
     }
 
     return 0;
@@ -28338,11 +28711,36 @@ int flecs_expr_ser_type_ops(
             ecs_strbuf_list_pop(str, "}");
             in_array ++;
             break;
-        default:
+        case EcsOpArray:
+        case EcsOpVector:
+        case EcsOpEnum:
+        case EcsOpBitmask:
+        case EcsOpScope:
+        case EcsOpPrimitive:
+        case EcsOpBool:
+        case EcsOpChar:
+        case EcsOpByte:
+        case EcsOpU8:
+        case EcsOpU16:
+        case EcsOpU32:
+        case EcsOpU64:
+        case EcsOpI8:
+        case EcsOpI16:
+        case EcsOpI32:
+        case EcsOpI64:
+        case EcsOpF32:
+        case EcsOpF64:
+        case EcsOpUPtr:
+        case EcsOpIPtr:
+        case EcsOpEntity:
+        case EcsOpString:
+        case EcsOpOpaque:
             if (flecs_expr_ser_type_op(world, op, base, str, is_expr)) {
                 goto error;
             }
             break;
+        default:
+            ecs_throw(ECS_INVALID_PARAMETER, "invalid operation");
         }
     }
 
@@ -28942,7 +29340,9 @@ char* ecs_interpolate_string(
                 goto error;
             }
 
-            ecs_parse_expr_desc_t expr_desc = { .vars = (ecs_vars_t*)vars };
+            ecs_parse_expr_desc_t expr_desc = { 
+                .vars = ECS_CONST_CAST(ecs_vars_t*, vars) 
+            };
             ecs_value_t expr_result = {0};
             if (!ecs_parse_expr(world, token, &expr_result, &expr_desc)) {
                 goto error;
@@ -29546,8 +29946,9 @@ ecs_entity_t flecs_largest_type(
     case EcsIPtr:   return ecs_id(ecs_i64_t);
     case EcsString: return ecs_id(ecs_string_t);
     case EcsEntity: return ecs_id(ecs_entity_t);
-    default: ecs_abort(ECS_INTERNAL_ERROR, NULL);
+    default: ecs_throw(ECS_INTERNAL_ERROR, NULL);
     }
+error:
     return 0;
 }
 
@@ -29593,7 +29994,12 @@ bool flecs_oper_valid_for_type(
     case EcsShiftLeft:
     case EcsShiftRight:
         return (type == ecs_id(ecs_u64_t));
+    case EcsExprOperUnknown:
+    case EcsLeftParen:
+    case EcsMin:
+        return false;
     default: 
+        ecs_abort(ECS_INTERNAL_ERROR, NULL);
         return false;
     }
 }
@@ -29662,9 +30068,23 @@ bool flecs_expr_op_is_equality(
     case EcsCondLt:
     case EcsCondLtEq:
         return true;
-    default:
+    case EcsCondAnd:
+    case EcsCondOr:
+    case EcsShiftLeft:
+    case EcsShiftRight:
+    case EcsAdd:
+    case EcsSub:
+    case EcsMul:
+    case EcsDiv:
+    case EcsExprOperUnknown:
+    case EcsLeftParen:
+    case EcsMin:
         return false;
+    default:
+        ecs_throw(ECS_INTERNAL_ERROR, "invalid operator");
     }
+error:
+    return false;
 }
 
 static
@@ -29700,8 +30120,17 @@ ecs_entity_t flecs_binary_expr_type(
          * should not be casted to bool */
         result_type = ecs_id(ecs_bool_t);
         break;
-    default:
+    case EcsShiftLeft:
+    case EcsShiftRight:
+    case EcsAdd:
+    case EcsSub:
+    case EcsMul:
+    case EcsExprOperUnknown:
+    case EcsLeftParen:
+    case EcsMin:
         break;
+    default:
+        ecs_throw(ECS_INTERNAL_ERROR, "invalid operator");
     }
 
     /* Result type for arithmetic operators is determined by operands */
@@ -29751,6 +30180,8 @@ done:
 
     *operand_type_out = operand_type;
     return result_type;
+error:
+    return 0;
 }
 
 /* Macro's to let the compiler do the operations & conversion work for us */
@@ -29767,6 +30198,24 @@ done:
         ECS_BINARY_OP_T(left, right, result, op, ecs_i64_t, ecs_i64_t);\
     } else if (left->type == ecs_id(ecs_f64_t)) { \
         ECS_BINARY_OP_T(left, right, result, op, ecs_f64_t, ecs_f64_t);\
+    } else {\
+        ecs_abort(ECS_INTERNAL_ERROR, "unexpected type in binary expression");\
+    }
+
+#define ECS_BINARY_COND_EQ_OP(left, right, result, op)\
+    if (left->type == ecs_id(ecs_u64_t)) { \
+        ECS_BINARY_OP_T(left, right, result, op, ecs_bool_t, ecs_u64_t);\
+    } else if (left->type == ecs_id(ecs_i64_t)) { \
+        ECS_BINARY_OP_T(left, right, result, op, ecs_bool_t, ecs_i64_t);\
+    } else if (left->type == ecs_id(ecs_f64_t)) { \
+        ecs_parser_error(name, expr, ptr - expr, "unsupported operator for floating point");\
+        return -1;\
+    } else if (left->type == ecs_id(ecs_u8_t)) { \
+        ECS_BINARY_OP_T(left, right, result, op, ecs_bool_t, ecs_u8_t);\
+    } else if (left->type == ecs_id(ecs_char_t)) { \
+        ECS_BINARY_OP_T(left, right, result, op, ecs_bool_t, ecs_char_t);\
+    } else if (left->type == ecs_id(ecs_bool_t)) { \
+        ECS_BINARY_OP_T(left, right, result, op, ecs_bool_t, ecs_bool_t);\
     } else {\
         ecs_abort(ECS_INTERNAL_ERROR, "unexpected type in binary expression");\
     }
@@ -29818,12 +30267,12 @@ int flecs_binary_expr_do(
     ecs_entity_t operand_type, type = flecs_binary_expr_type(
         world, name, expr, ptr, lvalue, rvalue, op, &operand_type);
     if (!type) {
-        return -1;
+        goto error;
     }
 
     if (!flecs_oper_valid_for_type(type, op)) {
         ecs_parser_error(name, expr, ptr - expr, "invalid operator for type");
-        return -1;
+        goto error;
     }
 
     flecs_value_cast(world, stack, lvalue, operand_type);
@@ -29851,10 +30300,10 @@ int flecs_binary_expr_do(
         ECS_BINARY_OP(lvalue, rvalue, storage, /);
         break;
     case EcsCondEq:
-        ECS_BINARY_COND_OP(lvalue, rvalue, storage, ==);
+        ECS_BINARY_COND_EQ_OP(lvalue, rvalue, storage, ==);
         break;
     case EcsCondNeq:
-        ECS_BINARY_COND_OP(lvalue, rvalue, storage, !=);
+        ECS_BINARY_COND_EQ_OP(lvalue, rvalue, storage, !=);
         break;
     case EcsCondGt:
         ECS_BINARY_COND_OP(lvalue, rvalue, storage, >);
@@ -29880,9 +30329,13 @@ int flecs_binary_expr_do(
     case EcsShiftRight:
         ECS_BINARY_UINT_OP(lvalue, rvalue, storage, >>);
         break;
-    default:
+    case EcsExprOperUnknown:
+    case EcsLeftParen:
+    case EcsMin:
         ecs_parser_error(name, expr, ptr - expr, "unsupported operator");
-        return -1;
+        goto error;
+    default:
+        ecs_throw(ECS_INTERNAL_ERROR, NULL);
     }
 
     if (storage->ptr != result->ptr) {
@@ -29896,6 +30349,8 @@ int flecs_binary_expr_do(
     }
 
     return 0;
+error:
+    return -1;
 }
 
 static
@@ -30691,7 +31146,7 @@ void ecs_world_stats_get(
     ECS_COUNTER_RECORD(&s->performance.merge_time, t, world->info.merge_time_total);
     ECS_COUNTER_RECORD(&s->performance.rematch_time, t, world->info.rematch_time_total);
     ECS_GAUGE_RECORD(&s->performance.delta_time, t, delta_world_time);
-    if (delta_world_time != 0 && delta_frame_count != 0) {
+    if (ECS_NEQZERO(delta_world_time) && ECS_NEQZERO(delta_frame_count)) {
         ECS_GAUGE_RECORD(&s->performance.fps, t, (double)1 / (delta_world_time / (double)delta_frame_count));
     } else {
         ECS_GAUGE_RECORD(&s->performance.fps, t, 0);
@@ -32218,7 +32673,7 @@ ecs_data_t* flecs_duplicate_data(
     /* Copy each column */
     for (i = 0; i < column_count; i ++) {
         ecs_vec_t *column = &result->columns[i];
-        ecs_type_info_t *ti = table->type_info[i];
+        const ecs_type_info_t *ti = table->type_info[i];
         int32_t size = ti->size;
         ecs_copy_t copy = ti->hooks.copy;
         if (copy) {
@@ -32257,8 +32712,10 @@ void snapshot_table(
     ecs_assert(l != NULL, ECS_INTERNAL_ERROR, NULL);
     
     l->table = table;
-    l->type = flecs_type_copy((ecs_world_t*)world, &table->type);
-    l->data = flecs_duplicate_data((ecs_world_t*)world, table, &table->data);
+    l->type = flecs_type_copy(
+        ECS_CONST_CAST(ecs_world_t*, world), &table->type);
+    l->data = flecs_duplicate_data(
+        ECS_CONST_CAST(ecs_world_t*, world), table, &table->data);
 }
 
 static
@@ -32271,9 +32728,9 @@ ecs_snapshot_t* snapshot_create(
     ecs_snapshot_t *result = ecs_os_calloc_t(ecs_snapshot_t);
     ecs_assert(result != NULL, ECS_OUT_OF_MEMORY, NULL);
 
-    ecs_run_aperiodic((ecs_world_t*)world, 0);
+    ecs_run_aperiodic(ECS_CONST_CAST(ecs_world_t*, world), 0);
 
-    result->world = (ecs_world_t*)world;
+    result->world = ECS_CONST_CAST(ecs_world_t*, world);
 
     /* If no iterator is provided, the snapshot will be taken of the entire
      * world, and we can simply copy the entity index as it will be restored
@@ -32879,9 +33336,11 @@ ecs_entity_t ecs_system_init(
         system->multi_threaded = desc->multi_threaded;
         system->no_readonly = desc->no_readonly;
 
-        if (desc->interval != 0 || desc->rate != 0 || desc->tick_source != 0) {
+        if (ECS_NEQZERO(desc->interval) || ECS_NEQZERO(desc->rate) || 
+            ECS_NEQZERO(desc->tick_source)) 
+        {
 #ifdef FLECS_TIMER
-            if (desc->interval != 0) {
+            if (ECS_NEQZERO(desc->interval)) {
                 ecs_set_interval(world, entity, desc->interval);
             }
 
@@ -32944,9 +33403,11 @@ ecs_entity_t ecs_system_init(
             system->no_readonly = desc->no_readonly;
         }
 
-        if (desc->interval != 0 || desc->rate != 0 || desc->tick_source != 0) {
+        if (ECS_NEQZERO(desc->interval) || desc->rate != 0 || 
+            desc->tick_source != 0) 
+        {
 #ifdef FLECS_TIMER
-            if (desc->interval != 0) {
+            if (ECS_NEQZERO(desc->interval)) {
                 ecs_set_interval(world, entity, desc->interval);
             }
             if (desc->rate != 0) {
@@ -33142,15 +33603,17 @@ const char* flecs_json_token_str(
     case JsonColon: return ":";
     case JsonComma: return ",";
     case JsonNumber: return "number";
+    case JsonLargeString:
     case JsonString: return "string";
     case JsonTrue: return "true";
     case JsonFalse: return "false";
     case JsonNull: return "null";
     case JsonInvalid: return "invalid";
     default:
-        ecs_abort(ECS_INTERNAL_ERROR, NULL);
+        ecs_throw(ECS_INTERNAL_ERROR, NULL);
     }
-    return "invalid";
+error:
+    return "<<invalid token kind>>";
 }
 
 const char* flecs_json_parse(
@@ -33607,7 +34070,7 @@ int json_ser_enum(
     const EcsEnum *enum_type = ecs_get(world, op->type, EcsEnum);
     ecs_check(enum_type != NULL, ECS_INVALID_PARAMETER, NULL);
 
-    int32_t value = *(int32_t*)base;
+    int32_t value = *(const int32_t*)base;
     
     /* Enumeration constants are stored in a map that is keyed on the
      * enumeration value. */
@@ -33642,7 +34105,7 @@ int json_ser_bitmask(
     const EcsBitmask *bitmask_type = ecs_get(world, op->type, EcsBitmask);
     ecs_check(bitmask_type != NULL, ECS_INVALID_PARAMETER, NULL);
 
-    uint32_t value = *(uint32_t*)ptr;
+    uint32_t value = *(const uint32_t*)ptr;
     if (!value) {
         ecs_strbuf_appendch(str, '0');
         return 0;
@@ -33869,7 +34332,7 @@ int json_ser_type_op(
         break;
     case EcsOpF32:
         ecs_strbuf_appendflt(str, 
-            (ecs_f64_t)*(ecs_f32_t*)ECS_OFFSET(ptr, op->offset), '"');
+            (ecs_f64_t)*(const ecs_f32_t*)ECS_OFFSET(ptr, op->offset), '"');
         break;
     case EcsOpF64:
         ecs_strbuf_appendflt(str, 
@@ -33901,7 +34364,7 @@ int json_ser_type_op(
         }
         break;
     case EcsOpEntity: {
-        ecs_entity_t e = *(ecs_entity_t*)ECS_OFFSET(ptr, op->offset);
+        ecs_entity_t e = *(const ecs_entity_t*)ECS_OFFSET(ptr, op->offset);
         if (!e) {
             ecs_strbuf_appendch(str, '0');
         } else {
@@ -33909,17 +34372,31 @@ int json_ser_type_op(
         }
         break;
     }
-
-    default:
+    case EcsOpBool:
+    case EcsOpChar:
+    case EcsOpByte:
+    case EcsOpU8:
+    case EcsOpU16:
+    case EcsOpU32:
+    case EcsOpU64:
+    case EcsOpI8:
+    case EcsOpI16:
+    case EcsOpI32:
+    case EcsOpI64:
+    case EcsOpUPtr:
+    case EcsOpIPtr:
+    case EcsOpString:
         if (ecs_primitive_to_expr_buf(world, 
             flecs_json_op_to_primitive_kind(op->kind), 
             ECS_OFFSET(ptr, op->offset), str)) 
         {
-            /* Unknown operation */
             ecs_throw(ECS_INTERNAL_ERROR, NULL);
-            return -1;
         }
         break;
+    case EcsOpPrimitive:
+    case EcsOpScope:
+    default:
+        ecs_throw(ECS_INTERNAL_ERROR, NULL);
     }
 
     return 0;
@@ -33968,11 +34445,36 @@ int json_ser_type_ops(
             flecs_json_object_pop(str);
             in_array ++;
             break;
-        default:
+        case EcsOpArray:
+        case EcsOpVector:
+        case EcsOpScope:
+        case EcsOpEnum:
+        case EcsOpBitmask:
+        case EcsOpPrimitive:
+        case EcsOpBool:
+        case EcsOpChar:
+        case EcsOpByte:
+        case EcsOpU8:
+        case EcsOpU16:
+        case EcsOpU32:
+        case EcsOpU64:
+        case EcsOpI8:
+        case EcsOpI16:
+        case EcsOpI32:
+        case EcsOpI64:
+        case EcsOpF32:
+        case EcsOpF64:
+        case EcsOpUPtr:
+        case EcsOpIPtr:
+        case EcsOpEntity:
+        case EcsOpString:
+        case EcsOpOpaque:
             if (json_ser_type_op(world, op, base, str)) {
                 goto error;
             }
             break;
+        default:
+            ecs_throw(ECS_INTERNAL_ERROR, NULL);
         }
     }
 
@@ -34985,7 +35487,7 @@ void flecs_json_serialize_iter_result_parent(
         return;
     }
 
-    const ecs_table_record_t *tr = flecs_id_record_get_table(
+    ecs_table_record_t *tr = flecs_id_record_get_table(
         world->idr_childof_wildcard, it->table);
     if (tr == NULL) {
         return;
@@ -35044,7 +35546,7 @@ void flecs_json_serialize_iter_result_entity_labels(
     }
 
 #ifdef FLECS_DOC
-    const ecs_table_record_t *tr = flecs_id_record_get_table(
+    ecs_table_record_t *tr = flecs_id_record_get_table(
         ser_idr->idr_doc_name, it->table);
     if (tr == NULL) {
         return;
@@ -35085,7 +35587,7 @@ void flecs_json_serialize_iter_result_colors(
         return;
     }
 
-    const ecs_table_record_t *tr = flecs_id_record_get_table(
+    ecs_table_record_t *tr = flecs_id_record_get_table(
         ser_idr->idr_doc_color, it->table);
     if (tr == NULL) {
         return;
@@ -35725,17 +36227,35 @@ int json_typeinfo_ser_type_op(
         break;
     case EcsOpOpaque:
         /* Can't happen, already handled above */
-        ecs_abort(ECS_INTERNAL_ERROR, NULL);
+        ecs_throw(ECS_INTERNAL_ERROR, NULL);
         break;
-    default:
+    case EcsOpBool:
+    case EcsOpChar:
+    case EcsOpByte:
+    case EcsOpU8:
+    case EcsOpU16:
+    case EcsOpU32:
+    case EcsOpU64:
+    case EcsOpI8:
+    case EcsOpI16:
+    case EcsOpI32:
+    case EcsOpI64:
+    case EcsOpF32:
+    case EcsOpF64:
+    case EcsOpUPtr:
+    case EcsOpIPtr:
+    case EcsOpEntity:
+    case EcsOpString:
         if (json_typeinfo_ser_primitive( 
             flecs_json_op_to_primitive_kind(op->kind), str))
         {
-            /* Unknown operation */
             ecs_throw(ECS_INTERNAL_ERROR, NULL);
-            return -1;
         }
         break;
+    case EcsOpScope:
+    case EcsOpPrimitive:
+    default:
+        ecs_throw(ECS_INTERNAL_ERROR, NULL);
     }
 
     if (st) {
@@ -35743,9 +36263,9 @@ int json_typeinfo_ser_type_op(
             &st->members, ecs_member_t, op->member_index);
         ecs_assert(m != NULL, ECS_INTERNAL_ERROR, NULL);
 
-        bool value_range = m->range.min != m->range.max;
-        bool error_range = m->error_range.min != m->error_range.max;
-        bool warning_range = m->warning_range.min != m->warning_range.max;
+        bool value_range = ECS_NEQ(m->range.min, m->range.max);
+        bool error_range = ECS_NEQ(m->error_range.min, m->error_range.max);
+        bool warning_range = ECS_NEQ(m->warning_range.min, m->warning_range.max);
 
         ecs_entity_t unit = m->unit;
         if (unit || error_range || warning_range || value_range) {
@@ -35811,11 +36331,36 @@ int json_typeinfo_ser_type_ops(
         case EcsOpPop:
             flecs_json_object_pop(str);
             break;
-        default:
+        case EcsOpArray:
+        case EcsOpVector:
+        case EcsOpEnum:
+        case EcsOpBitmask:
+        case EcsOpBool:
+        case EcsOpChar:
+        case EcsOpByte:
+        case EcsOpU8:
+        case EcsOpU16:
+        case EcsOpU32:
+        case EcsOpU64:
+        case EcsOpI8:
+        case EcsOpI16:
+        case EcsOpI32:
+        case EcsOpI64:
+        case EcsOpF32:
+        case EcsOpF64:
+        case EcsOpUPtr:
+        case EcsOpIPtr:
+        case EcsOpEntity:
+        case EcsOpString:
+        case EcsOpOpaque:
             if (json_typeinfo_ser_type_op(world, op, str, st)) {
                 goto error;
             }
             break;
+        case EcsOpPrimitive:
+        case EcsOpScope:
+        default:
+            ecs_throw(ECS_INTERNAL_ERROR, NULL);
         }
     }
 
@@ -36558,7 +37103,7 @@ const char* flecs_json_parse_column(
 
     ecs_json_token_t token_kind = 0;
     ecs_vec_t *data = &table->data.columns[data_column];
-    ecs_type_info_t *ti = table->type_info[data_column];
+    const ecs_type_info_t *ti = table->type_info[data_column];
     ecs_size_t size = ti->size;
     ecs_entity_t type = ti->component;
     ecs_record_t **record_array = ecs_vec_first_t(records, ecs_record_t*);
@@ -36906,7 +37451,7 @@ error:
 
 #ifdef FLECS_REST
 
-ECS_TAG_DECLARE(EcsRestPlecs);
+static ECS_TAG_DECLARE(EcsRestPlecs);
 
 typedef struct {
     ecs_world_t *world;
@@ -36925,8 +37470,6 @@ int64_t ecs_rest_query_name_error_count = 0;
 int64_t ecs_rest_query_name_from_cache_count = 0;
 int64_t ecs_rest_enable_count = 0;
 int64_t ecs_rest_enable_error_count = 0;
-int64_t ecs_rest_set_count = 0;
-int64_t ecs_rest_set_error_count = 0;
 int64_t ecs_rest_delete_count = 0;
 int64_t ecs_rest_delete_error_count = 0;
 int64_t ecs_rest_world_stats_count = 0;
@@ -37054,7 +37597,7 @@ void flecs_rest_string_param(
 {
     const char *value = ecs_http_get_param(req, name);
     if (value) {
-        *value_out = (char*)value;
+        *value_out = ECS_CONST_CAST(char*, value);
     }
 }
 
@@ -37167,11 +37710,8 @@ bool flecs_rest_set(
     ecs_http_reply_t *reply,
     const char *path)
 {
-    ecs_os_linc(&ecs_rest_set_count);
-
     ecs_entity_t e;
     if (!(e = flecs_rest_entity_from_path(world, reply, path))) {
-        ecs_os_linc(&ecs_rest_set_error_count);
         return true;
     }
 
@@ -37182,7 +37722,6 @@ bool flecs_rest_set(
     if (ecs_entity_from_json(world, e, data, &desc) == NULL) {
         flecs_reply_error(reply, "invalid request");
         reply->code = 400;
-        ecs_os_linc(&ecs_rest_set_error_count);
         return true;
     }
     
@@ -37195,8 +37734,6 @@ bool flecs_rest_delete(
     ecs_http_reply_t *reply,
     const char *path)
 {
-    ecs_os_linc(&ecs_rest_set_count);
-
     ecs_entity_t e;
     if (!(e = flecs_rest_entity_from_path(world, reply, path))) {
         ecs_os_linc(&ecs_rest_delete_error_count);
@@ -37422,7 +37959,7 @@ bool flecs_rest_reply_query(
 #ifdef FLECS_MONITOR
 
 static
-void _flecs_rest_array_append(
+void flecs_rest_array_append_(
     ecs_strbuf_t *reply,
     const char *field,
     int32_t field_len,
@@ -37445,7 +37982,7 @@ void _flecs_rest_array_append(
 }
 
 #define flecs_rest_array_append(reply, field, values, t)\
-    _flecs_rest_array_append(reply, field, sizeof(field) - 1, values, t)
+    flecs_rest_array_append_(reply, field, sizeof(field) - 1, values, t)
 
 static
 void flecs_rest_gauge_append(
@@ -37738,7 +38275,7 @@ void flecs_rest_reply_table_append_memory(
     allocated += table->data.records.size * ECS_SIZEOF(ecs_record_t*);
 
     int32_t i, storage_count = table->storage_count;
-    ecs_type_info_t **ti = table->type_info;
+    const ecs_type_info_t **ti = table->type_info;
     ecs_vec_t *storages = table->data.columns;
 
     for (i = 0; i < storage_count; i ++) {
@@ -38037,8 +38574,8 @@ void FlecsCoreDocImport(
     ecs_struct_init(world, &(ecs_struct_desc_t){
         .entity = ecs_id(EcsComponent),
         .members = {
-            {.name = (char*)"size", .type = ecs_id(ecs_i32_t)},
-            {.name = (char*)"alignment", .type = ecs_id(ecs_i32_t)}
+            {.name = "size", .type = ecs_id(ecs_i32_t)},
+            {.name = "alignment", .type = ecs_id(ecs_i32_t)}
         }
     });
 
@@ -38196,9 +38733,9 @@ void FlecsCoreDocImport(
 #define WIN32_LEAN_AND_MEAN
 #endif
 #pragma comment(lib, "Ws2_32.lib")
-#include <winsock2.h>
-#include <ws2tcpip.h>
-#include <windows.h>
+#include <WinSock2.h>
+#include <WS2tcpip.h>
+#include <Windows.h>
 typedef SOCKET ecs_http_socket_t;
 #else
 #include <unistd.h>
@@ -38213,10 +38750,11 @@ typedef SOCKET ecs_http_socket_t;
 #include <netinet/in.h>
 #endif
 typedef int ecs_http_socket_t;
-#endif
 
 #if !defined(MSG_NOSIGNAL)
 #define MSG_NOSIGNAL (0)
+#endif
+
 #endif
 
 /* Max length of request method */
@@ -38236,9 +38774,6 @@ typedef int ecs_http_socket_t;
 
 /* Minimum interval between printing statistics (ms) */
 #define ECS_HTTP_MIN_STATS_INTERVAL (10 * 1000)
-
-/* Max length of headers in reply */
-#define ECS_HTTP_REPLY_HEADER_SIZE (1024)
 
 /* Receive buffer size */
 #define ECS_HTTP_SEND_RECV_BUFFER_SIZE (16 * 1024)
@@ -38460,6 +38995,7 @@ void http_sock_keep_alive(
 static
 void http_sock_nonblock(ecs_http_socket_t sock, bool enable) {
     (void)sock;
+    (void)enable;
 #ifdef ECS_TARGET_POSIX
     int flags;
     flags = fcntl(sock,F_GETFL,0);
@@ -38494,8 +39030,15 @@ int http_getnameinfo(
     ecs_assert(addr_len > 0, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(host_len > 0, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(port_len > 0, ECS_INTERNAL_ERROR, NULL);
-    return getnameinfo(addr, (uint32_t)addr_len, host, (uint32_t)host_len, 
-        port, (uint32_t)port_len, flags);
+#if defined(ECS_TARGET_WINDOWS)
+    return getnameinfo(addr, addr_len, host, 
+        flecs_ito(uint32_t, host_len), port, flecs_ito(uint32_t, port_len), 
+        flags);
+#else
+    return getnameinfo(addr, flecs_ito(uint32_t, addr_len), host, 
+        flecs_ito(uint32_t, host_len), port, flecs_ito(uint32_t, port_len), 
+        flags);
+#endif
 }
 
 static
@@ -38505,7 +39048,11 @@ int http_bind(
     ecs_size_t addr_len)
 {
     ecs_assert(addr_len > 0, ECS_INTERNAL_ERROR, NULL);
-    return bind(sock, addr, (uint32_t)addr_len);
+#if defined(ECS_TARGET_WINDOWS)
+    return bind(sock, addr, addr_len);
+#else
+    return bind(sock, addr, flecs_ito(uint32_t, addr_len));
+#endif
 }
 
 static
@@ -38765,7 +39312,8 @@ char* http_decode_request(
     for (i = 0; i < count; i ++) {
         req->pub.params[i].key = &res[frag->param_offsets[i]];
         req->pub.params[i].value = &res[frag->param_value_offsets[i]];
-        http_decode_url_str((char*)req->pub.params[i].value);
+        /* Safe, member is only const so that end-user can't change it */
+        http_decode_url_str(ECS_CONST_CAST(char*, req->pub.params[i].value));
     }
 
     req->pub.header_count = frag->header_count;
@@ -38836,7 +39384,8 @@ bool http_parse_request(
             frag->buf.max = ECS_HTTP_METHOD_LEN_MAX;
             frag->state = HttpFragStateMethod;
             frag->header_buf_ptr = frag->header_buf;
-            /* fallthrough */
+            
+            /* fall through */
         case HttpFragStateMethod:
             if (c == ' ') {
                 http_parse_method(frag);
@@ -38877,7 +39426,8 @@ bool http_parse_request(
             }
             http_header_buf_reset(frag);
             frag->state = HttpFragStateHeaderName;
-            /* fallthrough */
+
+            /* fall through */
         case HttpFragStateHeaderName:
             if (c == ':') {
                 frag->state = HttpFragStateHeaderValueStart;
@@ -38905,7 +39455,8 @@ bool http_parse_request(
             if (c == ' ') { /* skip first space */
                 break;
             }
-            /* fallthrough */
+
+            /* fall through */
         case HttpFragStateHeaderValue:
             if (c == '\r') {
                 if (frag->parse_content_length) {
@@ -39297,7 +39848,7 @@ void http_accept_connections(
 #ifdef ECS_TARGET_WINDOWS
     /* If on Windows, test if winsock needs to be initialized */
     SOCKET testsocket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
-    if (SOCKET_ERROR == testsocket && WSANOTINITIALISED == WSAGetLastError()) {
+    if (INVALID_SOCKET == testsocket && WSANOTINITIALISED == WSAGetLastError()){
         WSADATA data = { 0 };
         int result = WSAStartup(MAKEWORD(2, 2), &data);
         if (result) {
@@ -39435,7 +39986,9 @@ void http_do_request(
     ecs_http_reply_t *reply,
     const ecs_http_request_impl_t *req)
 {
-    if (srv->callback((ecs_http_request_t*)req, reply, srv->ctx) == false) {
+    if (srv->callback(ECS_CONST_CAST(ecs_http_request_t*, req), reply, 
+        srv->ctx) == false) 
+    {
         reply->code = 404;
         reply->status = "Resource not found";
         ecs_os_linc(&ecs_http_request_not_handled_count);
@@ -39502,7 +40055,8 @@ void http_purge_request_cache(
             ecs_http_request_entry_t *entry = &entries[i];
             if (fini || ((time - entry->time) > ECS_HTTP_CACHE_PURGE_TIMEOUT)) {
                 ecs_http_request_key_t *key = &keys[i];
-                ecs_os_free((char*)key->array);
+                /* Safe, code owns the value */
+                ecs_os_free(ECS_CONST_CAST(char*, key->array));
                 ecs_os_free(entry->content);
                 flecs_hm_bucket_remove(&srv->request_cache, bucket, 
                     ecs_map_key(&it), i);
@@ -40617,7 +41171,7 @@ void flecs_rule_discover_vars(
     flecs_set_var_label(&rule_vars[0], NULL);
     rule_vars[0].id = 0;
     rule_vars[0].table_id = EcsVarNone;
-    var_names[0] = (char*)rule_vars[0].name;
+    var_names[0] = ECS_CONST_CAST(char*, rule_vars[0].name);
     rule_vars ++;
     var_names ++;
     var_count --;
@@ -40626,7 +41180,7 @@ void flecs_rule_discover_vars(
         ecs_rule_var_t *user_vars = ecs_vec_first_t(vars, ecs_rule_var_t);
         ecs_os_memcpy_n(rule_vars, user_vars, ecs_rule_var_t, var_count);
         for (i = 0; i < var_count; i ++) {
-            var_names[i] = (char*)rule_vars[i].name;
+            var_names[i] = ECS_CONST_CAST(char*, rule_vars[i].name);
         }
     }
 
@@ -41725,7 +42279,7 @@ int flecs_rule_compile(
 
 #ifdef FLECS_RULES
 
-ecs_mixins_t ecs_rule_t_mixins = {
+static ecs_mixins_t ecs_rule_t_mixins = {
     .type_name = "ecs_rule_t",
     .elems = {
         [EcsMixinWorld] = offsetof(ecs_rule_t, filter.world),
@@ -41784,10 +42338,10 @@ void flecs_rule_iter_mixin_init(
     ecs_poly_assert(poly, ecs_rule_t);
 
     if (filter) {
-        iter[1] = ecs_rule_iter(world, (ecs_rule_t*)poly);
+        iter[1] = ecs_rule_iter(world, ECS_CONST_CAST(ecs_rule_t*, poly));
         iter[0] = ecs_term_chain_iter(&iter[1], filter);
     } else {
-        iter[0] = ecs_rule_iter(world, (ecs_rule_t*)poly);
+        iter[0] = ecs_rule_iter(world, ECS_CONST_CAST(ecs_rule_t*, poly));
     }
 }
 
@@ -41985,6 +42539,7 @@ char* ecs_rule_str_w_profile(
                 ecs_strbuf_appendstr(&buf, ", #[yellow]\"");
                 ecs_strbuf_appendstr(&buf, rule->filter.terms[term_index].second.name);
                 ecs_strbuf_appendstr(&buf, "\"#[reset]");
+                break;
             }
             default:
                 break;
@@ -42195,7 +42750,7 @@ void flecs_rule_build_up_cache(
 
         ecs_record_t *r = flecs_entities_get_any(world, second);
         if (r->table) {
-            const ecs_table_record_t *r_tr = flecs_id_record_get_table(
+            ecs_table_record_t *r_tr = flecs_id_record_get_table(
                 cache->idr, r->table);
             if (!r_tr) {
                 return;
@@ -42249,7 +42804,7 @@ void flecs_rule_get_up_cache(
         }
     }
 
-    const ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
+    ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
     if (!tr) {
         ecs_vec_reset_t(a, &cache->entities, ecs_trav_elem_t);
         return;
@@ -42288,13 +42843,13 @@ ecs_allocator_t* flecs_rule_get_allocator(
 }
 
 static
-ecs_rule_op_ctx_t* _flecs_op_ctx(
+ecs_rule_op_ctx_t* flecs_op_ctx_(
     const ecs_rule_run_ctx_t *ctx)
 {
     return &ctx->op_ctx[ctx->op_index];
 }
 
-#define flecs_op_ctx(ctx, op_kind) (&_flecs_op_ctx(ctx)->is.op_kind)
+#define flecs_op_ctx(ctx, op_kind) (&flecs_op_ctx_(ctx)->is.op_kind)
 
 static
 ecs_table_range_t flecs_range_from_entity(
@@ -42825,7 +43380,7 @@ bool flecs_rule_with_id(
         }
     }
 
-    const ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
+    ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
     if (!tr) {
         return false;
     }
@@ -44139,7 +44694,7 @@ ecs_iter_t ecs_rule_iter(
     ecs_run_aperiodic(rule->filter.world, EcsAperiodicEmptyTables);
 
     int32_t i, var_count = rule->var_count, op_count = rule->op_count;
-    it.world = (ecs_world_t*)world;
+    it.world = ECS_CONST_CAST(ecs_world_t*, world);
     it.real_world = rule->filter.world;
     it.terms = rule->filter.terms;
     it.next = ecs_rule_next;
@@ -44212,7 +44767,8 @@ void ecs_doc_set_name(
     const char *name)
 {
     ecs_set_pair(world, entity, EcsDocDescription, EcsName, {
-        .value = (char*)name
+        /* Safe, value gets copied by copy hook */
+        .value = ECS_CONST_CAST(char*, name)
     });
 }
 
@@ -44222,7 +44778,8 @@ void ecs_doc_set_brief(
     const char *description)
 {
     ecs_set_pair(world, entity, EcsDocDescription, EcsDocBrief, {
-        .value = (char*)description
+        /* Safe, value gets copied by copy hook */
+        .value = ECS_CONST_CAST(char*, description)
     });
 }
 
@@ -44232,7 +44789,8 @@ void ecs_doc_set_detail(
     const char *description)
 {
     ecs_set_pair(world, entity, EcsDocDescription, EcsDocDetail, {
-        .value = (char*)description
+        /* Safe, value gets copied by copy hook */
+        .value = ECS_CONST_CAST(char*, description)
     });
 }
 
@@ -44242,7 +44800,8 @@ void ecs_doc_set_link(
     const char *link)
 {
     ecs_set_pair(world, entity, EcsDocDescription, EcsDocLink, {
-        .value = (char*)link
+        /* Safe, value gets copied by copy hook */
+        .value = ECS_CONST_CAST(char*, link)
     });
 }
 
@@ -44252,7 +44811,8 @@ void ecs_doc_set_color(
     const char *color)
 {
     ecs_set_pair(world, entity, EcsDocDescription, EcsDocColor, {
-        .value = (char*)color
+        /* Safe, value gets copied by copy hook */
+        .value = ECS_CONST_CAST(char*, color)
     });
 }
 
@@ -44356,9 +44916,6 @@ void FlecsDocImport(
 
 #include <ctype.h>
 
-#define ECS_ANNOTATION_LENGTH_MAX (16)
-
-#define TOK_NEWLINE '\n'
 #define TOK_COLON ':'
 #define TOK_AND ','
 #define TOK_OR "||"
@@ -44369,7 +44926,6 @@ void FlecsDocImport(
 #define TOK_BRACKET_CLOSE ']'
 #define TOK_SCOPE_OPEN '{'
 #define TOK_SCOPE_CLOSE '}'
-#define TOK_WILDCARD '*'
 #define TOK_VARIABLE '$'
 #define TOK_PAREN_OPEN '('
 #define TOK_PAREN_CLOSE ')'
@@ -44624,15 +45180,16 @@ int flecs_parse_identifier(
         }
     }
 
-    out->name = ecs_os_strdup(tptr);
+    char *name = ecs_os_strdup(tptr);
+    out->name = name;
 
-    ecs_size_t len = ecs_os_strlen(out->name);
+    ecs_size_t len = ecs_os_strlen(name);
     if (out->flags & EcsIsName) {
-        if (out->name[len - 1] != TOK_EXPR_STRING) {
+        if (name[len - 1] != TOK_EXPR_STRING) {
             ecs_parser_error(NULL, token, 0, "missing '\"' at end of string");
             return -1;
         } else {
-            out->name[len - 1] = '\0';
+            name[len - 1] = '\0';
         }
     }
 
@@ -44671,8 +45228,9 @@ ecs_oper_kind_t flecs_parse_operator(
     } else if (ch == TOK_NOT) {
         return EcsNot;
     } else {
-        ecs_abort(ECS_INTERNAL_ERROR, NULL);
+        ecs_throw(ECS_INTERNAL_ERROR, NULL);
     }
+error:
     return 0;
 }
 
@@ -45302,15 +45860,15 @@ char* ecs_parse_term(
             }
         }
     }
-    
+
     ptr = ecs_parse_ws_eol(ptr);
     if (!ptr[0]) {
         *term = (ecs_term_t){0};
-        return (char*)ptr;
+        return ECS_CONST_CAST(char*, ptr);
     }
 
     if (ptr == expr && !strcmp(expr, "0")) {
-        return (char*)&ptr[1];
+        return ECS_CONST_CAST(char*, &ptr[1]);
     }
 
     /* Parse next element */
@@ -45322,7 +45880,8 @@ char* ecs_parse_term(
     /* Check for $() notation */
     if (term->first.name && !ecs_os_strcmp(term->first.name, "$")) {
         if (term->src.name) {
-            ecs_os_free(term->first.name);
+            /* Safe, parser owns name */
+            ecs_os_free(ECS_CONST_CAST(char*, term->first.name));
             
             term->first = term->src;
 
@@ -45379,7 +45938,8 @@ char* ecs_parse_term(
 
         src->flags = EcsIsEntity;
         src->id = 0;
-        ecs_os_free(term->first.name);
+        /* Safe, parser owns string */
+        ecs_os_free(ECS_CONST_CAST(char*, term->first.name));
         term->first.name = NULL;
     }
 
@@ -45422,7 +45982,7 @@ char* ecs_parse_term(
 
     ptr = ecs_parse_ws(ptr);
 
-    return (char*)ptr;
+    return ECS_CONST_CAST(char*, ptr);
 error:
     if (term) {
         ecs_term_fini(term);
@@ -45771,7 +46331,8 @@ const char* meta_parse_member(
         /* If the [ was separated by a space, it will not be parsed as part of
          * the name */
         if (*ptr == '[') {
-            array_start = (char*)ptr; /* safe, will not be modified */
+            /* safe, will not be modified */
+            array_start = ECS_CONST_CAST(char*, ptr);
         }
     }
 
@@ -46244,8 +46805,13 @@ int ecs_meta_from_desc(
             goto error;
         }
         break;
-    default:
+    case EcsPrimitiveType:
+    case EcsArrayType:
+    case EcsVectorType:
+    case EcsOpaqueType:
         break;
+    default:
+        ecs_throw(ECS_INTERNAL_ERROR, "invalid type kind");
     }
 
     return 0;
@@ -46340,7 +46906,7 @@ int ecs_app_run(
     /* Don't set FPS & threads if custom run action is set, as the platform on
      * which the app is running may not support it. */
     if (run_action == flecs_default_run_action) {
-        if (ecs_app_desc.target_fps != 0) {
+        if (ECS_NEQZERO(ecs_app_desc.target_fps)) {
             ecs_set_target_fps(world, ecs_app_desc.target_fps);
         }
         if (ecs_app_desc.threads) {
@@ -46483,10 +47049,6 @@ const ecs_entity_t EcsOnTableCreate =               FLECS_HI_COMPONENT_ID + 38;
 const ecs_entity_t EcsOnTableDelete =               FLECS_HI_COMPONENT_ID + 39;
 const ecs_entity_t EcsOnTableEmpty =                FLECS_HI_COMPONENT_ID + 40;
 const ecs_entity_t EcsOnTableFill =                 FLECS_HI_COMPONENT_ID + 41;
-const ecs_entity_t EcsOnCreateTrigger =             FLECS_HI_COMPONENT_ID + 42;
-const ecs_entity_t EcsOnDeleteTrigger =             FLECS_HI_COMPONENT_ID + 43;
-const ecs_entity_t EcsOnDeleteObservable =          FLECS_HI_COMPONENT_ID + 44;
-const ecs_entity_t EcsOnComponentHooks =            FLECS_HI_COMPONENT_ID + 45;
 const ecs_entity_t EcsOnDeleteTarget =              FLECS_HI_COMPONENT_ID + 46;
 
 /* Timers */
@@ -46736,7 +47298,7 @@ const ecs_stage_t* flecs_stage_from_readonly_world(
         return &world->stages[0];
 
     } else if (ecs_poly_is(world, ecs_stage_t)) {
-        return (ecs_stage_t*)world;
+        return ECS_CONST_CAST(ecs_stage_t*, world);
     }
     
     return NULL;    
@@ -46757,7 +47319,7 @@ ecs_stage_t* flecs_stage_from_world(
     }
 
     *world_ptr = ((ecs_stage_t*)world)->world;
-    return (ecs_stage_t*)world;
+    return ECS_CONST_CAST(ecs_stage_t*, world);
 }
 
 ecs_world_t* flecs_suspend_readonly(
@@ -46767,7 +47329,7 @@ ecs_world_t* flecs_suspend_readonly(
     ecs_assert(stage_world != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(state != NULL, ECS_INTERNAL_ERROR, NULL);
 
-    ecs_world_t *world = (ecs_world_t*)ecs_get_world(stage_world);
+    ecs_world_t *world = ECS_CONST_CAST(ecs_world_t*, ecs_get_world(stage_world));
     ecs_poly_assert(world, ecs_world_t);
 
     bool is_readonly = ECS_BIT_IS_SET(world->flags, EcsWorldReadonly);
@@ -47076,7 +47638,7 @@ bool flecs_world_iter_next(
     }
 
     ecs_world_t *world = it->real_world;
-    it->entities = (ecs_entity_t*)flecs_entities_ids(world);
+    it->entities = ECS_CONST_CAST(ecs_entity_t*, flecs_entities_ids(world));
     it->count = flecs_entities_count(world);
     flecs_iter_validate(it);
 
@@ -47097,8 +47659,8 @@ void flecs_world_iter_init(
         iter[0] = ecs_term_iter(world, filter);
     } else {
         iter[0] = (ecs_iter_t){
-            .world = (ecs_world_t*)world,
-            .real_world = (ecs_world_t*)ecs_get_world(world),
+            .world = ECS_CONST_CAST(ecs_world_t*, world),
+            .real_world = ECS_CONST_CAST(ecs_world_t*, ecs_get_world(world)),
             .next = flecs_world_iter_next
         };
     }
@@ -47370,23 +47932,6 @@ ecs_world_t *ecs_init(void) {
     return world;
 }
 
-#define ARG(short, long, action)\
-    if (i < argc) {\
-        if (argv[i][0] == '-') {\
-            if (argv[i][1] == '-') {\
-                if (long && !strcmp(&argv[i][2], long ? long : "")) {\
-                    action;\
-                    parsed = true;\
-                }\
-            } else {\
-                if (short && argv[i][1] == short) {\
-                    action;\
-                    parsed = true;\
-                }\
-            }\
-        }\
-    }
-
 ecs_world_t* ecs_init_w_args(
     int argc,
     char *argv[])
@@ -47394,7 +47939,7 @@ ecs_world_t* ecs_init_w_args(
     ecs_world_t *world = ecs_init();
 
     (void)argc;
-    (void) argv;
+    (void)argv;
 
 #ifdef FLECS_DOC
     if (argc) {
@@ -47878,7 +48423,7 @@ void ecs_measure_frame_time(
     ecs_poly_assert(world, ecs_world_t);
     ecs_check(ecs_os_has_time(), ECS_MISSING_OS_API, NULL);
 
-    if (world->info.target_fps == (ecs_ftime_t)0 || enable) {
+    if (ECS_EQZERO(world->info.target_fps) || enable) {
         ECS_BIT_COND(world->flags, EcsWorldMeasureFrameTime, enable);
     }
 error:
@@ -48015,7 +48560,7 @@ ecs_type_info_t* flecs_type_info_ensure(
         ecs_assert(ti_mut != NULL, ECS_INTERNAL_ERROR, NULL);
         ti_mut->component = component;
     } else {
-        ti_mut = (ecs_type_info_t*)ti;
+        ti_mut = ECS_CONST_CAST(ecs_type_info_t*, ti);
     }
 
     if (!ti_mut->name) {
@@ -48108,7 +48653,7 @@ void flecs_type_info_fini(
     }
     if (ti->name) {
         /* Safe to cast away const, world has ownership over string */
-        ecs_os_free((char*)ti->name);
+        ecs_os_free(ECS_CONST_CAST(char*, ti->name));
         ti->name = NULL;
     }
 }
@@ -48143,7 +48688,7 @@ ecs_ftime_t flecs_insert_sleep(
     ecs_time_t start = *stop, now = start;
     ecs_ftime_t delta_time = (ecs_ftime_t)ecs_time_measure(stop);
 
-    if (world->info.target_fps == (ecs_ftime_t)0.0) {
+    if (ECS_EQZERO(world->info.target_fps)) {
         return delta_time;
     }
 
@@ -48161,7 +48706,7 @@ ecs_ftime_t flecs_insert_sleep(
     do {
         /* Only call sleep when sleep_time is not 0. On some platforms, even
          * a sleep with a timeout of 0 can cause stutter. */
-        if (sleep_time != 0) {
+        if (ECS_NEQZERO(sleep_time)) {
             ecs_sleepf((double)sleep_time);
         }
 
@@ -48183,14 +48728,16 @@ ecs_ftime_t flecs_start_measure_frame(
 
     ecs_ftime_t delta_time = 0;
 
-    if ((world->flags & EcsWorldMeasureFrameTime) || (user_delta_time == 0)) {
+    if ((world->flags & EcsWorldMeasureFrameTime) || 
+        (ECS_EQZERO(user_delta_time))) 
+    {
         ecs_time_t t = world->frame_start_time;
         do {
             if (world->frame_start_time.nanosec || world->frame_start_time.sec){ 
                 delta_time = flecs_insert_sleep(world, &t);
             } else {
                 ecs_time_measure(&t);
-                if (world->info.target_fps != 0) {
+                if (ECS_NEQZERO(world->info.target_fps)) {
                     delta_time = (ecs_ftime_t)1.0 / world->info.target_fps;
                 } else {
                     /* Best guess */
@@ -48199,7 +48746,7 @@ ecs_ftime_t flecs_start_measure_frame(
             }
         
         /* Keep trying while delta_time is zero */
-        } while (delta_time == 0);
+        } while (ECS_EQZERO(delta_time));
 
         world->frame_start_time = t;  
 
@@ -48228,12 +48775,12 @@ ecs_ftime_t ecs_frame_begin(
 {
     ecs_poly_assert(world, ecs_world_t);
     ecs_check(!(world->flags & EcsWorldReadonly), ECS_INVALID_OPERATION, NULL);
-    ecs_check(user_delta_time != 0 || ecs_os_has_time(), 
+    ecs_check(ECS_NEQZERO(user_delta_time) || ecs_os_has_time(), 
         ECS_MISSING_OS_API, "get_time");
 
     /* Start measuring total frame time */
     ecs_ftime_t delta_time = flecs_start_measure_frame(world, user_delta_time);
-    if (user_delta_time == 0) {
+    if (ECS_EQZERO(user_delta_time)) {
         user_delta_time = delta_time;
     }  
 
@@ -48338,7 +48885,7 @@ void flecs_process_pending_tables(
     }
 
     /* Safe to cast, world is not readonly */
-    ecs_world_t *world = (ecs_world_t*)world_r;
+    ecs_world_t *world = ECS_CONST_CAST(ecs_world_t*, world_r);
     
     /* If pending buffer is NULL there already is a stackframe that's iterating
      * the table list. This can happen when an observer for a table event results
@@ -48484,11 +49031,11 @@ int32_t ecs_delete_empty_tables(
     int32_t delete_count = 0, clear_count = 0;
     bool time_budget = false;
 
-    if (time_budget_seconds != 0 || (ecs_should_log_1() && ecs_os_has_time())) {
+    if (ECS_NEQZERO(time_budget_seconds) || (ecs_should_log_1() && ecs_os_has_time())) {
         ecs_time_measure(&start);
     }
 
-    if (time_budget_seconds != 0) {
+    if (ECS_NEQZERO(time_budget_seconds)) {
         time_budget = true;
     }
 
@@ -48603,11 +49150,11 @@ ecs_event_record_t* flecs_event_record_get(
     ecs_assert(o != NULL, ECS_INTERNAL_ERROR, NULL);
     
     /* Builtin events*/
-    if      (event == EcsOnAdd)     return (ecs_event_record_t*)&o->on_add;
-    else if (event == EcsOnRemove)  return (ecs_event_record_t*)&o->on_remove;
-    else if (event == EcsOnSet)     return (ecs_event_record_t*)&o->on_set;
-    else if (event == EcsUnSet)     return (ecs_event_record_t*)&o->un_set;
-    else if (event == EcsWildcard)  return (ecs_event_record_t*)&o->on_wildcard;
+    if      (event == EcsOnAdd)     return ECS_CONST_CAST(ecs_event_record_t*, &o->on_add);
+    else if (event == EcsOnRemove)  return ECS_CONST_CAST(ecs_event_record_t*, &o->on_remove);
+    else if (event == EcsOnSet)     return ECS_CONST_CAST(ecs_event_record_t*, &o->on_set);
+    else if (event == EcsUnSet)     return ECS_CONST_CAST(ecs_event_record_t*, &o->un_set);
+    else if (event == EcsWildcard)  return ECS_CONST_CAST(ecs_event_record_t*, &o->on_wildcard);
 
     /* User events */
     return flecs_sparse_try_t(&o->events, ecs_event_record_t, event);
@@ -48629,13 +49176,13 @@ ecs_event_record_t* flecs_event_record_ensure(
 }
 
 static
-ecs_event_record_t* flecs_event_record_get_if(
+const ecs_event_record_t* flecs_event_record_get_if(
     const ecs_observable_t *o,
     ecs_entity_t event)
 {
     ecs_assert(o != NULL, ECS_INTERNAL_ERROR, NULL);
 
-    ecs_event_record_t *er = flecs_event_record_get(o, event);
+    const ecs_event_record_t *er = flecs_event_record_get(o, event);
     if (er) {
         if (ecs_map_is_init(&er->event_ids)) {
             return er;
@@ -48774,7 +49321,7 @@ bool flecs_observers_exist(
     ecs_id_t id,
     ecs_entity_t event)
 {
-    ecs_event_record_t *er = flecs_event_record_get_if(observable, event);
+    const ecs_event_record_t *er = flecs_event_record_get_if(observable, event);
     if (!er) {
         return false;
     }
@@ -48820,7 +49367,7 @@ void flecs_emit_propagate(
                 continue;
             }
 
-            bool owned = flecs_id_record_get_table(idr, table);
+            bool owned = flecs_id_record_get_table(idr, table) != NULL;
 
             int32_t e, entity_count = ecs_table_count(table);
             it->table = table;
@@ -49005,7 +49552,7 @@ void* flecs_override(
              * after it was inherited, as this does not change the actual value
              * of the component for the entity (it is copied from the existing
              * overridden component), and does not require an OnSet event. */
-            const ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
+            ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
             if (!tr) {
                 continue;
             }
@@ -49028,8 +49575,8 @@ void* flecs_override(
 static
 void flecs_emit_forward_up(
     ecs_world_t *world,
-    ecs_event_record_t *er,
-    ecs_event_record_t *er_onset,
+    const ecs_event_record_t *er,
+    const ecs_event_record_t *er_onset,
     const ecs_type_t *emit_ids,
     ecs_iter_t *it,
     ecs_table_t *table,
@@ -49041,8 +49588,8 @@ void flecs_emit_forward_up(
 static
 void flecs_emit_forward_id(
     ecs_world_t *world,
-    ecs_event_record_t *er,
-    ecs_event_record_t *er_onset,
+    const ecs_event_record_t *er,
+    const ecs_event_record_t *er_onset,
     const ecs_type_t *emit_ids,
     ecs_iter_t *it,
     ecs_table_t *table,
@@ -49088,7 +49635,7 @@ void flecs_emit_forward_id(
         it->sizes[0] = size;
     }
 
-    const ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
+    ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
     bool owned = tr != NULL;
 
     for (ider_i = 0; ider_i < ider_count; ider_i ++) {
@@ -49143,8 +49690,8 @@ void flecs_emit_forward_id(
 static
 void flecs_emit_forward_and_cache_id(
     ecs_world_t *world,
-    ecs_event_record_t *er,
-    ecs_event_record_t *er_onset,
+    const ecs_event_record_t *er,
+    const ecs_event_record_t *er_onset,
     const ecs_type_t *emit_ids,
     ecs_iter_t *it,
     ecs_table_t *table,
@@ -49204,8 +49751,8 @@ bool flecs_emit_stack_has(
 static
 void flecs_emit_forward_cached_ids(
     ecs_world_t *world,
-    ecs_event_record_t *er,
-    ecs_event_record_t *er_onset,
+    const ecs_event_record_t *er,
+    const ecs_event_record_t *er_onset,
     const ecs_type_t *emit_ids,
     ecs_iter_t *it,
     ecs_table_t *table,
@@ -49269,8 +49816,8 @@ void flecs_emit_dump_cache(
 static
 void flecs_emit_forward_table_up(
     ecs_world_t *world,
-    ecs_event_record_t *er,
-    ecs_event_record_t *er_onset,
+    const ecs_event_record_t *er,
+    const ecs_event_record_t *er_onset,
     const ecs_type_t *emit_ids,
     ecs_iter_t *it,
     ecs_table_t *table,
@@ -49417,8 +49964,8 @@ void flecs_emit_forward_table_up(
 static
 void flecs_emit_forward_up(
     ecs_world_t *world,
-    ecs_event_record_t *er,
-    ecs_event_record_t *er_onset,
+    const ecs_event_record_t *er,
+    const ecs_event_record_t *er_onset,
     const ecs_type_t *emit_ids,
     ecs_iter_t *it,
     ecs_table_t *table,
@@ -49444,8 +49991,8 @@ void flecs_emit_forward_up(
 static
 void flecs_emit_forward(
     ecs_world_t *world,
-    ecs_event_record_t *er,
-    ecs_event_record_t *er_onset,
+    const ecs_event_record_t *er,
+    const ecs_event_record_t *er_onset,
     const ecs_type_t *emit_ids,
     ecs_iter_t *it,
     ecs_table_t *table,
@@ -49584,7 +50131,7 @@ void flecs_emit(
         .other_table = other_table,
         .offset = offset,
         .count = count,
-        .param = (void*)desc->param,
+        .param = ECS_CONST_CAST(void*, desc->param),
         .flags = desc->flags | EcsIterIsValid
     };
 
@@ -49605,10 +50152,10 @@ void flecs_emit(
      * inherited components, for example when an IsA relationship is added to an
      * entity. This doesn't add much overhead, as fetching records is cheap for
      * builtin event types. */
-    ecs_event_record_t *er = flecs_event_record_get_if(observable, event);
-    ecs_event_record_t *wcer = flecs_event_record_get_if(observable, EcsWildcard);
-    ecs_event_record_t *er_onset = flecs_event_record_get_if(observable, EcsOnSet);
-    ecs_event_record_t *er_unset = flecs_event_record_get_if(observable, EcsUnSet);
+    const ecs_event_record_t *er = flecs_event_record_get_if(observable, event);
+    const ecs_event_record_t *wcer = flecs_event_record_get_if(observable, EcsWildcard);
+    const ecs_event_record_t *er_onset = flecs_event_record_get_if(observable, EcsOnSet);
+    const ecs_event_record_t *er_unset = flecs_event_record_get_if(observable, EcsUnSet);
 
     ecs_data_t *storage = NULL;
     ecs_vec_t *columns = NULL;
@@ -49675,7 +50222,7 @@ repeat_event:
             ecs_flags32_t idr_flags = idr->flags;
 
             if (is_pair && (idr_flags & EcsIdTraversable)) {
-                ecs_event_record_t *er_fwd = NULL;
+                const ecs_event_record_t *er_fwd = NULL;
                 if (ECS_PAIR_FIRST(id) == EcsIsA) {
                     if (event == EcsOnAdd) {
                         if (!world->stages[0].base) {
@@ -49753,7 +50300,7 @@ repeat_event:
         }
 
         ecs_assert(idr != NULL, ECS_INTERNAL_ERROR, NULL);
-        const ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
+        ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
         if (tr == NULL) {
             /* When a single batch contains multiple add's for an exclusive
              * relationship, it's possible that an id was in the added list
@@ -49900,7 +50447,7 @@ void ecs_emit(
     ecs_world_t *stage,
     ecs_event_desc_t *desc)
 {
-    ecs_world_t *world = (ecs_world_t*)ecs_get_world(stage);
+    ecs_world_t *world = ECS_CONST_CAST(ecs_world_t*, ecs_get_world(stage));
     if (desc->entity) {
         ecs_assert(desc->table == NULL, ECS_INVALID_PARAMETER, NULL);
         ecs_assert(desc->offset == 0, ECS_INVALID_PARAMETER, NULL);
@@ -50039,7 +50586,7 @@ int flecs_term_id_lookup(
     bool free_name,
     ecs_filter_finalize_ctx_t *ctx)
 {
-    char *name = term_id->name;
+    const char *name = term_id->name;
     if (!name) {
         return 0;
     }
@@ -50048,7 +50595,8 @@ int flecs_term_id_lookup(
         if (!ecs_os_strcmp(name, "This") || !ecs_os_strcmp(name, "this")) {
             term_id->id = EcsThis;
             if (free_name) {
-                ecs_os_free(term_id->name);
+                /* Safe, if free_name is true the filter owns the name */
+                ecs_os_free(ECS_CONST_CAST(char*, term_id->name));
             }
             term_id->name = NULL;
         }
@@ -50107,7 +50655,8 @@ int flecs_term_id_lookup(
         }
 
         if (free_name) {
-            ecs_os_free(name);
+            /* Safe, if free_name is true, the filter owns the name */
+            ecs_os_free(ECS_CONST_CAST(char*, name));
         }
 
         term_id->name = NULL;
@@ -50984,9 +51533,10 @@ ecs_term_t ecs_term_move(
 void ecs_term_fini(
     ecs_term_t *term)
 {
-    ecs_os_free(term->first.name);
-    ecs_os_free(term->src.name);
-    ecs_os_free(term->second.name);
+    /* Safe, values are owned by term */
+    ecs_os_free(ECS_CONST_CAST(char*, term->first.name));
+    ecs_os_free(ECS_CONST_CAST(char*, term->src.name));
+    ecs_os_free(ECS_CONST_CAST(char*, term->second.name));
     ecs_os_free(term->name);
 
     term->first.name = NULL;
@@ -51241,10 +51791,10 @@ void flecs_filter_iter_init(
     ecs_poly_assert(poly, ecs_filter_t);
 
     if (filter) {
-        iter[1] = ecs_filter_iter(world, (ecs_filter_t*)poly);
+        iter[1] = ecs_filter_iter(world, ECS_CONST_CAST(ecs_filter_t*, poly));
         iter[0] = ecs_term_chain_iter(&iter[1], filter);
     } else {
-        iter[0] = ecs_filter_iter(world, (ecs_filter_t*)poly);
+        iter[0] = ecs_filter_iter(world, ECS_CONST_CAST(ecs_filter_t*, poly));
     }
 }
 
@@ -52154,8 +52704,8 @@ ecs_iter_t ecs_term_iter(
     }
 
     ecs_iter_t it = {
-        .real_world = (ecs_world_t*)world,
-        .world = (ecs_world_t*)stage,
+        .real_world = ECS_CONST_CAST(ecs_world_t*, world),
+        .world = ECS_CONST_CAST(ecs_world_t*, stage),
         .field_count = 1,
         .next = ecs_term_next
     };
@@ -52192,11 +52742,11 @@ ecs_iter_t ecs_term_chain_iter(
     }
 
     ecs_iter_t it = {
-        .real_world = (ecs_world_t*)world,
+        .real_world = world,
         .world = chain_it->world,
         .terms = term,
         .field_count = 1,
-        .chain_it = (ecs_iter_t*)chain_it,
+        .chain_it = ECS_CONST_CAST(ecs_iter_t*, chain_it),
         .next = ecs_term_next
     };
 
@@ -52557,8 +53107,8 @@ ecs_iter_t flecs_filter_iter_w_flags(
     }
 
     ecs_iter_t it = {
-        .real_world = (ecs_world_t*)world,
-        .world = (ecs_world_t*)stage,
+        .real_world = ECS_CONST_CAST(ecs_world_t*, world),
+        .world = ECS_CONST_CAST(ecs_world_t*, stage),
         .terms = filter ? filter->terms : NULL,
         .next = ecs_filter_next,
         .flags = flags,
@@ -52612,7 +53162,7 @@ ecs_iter_t flecs_filter_iter_w_flags(
         it.variable_count = 1;
 
         /* Set variable name array */
-        it.variable_names = (char**)filter->variable_names;
+        it.variable_names = ECS_CONST_CAST(char**, filter->variable_names);
     }
 
     flecs_iter_init(stage, &it, flecs_iter_cache_all);
@@ -52638,7 +53188,7 @@ ecs_iter_t ecs_filter_chain_iter(
         .field_count = filter->field_count,
         .world = chain_it->world,
         .real_world = chain_it->real_world,
-        .chain_it = (ecs_iter_t*)chain_it,
+        .chain_it = ECS_CONST_CAST(ecs_iter_t*, chain_it),
         .next = ecs_filter_next,
         .sizes = filter->sizes
     };
@@ -53229,7 +53779,7 @@ int32_t flecs_relation_depth_walk(
 {
     int32_t result = 0;
 
-    const ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
+    ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
     if (!tr) {
         return 0;
     }
@@ -54421,7 +54971,7 @@ void ecs_table_cache_insert(
     }
 
     result->cache = cache;
-    result->table = (ecs_table_t*)table;
+    result->table = ECS_CONST_CAST(ecs_table_t*, table);
     result->empty = empty;
 
     flecs_table_cache_list_insert(cache, result);
@@ -54571,7 +55121,7 @@ bool flecs_table_cache_all_iter(
     return out->next != NULL || out->next_list != NULL;
 }
 
-ecs_table_cache_hdr_t* _flecs_table_cache_next(
+ecs_table_cache_hdr_t* flecs_table_cache_next_(
     ecs_table_cache_iter_t *it)
 {
     ecs_table_cache_hdr_t *next = it->next;
@@ -56146,7 +56696,7 @@ void flecs_query_sort_table(
     void *ptr = NULL;
     int32_t size = 0;
     if (column_index != -1) {
-        ecs_type_info_t *ti = table->type_info[column_index];
+        const ecs_type_info_t *ti = table->type_info[column_index];
         ecs_vec_t *column = &data->columns[column_index];
         size = ti->size;
         ptr = ecs_vec_first(column);
@@ -56919,10 +57469,10 @@ void flecs_query_iter_init(
     ecs_poly_assert(poly, ecs_query_t);
 
     if (filter) {
-        iter[1] = ecs_query_iter(world, (ecs_query_t*)poly);
+        iter[1] = ecs_query_iter(world, ECS_CONST_CAST(ecs_query_t*, poly));
         iter[0] = ecs_term_chain_iter(&iter[1], filter);
     } else {
-        iter[0] = ecs_query_iter(world, (ecs_query_t*)poly);
+        iter[0] = ecs_query_iter(world, ECS_CONST_CAST(ecs_query_t*, poly));
     }
 }
 
@@ -57297,7 +57847,7 @@ ecs_iter_t ecs_query_iter(
 
     ecs_iter_t result = {
         .real_world = world,
-        .world = (ecs_world_t*)stage,
+        .world = ECS_CONST_CAST(ecs_world_t*, stage),
         .terms = query->filter.terms,
         .field_count = query->filter.field_count,
         .table_count = table_count,
@@ -57312,8 +57862,8 @@ ecs_iter_t ecs_query_iter(
     if (!(query->flags & EcsQueryTrivialIter)) {
         /* Check if non-This terms (like singleton terms) still match */
         if (!(filter->flags & EcsFilterMatchOnlyThis)) {
-            fit = flecs_filter_iter_w_flags(
-                (ecs_world_t*)stage, &query->filter, EcsIterIgnoreThis);
+            fit = flecs_filter_iter_w_flags(ECS_CONST_CAST(ecs_world_t*, stage),
+                &query->filter, EcsIterIgnoreThis);
             if (!ecs_filter_next(&fit)) {
                 /* No match, so return nothing */
                 ecs_iter_fini(&fit);
@@ -58577,7 +59127,7 @@ void flecs_add_overrides_for_base(
     }
 
     if (flags & EcsTableHasIsA) {
-        const ecs_table_record_t *tr = flecs_id_record_get_table(
+        ecs_table_record_t *tr = flecs_id_record_get_table(
             world->idr_isa_wildcard, base_table);
         ecs_assert(tr != NULL, ECS_INTERNAL_ERROR, NULL);
         int32_t i = tr->column, end = i + tr->count;
@@ -58604,7 +59154,7 @@ void flecs_add_with_property(
         return;
     }
     
-    const ecs_table_record_t *tr = flecs_id_record_get_table(
+    ecs_table_record_t *tr = flecs_id_record_get_table(
         idr_with_wildcard, table);
     if (tr) {
         int32_t i = tr->column, end = i + tr->count;
@@ -58653,7 +59203,7 @@ ecs_table_t* flecs_find_table_with(
             return flecs_table_ensure(world, &dst_type, true, node);
         } else if (idr->flags & EcsIdExclusive) {
             /* Relationship is exclusive, check if table already has it */
-            const ecs_table_record_t *tr = flecs_id_record_get_table(idr, node);
+            ecs_table_record_t *tr = flecs_id_record_get_table(idr, node);
             if (tr) {
                 /* Table already has an instance of the relationship, create
                  * a new id sequence with the existing id replaced */
@@ -59019,7 +59569,7 @@ ecs_table_t* ecs_table_find(
     int32_t id_count)
 {
     ecs_type_t type = {
-        .array = (ecs_id_t*)ids,
+        .array = ECS_CONST_CAST(ecs_id_t*, ids),
         .count = id_count
     };
     return flecs_table_ensure(world, &type, false, NULL);
@@ -59079,7 +59629,8 @@ void flecs_iter_init(
     ecs_assert(!ECS_BIT_IS_SET(it->flags, EcsIterIsValid), 
         ECS_INTERNAL_ERROR, NULL);
 
-    ecs_stage_t *stage = flecs_stage_from_world((ecs_world_t**)&world);
+    ecs_stage_t *stage = flecs_stage_from_world(
+        ECS_CONST_CAST(ecs_world_t**, &world));
     ecs_stack_t *stack = &stage->allocators.iter_stack;
 
     it->priv.cache.used = 0;
@@ -59798,7 +60349,7 @@ void ecs_iter_set_var_as_table(
     int32_t var_id,
     const ecs_table_t *table)
 {
-    ecs_table_range_t range = { .table = (ecs_table_t*)table };
+    ecs_table_range_t range = { .table = ECS_CONST_CAST(ecs_table_t*, table) };
     ecs_iter_set_var_as_range(it, var_id, &range);
 }
 
@@ -59873,7 +60424,7 @@ ecs_iter_t ecs_page_iter(
     };
     result.next = ecs_page_next;
     result.fini = ecs_chained_iter_fini;
-    result.chain_it = (ecs_iter_t*)it;
+    result.chain_it = ECS_CONST_CAST(ecs_iter_t*, it);
 
     return result;
 error:
@@ -60023,7 +60574,7 @@ ecs_iter_t ecs_worker_iter(
     };
     result.next = ecs_worker_next;
     result.fini = ecs_chained_iter_fini;
-    result.chain_it = (ecs_iter_t*)it;
+    result.chain_it = ECS_CONST_CAST(ecs_iter_t*, it);
 
     return result;
 error:
@@ -60132,7 +60683,7 @@ static int64_t flecs_s_max[] = {
 static uint64_t flecs_u_max[] = { 
     [1] = UINT8_MAX, [2] = UINT16_MAX, [4] = UINT32_MAX, [8] = UINT64_MAX };
 
-uint64_t _flecs_ito(
+uint64_t flecs_ito_(
     size_t size,
     bool is_signed,
     bool lt_zero,
@@ -61901,8 +62452,8 @@ ecs_entity_t ecs_lookup_path_w_sep(
     ecs_entity_t cur;
     bool lookup_path_search = false;
 
-    ecs_entity_t *lookup_path = ecs_get_lookup_path(stage);
-    ecs_entity_t *lookup_path_cur = lookup_path;
+    const ecs_entity_t *lookup_path = ecs_get_lookup_path(stage);
+    const ecs_entity_t *lookup_path_cur = lookup_path;
     while (lookup_path_cur && *lookup_path_cur) {
         lookup_path_cur ++;
     }
@@ -62004,8 +62555,9 @@ ecs_entity_t* ecs_set_lookup_path(
     ecs_check(world != NULL, ECS_INVALID_PARAMETER, NULL);
     ecs_stage_t *stage = flecs_stage_from_world(&world);
 
-    ecs_entity_t *cur = stage->lookup_path;
-    stage->lookup_path = (ecs_entity_t*)lookup_path;
+    /* Safe: application owns lookup path */
+    ecs_entity_t *cur = ECS_CONST_CAST(ecs_entity_t*, stage->lookup_path);
+    stage->lookup_path = lookup_path;
 
     return cur;
 error:
@@ -62017,7 +62569,8 @@ ecs_entity_t* ecs_get_lookup_path(
 {
     ecs_check(world != NULL, ECS_INVALID_PARAMETER, NULL);
     const ecs_stage_t *stage = flecs_stage_from_readonly_world(world);
-    return stage->lookup_path;
+    /* Safe: application owns lookup path */
+    return ECS_CONST_CAST(ecs_entity_t*, stage->lookup_path);
 error:
     return NULL;
 }
@@ -62770,7 +63323,7 @@ ecs_table_record_t* flecs_table_record_get(
     return (ecs_table_record_t*)ecs_table_cache_get(&idr->cache, table);
 }
 
-const ecs_table_record_t* flecs_id_record_get_table(
+ecs_table_record_t* flecs_id_record_get_table(
     const ecs_id_record_t *idr,
     const ecs_table_t *table)
 {

--- a/flecs.h
+++ b/flecs.h
@@ -522,6 +522,38 @@ extern "C" {
     #endif
 #endif
 
+/* Ignored warnings */
+#if defined(ECS_TARGET_CLANG)
+/* Warns for double or redundant semicolons. There are legitimate cases where a
+ * semicolon after an empty statement is useful, for example after a macro that
+ * is replaced with a code block. With this warning enabled, semicolons would 
+ * only have to be added after macro's that are not code blocks, which in some
+ * cases isn't possible as the implementation of a macro can be different in
+ * debug/release mode. */
+#pragma clang diagnostic ignored "-Wextra-semi-stmt"
+/* This is valid in C99, and Flecs must be compiled as C99. */
+#pragma clang diagnostic ignored "-Wdeclaration-after-statement"
+/* Clang attribute to detect fallthrough isn't supported on older versions. 
+ * Implicit fallthrough is still detected by gcc and ignored with "fall through"
+ * comments */
+#pragma clang diagnostic ignored "-Wimplicit-fallthrough"
+/* This warning prevents adding a default case when all enum constants are part
+ * of the switch. In C however an enum type can assume any value in the range of
+ * the type, and this warning makes it harder to catch invalid enum values. */
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+/* This warning prevents some casts of function results to a different kind of
+ * type, e.g. casting an int result to double. Not very useful in practice, as
+ * it just forces the code to assign to a variable first, then cast. */
+#pragma clang diagnostic ignored "-Wbad-function-cast"
+/* Format strings can be passed down from other functions. */
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#elif defined(ECS_TARGET_GCC)
+#pragma GCC diagnostic ignored "-Wextra-semi-stmt"
+#pragma GCC diagnostic ignored "-Wdeclaration-after-statement"
+#pragma GCC diagnostic ignored "-Wbad-function-cast"
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+#endif
+
 /* Standard library dependencies */
 #include <assert.h>
 #include <stdarg.h>
@@ -662,8 +694,20 @@ typedef struct ecs_allocator_t ecs_allocator_t;
 #define ECS_CAST(T, V) (static_cast<T>(V))
 #endif
 
-#define ECS_CONCAT(a, b) a ## b
+/* Utility macro for doing const casts without warnings */
+#ifndef __cplusplus
+#define ECS_CONST_CAST(type, value) ((type)(uintptr_t)(value))
+#else
+#define ECS_CONST_CAST(type, value) (const_cast<type>(value))
+#endif
 
+/* Utility macro's to do bitwise comparisons between floats without warnings */
+#define ECS_EQ(a, b) (ecs_os_memcmp(&(a), &(b), sizeof(a)) == 0)
+#define ECS_NEQ(a, b) (!ECS_EQ(a, b))
+#define ECS_EQZERO(a) ECS_EQ(a, (uint64_t){0})
+#define ECS_NEQZERO(a) ECS_NEQ(a, (uint64_t){0})
+
+#define ECS_CONCAT(a, b) a ## b
 
 ////////////////////////////////////////////////////////////////////////////////
 //// Magic numbers for sanity checking
@@ -708,10 +752,7 @@ typedef struct ecs_allocator_t ecs_allocator_t;
 ////////////////////////////////////////////////////////////////////////////////
 
 /** Translate C type to id. */
-#define ecs_id(T) FLECS__E##T
-
-/** Translate C type to system function. */
-#define ecs_iter_action(T) FLECS__F##T
+#define ecs_id(T) FLECS_ID##T##ID_
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -790,7 +831,7 @@ typedef struct ecs_allocator_t ecs_allocator_t;
         (void)type_info;\
         for (int32_t i = 0; i < _count; i ++) {\
             type *dst_var = &((type*)_dst_ptr)[i];\
-            type *src_var = &((type*)_src_ptr)[i];\
+            const type *src_var = &((const type*)_src_ptr)[i];\
             (void)dst_var;\
             (void)src_var;\
             __VA_ARGS__\
@@ -925,7 +966,7 @@ void ecs_vec_remove_last(
 FLECS_API
 ecs_vec_t ecs_vec_copy(
     struct ecs_allocator_t *allocator,
-    ecs_vec_t *vec,
+    const ecs_vec_t *vec,
     ecs_size_t size);
 
 #define ecs_vec_copy_t(allocator, vec, T) \
@@ -1438,7 +1479,7 @@ ecs_map_val_t* ecs_map_get(
 
 /* Get element as pointer (auto-dereferences _ptr) */
 FLECS_API
-void* _ecs_map_get_deref(
+void* ecs_map_get_deref_(
     const ecs_map_t *map,
     ecs_map_key_t key);
 
@@ -1509,7 +1550,7 @@ void ecs_map_copy(
     const ecs_map_t *src);
 
 #define ecs_map_get_ref(m, T, k) ECS_CAST(T**, ecs_map_get(m, k))
-#define ecs_map_get_deref(m, T, k) ECS_CAST(T*, _ecs_map_get_deref(m, k))
+#define ecs_map_get_deref(m, T, k) ECS_CAST(T*, ecs_map_get_deref_(m, k))
 #define ecs_map_ensure_ref(m, T, k) ECS_CAST(T**, ecs_map_ensure(m, k))
 
 #define ecs_map_insert_ptr(m, k, v) ecs_map_insert(m, k, ECS_CAST(ecs_map_val_t, v))
@@ -2224,7 +2265,7 @@ void ecs_os_set_api_defaults(void);
 #define ecs_offset(ptr, T, index)\
     ECS_CAST(T*, ECS_OFFSET(ptr, ECS_SIZEOF(T) * index))
 
-#if defined(ECS_TARGET_MSVC)
+#ifndef ECS_TARGET_POSIX
 #define ecs_os_strcat(str1, str2) strcat_s(str1, INT_MAX, str2)
 #define ecs_os_sprintf(ptr, ...) sprintf_s(ptr, INT_MAX, __VA_ARGS__)
 #define ecs_os_vsprintf(ptr, fmt, args) vsprintf_s(ptr, INT_MAX, fmt, args)
@@ -2247,7 +2288,7 @@ void ecs_os_set_api_defaults(void);
 #endif
 
 /* Files */
-#if defined(ECS_TARGET_MSVC)
+#ifndef ECS_TARGET_POSIX
 #define ecs_os_fopen(result, file, mode) fopen_s(result, file, mode)
 #else
 #define ecs_os_fopen(result, file, mode) (*(result)) = fopen(file, mode)
@@ -2724,12 +2765,11 @@ typedef struct ecs_term_id_t {
                                  * To explicitly set the id to 0, leave the id
                                  * member to 0 and set EcsIsEntity in flags. */
 
-    char *name;                 /**< Name. This can be either the variable name
+    const char *name;           /**< Name. This can be either the variable name
                                  * (when the EcsIsVariable flag is set) or an
-                                 * entity name. Entity names are used to 
-                                 * initialize the id member during term 
-                                 * finalization and will be freed when term.move
-                                 * is set to true. */
+                                 * entity name. When ecs_term_t::move is true,
+                                 * the API assumes ownership over the string and
+                                 * will free it when the term is destroyed. */
 
     ecs_entity_t trav;          /**< Relationship to traverse when looking for the
                                  * component. The relationship must have
@@ -3232,7 +3272,7 @@ extern "C" {
 ////////////////////////////////////////////////////////////////////////////////
 
 /** This allows passing 0 as type to functions that accept ids */
-#define FLECS__E0 0
+#define FLECS_ID0ID_ 0
 
 FLECS_API
 char* ecs_module_path_from_c(
@@ -3335,7 +3375,7 @@ typedef struct {
 } flecs_hashmap_result_t;
 
 FLECS_DBG_API
-void _flecs_hashmap_init(
+void flecs_hashmap_init_(
     ecs_hashmap_t *hm,
     ecs_size_t key_size,
     ecs_size_t value_size,
@@ -3344,34 +3384,34 @@ void _flecs_hashmap_init(
     ecs_allocator_t *allocator);
 
 #define flecs_hashmap_init(hm, K, V, hash, compare, allocator)\
-    _flecs_hashmap_init(hm, ECS_SIZEOF(K), ECS_SIZEOF(V), hash, compare, allocator)
+    flecs_hashmap_init_(hm, ECS_SIZEOF(K), ECS_SIZEOF(V), hash, compare, allocator)
 
 FLECS_DBG_API
 void flecs_hashmap_fini(
     ecs_hashmap_t *map);
 
 FLECS_DBG_API
-void* _flecs_hashmap_get(
+void* flecs_hashmap_get_(
     const ecs_hashmap_t *map,
     ecs_size_t key_size,
     const void *key,
     ecs_size_t value_size);
 
 #define flecs_hashmap_get(map, key, V)\
-    (V*)_flecs_hashmap_get(map, ECS_SIZEOF(*key), key, ECS_SIZEOF(V))
+    (V*)flecs_hashmap_get_(map, ECS_SIZEOF(*key), key, ECS_SIZEOF(V))
 
 FLECS_DBG_API
-flecs_hashmap_result_t _flecs_hashmap_ensure(
+flecs_hashmap_result_t flecs_hashmap_ensure_(
     ecs_hashmap_t *map,
     ecs_size_t key_size,
     const void *key,
     ecs_size_t value_size);
 
 #define flecs_hashmap_ensure(map, key, V)\
-    _flecs_hashmap_ensure(map, ECS_SIZEOF(*key), key, ECS_SIZEOF(V))
+    flecs_hashmap_ensure_(map, ECS_SIZEOF(*key), key, ECS_SIZEOF(V))
 
 FLECS_DBG_API
-void _flecs_hashmap_set(
+void flecs_hashmap_set_(
     ecs_hashmap_t *map,
     ecs_size_t key_size,
     void *key,
@@ -3379,20 +3419,20 @@ void _flecs_hashmap_set(
     const void *value);
 
 #define flecs_hashmap_set(map, key, value)\
-    _flecs_hashmap_set(map, ECS_SIZEOF(*key), key, ECS_SIZEOF(*value), value)
+    flecs_hashmap_set_(map, ECS_SIZEOF(*key), key, ECS_SIZEOF(*value), value)
 
 FLECS_DBG_API
-void _flecs_hashmap_remove(
+void flecs_hashmap_remove_(
     ecs_hashmap_t *map,
     ecs_size_t key_size,
     const void *key,
     ecs_size_t value_size);
 
 #define flecs_hashmap_remove(map, key, V)\
-    _flecs_hashmap_remove(map, ECS_SIZEOF(*key), key, ECS_SIZEOF(V))
+    flecs_hashmap_remove_(map, ECS_SIZEOF(*key), key, ECS_SIZEOF(V))
 
 FLECS_DBG_API
-void _flecs_hashmap_remove_w_hash(
+void flecs_hashmap_remove_w_hash_(
     ecs_hashmap_t *map,
     ecs_size_t key_size,
     const void *key,
@@ -3400,7 +3440,7 @@ void _flecs_hashmap_remove_w_hash(
     uint64_t hash);
 
 #define flecs_hashmap_remove_w_hash(map, key, V, hash)\
-    _flecs_hashmap_remove_w_hash(map, ECS_SIZEOF(*key), key, ECS_SIZEOF(V), hash)
+    flecs_hashmap_remove_w_hash_(map, ECS_SIZEOF(*key), key, ECS_SIZEOF(V), hash)
 
 FLECS_DBG_API
 ecs_hm_bucket_t* flecs_hashmap_get_bucket(
@@ -3424,17 +3464,17 @@ flecs_hashmap_iter_t flecs_hashmap_iter(
     ecs_hashmap_t *map);
 
 FLECS_DBG_API
-void* _flecs_hashmap_next(
+void* flecs_hashmap_next_(
     flecs_hashmap_iter_t *it,
     ecs_size_t key_size,
     void *key_out,
     ecs_size_t value_size);
 
 #define flecs_hashmap_next(map, V)\
-    (V*)_flecs_hashmap_next(map, 0, NULL, ECS_SIZEOF(V))
+    (V*)flecs_hashmap_next_(map, 0, NULL, ECS_SIZEOF(V))
 
 #define flecs_hashmap_next_w_key(map, K, key, V)\
-    (V*)_flecs_hashmap_next(map, ECS_SIZEOF(K), key, ECS_SIZEOF(V))
+    (V*)flecs_hashmap_next_(map, ECS_SIZEOF(K), key, ECS_SIZEOF(V))
 
 #ifdef __cplusplus
 }
@@ -4753,12 +4793,12 @@ ecs_entity_t ecs_get_entity(
  * @return True if the pointer is of the specified type.
  */
 FLECS_API
-bool _ecs_poly_is(
+bool ecs_poly_is_(
     const ecs_poly_t *object,
     int32_t type);
 
 #define ecs_poly_is(object, type)\
-    _ecs_poly_is(object, type##_magic)
+    ecs_poly_is_(object, type##_magic)
 
 /** Make a pair id.
  * This function is equivalent to using the ecs_pair macro, and is added for
@@ -8183,7 +8223,7 @@ int ecs_value_move_ctor(
         ecs_assert(id_ != 0, ECS_INVALID_PARAMETER, NULL); \
     } \
     (void)id_; \
-    (void)ecs_id(id_);
+    (void)ecs_id(id_)
 
 /** Declare & define an entity.
  *
@@ -8193,7 +8233,7 @@ int ecs_value_move_ctor(
 #define ECS_ENTITY(world, id, ...) \
     ecs_entity_t ecs_id(id); \
     ecs_entity_t id = 0; \
-    ECS_ENTITY_DEFINE(world, id, __VA_ARGS__);
+    ECS_ENTITY_DEFINE(world, id, __VA_ARGS__)
 
 /** Forward declare a tag. */
 #define ECS_TAG_DECLARE ECS_DECLARE
@@ -8249,8 +8289,8 @@ int ecs_value_move_ctor(
         desc.type.size = ECS_SIZEOF(id_); \
         desc.type.alignment = ECS_ALIGNOF(id_); \
         ecs_id(id_) = ecs_component_init(world, &desc);\
-        ecs_assert(ecs_id(id_) != 0, ECS_INVALID_PARAMETER, NULL);\
-    }
+    }\
+    ecs_assert(ecs_id(id_) != 0, ECS_INVALID_PARAMETER, NULL)
 
 /** Declare & define a component.
  *
@@ -8294,7 +8334,7 @@ int ecs_value_move_ctor(
     ECS_OBSERVER_DEFINE(world, id, kind, __VA_ARGS__);\
     ecs_entity_t id = ecs_id(id);\
     (void)ecs_id(id);\
-    (void)id;
+    (void)id
 
 /** Shorthand for creating an entity with ecs_entity_init.
  *
@@ -9108,7 +9148,7 @@ extern "C" {
 ////////////////////////////////////////////////////////////////////////////////
 
 FLECS_API
-void _ecs_deprecated(
+void ecs_deprecated_(
     const char *file, 
     int32_t line, 
     const char *msg);
@@ -9120,7 +9160,7 @@ void _ecs_deprecated(
  * @param level The log level.
  */
 FLECS_API
-void _ecs_log_push(int32_t level);
+void ecs_log_push_(int32_t level);
 
 /** Decrease log stack.
  * This operation decreases the indent_ value of the OS API and can be useful to
@@ -9129,7 +9169,7 @@ void _ecs_log_push(int32_t level);
  * @param level The log level.
  */
 FLECS_API
-void _ecs_log_pop(int32_t level);
+void ecs_log_pop_(int32_t level);
 
 /** Should current level be logged.
  * This operation returns true when the specified log level should be logged 
@@ -9156,13 +9196,13 @@ const char* ecs_strerror(
 //// Dummy macros for when logging is disabled
 ////////////////////////////////////////////////////////////////////////////////
 
-#define _ecs_deprecated(file, line, msg)\
+#define ecs_deprecated_(file, line, msg)\
     (void)file;\
     (void)line;\
     (void)msg
 
-#define _ecs_log_push(level)
-#define _ecs_log_pop(level)
+#define ecs_log_push_(level)
+#define ecs_log_pop_(level)
 #define ecs_should_log(level) false
 
 #define ecs_strerror(error_code)\
@@ -9176,7 +9216,7 @@ const char* ecs_strerror(
 ////////////////////////////////////////////////////////////////////////////////
 
 FLECS_API
-void _ecs_print(
+void ecs_print_(
     int32_t level,
     const char *file,
     int32_t line,
@@ -9184,7 +9224,7 @@ void _ecs_print(
     ...);
 
 FLECS_API
-void _ecs_printv(
+void ecs_printv_(
     int level,
     const char *file,
     int32_t line,
@@ -9192,7 +9232,7 @@ void _ecs_printv(
     va_list args);
 
 FLECS_API
-void _ecs_log(
+void ecs_log_(
     int32_t level,
     const char *file,
     int32_t line,
@@ -9200,7 +9240,7 @@ void _ecs_log(
     ...);
 
 FLECS_API
-void _ecs_logv(
+void ecs_logv_(
     int level,
     const char *file,
     int32_t line,
@@ -9208,7 +9248,7 @@ void _ecs_logv(
     va_list args);
 
 FLECS_API
-void _ecs_abort(
+void ecs_abort_(
     int32_t error_code,
     const char *file,
     int32_t line,
@@ -9216,7 +9256,7 @@ void _ecs_abort(
     ...);
 
 FLECS_API
-bool _ecs_assert(
+bool ecs_assert_(
     bool condition,
     int32_t error_code,
     const char *condition_str,
@@ -9226,7 +9266,7 @@ bool _ecs_assert(
     ...);
 
 FLECS_API
-void _ecs_parser_error(
+void ecs_parser_error_(
     const char *name,
     const char *expr, 
     int64_t column,
@@ -9234,7 +9274,7 @@ void _ecs_parser_error(
     ...);
 
 FLECS_API
-void _ecs_parser_errorv(
+void ecs_parser_errorv_(
     const char *name,
     const char *expr, 
     int64_t column,
@@ -9250,37 +9290,37 @@ void _ecs_parser_errorv(
 
 /* Base logging function. Accepts a custom level */
 #define ecs_print(level, ...)\
-    _ecs_print(level, __FILE__, __LINE__, __VA_ARGS__)
+    ecs_print_(level, __FILE__, __LINE__, __VA_ARGS__)
 
 #define ecs_printv(level, fmt, args)\
-    _ecs_printv(level, __FILE__, __LINE__, fmt, args)
+    ecs_printv_(level, __FILE__, __LINE__, fmt, args)
 
 #define ecs_log(level, ...)\
-    _ecs_log(level, __FILE__, __LINE__, __VA_ARGS__)
+    ecs_log_(level, __FILE__, __LINE__, __VA_ARGS__)
 
 #define ecs_logv(level, fmt, args)\
-    _ecs_logv(level, __FILE__, __LINE__, fmt, args)
+    ecs_logv_(level, __FILE__, __LINE__, fmt, args)
 
 /* Tracing. Used for logging of infrequent events  */
-#define _ecs_trace(file, line, ...) _ecs_log(0, file, line, __VA_ARGS__)
-#define ecs_trace(...) _ecs_trace(__FILE__, __LINE__, __VA_ARGS__)
+#define ecs_trace_(file, line, ...) ecs_log_(0, file, line, __VA_ARGS__)
+#define ecs_trace(...) ecs_trace_(__FILE__, __LINE__, __VA_ARGS__)
 
 /* Warning. Used when an issue occurs, but operation is successful */
-#define _ecs_warn(file, line, ...) _ecs_log(-2, file, line, __VA_ARGS__)
-#define ecs_warn(...) _ecs_warn(__FILE__, __LINE__, __VA_ARGS__)
+#define ecs_warn_(file, line, ...) ecs_log_(-2, file, line, __VA_ARGS__)
+#define ecs_warn(...) ecs_warn_(__FILE__, __LINE__, __VA_ARGS__)
 
 /* Error. Used when an issue occurs, and operation failed. */
-#define _ecs_err(file, line, ...) _ecs_log(-3, file, line, __VA_ARGS__)
-#define ecs_err(...) _ecs_err(__FILE__, __LINE__, __VA_ARGS__)
+#define ecs_err_(file, line, ...) ecs_log_(-3, file, line, __VA_ARGS__)
+#define ecs_err(...) ecs_err_(__FILE__, __LINE__, __VA_ARGS__)
 
 /* Fatal. Used when an issue occurs, and the application cannot continue. */
-#define _ecs_fatal(file, line, ...) _ecs_log(-4, file, line, __VA_ARGS__)
-#define ecs_fatal(...) _ecs_fatal(__FILE__, __LINE__, __VA_ARGS__)
+#define ecs_fatal_(file, line, ...) ecs_log_(-4, file, line, __VA_ARGS__)
+#define ecs_fatal(...) ecs_fatal_(__FILE__, __LINE__, __VA_ARGS__)
 
 /* Optionally include warnings about using deprecated features */
 #ifndef FLECS_NO_DEPRECATED_WARNINGS
 #define ecs_deprecated(...)\
-    _ecs_deprecated(__FILE__, __LINE__, __VA_ARGS__)
+    ecs_deprecated_(__FILE__, __LINE__, __VA_ARGS__)
 #else
 #define ecs_deprecated(...)
 #endif // FLECS_NO_DEPRECATED_WARNINGS
@@ -9303,13 +9343,13 @@ void _ecs_parser_errorv(
 #define ecs_dbg_2(...) ecs_log(2, __VA_ARGS__);
 #define ecs_dbg_3(...) ecs_log(3, __VA_ARGS__);
 
-#define ecs_log_push_1() _ecs_log_push(1);
-#define ecs_log_push_2() _ecs_log_push(2);
-#define ecs_log_push_3() _ecs_log_push(3);
+#define ecs_log_push_1() ecs_log_push_(1);
+#define ecs_log_push_2() ecs_log_push_(2);
+#define ecs_log_push_3() ecs_log_push_(3);
 
-#define ecs_log_pop_1() _ecs_log_pop(1);
-#define ecs_log_pop_2() _ecs_log_pop(2);
-#define ecs_log_pop_3() _ecs_log_pop(3);
+#define ecs_log_pop_1() ecs_log_pop_(1);
+#define ecs_log_pop_2() ecs_log_pop_(2);
+#define ecs_log_pop_3() ecs_log_pop_(3);
 
 #define ecs_should_log_1() ecs_should_log(1)
 #define ecs_should_log_2() ecs_should_log(2)
@@ -9324,12 +9364,12 @@ void _ecs_parser_errorv(
 #define ecs_dbg_2(...) ecs_log(2, __VA_ARGS__);
 #define ecs_dbg_3(...)
 
-#define ecs_log_push_1() _ecs_log_push(1);
-#define ecs_log_push_2() _ecs_log_push(2);
+#define ecs_log_push_1() ecs_log_push_(1);
+#define ecs_log_push_2() ecs_log_push_(2);
 #define ecs_log_push_3()
 
-#define ecs_log_pop_1() _ecs_log_pop(1);
-#define ecs_log_pop_2() _ecs_log_pop(2);
+#define ecs_log_pop_1() ecs_log_pop_(1);
+#define ecs_log_pop_2() ecs_log_pop_(2);
 #define ecs_log_pop_3()
 
 #define ecs_should_log_1() ecs_should_log(1)
@@ -9344,11 +9384,11 @@ void _ecs_parser_errorv(
 #define ecs_dbg_2(...)
 #define ecs_dbg_3(...)
 
-#define ecs_log_push_1() _ecs_log_push(1);
+#define ecs_log_push_1() ecs_log_push_(1);
 #define ecs_log_push_2()
 #define ecs_log_push_3()
 
-#define ecs_log_pop_1() _ecs_log_pop(1);
+#define ecs_log_pop_1() ecs_log_pop_(1);
 #define ecs_log_pop_2()
 #define ecs_log_pop_3()
 
@@ -9396,13 +9436,13 @@ void _ecs_parser_errorv(
 #define ecs_dbg ecs_dbg_1
 
 /* Default level for push/pop is 0 */
-#define ecs_log_push() _ecs_log_push(0)
-#define ecs_log_pop() _ecs_log_pop(0)
+#define ecs_log_push() ecs_log_push_(0)
+#define ecs_log_pop() ecs_log_pop_(0)
 
 /** Abort.
  * Unconditionally aborts process. */
 #define ecs_abort(error_code, ...)\
-    _ecs_abort(error_code, __FILE__, __LINE__, __VA_ARGS__);\
+    ecs_abort_(error_code, __FILE__, __LINE__, __VA_ARGS__);\
     ecs_os_abort(); abort(); /* satisfy compiler/static analyzers */
 
 /** Assert. 
@@ -9411,7 +9451,7 @@ void _ecs_parser_errorv(
 #define ecs_assert(condition, error_code, ...)
 #else
 #define ecs_assert(condition, error_code, ...)\
-    if (!_ecs_assert(condition, error_code, #condition, __FILE__, __LINE__, __VA_ARGS__)) {\
+    if (!ecs_assert_(condition, error_code, #condition, __FILE__, __LINE__, __VA_ARGS__)) {\
         ecs_os_abort();\
     }\
     assert(condition) /* satisfy compiler/static analyzers */
@@ -9442,7 +9482,7 @@ void _ecs_parser_errorv(
 #else
 #ifdef FLECS_SOFT_ASSERT
 #define ecs_check(condition, error_code, ...)\
-    if (!_ecs_assert(condition, error_code, #condition, __FILE__, __LINE__, __VA_ARGS__)) {\
+    if (!ecs_assert_(condition, error_code, #condition, __FILE__, __LINE__, __VA_ARGS__)) {\
         goto error;\
     }
 #else // FLECS_SOFT_ASSERT
@@ -9459,7 +9499,7 @@ void _ecs_parser_errorv(
 #else
 #ifdef FLECS_SOFT_ASSERT
 #define ecs_throw(error_code, ...)\
-    _ecs_abort(error_code, __FILE__, __LINE__, __VA_ARGS__);\
+    ecs_abort_(error_code, __FILE__, __LINE__, __VA_ARGS__);\
     goto error;
 #else
 #define ecs_throw(error_code, ...)\
@@ -9470,10 +9510,10 @@ void _ecs_parser_errorv(
 
 /** Parser error */
 #define ecs_parser_error(name, expr, column, ...)\
-    _ecs_parser_error(name, expr, column, __VA_ARGS__)
+    ecs_parser_error_(name, expr, column, __VA_ARGS__)
 
 #define ecs_parser_errorv(name, expr, column, fmt, args)\
-    _ecs_parser_errorv(name, expr, column, fmt, args)
+    ecs_parser_errorv_(name, expr, column, fmt, args)
 
 #endif // FLECS_LEGACY
 
@@ -10746,7 +10786,7 @@ ecs_entity_t ecs_system_init(
         desc.callback = id_; \
         ecs_id(id_) = ecs_system_init(world, &desc); \
     } \
-    ecs_assert(ecs_id(id_) != 0, ECS_INVALID_PARAMETER, NULL);
+    ecs_assert(ecs_id(id_) != 0, ECS_INVALID_PARAMETER, NULL)
 
 /** Declare & define a system.
  * 
@@ -10757,7 +10797,7 @@ ecs_entity_t ecs_system_init(
     ecs_entity_t ecs_id(id) = 0; ECS_SYSTEM_DEFINE(world, id, phase, __VA_ARGS__);\
     ecs_entity_t id = ecs_id(id);\
     (void)ecs_id(id);\
-    (void)id;
+    (void)id
 
 /** Shorthand for creating a system with ecs_system_init.
  *
@@ -11410,7 +11450,7 @@ FLECS_API extern ECS_TAG_DECLARE(EcsCounterId);
 FLECS_API extern ECS_TAG_DECLARE(EcsGauge);
 
 /** Tag added to metric instances */
-FLECS_API extern ECS_COMPONENT_DECLARE(EcsMetricInstance);
+FLECS_API extern ECS_TAG_DECLARE(EcsMetricInstance);
 
 /** Component with metric instance value */
 FLECS_API extern ECS_COMPONENT_DECLARE(EcsMetricValue);
@@ -11574,6 +11614,7 @@ FLECS_API extern ECS_COMPONENT_DECLARE(FlecsAlerts);
 FLECS_API extern ECS_COMPONENT_DECLARE(EcsAlert);
 FLECS_API extern ECS_COMPONENT_DECLARE(EcsAlertInstance);
 FLECS_API extern ECS_COMPONENT_DECLARE(EcsAlertsActive);
+FLECS_API extern ECS_COMPONENT_DECLARE(EcsAlertTimeout);
 
 /* Alert severity tags */
 FLECS_API extern ECS_TAG_DECLARE(EcsAlertInfo);
@@ -15064,7 +15105,7 @@ ecs_entity_t ecs_module_init(
 
 #define ECS_MODULE(world, id)\
     ecs_entity_t ecs_id(id) = 0; ECS_MODULE_DEFINE(world, id)\
-    (void)ecs_id(id);
+    (void)ecs_id(id)
 
 /** Wrapper around ecs_import.
  * This macro provides a convenient way to load a module with the world. It can
@@ -15072,7 +15113,7 @@ ecs_entity_t ecs_module_init(
  *
  * ECS_IMPORT(world, FlecsSystemsPhysics);
  */
-#define ECS_IMPORT(world, id) ecs_import_c(world, id##Import, #id);
+#define ECS_IMPORT(world, id) ecs_import_c(world, id##Import, #id)
 
 #ifdef __cplusplus
 }
@@ -18013,7 +18054,8 @@ struct app_builder {
     {
         const ecs_world_info_t *stats = ecs_get_world_info(world);
         m_desc.target_fps = stats->target_fps;
-        if (m_desc.target_fps == static_cast<ecs_ftime_t>(0.0)) {
+        ecs_ftime_t t_zero = 0.0;
+        if (ECS_EQ(m_desc.target_fps, t_zero)) {
             m_desc.target_fps = 60;
         }
     }
@@ -21042,6 +21084,7 @@ private:
 } // namespace flecs
 
 /** @} */
+
 /**
  * @file addons/cpp/entity.hpp
  * @brief Entity class.
@@ -26864,8 +26907,8 @@ struct filter_builder final : _::filter_builder_base<Components...> {
         if (name != nullptr) {
             ecs_entity_desc_t entity_desc = {};
             entity_desc.name = name;
-            entity_desc.sep = "::",
-            entity_desc.root_sep = "::",
+            entity_desc.sep = "::";
+            entity_desc.root_sep = "::";
             this->m_desc.entity = ecs_entity_init(world, &entity_desc);
         }
     }
@@ -27361,8 +27404,8 @@ struct query_builder final : _::query_builder_base<Components...> {
         if (name != nullptr) {
             ecs_entity_desc_t entity_desc = {};
             entity_desc.name = name;
-            entity_desc.sep = "::",
-            entity_desc.root_sep = "::",
+            entity_desc.sep = "::";
+            entity_desc.root_sep = "::";
             this->m_desc.filter.entity = ecs_entity_init(world, &entity_desc);
         }
     }
@@ -28761,8 +28804,8 @@ struct rule_builder final : _::rule_builder_base<Components...> {
         if (name != nullptr) {
             ecs_entity_desc_t entity_desc = {};
             entity_desc.name = name;
-            entity_desc.sep = "::",
-            entity_desc.root_sep = "::",
+            entity_desc.sep = "::";
+            entity_desc.root_sep = "::";
             this->m_desc.entity = ecs_entity_init(world, &entity_desc);
         }
     }
@@ -29605,8 +29648,8 @@ struct alert_builder final : _::alert_builder_base<Components...> {
         if (name != nullptr) {
             ecs_entity_desc_t entity_desc = {};
             entity_desc.name = name;
-            entity_desc.sep = "::",
-            entity_desc.root_sep = "::",
+            entity_desc.sep = "::";
+            entity_desc.root_sep = "::";
             this->m_desc.entity = ecs_entity_init(world, &entity_desc);
         }
     }

--- a/flecs.h
+++ b/flecs.h
@@ -547,11 +547,16 @@ extern "C" {
 #pragma clang diagnostic ignored "-Wbad-function-cast"
 /* Format strings can be passed down from other functions. */
 #pragma clang diagnostic ignored "-Wformat-nonliteral"
-#elif defined(ECS_TARGET_GCC)
-#pragma GCC diagnostic ignored "-Wextra-semi-stmt"
+/* Useful, but not reliable enough. It can incorrectly flag macro's as unused
+ * in standalone builds. */
+#pragma clang diagnostic ignored "-Wunused-macros"
+#elif defined(ECS_TARGET_GNU)
+#ifndef __cplusplus
 #pragma GCC diagnostic ignored "-Wdeclaration-after-statement"
 #pragma GCC diagnostic ignored "-Wbad-function-cast"
+#endif
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
+#pragma GCC diagnostic ignored "-Wunused-macros"
 #endif
 
 /* Standard library dependencies */

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -587,12 +587,11 @@ typedef struct ecs_term_id_t {
                                  * To explicitly set the id to 0, leave the id
                                  * member to 0 and set EcsIsEntity in flags. */
 
-    char *name;                 /**< Name. This can be either the variable name
+    const char *name;           /**< Name. This can be either the variable name
                                  * (when the EcsIsVariable flag is set) or an
-                                 * entity name. Entity names are used to 
-                                 * initialize the id member during term 
-                                 * finalization and will be freed when term.move
-                                 * is set to true. */
+                                 * entity name. When ecs_term_t::move is true,
+                                 * the API assumes ownership over the string and
+                                 * will free it when the term is destroyed. */
 
     ecs_entity_t trav;          /**< Relationship to traverse when looking for the
                                  * component. The relationship must have
@@ -2046,12 +2045,12 @@ ecs_entity_t ecs_get_entity(
  * @return True if the pointer is of the specified type.
  */
 FLECS_API
-bool _ecs_poly_is(
+bool ecs_poly_is_(
     const ecs_poly_t *object,
     int32_t type);
 
 #define ecs_poly_is(object, type)\
-    _ecs_poly_is(object, type##_magic)
+    ecs_poly_is_(object, type##_magic)
 
 /** Make a pair id.
  * This function is equivalent to using the ecs_pair macro, and is added for

--- a/include/flecs/addons/alerts.h
+++ b/include/flecs/addons/alerts.h
@@ -43,6 +43,7 @@ FLECS_API extern ECS_COMPONENT_DECLARE(FlecsAlerts);
 FLECS_API extern ECS_COMPONENT_DECLARE(EcsAlert);
 FLECS_API extern ECS_COMPONENT_DECLARE(EcsAlertInstance);
 FLECS_API extern ECS_COMPONENT_DECLARE(EcsAlertsActive);
+FLECS_API extern ECS_COMPONENT_DECLARE(EcsAlertTimeout);
 
 /* Alert severity tags */
 FLECS_API extern ECS_TAG_DECLARE(EcsAlertInfo);

--- a/include/flecs/addons/cpp/mixins/alerts/builder.hpp
+++ b/include/flecs/addons/cpp/mixins/alerts/builder.hpp
@@ -29,8 +29,8 @@ struct alert_builder final : _::alert_builder_base<Components...> {
         if (name != nullptr) {
             ecs_entity_desc_t entity_desc = {};
             entity_desc.name = name;
-            entity_desc.sep = "::",
-            entity_desc.root_sep = "::",
+            entity_desc.sep = "::";
+            entity_desc.root_sep = "::";
             this->m_desc.entity = ecs_entity_init(world, &entity_desc);
         }
     }

--- a/include/flecs/addons/cpp/mixins/app/builder.hpp
+++ b/include/flecs/addons/cpp/mixins/app/builder.hpp
@@ -22,7 +22,8 @@ struct app_builder {
     {
         const ecs_world_info_t *stats = ecs_get_world_info(world);
         m_desc.target_fps = stats->target_fps;
-        if (m_desc.target_fps == static_cast<ecs_ftime_t>(0.0)) {
+        ecs_ftime_t t_zero = 0.0;
+        if (ECS_EQ(m_desc.target_fps, t_zero)) {
             m_desc.target_fps = 60;
         }
     }

--- a/include/flecs/addons/cpp/mixins/filter/builder.hpp
+++ b/include/flecs/addons/cpp/mixins/filter/builder.hpp
@@ -29,8 +29,8 @@ struct filter_builder final : _::filter_builder_base<Components...> {
         if (name != nullptr) {
             ecs_entity_desc_t entity_desc = {};
             entity_desc.name = name;
-            entity_desc.sep = "::",
-            entity_desc.root_sep = "::",
+            entity_desc.sep = "::";
+            entity_desc.root_sep = "::";
             this->m_desc.entity = ecs_entity_init(world, &entity_desc);
         }
     }

--- a/include/flecs/addons/cpp/mixins/query/builder.hpp
+++ b/include/flecs/addons/cpp/mixins/query/builder.hpp
@@ -29,8 +29,8 @@ struct query_builder final : _::query_builder_base<Components...> {
         if (name != nullptr) {
             ecs_entity_desc_t entity_desc = {};
             entity_desc.name = name;
-            entity_desc.sep = "::",
-            entity_desc.root_sep = "::",
+            entity_desc.sep = "::";
+            entity_desc.root_sep = "::";
             this->m_desc.filter.entity = ecs_entity_init(world, &entity_desc);
         }
     }

--- a/include/flecs/addons/cpp/mixins/rule/builder.hpp
+++ b/include/flecs/addons/cpp/mixins/rule/builder.hpp
@@ -28,8 +28,8 @@ struct rule_builder final : _::rule_builder_base<Components...> {
         if (name != nullptr) {
             ecs_entity_desc_t entity_desc = {};
             entity_desc.name = name;
-            entity_desc.sep = "::",
-            entity_desc.root_sep = "::",
+            entity_desc.sep = "::";
+            entity_desc.root_sep = "::";
             this->m_desc.entity = ecs_entity_init(world, &entity_desc);
         }
     }

--- a/include/flecs/addons/flecs_c.h
+++ b/include/flecs/addons/flecs_c.h
@@ -43,7 +43,7 @@
         ecs_assert(id_ != 0, ECS_INVALID_PARAMETER, NULL); \
     } \
     (void)id_; \
-    (void)ecs_id(id_);
+    (void)ecs_id(id_)
 
 /** Declare & define an entity.
  *
@@ -53,7 +53,7 @@
 #define ECS_ENTITY(world, id, ...) \
     ecs_entity_t ecs_id(id); \
     ecs_entity_t id = 0; \
-    ECS_ENTITY_DEFINE(world, id, __VA_ARGS__);
+    ECS_ENTITY_DEFINE(world, id, __VA_ARGS__)
 
 /** Forward declare a tag. */
 #define ECS_TAG_DECLARE ECS_DECLARE
@@ -109,8 +109,8 @@
         desc.type.size = ECS_SIZEOF(id_); \
         desc.type.alignment = ECS_ALIGNOF(id_); \
         ecs_id(id_) = ecs_component_init(world, &desc);\
-        ecs_assert(ecs_id(id_) != 0, ECS_INVALID_PARAMETER, NULL);\
-    }
+    }\
+    ecs_assert(ecs_id(id_) != 0, ECS_INVALID_PARAMETER, NULL)
 
 /** Declare & define a component.
  *
@@ -154,7 +154,7 @@
     ECS_OBSERVER_DEFINE(world, id, kind, __VA_ARGS__);\
     ecs_entity_t id = ecs_id(id);\
     (void)ecs_id(id);\
-    (void)id;
+    (void)id
 
 /** Shorthand for creating an entity with ecs_entity_init.
  *

--- a/include/flecs/addons/log.h
+++ b/include/flecs/addons/log.h
@@ -47,7 +47,7 @@ extern "C" {
 ////////////////////////////////////////////////////////////////////////////////
 
 FLECS_API
-void _ecs_deprecated(
+void ecs_deprecated_(
     const char *file, 
     int32_t line, 
     const char *msg);
@@ -59,7 +59,7 @@ void _ecs_deprecated(
  * @param level The log level.
  */
 FLECS_API
-void _ecs_log_push(int32_t level);
+void ecs_log_push_(int32_t level);
 
 /** Decrease log stack.
  * This operation decreases the indent_ value of the OS API and can be useful to
@@ -68,7 +68,7 @@ void _ecs_log_push(int32_t level);
  * @param level The log level.
  */
 FLECS_API
-void _ecs_log_pop(int32_t level);
+void ecs_log_pop_(int32_t level);
 
 /** Should current level be logged.
  * This operation returns true when the specified log level should be logged 
@@ -95,13 +95,13 @@ const char* ecs_strerror(
 //// Dummy macros for when logging is disabled
 ////////////////////////////////////////////////////////////////////////////////
 
-#define _ecs_deprecated(file, line, msg)\
+#define ecs_deprecated_(file, line, msg)\
     (void)file;\
     (void)line;\
     (void)msg
 
-#define _ecs_log_push(level)
-#define _ecs_log_pop(level)
+#define ecs_log_push_(level)
+#define ecs_log_pop_(level)
 #define ecs_should_log(level) false
 
 #define ecs_strerror(error_code)\
@@ -115,7 +115,7 @@ const char* ecs_strerror(
 ////////////////////////////////////////////////////////////////////////////////
 
 FLECS_API
-void _ecs_print(
+void ecs_print_(
     int32_t level,
     const char *file,
     int32_t line,
@@ -123,7 +123,7 @@ void _ecs_print(
     ...);
 
 FLECS_API
-void _ecs_printv(
+void ecs_printv_(
     int level,
     const char *file,
     int32_t line,
@@ -131,7 +131,7 @@ void _ecs_printv(
     va_list args);
 
 FLECS_API
-void _ecs_log(
+void ecs_log_(
     int32_t level,
     const char *file,
     int32_t line,
@@ -139,7 +139,7 @@ void _ecs_log(
     ...);
 
 FLECS_API
-void _ecs_logv(
+void ecs_logv_(
     int level,
     const char *file,
     int32_t line,
@@ -147,7 +147,7 @@ void _ecs_logv(
     va_list args);
 
 FLECS_API
-void _ecs_abort(
+void ecs_abort_(
     int32_t error_code,
     const char *file,
     int32_t line,
@@ -155,7 +155,7 @@ void _ecs_abort(
     ...);
 
 FLECS_API
-bool _ecs_assert(
+bool ecs_assert_(
     bool condition,
     int32_t error_code,
     const char *condition_str,
@@ -165,7 +165,7 @@ bool _ecs_assert(
     ...);
 
 FLECS_API
-void _ecs_parser_error(
+void ecs_parser_error_(
     const char *name,
     const char *expr, 
     int64_t column,
@@ -173,7 +173,7 @@ void _ecs_parser_error(
     ...);
 
 FLECS_API
-void _ecs_parser_errorv(
+void ecs_parser_errorv_(
     const char *name,
     const char *expr, 
     int64_t column,
@@ -189,37 +189,37 @@ void _ecs_parser_errorv(
 
 /* Base logging function. Accepts a custom level */
 #define ecs_print(level, ...)\
-    _ecs_print(level, __FILE__, __LINE__, __VA_ARGS__)
+    ecs_print_(level, __FILE__, __LINE__, __VA_ARGS__)
 
 #define ecs_printv(level, fmt, args)\
-    _ecs_printv(level, __FILE__, __LINE__, fmt, args)
+    ecs_printv_(level, __FILE__, __LINE__, fmt, args)
 
 #define ecs_log(level, ...)\
-    _ecs_log(level, __FILE__, __LINE__, __VA_ARGS__)
+    ecs_log_(level, __FILE__, __LINE__, __VA_ARGS__)
 
 #define ecs_logv(level, fmt, args)\
-    _ecs_logv(level, __FILE__, __LINE__, fmt, args)
+    ecs_logv_(level, __FILE__, __LINE__, fmt, args)
 
 /* Tracing. Used for logging of infrequent events  */
-#define _ecs_trace(file, line, ...) _ecs_log(0, file, line, __VA_ARGS__)
-#define ecs_trace(...) _ecs_trace(__FILE__, __LINE__, __VA_ARGS__)
+#define ecs_trace_(file, line, ...) ecs_log_(0, file, line, __VA_ARGS__)
+#define ecs_trace(...) ecs_trace_(__FILE__, __LINE__, __VA_ARGS__)
 
 /* Warning. Used when an issue occurs, but operation is successful */
-#define _ecs_warn(file, line, ...) _ecs_log(-2, file, line, __VA_ARGS__)
-#define ecs_warn(...) _ecs_warn(__FILE__, __LINE__, __VA_ARGS__)
+#define ecs_warn_(file, line, ...) ecs_log_(-2, file, line, __VA_ARGS__)
+#define ecs_warn(...) ecs_warn_(__FILE__, __LINE__, __VA_ARGS__)
 
 /* Error. Used when an issue occurs, and operation failed. */
-#define _ecs_err(file, line, ...) _ecs_log(-3, file, line, __VA_ARGS__)
-#define ecs_err(...) _ecs_err(__FILE__, __LINE__, __VA_ARGS__)
+#define ecs_err_(file, line, ...) ecs_log_(-3, file, line, __VA_ARGS__)
+#define ecs_err(...) ecs_err_(__FILE__, __LINE__, __VA_ARGS__)
 
 /* Fatal. Used when an issue occurs, and the application cannot continue. */
-#define _ecs_fatal(file, line, ...) _ecs_log(-4, file, line, __VA_ARGS__)
-#define ecs_fatal(...) _ecs_fatal(__FILE__, __LINE__, __VA_ARGS__)
+#define ecs_fatal_(file, line, ...) ecs_log_(-4, file, line, __VA_ARGS__)
+#define ecs_fatal(...) ecs_fatal_(__FILE__, __LINE__, __VA_ARGS__)
 
 /* Optionally include warnings about using deprecated features */
 #ifndef FLECS_NO_DEPRECATED_WARNINGS
 #define ecs_deprecated(...)\
-    _ecs_deprecated(__FILE__, __LINE__, __VA_ARGS__)
+    ecs_deprecated_(__FILE__, __LINE__, __VA_ARGS__)
 #else
 #define ecs_deprecated(...)
 #endif // FLECS_NO_DEPRECATED_WARNINGS
@@ -242,13 +242,13 @@ void _ecs_parser_errorv(
 #define ecs_dbg_2(...) ecs_log(2, __VA_ARGS__);
 #define ecs_dbg_3(...) ecs_log(3, __VA_ARGS__);
 
-#define ecs_log_push_1() _ecs_log_push(1);
-#define ecs_log_push_2() _ecs_log_push(2);
-#define ecs_log_push_3() _ecs_log_push(3);
+#define ecs_log_push_1() ecs_log_push_(1);
+#define ecs_log_push_2() ecs_log_push_(2);
+#define ecs_log_push_3() ecs_log_push_(3);
 
-#define ecs_log_pop_1() _ecs_log_pop(1);
-#define ecs_log_pop_2() _ecs_log_pop(2);
-#define ecs_log_pop_3() _ecs_log_pop(3);
+#define ecs_log_pop_1() ecs_log_pop_(1);
+#define ecs_log_pop_2() ecs_log_pop_(2);
+#define ecs_log_pop_3() ecs_log_pop_(3);
 
 #define ecs_should_log_1() ecs_should_log(1)
 #define ecs_should_log_2() ecs_should_log(2)
@@ -263,12 +263,12 @@ void _ecs_parser_errorv(
 #define ecs_dbg_2(...) ecs_log(2, __VA_ARGS__);
 #define ecs_dbg_3(...)
 
-#define ecs_log_push_1() _ecs_log_push(1);
-#define ecs_log_push_2() _ecs_log_push(2);
+#define ecs_log_push_1() ecs_log_push_(1);
+#define ecs_log_push_2() ecs_log_push_(2);
 #define ecs_log_push_3()
 
-#define ecs_log_pop_1() _ecs_log_pop(1);
-#define ecs_log_pop_2() _ecs_log_pop(2);
+#define ecs_log_pop_1() ecs_log_pop_(1);
+#define ecs_log_pop_2() ecs_log_pop_(2);
 #define ecs_log_pop_3()
 
 #define ecs_should_log_1() ecs_should_log(1)
@@ -283,11 +283,11 @@ void _ecs_parser_errorv(
 #define ecs_dbg_2(...)
 #define ecs_dbg_3(...)
 
-#define ecs_log_push_1() _ecs_log_push(1);
+#define ecs_log_push_1() ecs_log_push_(1);
 #define ecs_log_push_2()
 #define ecs_log_push_3()
 
-#define ecs_log_pop_1() _ecs_log_pop(1);
+#define ecs_log_pop_1() ecs_log_pop_(1);
 #define ecs_log_pop_2()
 #define ecs_log_pop_3()
 
@@ -335,13 +335,13 @@ void _ecs_parser_errorv(
 #define ecs_dbg ecs_dbg_1
 
 /* Default level for push/pop is 0 */
-#define ecs_log_push() _ecs_log_push(0)
-#define ecs_log_pop() _ecs_log_pop(0)
+#define ecs_log_push() ecs_log_push_(0)
+#define ecs_log_pop() ecs_log_pop_(0)
 
 /** Abort.
  * Unconditionally aborts process. */
 #define ecs_abort(error_code, ...)\
-    _ecs_abort(error_code, __FILE__, __LINE__, __VA_ARGS__);\
+    ecs_abort_(error_code, __FILE__, __LINE__, __VA_ARGS__);\
     ecs_os_abort(); abort(); /* satisfy compiler/static analyzers */
 
 /** Assert. 
@@ -350,7 +350,7 @@ void _ecs_parser_errorv(
 #define ecs_assert(condition, error_code, ...)
 #else
 #define ecs_assert(condition, error_code, ...)\
-    if (!_ecs_assert(condition, error_code, #condition, __FILE__, __LINE__, __VA_ARGS__)) {\
+    if (!ecs_assert_(condition, error_code, #condition, __FILE__, __LINE__, __VA_ARGS__)) {\
         ecs_os_abort();\
     }\
     assert(condition) /* satisfy compiler/static analyzers */
@@ -381,7 +381,7 @@ void _ecs_parser_errorv(
 #else
 #ifdef FLECS_SOFT_ASSERT
 #define ecs_check(condition, error_code, ...)\
-    if (!_ecs_assert(condition, error_code, #condition, __FILE__, __LINE__, __VA_ARGS__)) {\
+    if (!ecs_assert_(condition, error_code, #condition, __FILE__, __LINE__, __VA_ARGS__)) {\
         goto error;\
     }
 #else // FLECS_SOFT_ASSERT
@@ -398,7 +398,7 @@ void _ecs_parser_errorv(
 #else
 #ifdef FLECS_SOFT_ASSERT
 #define ecs_throw(error_code, ...)\
-    _ecs_abort(error_code, __FILE__, __LINE__, __VA_ARGS__);\
+    ecs_abort_(error_code, __FILE__, __LINE__, __VA_ARGS__);\
     goto error;
 #else
 #define ecs_throw(error_code, ...)\
@@ -409,10 +409,10 @@ void _ecs_parser_errorv(
 
 /** Parser error */
 #define ecs_parser_error(name, expr, column, ...)\
-    _ecs_parser_error(name, expr, column, __VA_ARGS__)
+    ecs_parser_error_(name, expr, column, __VA_ARGS__)
 
 #define ecs_parser_errorv(name, expr, column, fmt, args)\
-    _ecs_parser_errorv(name, expr, column, fmt, args)
+    ecs_parser_errorv_(name, expr, column, fmt, args)
 
 #endif // FLECS_LEGACY
 

--- a/include/flecs/addons/metrics.h
+++ b/include/flecs/addons/metrics.h
@@ -53,7 +53,7 @@ FLECS_API extern ECS_TAG_DECLARE(EcsCounterId);
 FLECS_API extern ECS_TAG_DECLARE(EcsGauge);
 
 /** Tag added to metric instances */
-FLECS_API extern ECS_COMPONENT_DECLARE(EcsMetricInstance);
+FLECS_API extern ECS_TAG_DECLARE(EcsMetricInstance);
 
 /** Component with metric instance value */
 FLECS_API extern ECS_COMPONENT_DECLARE(EcsMetricValue);

--- a/include/flecs/addons/module.h
+++ b/include/flecs/addons/module.h
@@ -105,7 +105,7 @@ ecs_entity_t ecs_module_init(
 
 #define ECS_MODULE(world, id)\
     ecs_entity_t ecs_id(id) = 0; ECS_MODULE_DEFINE(world, id)\
-    (void)ecs_id(id);
+    (void)ecs_id(id)
 
 /** Wrapper around ecs_import.
  * This macro provides a convenient way to load a module with the world. It can
@@ -113,7 +113,7 @@ ecs_entity_t ecs_module_init(
  *
  * ECS_IMPORT(world, FlecsSystemsPhysics);
  */
-#define ECS_IMPORT(world, id) ecs_import_c(world, id##Import, #id);
+#define ECS_IMPORT(world, id) ecs_import_c(world, id##Import, #id)
 
 #ifdef __cplusplus
 }

--- a/include/flecs/addons/system.h
+++ b/include/flecs/addons/system.h
@@ -121,7 +121,7 @@ ecs_entity_t ecs_system_init(
         desc.callback = id_; \
         ecs_id(id_) = ecs_system_init(world, &desc); \
     } \
-    ecs_assert(ecs_id(id_) != 0, ECS_INVALID_PARAMETER, NULL);
+    ecs_assert(ecs_id(id_) != 0, ECS_INVALID_PARAMETER, NULL)
 
 /** Declare & define a system.
  * 
@@ -132,7 +132,7 @@ ecs_entity_t ecs_system_init(
     ecs_entity_t ecs_id(id) = 0; ECS_SYSTEM_DEFINE(world, id, phase, __VA_ARGS__);\
     ecs_entity_t id = ecs_id(id);\
     (void)ecs_id(id);\
-    (void)id;
+    (void)id
 
 /** Shorthand for creating a system with ecs_system_init.
  *

--- a/include/flecs/private/api_defines.h
+++ b/include/flecs/private/api_defines.h
@@ -92,11 +92,16 @@
 #pragma clang diagnostic ignored "-Wbad-function-cast"
 /* Format strings can be passed down from other functions. */
 #pragma clang diagnostic ignored "-Wformat-nonliteral"
-#elif defined(ECS_TARGET_GCC)
-#pragma GCC diagnostic ignored "-Wextra-semi-stmt"
+/* Useful, but not reliable enough. It can incorrectly flag macro's as unused
+ * in standalone builds. */
+#pragma clang diagnostic ignored "-Wunused-macros"
+#elif defined(ECS_TARGET_GNU)
+#ifndef __cplusplus
 #pragma GCC diagnostic ignored "-Wdeclaration-after-statement"
 #pragma GCC diagnostic ignored "-Wbad-function-cast"
+#endif
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
+#pragma GCC diagnostic ignored "-Wunused-macros"
 #endif
 
 /* Standard library dependencies */

--- a/include/flecs/private/api_support.h
+++ b/include/flecs/private/api_support.h
@@ -33,7 +33,7 @@ extern "C" {
 ////////////////////////////////////////////////////////////////////////////////
 
 /** This allows passing 0 as type to functions that accept ids */
-#define FLECS__E0 0
+#define FLECS_ID0ID_ 0
 
 FLECS_API
 char* ecs_module_path_from_c(

--- a/include/flecs/private/hashmap.h
+++ b/include/flecs/private/hashmap.h
@@ -40,7 +40,7 @@ typedef struct {
 } flecs_hashmap_result_t;
 
 FLECS_DBG_API
-void _flecs_hashmap_init(
+void flecs_hashmap_init_(
     ecs_hashmap_t *hm,
     ecs_size_t key_size,
     ecs_size_t value_size,
@@ -49,34 +49,34 @@ void _flecs_hashmap_init(
     ecs_allocator_t *allocator);
 
 #define flecs_hashmap_init(hm, K, V, hash, compare, allocator)\
-    _flecs_hashmap_init(hm, ECS_SIZEOF(K), ECS_SIZEOF(V), hash, compare, allocator)
+    flecs_hashmap_init_(hm, ECS_SIZEOF(K), ECS_SIZEOF(V), hash, compare, allocator)
 
 FLECS_DBG_API
 void flecs_hashmap_fini(
     ecs_hashmap_t *map);
 
 FLECS_DBG_API
-void* _flecs_hashmap_get(
+void* flecs_hashmap_get_(
     const ecs_hashmap_t *map,
     ecs_size_t key_size,
     const void *key,
     ecs_size_t value_size);
 
 #define flecs_hashmap_get(map, key, V)\
-    (V*)_flecs_hashmap_get(map, ECS_SIZEOF(*key), key, ECS_SIZEOF(V))
+    (V*)flecs_hashmap_get_(map, ECS_SIZEOF(*key), key, ECS_SIZEOF(V))
 
 FLECS_DBG_API
-flecs_hashmap_result_t _flecs_hashmap_ensure(
+flecs_hashmap_result_t flecs_hashmap_ensure_(
     ecs_hashmap_t *map,
     ecs_size_t key_size,
     const void *key,
     ecs_size_t value_size);
 
 #define flecs_hashmap_ensure(map, key, V)\
-    _flecs_hashmap_ensure(map, ECS_SIZEOF(*key), key, ECS_SIZEOF(V))
+    flecs_hashmap_ensure_(map, ECS_SIZEOF(*key), key, ECS_SIZEOF(V))
 
 FLECS_DBG_API
-void _flecs_hashmap_set(
+void flecs_hashmap_set_(
     ecs_hashmap_t *map,
     ecs_size_t key_size,
     void *key,
@@ -84,20 +84,20 @@ void _flecs_hashmap_set(
     const void *value);
 
 #define flecs_hashmap_set(map, key, value)\
-    _flecs_hashmap_set(map, ECS_SIZEOF(*key), key, ECS_SIZEOF(*value), value)
+    flecs_hashmap_set_(map, ECS_SIZEOF(*key), key, ECS_SIZEOF(*value), value)
 
 FLECS_DBG_API
-void _flecs_hashmap_remove(
+void flecs_hashmap_remove_(
     ecs_hashmap_t *map,
     ecs_size_t key_size,
     const void *key,
     ecs_size_t value_size);
 
 #define flecs_hashmap_remove(map, key, V)\
-    _flecs_hashmap_remove(map, ECS_SIZEOF(*key), key, ECS_SIZEOF(V))
+    flecs_hashmap_remove_(map, ECS_SIZEOF(*key), key, ECS_SIZEOF(V))
 
 FLECS_DBG_API
-void _flecs_hashmap_remove_w_hash(
+void flecs_hashmap_remove_w_hash_(
     ecs_hashmap_t *map,
     ecs_size_t key_size,
     const void *key,
@@ -105,7 +105,7 @@ void _flecs_hashmap_remove_w_hash(
     uint64_t hash);
 
 #define flecs_hashmap_remove_w_hash(map, key, V, hash)\
-    _flecs_hashmap_remove_w_hash(map, ECS_SIZEOF(*key), key, ECS_SIZEOF(V), hash)
+    flecs_hashmap_remove_w_hash_(map, ECS_SIZEOF(*key), key, ECS_SIZEOF(V), hash)
 
 FLECS_DBG_API
 ecs_hm_bucket_t* flecs_hashmap_get_bucket(
@@ -129,17 +129,17 @@ flecs_hashmap_iter_t flecs_hashmap_iter(
     ecs_hashmap_t *map);
 
 FLECS_DBG_API
-void* _flecs_hashmap_next(
+void* flecs_hashmap_next_(
     flecs_hashmap_iter_t *it,
     ecs_size_t key_size,
     void *key_out,
     ecs_size_t value_size);
 
 #define flecs_hashmap_next(map, V)\
-    (V*)_flecs_hashmap_next(map, 0, NULL, ECS_SIZEOF(V))
+    (V*)flecs_hashmap_next_(map, 0, NULL, ECS_SIZEOF(V))
 
 #define flecs_hashmap_next_w_key(map, K, key, V)\
-    (V*)_flecs_hashmap_next(map, ECS_SIZEOF(K), key, ECS_SIZEOF(V))
+    (V*)flecs_hashmap_next_(map, ECS_SIZEOF(K), key, ECS_SIZEOF(V))
 
 #ifdef __cplusplus
 }

--- a/include/flecs/private/map.h
+++ b/include/flecs/private/map.h
@@ -102,7 +102,7 @@ ecs_map_val_t* ecs_map_get(
 
 /* Get element as pointer (auto-dereferences _ptr) */
 FLECS_API
-void* _ecs_map_get_deref(
+void* ecs_map_get_deref_(
     const ecs_map_t *map,
     ecs_map_key_t key);
 
@@ -173,7 +173,7 @@ void ecs_map_copy(
     const ecs_map_t *src);
 
 #define ecs_map_get_ref(m, T, k) ECS_CAST(T**, ecs_map_get(m, k))
-#define ecs_map_get_deref(m, T, k) ECS_CAST(T*, _ecs_map_get_deref(m, k))
+#define ecs_map_get_deref(m, T, k) ECS_CAST(T*, ecs_map_get_deref_(m, k))
 #define ecs_map_ensure_ref(m, T, k) ECS_CAST(T**, ecs_map_ensure(m, k))
 
 #define ecs_map_insert_ptr(m, k, v) ecs_map_insert(m, k, ECS_CAST(ecs_map_val_t, v))

--- a/include/flecs/private/vec.h
+++ b/include/flecs/private/vec.h
@@ -85,7 +85,7 @@ void ecs_vec_remove_last(
 FLECS_API
 ecs_vec_t ecs_vec_copy(
     struct ecs_allocator_t *allocator,
-    ecs_vec_t *vec,
+    const ecs_vec_t *vec,
     ecs_size_t size);
 
 #define ecs_vec_copy_t(allocator, vec, T) \

--- a/src/addons/app.c
+++ b/src/addons/app.c
@@ -84,7 +84,7 @@ int ecs_app_run(
     /* Don't set FPS & threads if custom run action is set, as the platform on
      * which the app is running may not support it. */
     if (run_action == flecs_default_run_action) {
-        if (ecs_app_desc.target_fps != 0) {
+        if (ECS_NEQZERO(ecs_app_desc.target_fps)) {
             ecs_set_target_fps(world, ecs_app_desc.target_fps);
         }
         if (ecs_app_desc.threads) {

--- a/src/addons/coredoc.c
+++ b/src/addons/coredoc.c
@@ -24,8 +24,8 @@ void FlecsCoreDocImport(
     ecs_struct_init(world, &(ecs_struct_desc_t){
         .entity = ecs_id(EcsComponent),
         .members = {
-            {.name = (char*)"size", .type = ecs_id(ecs_i32_t)},
-            {.name = (char*)"alignment", .type = ecs_id(ecs_i32_t)}
+            {.name = "size", .type = ecs_id(ecs_i32_t)},
+            {.name = "alignment", .type = ecs_id(ecs_i32_t)}
         }
     });
 

--- a/src/addons/doc.c
+++ b/src/addons/doc.c
@@ -28,7 +28,8 @@ void ecs_doc_set_name(
     const char *name)
 {
     ecs_set_pair(world, entity, EcsDocDescription, EcsName, {
-        .value = (char*)name
+        /* Safe, value gets copied by copy hook */
+        .value = ECS_CONST_CAST(char*, name)
     });
 }
 
@@ -38,7 +39,8 @@ void ecs_doc_set_brief(
     const char *description)
 {
     ecs_set_pair(world, entity, EcsDocDescription, EcsDocBrief, {
-        .value = (char*)description
+        /* Safe, value gets copied by copy hook */
+        .value = ECS_CONST_CAST(char*, description)
     });
 }
 
@@ -48,7 +50,8 @@ void ecs_doc_set_detail(
     const char *description)
 {
     ecs_set_pair(world, entity, EcsDocDescription, EcsDocDetail, {
-        .value = (char*)description
+        /* Safe, value gets copied by copy hook */
+        .value = ECS_CONST_CAST(char*, description)
     });
 }
 
@@ -58,7 +61,8 @@ void ecs_doc_set_link(
     const char *link)
 {
     ecs_set_pair(world, entity, EcsDocDescription, EcsDocLink, {
-        .value = (char*)link
+        /* Safe, value gets copied by copy hook */
+        .value = ECS_CONST_CAST(char*, link)
     });
 }
 
@@ -68,7 +72,8 @@ void ecs_doc_set_color(
     const char *color)
 {
     ecs_set_pair(world, entity, EcsDocDescription, EcsDocColor, {
-        .value = (char*)color
+        /* Safe, value gets copied by copy hook */
+        .value = ECS_CONST_CAST(char*, color)
     });
 }
 

--- a/src/addons/expr/utils.c
+++ b/src/addons/expr/utils.c
@@ -312,7 +312,9 @@ char* ecs_interpolate_string(
                 goto error;
             }
 
-            ecs_parse_expr_desc_t expr_desc = { .vars = (ecs_vars_t*)vars };
+            ecs_parse_expr_desc_t expr_desc = { 
+                .vars = ECS_CONST_CAST(ecs_vars_t*, vars) 
+            };
             ecs_value_t expr_result = {0};
             if (!ecs_parse_expr(world, token, &expr_result, &expr_desc)) {
                 goto error;

--- a/src/addons/json/deserialize.c
+++ b/src/addons/json/deserialize.c
@@ -684,7 +684,7 @@ const char* flecs_json_parse_column(
 
     ecs_json_token_t token_kind = 0;
     ecs_vec_t *data = &table->data.columns[data_column];
-    ecs_type_info_t *ti = table->type_info[data_column];
+    const ecs_type_info_t *ti = table->type_info[data_column];
     ecs_size_t size = ti->size;
     ecs_entity_t type = ti->component;
     ecs_record_t **record_array = ecs_vec_first_t(records, ecs_record_t*);

--- a/src/addons/json/json.c
+++ b/src/addons/json/json.c
@@ -20,15 +20,17 @@ const char* flecs_json_token_str(
     case JsonColon: return ":";
     case JsonComma: return ",";
     case JsonNumber: return "number";
+    case JsonLargeString:
     case JsonString: return "string";
     case JsonTrue: return "true";
     case JsonFalse: return "false";
     case JsonNull: return "null";
     case JsonInvalid: return "invalid";
     default:
-        ecs_abort(ECS_INTERNAL_ERROR, NULL);
+        ecs_throw(ECS_INTERNAL_ERROR, NULL);
     }
-    return "invalid";
+error:
+    return "<<invalid token kind>>";
 }
 
 const char* flecs_json_parse(

--- a/src/addons/json/serialize_type_info.c
+++ b/src/addons/json/serialize_type_info.c
@@ -230,17 +230,35 @@ int json_typeinfo_ser_type_op(
         break;
     case EcsOpOpaque:
         /* Can't happen, already handled above */
-        ecs_abort(ECS_INTERNAL_ERROR, NULL);
+        ecs_throw(ECS_INTERNAL_ERROR, NULL);
         break;
-    default:
+    case EcsOpBool:
+    case EcsOpChar:
+    case EcsOpByte:
+    case EcsOpU8:
+    case EcsOpU16:
+    case EcsOpU32:
+    case EcsOpU64:
+    case EcsOpI8:
+    case EcsOpI16:
+    case EcsOpI32:
+    case EcsOpI64:
+    case EcsOpF32:
+    case EcsOpF64:
+    case EcsOpUPtr:
+    case EcsOpIPtr:
+    case EcsOpEntity:
+    case EcsOpString:
         if (json_typeinfo_ser_primitive( 
             flecs_json_op_to_primitive_kind(op->kind), str))
         {
-            /* Unknown operation */
             ecs_throw(ECS_INTERNAL_ERROR, NULL);
-            return -1;
         }
         break;
+    case EcsOpScope:
+    case EcsOpPrimitive:
+    default:
+        ecs_throw(ECS_INTERNAL_ERROR, NULL);
     }
 
     if (st) {
@@ -248,9 +266,9 @@ int json_typeinfo_ser_type_op(
             &st->members, ecs_member_t, op->member_index);
         ecs_assert(m != NULL, ECS_INTERNAL_ERROR, NULL);
 
-        bool value_range = m->range.min != m->range.max;
-        bool error_range = m->error_range.min != m->error_range.max;
-        bool warning_range = m->warning_range.min != m->warning_range.max;
+        bool value_range = ECS_NEQ(m->range.min, m->range.max);
+        bool error_range = ECS_NEQ(m->error_range.min, m->error_range.max);
+        bool warning_range = ECS_NEQ(m->warning_range.min, m->warning_range.max);
 
         ecs_entity_t unit = m->unit;
         if (unit || error_range || warning_range || value_range) {
@@ -316,11 +334,36 @@ int json_typeinfo_ser_type_ops(
         case EcsOpPop:
             flecs_json_object_pop(str);
             break;
-        default:
+        case EcsOpArray:
+        case EcsOpVector:
+        case EcsOpEnum:
+        case EcsOpBitmask:
+        case EcsOpBool:
+        case EcsOpChar:
+        case EcsOpByte:
+        case EcsOpU8:
+        case EcsOpU16:
+        case EcsOpU32:
+        case EcsOpU64:
+        case EcsOpI8:
+        case EcsOpI16:
+        case EcsOpI32:
+        case EcsOpI64:
+        case EcsOpF32:
+        case EcsOpF64:
+        case EcsOpUPtr:
+        case EcsOpIPtr:
+        case EcsOpEntity:
+        case EcsOpString:
+        case EcsOpOpaque:
             if (json_typeinfo_ser_type_op(world, op, str, st)) {
                 goto error;
             }
             break;
+        case EcsOpPrimitive:
+        case EcsOpScope:
+        default:
+            ecs_throw(ECS_INTERNAL_ERROR, NULL);
         }
     }
 

--- a/src/addons/log.c
+++ b/src/addons/log.c
@@ -135,7 +135,7 @@ void flecs_colorize_buf(
     }
 }
 
-void _ecs_printv(
+void ecs_printv_(
     int level,
     const char *file,
     int32_t line,
@@ -164,7 +164,7 @@ void _ecs_printv(
     }
 }
 
-void _ecs_print(
+void ecs_print_(
     int level,
     const char *file,
     int32_t line,
@@ -173,11 +173,11 @@ void _ecs_print(
 {
     va_list args;
     va_start(args, fmt);
-    _ecs_printv(level, file, line, fmt, args);
+    ecs_printv_(level, file, line, fmt, args);
     va_end(args);    
 }
 
-void _ecs_logv(
+void ecs_logv_(
     int level,
     const char *file,
     int32_t line,
@@ -188,10 +188,10 @@ void _ecs_logv(
         return;
     }
 
-    _ecs_printv(level, file, line, fmt, args);
+    ecs_printv_(level, file, line, fmt, args);
 }
 
-void _ecs_log(
+void ecs_log_(
     int level,
     const char *file,
     int32_t line,
@@ -204,12 +204,12 @@ void _ecs_log(
 
     va_list args;
     va_start(args, fmt);
-    _ecs_printv(level, file, line, fmt, args);
+    ecs_printv_(level, file, line, fmt, args);
     va_end(args);    
 }
 
 
-void _ecs_log_push(
+void ecs_log_push_(
     int32_t level) 
 {
     if (level <= ecs_os_api.log_level_) {
@@ -217,7 +217,7 @@ void _ecs_log_push(
     }
 }
 
-void _ecs_log_pop(
+void ecs_log_pop_(
     int32_t level)
 {
     if (level <= ecs_os_api.log_level_) {
@@ -226,7 +226,7 @@ void _ecs_log_pop(
     }
 }
 
-void _ecs_parser_errorv(
+void ecs_parser_errorv_(
     const char *name,
     const char *expr, 
     int64_t column_arg,
@@ -291,7 +291,7 @@ void _ecs_parser_errorv(
     }
 }
 
-void _ecs_parser_error(
+void ecs_parser_error_(
     const char *name,
     const char *expr, 
     int64_t column,
@@ -301,12 +301,12 @@ void _ecs_parser_error(
     if (ecs_os_api.log_level_  >= -2) {
         va_list args;
         va_start(args, fmt);
-        _ecs_parser_errorv(name, expr, column, fmt, args);
+        ecs_parser_errorv_(name, expr, column, fmt, args);
         va_end(args);
     }
 }
 
-void _ecs_abort(
+void ecs_abort_(
     int32_t err,
     const char *file,
     int32_t line,
@@ -318,15 +318,15 @@ void _ecs_abort(
         va_start(args, fmt);
         char *msg = ecs_vasprintf(fmt, args);
         va_end(args);
-        _ecs_fatal(file, line, "%s (%s)", msg, ecs_strerror(err));
+        ecs_fatal_(file, line, "%s (%s)", msg, ecs_strerror(err));
         ecs_os_free(msg);
     } else {
-        _ecs_fatal(file, line, "%s", ecs_strerror(err));
+        ecs_fatal_(file, line, "%s", ecs_strerror(err));
     }
     ecs_os_api.log_last_error_ = err;
 }
 
-bool _ecs_assert(
+bool ecs_assert_(
     bool condition,
     int32_t err,
     const char *cond_str,
@@ -341,11 +341,11 @@ bool _ecs_assert(
             va_start(args, fmt);
             char *msg = ecs_vasprintf(fmt, args);
             va_end(args);            
-            _ecs_fatal(file, line, "assert: %s %s (%s)", 
+            ecs_fatal_(file, line, "assert: %s %s (%s)", 
                 cond_str, msg, ecs_strerror(err));
             ecs_os_free(msg);
         } else {
-            _ecs_fatal(file, line, "assert: %s %s", 
+            ecs_fatal_(file, line, "assert: %s %s", 
                 cond_str, ecs_strerror(err));
         }
         ecs_os_api.log_last_error_ = err;
@@ -354,12 +354,12 @@ bool _ecs_assert(
     return condition;
 }
 
-void _ecs_deprecated(
+void ecs_deprecated_(
     const char *file,
     int32_t line,
     const char *msg)
 {
-    _ecs_err(file, line, "%s", msg);
+    ecs_err_(file, line, "%s", msg);
 }
 
 bool ecs_should_log(int32_t level) {
@@ -430,7 +430,7 @@ const char* ecs_strerror(
 
 /* Empty bodies for when logging is disabled */
 
-void _ecs_log(
+void ecs_log_(
     int32_t level,
     const char *file,
     int32_t line,
@@ -443,7 +443,7 @@ void _ecs_log(
     (void)fmt;
 }
 
-void _ecs_parser_error(
+void ecs_parser_error_(
     const char *name,
     const char *expr, 
     int64_t column,
@@ -456,7 +456,7 @@ void _ecs_parser_error(
     (void)fmt;
 }
 
-void _ecs_parser_errorv(
+void ecs_parser_errorv_(
     const char *name,
     const char *expr, 
     int64_t column,
@@ -470,7 +470,7 @@ void _ecs_parser_errorv(
     (void)args;
 }
 
-void _ecs_abort(
+void ecs_abort_(
     int32_t error_code,
     const char *file,
     int32_t line,
@@ -483,7 +483,7 @@ void _ecs_abort(
     (void)fmt;
 }
 
-bool _ecs_assert(
+bool ecs_assert_(
     bool condition,
     int32_t error_code,
     const char *condition_str,

--- a/src/addons/meta/api.c
+++ b/src/addons/meta/api.c
@@ -30,7 +30,16 @@ bool flecs_type_is_number(
     case EcsF32:
     case EcsF64:
         return true;
+
+    case EcsBool:
+    case EcsByte:
+    case EcsUPtr:
+    case EcsIPtr:
+    case EcsString:
+    case EcsEntity:
+        return false;
     default:
+        ecs_abort(ECS_INVALID_PARAMETER, NULL);
         return false;
     }
 }
@@ -173,11 +182,11 @@ bool flecs_member_range_overlaps(
     const ecs_member_value_range_t *range,
     const ecs_member_value_range_t *with)
 {
-    if (with->min == with->max) {
+    if (ECS_EQ(with->min, with->max)) {
         return false;
     }
 
-    if (range->min == range->max) {
+    if (ECS_EQ(range->min, range->max)) {
         return false;
     }
 
@@ -230,7 +239,7 @@ ecs_entity_t ecs_struct_init(
         const ecs_member_value_range_t *range = &m_desc->range;
         const ecs_member_value_range_t *error = &m_desc->error_range;
         const ecs_member_value_range_t *warning = &m_desc->warning_range;
-        if (range->min != range->max) {
+        if (ECS_NEQ(range->min, range->max)) {
             ranges = ecs_get_mut(world, m, EcsMemberRanges);
             if (range->min > range->max) {
                 char *member_name = ecs_get_fullpath(world, m);
@@ -242,7 +251,7 @@ ecs_entity_t ecs_struct_init(
             ranges->value.min = range->min;
             ranges->value.max = range->max;
         }
-        if (error->min != error->max) {
+        if (ECS_NEQ(error->min, error->max)) {
             if (error->min > error->max) {
                 char *member_name = ecs_get_fullpath(world, m);
                 ecs_err("member '%s' has an invalid error range [%d..%d]",
@@ -264,7 +273,7 @@ ecs_entity_t ecs_struct_init(
             ranges->error.max = error->max;
         }
 
-        if (warning->min != warning->max) {
+        if (ECS_NEQ(warning->min, warning->max)) {
             if (warning->min > warning->max) {
                 char *member_name = ecs_get_fullpath(world, m);
                 ecs_err("member '%s' has an invalid warning range [%d..%d]",
@@ -400,7 +409,7 @@ ecs_entity_t ecs_unit_prefix_init(
     }
 
     ecs_set(world, t, EcsUnitPrefix, {
-        .symbol = (char*)desc->symbol,
+        .symbol = ECS_CONST_CAST(char*, desc->symbol),
         .translation = desc->translation
     });
 

--- a/src/addons/meta/cursor.c
+++ b/src/addons/meta/cursor.c
@@ -1046,7 +1046,13 @@ int ecs_meta_set_float(
     void *ptr = flecs_meta_cursor_get_ptr(cursor->world, scope);
 
     switch(op->kind) {
-    cases_T_bool(ptr, value);
+    case EcsOpBool:
+        if (ECS_EQZERO(value)) {
+            set_T(bool, ptr, false);
+        } else {
+            set_T(bool, ptr, true);
+        }
+        break;
     cases_T_signed(ptr, value, ecs_meta_bounds_float);
     cases_T_unsigned(ptr, value, ecs_meta_bounds_float);
     cases_T_float(ptr, value);

--- a/src/addons/meta/cursor.c
+++ b/src/addons/meta/cursor.c
@@ -39,6 +39,7 @@ const char* flecs_meta_op_kind_str(
     case EcsOpIPtr: return "IPtr";
     case EcsOpString: return "String";
     case EcsOpEntity: return "Entity";
+    case EcsOpScope: return "Scope";
     default: return "<< invalid kind >>";
     }
 }
@@ -49,7 +50,7 @@ ecs_meta_scope_t* flecs_meta_cursor_get_scope(
     const ecs_meta_cursor_t *cursor)
 {
     ecs_check(cursor != NULL, ECS_INVALID_PARAMETER, NULL);
-    return (ecs_meta_scope_t*)&cursor->scope[cursor->depth];
+    return ECS_CONST_CAST(ecs_meta_scope_t*, &cursor->scope[cursor->depth]);
 error:
     return NULL;
 }
@@ -540,7 +541,11 @@ int ecs_meta_push(
             next_scope->ops = &next_scope->ops[1];
             next_scope->op_count --;
             break;
-
+        
+        case EcsPrimitiveType:
+        case EcsEnumType:
+        case EcsBitmaskType:
+        case EcsOpaqueType:
         default:
             break;
         }
@@ -550,12 +555,35 @@ int ecs_meta_push(
         break;
     }
 
-    default: {
+    case EcsOpPop:
+    case EcsOpScope:
+    case EcsOpEnum:
+    case EcsOpBitmask:
+    case EcsOpPrimitive:
+    case EcsOpBool:
+    case EcsOpChar:
+    case EcsOpByte:
+    case EcsOpU8:
+    case EcsOpU16:
+    case EcsOpU32:
+    case EcsOpU64:
+    case EcsOpI8:
+    case EcsOpI16:
+    case EcsOpI32:
+    case EcsOpI64:
+    case EcsOpF32:
+    case EcsOpF64:
+    case EcsOpUPtr:
+    case EcsOpIPtr:
+    case EcsOpString:
+    case EcsOpEntity: {
         char *path = ecs_get_fullpath(world, scope->type);
         ecs_err("invalid push for type '%s'", path);
         ecs_os_free(path);
         goto error;
     }
+    default:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid operation");
     }
 
     if (scope->is_collection && !scope->opaque) {
@@ -684,7 +712,7 @@ const char* ecs_meta_get_member(
 }
 
 /* Utilities for type conversions and bounds checking */
-struct {
+static struct {
     int64_t min, max;
 } ecs_meta_bounds_signed[EcsMetaTypeOpKindLast + 1] = {
     [EcsOpBool]    = {false,      true},
@@ -708,7 +736,7 @@ struct {
     [EcsOpBitmask] = {0,          INT32_MAX}
 };
 
-struct {
+static struct {
     uint64_t min, max;
 } ecs_meta_bounds_unsigned[EcsMetaTypeOpKindLast + 1] = {
     [EcsOpBool]    = {false,      true},
@@ -729,7 +757,7 @@ struct {
     [EcsOpBitmask] = {0,          UINT32_MAX}
 };
 
-struct {
+static struct {
     double min, max;
 } ecs_meta_bounds_float[EcsMetaTypeOpKindLast + 1] = {
     [EcsOpBool]    = {false,      true},
@@ -834,12 +862,24 @@ int ecs_meta_set_bool(
         }
     }
     /* fall through */
-    default:
+    case EcsOpArray:
+    case EcsOpVector:
+    case EcsOpPush:
+    case EcsOpPop:
+    case EcsOpScope:
+    case EcsOpPrimitive:
+    case EcsOpF32:
+    case EcsOpF64:
+    case EcsOpString:
         flecs_meta_conversion_error(cursor, op, "bool");
         return -1;
+    default:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid operation");
     }
 
     return 0;
+error:
+    return -1;
 }
 
 int ecs_meta_set_char(
@@ -868,12 +908,32 @@ int ecs_meta_set_char(
         }
     }
     /* fall through */
-    default:
+    case EcsOpArray:
+    case EcsOpVector:
+    case EcsOpPush:
+    case EcsOpPop:
+    case EcsOpScope:
+    case EcsOpBitmask:
+    case EcsOpPrimitive:
+    case EcsOpByte:
+    case EcsOpU8:
+    case EcsOpU16:
+    case EcsOpU32:
+    case EcsOpU64:
+    case EcsOpF32:
+    case EcsOpF64:
+    case EcsOpUPtr:
+    case EcsOpString:
+    case EcsOpEntity:
         flecs_meta_conversion_error(cursor, op, "char");
         return -1;
+    default:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid operation");
     }
 
     return 0;
+error:
+    return -1;
 }
 
 int ecs_meta_set_int(
@@ -907,14 +967,24 @@ int ecs_meta_set_int(
         }
     }
     /* fall through */
-    default: {
+    case EcsOpArray:
+    case EcsOpVector:
+    case EcsOpPush:
+    case EcsOpPop:
+    case EcsOpScope:
+    case EcsOpPrimitive:
+    case EcsOpString: {
         if(!value) return ecs_meta_set_null(cursor);
         flecs_meta_conversion_error(cursor, op, "int");
         return -1;
     }
+    default:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid operation");
     }
 
     return 0;
+error:
+    return -1;
 }
 
 int ecs_meta_set_uint(
@@ -948,13 +1018,23 @@ int ecs_meta_set_uint(
         }
     }
     /* fall through */
-    default:
+    case EcsOpArray:
+    case EcsOpVector:
+    case EcsOpPush:
+    case EcsOpPop:
+    case EcsOpScope:
+    case EcsOpPrimitive:
+    case EcsOpString:
         if(!value) return ecs_meta_set_null(cursor);
         flecs_meta_conversion_error(cursor, op, "uint");
         return -1;
+    default:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid operation");
     }
 
     return 0;
+error:
+    return -1;
 }
 
 int ecs_meta_set_float(
@@ -986,17 +1066,28 @@ int ecs_meta_set_float(
             break;
         } else if (opaque->assign_entity && (value >= 0)) {
             opaque->assign_entity(
-                ptr, (ecs_world_t*)cursor->world, (ecs_entity_t)value);
+                ptr, ECS_CONST_CAST(ecs_world_t*, cursor->world), 
+                    (ecs_entity_t)value);
             break;
         }
     }
     /* fall through */
-    default:
+    case EcsOpArray:
+    case EcsOpVector:
+    case EcsOpPush:
+    case EcsOpPop:
+    case EcsOpScope:
+    case EcsOpPrimitive:
+    case EcsOpString:
         flecs_meta_conversion_error(cursor, op, "float");
         return -1;
+    default:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid operation");
     }
 
     return 0;
+error:
+    return -1;
 }
 
 int ecs_meta_set_value(
@@ -1169,7 +1260,7 @@ int ecs_meta_set_string(
             }
         } else {
             ecs_err("invalid value for boolean '%s'", value);
-            return -1;
+            goto error;
         }
         break;
     case EcsOpI8:
@@ -1216,7 +1307,7 @@ int ecs_meta_set_string(
             char *path = ecs_get_fullpath(cursor->world, op->type);
             ecs_err("unresolved enum constant '%s' for type '%s'", value, path);
             ecs_os_free(path);
-            return -1;
+            goto error;
         }
 
         const ecs_i32_t *v = ecs_get_pair_object(
@@ -1225,7 +1316,7 @@ int ecs_meta_set_string(
             char *path = ecs_get_fullpath(cursor->world, op->type);
             ecs_err("'%s' is not an enum constant for type '%s'", value, path);
             ecs_os_free(path);
-            return -1;
+            goto error;
         }
 
         set_T(ecs_i32_t, ptr, v[0]);
@@ -1233,20 +1324,20 @@ int ecs_meta_set_string(
     }
     case EcsOpBitmask:
         if (flecs_meta_parse_bitmask(cursor, op, ptr, value) != 0) {
-            return -1;
+            goto error;
         }
         break;
     case EcsOpEntity: {
         ecs_entity_t e = 0;
         if (flecs_meta_cursor_lookup(cursor, value, &e)) {
-            return -1;
+            goto error;
         }
         set_T(ecs_entity_t, ptr, e);
         break;
     }
     case EcsOpPop:
         ecs_err("excess element '%s' in scope", value);
-        return -1;
+        goto error;
     case EcsOpOpaque: {
         const EcsOpaque *opaque = ecs_get(cursor->world, op->type, EcsOpaque);
         ecs_assert(opaque != NULL, ECS_INVALID_OPERATION, NULL);
@@ -1259,20 +1350,30 @@ int ecs_meta_set_string(
         } else if (opaque->assign_entity) {
             ecs_entity_t e = 0;
             if (flecs_meta_cursor_lookup(cursor, value, &e)) {
-                return -1;
+                goto error;
             }
-            opaque->assign_entity(ptr, (ecs_world_t*)cursor->world, e);
+            opaque->assign_entity(ptr, 
+                ECS_CONST_CAST(ecs_world_t*, cursor->world), e);
             break;
         }
     }
     /* fall through */
-    default:
+    case EcsOpArray:
+    case EcsOpVector:
+    case EcsOpPush:
+    case EcsOpScope:
+    case EcsOpPrimitive:
         ecs_err("unsupported conversion from string '%s' to '%s'",
             value, flecs_meta_op_kind_str(op->kind));
-        return -1;
+        goto error;
+    default:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid operation");
+        break;
     }
 
     return 0;
+error:
+    return -1;
 }
 
 int ecs_meta_set_string_literal(
@@ -1286,7 +1387,7 @@ int ecs_meta_set_string_literal(
     ecs_size_t len = ecs_os_strlen(value);
     if (value[0] != '\"' || value[len - 1] != '\"') {
         ecs_err("invalid string literal '%s'", value);
-        return -1;
+        goto error;
     }
 
     switch(op->kind) {
@@ -1294,10 +1395,31 @@ int ecs_meta_set_string_literal(
         set_T(ecs_char_t, ptr, value[1]);
         break;
 
-    default:
-    case EcsOpEntity:
-    case EcsOpString:
+    case EcsOpArray:
+    case EcsOpVector:
     case EcsOpOpaque:
+    case EcsOpPush:
+    case EcsOpPop:
+    case EcsOpScope:
+    case EcsOpEnum:
+    case EcsOpBitmask:
+    case EcsOpPrimitive:
+    case EcsOpBool:
+    case EcsOpByte:
+    case EcsOpU8:
+    case EcsOpU16:
+    case EcsOpU32:
+    case EcsOpU64:
+    case EcsOpI8:
+    case EcsOpI16:
+    case EcsOpI32:
+    case EcsOpI64:
+    case EcsOpF32:
+    case EcsOpF64:
+    case EcsOpUPtr:
+    case EcsOpIPtr:
+    case EcsOpString:
+    case EcsOpEntity:
         len -= 2;
 
         char *result = ecs_os_malloc(len + 1);
@@ -1311,9 +1433,14 @@ int ecs_meta_set_string_literal(
 
         ecs_os_free(result);
         break;
+    default:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid operation");
+        break;
     }
 
     return 0;
+error:
+    return -1;
 }
 
 int ecs_meta_set_entity(
@@ -1331,17 +1458,46 @@ int ecs_meta_set_entity(
     case EcsOpOpaque: {
         const EcsOpaque *opaque = ecs_get(cursor->world, op->type, EcsOpaque);
         if (opaque && opaque->assign_entity) {
-            opaque->assign_entity(ptr, (ecs_world_t*)cursor->world, value);
+            opaque->assign_entity(ptr, 
+                ECS_CONST_CAST(ecs_world_t*, cursor->world), value);
             break;
         }
     }
     /* fall through */
-    default:
+    case EcsOpArray:
+    case EcsOpVector:
+    case EcsOpPush:
+    case EcsOpPop:
+    case EcsOpScope:
+    case EcsOpEnum:
+    case EcsOpBitmask:
+    case EcsOpPrimitive:
+    case EcsOpBool:
+    case EcsOpChar:
+    case EcsOpByte:
+    case EcsOpU8:
+    case EcsOpU16:
+    case EcsOpU32:
+    case EcsOpU64:
+    case EcsOpI8:
+    case EcsOpI16:
+    case EcsOpI32:
+    case EcsOpI64:
+    case EcsOpF32:
+    case EcsOpF64:
+    case EcsOpUPtr:
+    case EcsOpIPtr:
+    case EcsOpString:
         flecs_meta_conversion_error(cursor, op, "entity");
-        return -1;
+        goto error;
+    default:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid operation");
+        break;
     }
 
     return 0;
+error:
+    return -1;
 }
 
 int ecs_meta_set_null(
@@ -1363,12 +1519,40 @@ int ecs_meta_set_null(
         }
     }
     /* fall through */
-    default:
+    case EcsOpArray:
+    case EcsOpVector:
+    case EcsOpPush:
+    case EcsOpPop:
+    case EcsOpScope:
+    case EcsOpEnum:
+    case EcsOpBitmask:
+    case EcsOpPrimitive:
+    case EcsOpBool:
+    case EcsOpChar:
+    case EcsOpByte:
+    case EcsOpU8:
+    case EcsOpU16:
+    case EcsOpU32:
+    case EcsOpU64:
+    case EcsOpI8:
+    case EcsOpI16:
+    case EcsOpI32:
+    case EcsOpI64:
+    case EcsOpF32:
+    case EcsOpF64:
+    case EcsOpUPtr:
+    case EcsOpIPtr:
+    case EcsOpEntity:
         flecs_meta_conversion_error(cursor, op, "null");
-        return -1;
+        goto error;
+    default:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid operation");
+        break;
     }
 
     return 0;
+error:
+    return -1;
 }
 
 bool ecs_meta_get_bool(
@@ -1391,14 +1575,24 @@ bool ecs_meta_get_bool(
     case EcsOpU64:  return *(ecs_u64_t*)ptr != 0;
     case EcsOpIPtr: return *(ecs_iptr_t*)ptr != 0;
     case EcsOpUPtr: return *(ecs_uptr_t*)ptr != 0;
-    case EcsOpF32:  return *(ecs_f32_t*)ptr != 0;
-    case EcsOpF64:  return *(ecs_f64_t*)ptr != 0;
+    case EcsOpF32:  return ECS_NEQZERO(*(ecs_f32_t*)ptr);
+    case EcsOpF64:  return ECS_NEQZERO(*(ecs_f64_t*)ptr);
     case EcsOpString: return *(const char**)ptr != NULL;
     case EcsOpEnum: return *(ecs_i32_t*)ptr != 0;
     case EcsOpBitmask: return *(ecs_u32_t*)ptr != 0;
     case EcsOpEntity: return *(ecs_entity_t*)ptr != 0;
-    default: ecs_throw(ECS_INVALID_PARAMETER,
-                "invalid element for bool");
+    case EcsOpArray:
+    case EcsOpVector:
+    case EcsOpOpaque:
+    case EcsOpPush:
+    case EcsOpPop:
+    case EcsOpScope:
+    case EcsOpPrimitive:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid element for bool");
+        break;
+    default:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid operation");
+        break;
     }
 
 error:
@@ -1412,9 +1606,35 @@ char ecs_meta_get_char(
     ecs_meta_type_op_t *op = flecs_meta_cursor_get_op(scope);
     void *ptr = flecs_meta_cursor_get_ptr(cursor->world, scope);
     switch(op->kind) {
-    case EcsOpChar: return *(ecs_char_t*)ptr != 0;
-    default: ecs_throw(ECS_INVALID_PARAMETER,
-                "invalid element for char");
+    case EcsOpChar: 
+        return *(ecs_char_t*)ptr != 0;
+    case EcsOpArray:
+    case EcsOpVector:
+    case EcsOpOpaque:
+    case EcsOpPush:
+    case EcsOpPop:
+    case EcsOpScope:
+    case EcsOpEnum:
+    case EcsOpBitmask:
+    case EcsOpPrimitive:
+    case EcsOpBool:
+    case EcsOpByte:
+    case EcsOpU8:
+    case EcsOpU16:
+    case EcsOpU32:
+    case EcsOpU64:
+    case EcsOpI8:
+    case EcsOpI16:
+    case EcsOpI32:
+    case EcsOpI64:
+    case EcsOpF32:
+    case EcsOpF64:
+    case EcsOpUPtr:
+    case EcsOpIPtr:
+    case EcsOpString:
+    case EcsOpEntity:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid element for char");
+        break;
     }
 
 error:
@@ -1428,31 +1648,41 @@ int64_t ecs_meta_get_int(
     ecs_meta_type_op_t *op = flecs_meta_cursor_get_op(scope);
     void *ptr = flecs_meta_cursor_get_ptr(cursor->world, scope);
     switch(op->kind) {
-    case EcsOpBool: return *(ecs_bool_t*)ptr;
-    case EcsOpI8:   return *(ecs_i8_t*)ptr;
-    case EcsOpU8:   return *(ecs_u8_t*)ptr;
-    case EcsOpChar: return *(ecs_char_t*)ptr;
-    case EcsOpByte: return *(ecs_u8_t*)ptr;
-    case EcsOpI16:  return *(ecs_i16_t*)ptr;
-    case EcsOpU16:  return *(ecs_u16_t*)ptr;
-    case EcsOpI32:  return *(ecs_i32_t*)ptr;
-    case EcsOpU32:  return *(ecs_u32_t*)ptr;
-    case EcsOpI64:  return *(ecs_i64_t*)ptr;
-    case EcsOpU64:  return flecs_uto(int64_t, *(ecs_u64_t*)ptr);
-    case EcsOpIPtr: return *(ecs_iptr_t*)ptr;
-    case EcsOpUPtr: return flecs_uto(int64_t, *(ecs_uptr_t*)ptr);
-    case EcsOpF32:  return (int64_t)*(ecs_f32_t*)ptr;
-    case EcsOpF64:  return (int64_t)*(ecs_f64_t*)ptr;
+    case EcsOpBool: return *(const ecs_bool_t*)ptr;
+    case EcsOpI8:   return *(const ecs_i8_t*)ptr;
+    case EcsOpU8:   return *(const ecs_u8_t*)ptr;
+    case EcsOpChar: return *(const ecs_char_t*)ptr;
+    case EcsOpByte: return *(const ecs_u8_t*)ptr;
+    case EcsOpI16:  return *(const ecs_i16_t*)ptr;
+    case EcsOpU16:  return *(const ecs_u16_t*)ptr;
+    case EcsOpI32:  return *(const ecs_i32_t*)ptr;
+    case EcsOpU32:  return *(const ecs_u32_t*)ptr;
+    case EcsOpI64:  return *(const ecs_i64_t*)ptr;
+    case EcsOpU64:  return flecs_uto(int64_t, *(const ecs_u64_t*)ptr);
+    case EcsOpIPtr: return *(const ecs_iptr_t*)ptr;
+    case EcsOpUPtr: return flecs_uto(int64_t, *(const ecs_uptr_t*)ptr);
+    case EcsOpF32:  return (int64_t)*(const ecs_f32_t*)ptr;
+    case EcsOpF64:  return (int64_t)*(const ecs_f64_t*)ptr;
     case EcsOpString: return atoi(*(const char**)ptr);
-    case EcsOpEnum: return *(ecs_i32_t*)ptr;
-    case EcsOpBitmask: return *(ecs_u32_t*)ptr;
+    case EcsOpEnum: return *(const ecs_i32_t*)ptr;
+    case EcsOpBitmask: return *(const ecs_u32_t*)ptr;
     case EcsOpEntity:
         ecs_throw(ECS_INVALID_PARAMETER,
             "invalid conversion from entity to int");
         break;
-    default: ecs_throw(ECS_INVALID_PARAMETER, "invalid element for int");
+    case EcsOpArray:
+    case EcsOpVector:
+    case EcsOpOpaque:
+    case EcsOpPush:
+    case EcsOpPop:
+    case EcsOpScope:
+    case EcsOpPrimitive:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid element for int");
+        break;
+    default:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid operation");
+        break;
     }
-
 error:
     return 0;
 }
@@ -1465,25 +1695,36 @@ uint64_t ecs_meta_get_uint(
     void *ptr = flecs_meta_cursor_get_ptr(cursor->world, scope);
     switch(op->kind) {
     case EcsOpBool: return *(ecs_bool_t*)ptr;
-    case EcsOpI8:   return flecs_ito(uint64_t, *(ecs_i8_t*)ptr);
+    case EcsOpI8:   return flecs_ito(uint64_t, *(const ecs_i8_t*)ptr);
     case EcsOpU8:   return *(ecs_u8_t*)ptr;
-    case EcsOpChar: return flecs_ito(uint64_t, *(ecs_char_t*)ptr);
-    case EcsOpByte: return flecs_ito(uint64_t, *(ecs_u8_t*)ptr);
-    case EcsOpI16:  return flecs_ito(uint64_t, *(ecs_i16_t*)ptr);
+    case EcsOpChar: return flecs_ito(uint64_t, *(const ecs_char_t*)ptr);
+    case EcsOpByte: return flecs_ito(uint64_t, *(const ecs_u8_t*)ptr);
+    case EcsOpI16:  return flecs_ito(uint64_t, *(const ecs_i16_t*)ptr);
     case EcsOpU16:  return *(ecs_u16_t*)ptr;
-    case EcsOpI32:  return flecs_ito(uint64_t, *(ecs_i32_t*)ptr);
+    case EcsOpI32:  return flecs_ito(uint64_t, *(const ecs_i32_t*)ptr);
     case EcsOpU32:  return *(ecs_u32_t*)ptr;
-    case EcsOpI64:  return flecs_ito(uint64_t, *(ecs_i64_t*)ptr);
+    case EcsOpI64:  return flecs_ito(uint64_t, *(const ecs_i64_t*)ptr);
     case EcsOpU64:  return *(ecs_u64_t*)ptr;
-    case EcsOpIPtr: return flecs_ito(uint64_t, *(ecs_i64_t*)ptr);
+    case EcsOpIPtr: return flecs_ito(uint64_t, *(const ecs_i64_t*)ptr);
     case EcsOpUPtr: return *(ecs_uptr_t*)ptr;
-    case EcsOpF32:  return flecs_ito(uint64_t, *(ecs_f32_t*)ptr);
-    case EcsOpF64:  return flecs_ito(uint64_t, *(ecs_f64_t*)ptr);
+    case EcsOpF32:  return flecs_ito(uint64_t, *(const ecs_f32_t*)ptr);
+    case EcsOpF64:  return flecs_ito(uint64_t, *(const ecs_f64_t*)ptr);
     case EcsOpString: return flecs_ito(uint64_t, atoi(*(const char**)ptr));
-    case EcsOpEnum: return flecs_ito(uint64_t, *(ecs_i32_t*)ptr);
-    case EcsOpBitmask: return *(ecs_u32_t*)ptr;
-    case EcsOpEntity: return *(ecs_entity_t*)ptr;
-    default: ecs_throw(ECS_INVALID_PARAMETER, "invalid element for uint");
+    case EcsOpEnum: return flecs_ito(uint64_t, *(const ecs_i32_t*)ptr);
+    case EcsOpBitmask: return *(const ecs_u32_t*)ptr;
+    case EcsOpEntity: return *(const ecs_entity_t*)ptr;
+    case EcsOpArray:
+    case EcsOpVector:
+    case EcsOpOpaque:
+    case EcsOpPush:
+    case EcsOpPop:
+    case EcsOpScope:
+    case EcsOpPrimitive:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid element for uint");
+        break;
+    default:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid operation");
+        break;
     }
 error:
     return 0;
@@ -1495,29 +1736,40 @@ double flecs_meta_to_float(
     const void *ptr)
 {
     switch(kind) {
-    case EcsOpBool: return *(ecs_bool_t*)ptr;
-    case EcsOpI8:   return *(ecs_i8_t*)ptr;
-    case EcsOpU8:   return *(ecs_u8_t*)ptr;
-    case EcsOpChar: return *(ecs_char_t*)ptr;
-    case EcsOpByte: return *(ecs_u8_t*)ptr;
-    case EcsOpI16:  return *(ecs_i16_t*)ptr;
-    case EcsOpU16:  return *(ecs_u16_t*)ptr;
-    case EcsOpI32:  return *(ecs_i32_t*)ptr;
-    case EcsOpU32:  return *(ecs_u32_t*)ptr;
-    case EcsOpI64:  return (double)*(ecs_i64_t*)ptr;
-    case EcsOpU64:  return (double)*(ecs_u64_t*)ptr;
-    case EcsOpIPtr: return (double)*(ecs_iptr_t*)ptr;
-    case EcsOpUPtr: return (double)*(ecs_uptr_t*)ptr;
-    case EcsOpF32:  return (double)*(ecs_f32_t*)ptr;
-    case EcsOpF64:  return *(ecs_f64_t*)ptr;
-    case EcsOpString: return atof(*(const char**)ptr);
-    case EcsOpEnum: return *(ecs_i32_t*)ptr;
-    case EcsOpBitmask: return *(ecs_u32_t*)ptr;
+    case EcsOpBool: return *(const ecs_bool_t*)ptr;
+    case EcsOpI8:   return *(const ecs_i8_t*)ptr;
+    case EcsOpU8:   return *(const ecs_u8_t*)ptr;
+    case EcsOpChar: return *(const ecs_char_t*)ptr;
+    case EcsOpByte: return *(const ecs_u8_t*)ptr;
+    case EcsOpI16:  return *(const ecs_i16_t*)ptr;
+    case EcsOpU16:  return *(const ecs_u16_t*)ptr;
+    case EcsOpI32:  return *(const ecs_i32_t*)ptr;
+    case EcsOpU32:  return *(const ecs_u32_t*)ptr;
+    case EcsOpI64:  return (double)*(const ecs_i64_t*)ptr;
+    case EcsOpU64:  return (double)*(const ecs_u64_t*)ptr;
+    case EcsOpIPtr: return (double)*(const ecs_iptr_t*)ptr;
+    case EcsOpUPtr: return (double)*(const ecs_uptr_t*)ptr;
+    case EcsOpF32:  return (double)*(const ecs_f32_t*)ptr;
+    case EcsOpF64:  return *(const ecs_f64_t*)ptr;
+    case EcsOpString: return atof(*ECS_CONST_CAST(const char**, ptr));
+    case EcsOpEnum: return *(const ecs_i32_t*)ptr;
+    case EcsOpBitmask: return *(const ecs_u32_t*)ptr;
     case EcsOpEntity:
         ecs_throw(ECS_INVALID_PARAMETER,
             "invalid conversion from entity to float");
         break;
-    default: ecs_throw(ECS_INVALID_PARAMETER, "invalid element for float");
+    case EcsOpArray:
+    case EcsOpVector:
+    case EcsOpOpaque:
+    case EcsOpPush:
+    case EcsOpPop:
+    case EcsOpScope:
+    case EcsOpPrimitive:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid element for float");
+        break;
+    default:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid operation");
+        break;
     }
 error:
     return 0;
@@ -1540,7 +1792,34 @@ const char* ecs_meta_get_string(
     void *ptr = flecs_meta_cursor_get_ptr(cursor->world, scope);
     switch(op->kind) {
     case EcsOpString: return *(const char**)ptr;
-    default: ecs_throw(ECS_INVALID_PARAMETER, "invalid element for string");
+    case EcsOpArray:
+    case EcsOpVector:
+    case EcsOpOpaque:
+    case EcsOpPush:
+    case EcsOpPop:
+    case EcsOpScope:
+    case EcsOpEnum:
+    case EcsOpBitmask:
+    case EcsOpPrimitive:
+    case EcsOpChar:
+    case EcsOpBool:
+    case EcsOpByte:
+    case EcsOpU8:
+    case EcsOpU16:
+    case EcsOpU32:
+    case EcsOpU64:
+    case EcsOpI8:
+    case EcsOpI16:
+    case EcsOpI32:
+    case EcsOpI64:
+    case EcsOpF32:
+    case EcsOpF64:
+    case EcsOpUPtr:
+    case EcsOpIPtr:
+    case EcsOpEntity:
+    default:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid element for string");
+        break;
     }
 error:
     return 0;
@@ -1554,7 +1833,33 @@ ecs_entity_t ecs_meta_get_entity(
     void *ptr = flecs_meta_cursor_get_ptr(cursor->world, scope);
     switch(op->kind) {
     case EcsOpEntity: return *(ecs_entity_t*)ptr;
-    default: ecs_throw(ECS_INVALID_PARAMETER, "invalid element for entity");
+    case EcsOpArray:
+    case EcsOpVector:
+    case EcsOpOpaque:
+    case EcsOpPush:
+    case EcsOpPop:
+    case EcsOpScope:
+    case EcsOpEnum:
+    case EcsOpBitmask:
+    case EcsOpPrimitive:
+    case EcsOpChar:
+    case EcsOpBool:
+    case EcsOpByte:
+    case EcsOpU8:
+    case EcsOpU16:
+    case EcsOpU32:
+    case EcsOpU64:
+    case EcsOpI8:
+    case EcsOpI16:
+    case EcsOpI32:
+    case EcsOpI64:
+    case EcsOpF32:
+    case EcsOpF64:
+    case EcsOpUPtr:
+    case EcsOpIPtr:
+    case EcsOpString:
+        ecs_throw(ECS_INVALID_PARAMETER, "invalid element for entity");
+        break;
     }
 error:
     return 0;

--- a/src/addons/meta/meta.c
+++ b/src/addons/meta/meta.c
@@ -11,7 +11,7 @@
 
 static ECS_COPY(ecs_string_t, dst, src, {
     ecs_os_free(*(ecs_string_t*)dst);
-    *(ecs_string_t*)dst = ecs_os_strdup(*(ecs_string_t*)src);
+    *(ecs_string_t*)dst = ecs_os_strdup(*(const ecs_string_t*)src);
 })
 
 static ECS_MOVE(ecs_string_t, dst, src, {
@@ -79,7 +79,7 @@ static void flecs_struct_dtor(
     ecs_member_t *members = ecs_vec_first_t(&ptr->members, ecs_member_t);
     int32_t i, count = ecs_vec_count(&ptr->members);
     for (i = 0; i < count; i ++) {
-        ecs_os_free((char*)members[i].name);
+        ecs_os_free(ECS_CONST_CAST(char*, members[i].name));
     }
     ecs_vec_fini_t(NULL, &ptr->members, ecs_member_t);
 }
@@ -114,7 +114,7 @@ static void flecs_constants_dtor(
     ecs_map_iter_t it = ecs_map_iter(constants);
     while (ecs_map_next(&it)) {
         ecs_enum_constant_t *c = ecs_map_ptr(&it);
-        ecs_os_free((char*)c->name);
+        ecs_os_free(ECS_CONST_CAST(char*, c->name));
         ecs_os_free(c);
     }
     ecs_map_fini(constants);
@@ -122,7 +122,7 @@ static void flecs_constants_dtor(
 
 static void flecs_constants_copy(
     ecs_map_t *dst,
-    ecs_map_t *src)
+    const ecs_map_t *src)
 {
     ecs_map_copy(dst, src);
 
@@ -336,7 +336,7 @@ void flecs_set_struct_member(
         member->count = 1;
     }
 
-    ecs_os_strset((char**)&member->name, name);
+    ecs_os_strset(ECS_CONST_CAST(char**, &member->name), name);
 
     if (ranges) {
         member->range = ranges->value;
@@ -547,7 +547,7 @@ int flecs_add_constant_to_enum(
     while (ecs_map_next(&it)) {
         ecs_enum_constant_t *c = ecs_map_ptr(&it);
         if (c->constant == e) {
-            ecs_os_free((char*)c->name);
+            ecs_os_free(ECS_CONST_CAST(char*, c->name));
             ecs_map_remove_free(&ptr->constants, ecs_map_key(&it));
         }
     }
@@ -621,7 +621,7 @@ int flecs_add_constant_to_bitmask(
     while (ecs_map_next(&it)) {
         ecs_bitmask_constant_t *c = ecs_map_ptr(&it);
         if (c->constant == e) {
-            ecs_os_free((char*)c->name);
+            ecs_os_free(ECS_CONST_CAST(char*, c->name));
             ecs_map_remove_free(&ptr->constants, ecs_map_key(&it));
         }
     }
@@ -1328,126 +1328,126 @@ void FlecsMetaImport(
     ecs_entity_t type_kind = ecs_enum_init(world, &(ecs_enum_desc_t){
         .entity = ecs_entity(world, { .name = "TypeKind" }),
         .constants = {
-            {.name = "PrimitiveType"},
-            {.name = "BitmaskType"},
-            {.name = "EnumType"},
-            {.name = "StructType"},
-            {.name = "ArrayType"},
-            {.name = "VectorType"},
-            {.name = "OpaqueType"}
+            { .name = "PrimitiveType" },
+            { .name = "BitmaskType" },
+            { .name = "EnumType" },
+            { .name = "StructType" },
+            { .name = "ArrayType" },
+            { .name = "VectorType" },
+            { .name = "OpaqueType" }
         }
     });
 
     ecs_struct_init(world, &(ecs_struct_desc_t){
         .entity = ecs_id(EcsMetaType),
         .members = {
-            {.name = (char*)"kind", .type = type_kind}
+            { .name = "kind", .type = type_kind }
         }
     });
 
     ecs_entity_t primitive_kind = ecs_enum_init(world, &(ecs_enum_desc_t){
         .entity = ecs_entity(world, { .name = "PrimitiveKind" }),
         .constants = {
-            {.name = "Bool", 1}, 
-            {.name = "Char"}, 
-            {.name = "Byte"}, 
-            {.name = "U8"}, 
-            {.name = "U16"}, 
-            {.name = "U32"}, 
-            {.name = "U64"},
-            {.name = "I8"}, 
-            {.name = "I16"}, 
-            {.name = "I32"}, 
-            {.name = "I64"}, 
-            {.name = "F32"}, 
-            {.name = "F64"}, 
-            {.name = "UPtr"},
-            {.name = "IPtr"}, 
-            {.name = "String"}, 
-            {.name = "Entity"}
+            { .name = "Bool", 1 }, 
+            { .name = "Char" }, 
+            { .name = "Byte" }, 
+            { .name = "U8" }, 
+            { .name = "U16" }, 
+            { .name = "U32" }, 
+            { .name = "U64 "},
+            { .name = "I8" }, 
+            { .name = "I16" }, 
+            { .name = "I32" }, 
+            { .name = "I64" }, 
+            { .name = "F32" }, 
+            { .name = "F64" }, 
+            { .name = "UPtr "},
+            { .name = "IPtr" }, 
+            { .name = "String" }, 
+            { .name = "Entity" }
         }
     });
 
     ecs_struct_init(world, &(ecs_struct_desc_t){
         .entity = ecs_id(EcsPrimitive),
         .members = {
-            {.name = (char*)"kind", .type = primitive_kind}
+            { .name = "kind", .type = primitive_kind }
         }
     });
 
     ecs_struct_init(world, &(ecs_struct_desc_t){
         .entity = ecs_id(EcsMember),
         .members = {
-            {.name = (char*)"type", .type = ecs_id(ecs_entity_t)},
-            {.name = (char*)"count", .type = ecs_id(ecs_i32_t)},
-            {.name = (char*)"unit", .type = ecs_id(ecs_entity_t)},
-            {.name = (char*)"offset", .type = ecs_id(ecs_i32_t)}
+            { .name = "type", .type = ecs_id(ecs_entity_t) },
+            { .name = "count", .type = ecs_id(ecs_i32_t) },
+            { .name = "unit", .type = ecs_id(ecs_entity_t) },
+            { .name = "offset", .type = ecs_id(ecs_i32_t) }
         }
     });
 
     ecs_entity_t vr = ecs_struct_init(world, &(ecs_struct_desc_t){
         .entity = ecs_entity(world, { .name = "value_range" }),
         .members = {
-            {.name = (char*)"min", .type = ecs_id(ecs_f64_t)},
-            {.name = (char*)"max", .type = ecs_id(ecs_f64_t)}
+            { .name = "min", .type = ecs_id(ecs_f64_t) },
+            { .name = "max", .type = ecs_id(ecs_f64_t) }
         }
     });
 
     ecs_struct_init(world, &(ecs_struct_desc_t){
         .entity = ecs_id(EcsMemberRanges),
         .members = {
-            { .name = (char*)"value", .type = vr},
-            { .name = (char*)"warning", .type = vr},
-            { .name = (char*)"error", .type = vr}
+            { .name = "value", .type = vr },
+            { .name = "warning", .type = vr },
+            { .name = "error", .type = vr }
         }
     });
 
     ecs_struct_init(world, &(ecs_struct_desc_t){
         .entity = ecs_id(EcsArray),
         .members = {
-            {.name = (char*)"type", .type = ecs_id(ecs_entity_t)},
-            {.name = (char*)"count", .type = ecs_id(ecs_i32_t)},
+            { .name = "type", .type = ecs_id(ecs_entity_t) },
+            { .name = "count", .type = ecs_id(ecs_i32_t) },
         }
     });
 
     ecs_struct_init(world, &(ecs_struct_desc_t){
         .entity = ecs_id(EcsVector),
         .members = {
-            {.name = (char*)"type", .type = ecs_id(ecs_entity_t)}
+            { .name = "type", .type = ecs_id(ecs_entity_t) }
         }
     });
 
     ecs_struct_init(world, &(ecs_struct_desc_t){
         .entity = ecs_id(EcsOpaque),
         .members = {
-            { .name = (char*)"as_type", .type = ecs_id(ecs_entity_t) }
+            { .name = "as_type", .type = ecs_id(ecs_entity_t) }
         }
     });
 
     ecs_entity_t ut = ecs_struct_init(world, &(ecs_struct_desc_t){
         .entity = ecs_entity(world, { .name = "unit_translation" }),
         .members = {
-            {.name = (char*)"factor", .type = ecs_id(ecs_i32_t)},
-            {.name = (char*)"power", .type = ecs_id(ecs_i32_t)}
+            { .name = "factor", .type = ecs_id(ecs_i32_t) },
+            { .name = "power", .type = ecs_id(ecs_i32_t) }
         }
     });
 
     ecs_struct_init(world, &(ecs_struct_desc_t){
         .entity = ecs_id(EcsUnit),
         .members = {
-            {.name = (char*)"symbol", .type = ecs_id(ecs_string_t)},
-            {.name = (char*)"prefix", .type = ecs_id(ecs_entity_t)},
-            {.name = (char*)"base", .type = ecs_id(ecs_entity_t)},
-            {.name = (char*)"over", .type = ecs_id(ecs_entity_t)},
-            {.name = (char*)"translation", .type = ut}
+            { .name = "symbol", .type = ecs_id(ecs_string_t) },
+            { .name = "prefix", .type = ecs_id(ecs_entity_t) },
+            { .name = "base", .type = ecs_id(ecs_entity_t) },
+            { .name = "over", .type = ecs_id(ecs_entity_t) },
+            { .name = "translation", .type = ut }
         }
     });
 
     ecs_struct_init(world, &(ecs_struct_desc_t){
         .entity = ecs_id(EcsUnitPrefix),
         .members = {
-            {.name = (char*)"symbol", .type = ecs_id(ecs_string_t)},
-            {.name = (char*)"translation", .type = ut}
+            { .name = "symbol", .type = ecs_id(ecs_string_t) },
+            { .name = "translation", .type = ut }
         }
     });
 }

--- a/src/addons/meta/serialized.c
+++ b/src/addons/meta/serialized.c
@@ -63,7 +63,7 @@ int flecs_meta_serialize_primitive(
     }
 
     ecs_meta_type_op_t *op = flecs_meta_ops_add(ops, flecs_meta_primitive_to_op_kind(ptr->kind));
-    op->offset = offset,
+    op->offset = offset;
     op->type = type;
     op->size = flecs_meta_type_size(world, type);
     return 0;
@@ -79,7 +79,7 @@ int flecs_meta_serialize_enum(
     (void)world;
     
     ecs_meta_type_op_t *op = flecs_meta_ops_add(ops, EcsOpEnum);
-    op->offset = offset,
+    op->offset = offset;
     op->type = type;
     op->size = ECS_SIZEOF(ecs_i32_t);
     return 0;
@@ -95,7 +95,7 @@ int flecs_meta_serialize_bitmask(
     (void)world;
     
     ecs_meta_type_op_t *op = flecs_meta_ops_add(ops, EcsOpBitmask);
-    op->offset = offset,
+    op->offset = offset;
     op->type = type;
     op->size = ECS_SIZEOF(ecs_u32_t);
     return 0;
@@ -263,16 +263,11 @@ int flecs_meta_serialize_component(
         return -1;
     }
 
-    switch(ptr->kind) {
-    case EcsArrayType:
+    if (ptr->kind == EcsArrayType) {
         return flecs_meta_serialize_array_component(world, type, ops);
-        break;
-    default:
+    } else {
         return flecs_meta_serialize_type(world, type, 0, ops);
-        break;
     }
-
-    return 0;
 }
 
 void ecs_meta_type_serialized_init(

--- a/src/addons/meta_c.c
+++ b/src/addons/meta_c.c
@@ -338,7 +338,8 @@ const char* meta_parse_member(
         /* If the [ was separated by a space, it will not be parsed as part of
          * the name */
         if (*ptr == '[') {
-            array_start = (char*)ptr; /* safe, will not be modified */
+            /* safe, will not be modified */
+            array_start = ECS_CONST_CAST(char*, ptr);
         }
     }
 
@@ -811,8 +812,13 @@ int ecs_meta_from_desc(
             goto error;
         }
         break;
-    default:
+    case EcsPrimitiveType:
+    case EcsArrayType:
+    case EcsVectorType:
+    case EcsOpaqueType:
         break;
+    default:
+        ecs_throw(ECS_INTERNAL_ERROR, "invalid type kind");
     }
 
     return 0;

--- a/src/addons/metrics.c
+++ b/src/addons/metrics.c
@@ -19,14 +19,14 @@ ECS_TAG_DECLARE(EcsCounterId);
 ECS_TAG_DECLARE(EcsGauge);
 
 /* Internal components */
-ECS_COMPONENT_DECLARE(EcsMetricMember);
-ECS_COMPONENT_DECLARE(EcsMetricId);
-ECS_COMPONENT_DECLARE(EcsMetricOneOf);
-ECS_COMPONENT_DECLARE(EcsMetricCountIds);
-ECS_COMPONENT_DECLARE(EcsMetricCountTargets);
-ECS_COMPONENT_DECLARE(EcsMetricMemberInstance);
-ECS_COMPONENT_DECLARE(EcsMetricIdInstance);
-ECS_COMPONENT_DECLARE(EcsMetricOneOfInstance);
+static ECS_COMPONENT_DECLARE(EcsMetricMember);
+static ECS_COMPONENT_DECLARE(EcsMetricId);
+static ECS_COMPONENT_DECLARE(EcsMetricOneOf);
+static ECS_COMPONENT_DECLARE(EcsMetricCountIds);
+static ECS_COMPONENT_DECLARE(EcsMetricCountTargets);
+static ECS_COMPONENT_DECLARE(EcsMetricMemberInstance);
+static ECS_COMPONENT_DECLARE(EcsMetricIdInstance);
+static ECS_COMPONENT_DECLARE(EcsMetricOneOfInstance);
 
 /** Context for metric */
 typedef struct {

--- a/src/addons/module.c
+++ b/src/addons/module.c
@@ -87,8 +87,8 @@ ecs_entity_t ecs_import_from_library(
 {
     ecs_check(library_name != NULL, ECS_INVALID_PARAMETER, NULL);
 
-    char *import_func = (char*)module_name; /* safe */
-    char *module = (char*)module_name;
+    char *import_func = ECS_CONST_CAST(char*, module_name);
+    char *module = ECS_CONST_CAST(char*, module_name);
 
     if (!ecs_os_has_modules() || !ecs_os_has_dl()) {
         ecs_err(

--- a/src/addons/os_api_impl/windows_impl.inl
+++ b/src/addons/os_api_impl/windows_impl.inl
@@ -6,17 +6,32 @@
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
-#include <winsock2.h>
-#include <windows.h>
+#include <WinSock2.h>
+#include <Windows.h>
+
+typedef struct ecs_win_thread_t {
+    HANDLE thread;
+    ecs_os_thread_callback_t callback;
+    void *arg;
+} ecs_win_thread_t;
+
+static
+DWORD flecs_win_thread(void *ptr) {
+    ecs_win_thread_t *thread = ptr;
+    thread->callback(thread->arg);
+    return 0;
+}
 
 static
 ecs_os_thread_t win_thread_new(
     ecs_os_thread_callback_t callback, 
     void *arg)
 {
-    HANDLE *thread = ecs_os_malloc_t(HANDLE);
-    *thread = CreateThread(
-        NULL, 0, (LPTHREAD_START_ROUTINE)callback, arg, 0, NULL);
+    ecs_win_thread_t *thread = ecs_os_malloc_t(ecs_win_thread_t);
+    thread->arg= arg;
+    thread->callback = callback;
+    thread->thread = CreateThread(
+        NULL, 0, (LPTHREAD_START_ROUTINE)flecs_win_thread, thread, 0, NULL);
     return (ecs_os_thread_t)(uintptr_t)thread;
 }
 
@@ -24,8 +39,8 @@ static
 void* win_thread_join(
     ecs_os_thread_t thr)
 {
-    HANDLE *thread = (HANDLE*)(uintptr_t)thr;
-    DWORD r = WaitForSingleObject(*thread, INFINITE);
+    ecs_win_thread_t *thread = (ecs_win_thread_t*)(uintptr_t)thr;
+    DWORD r = WaitForSingleObject(thread->thread, INFINITE);
     if (r == WAIT_FAILED) {
         ecs_err("win_thread_join: WaitForSingleObject failed");
     }
@@ -43,14 +58,14 @@ static
 int32_t win_ainc(
     int32_t *count) 
 {
-    return InterlockedIncrement(count);
+    return InterlockedIncrement((volatile long*)count);
 }
 
 static
 int32_t win_adec(
     int32_t *count) 
 {
-    return InterlockedDecrement(count);
+    return InterlockedDecrement((volatile long*)count);
 }
 
 static
@@ -184,20 +199,21 @@ void win_enable_high_timer_resolution(bool enable)
         return;
     }
 
-    LONG (__stdcall *pNtSetTimerResolution)(
-        ULONG desired, BOOLEAN set, ULONG * current);
+    union {
+        LONG (__stdcall *f)(
+            ULONG desired, BOOLEAN set, ULONG * current);
+        FARPROC p;
+    } func;
 
-    pNtSetTimerResolution = (LONG(__stdcall*)(ULONG, BOOLEAN, ULONG*))
-        GetProcAddress(hntdll, "NtSetTimerResolution");
-
-    if(!pNtSetTimerResolution) {
+    func.p = GetProcAddress(hntdll, "NtSetTimerResolution");
+    if(!func.p) {
         return;
     }
 
     ULONG current, resolution = 10000; /* 1 ms */
 
     if (!enable && win_current_resolution) {
-        pNtSetTimerResolution(win_current_resolution, 0, &current);
+        func.f(win_current_resolution, 0, &current);
         win_current_resolution = 0;
         return;
     } else if (!enable) {
@@ -209,13 +225,13 @@ void win_enable_high_timer_resolution(bool enable)
     }
 
     if (win_current_resolution) {
-        pNtSetTimerResolution(win_current_resolution, 0, &current);
+        func.f(win_current_resolution, 0, &current);
     }
 
-    if (pNtSetTimerResolution(resolution, 1, &current)) {
+    if (func.f(resolution, 1, &current)) {
         /* Try setting a lower resolution */
         resolution *= 2;
-        if(pNtSetTimerResolution(resolution, 1, &current)) return;
+        if(func.f(resolution, 1, &current)) return;
     }
 
     win_current_resolution = resolution;
@@ -227,7 +243,7 @@ uint64_t win_time_now(void) {
 
     LARGE_INTEGER qpc_t;
     QueryPerformanceCounter(&qpc_t);
-    now = (uint64_t)(qpc_t.QuadPart / win_time_freq);
+    now = (uint64_t)((double)qpc_t.QuadPart / win_time_freq);
 
     return now;
 }

--- a/src/addons/pipeline/pipeline.c
+++ b/src/addons/pipeline/pipeline.c
@@ -514,8 +514,7 @@ void ecs_run_pipeline(
     }
 
     /* create any worker task threads request */
-    if (ecs_using_task_threads(world))
-    {
+    if (ecs_using_task_threads(world)) {
         flecs_create_worker_threads(world);
     }
 
@@ -523,8 +522,7 @@ void ecs_run_pipeline(
         ECS_CONST_CAST(EcsPipeline*, ecs_get(world, pipeline, EcsPipeline));
     flecs_workers_progress(world, p->state, delta_time);
 
-    if (ecs_using_task_threads(world))
-    {
+    if (ecs_using_task_threads(world)) {
         /* task threads were temporary and may now be joined */
         flecs_join_worker_threads(world);
     }
@@ -634,7 +632,8 @@ void flecs_run_pipeline(
             ecs_time_measure(&st);
         }
 
-        const int32_t i = flecs_run_pipeline_ops(world, stage, stage_index, stage_count, delta_time);
+        const int32_t i = flecs_run_pipeline_ops(
+            world, stage, stage_index, stage_count, delta_time);
 
         if (measure_time) {
             /* Don't include merge time in system time */
@@ -725,8 +724,7 @@ bool ecs_progress(
     }
 
     /* create any worker task threads request */
-    if (ecs_using_task_threads(world))
-    {
+    if (ecs_using_task_threads(world)) {
         flecs_create_worker_threads(world);
     }
 
@@ -739,8 +737,7 @@ bool ecs_progress(
 
     ecs_frame_end(world);
 
-    if (ecs_using_task_threads(world))
-    {
+    if (ecs_using_task_threads(world)) {
         /* task threads were temporary and may now be joined */
         flecs_join_worker_threads(world);
     }

--- a/src/addons/pipeline/pipeline.c
+++ b/src/addons/pipeline/pipeline.c
@@ -181,7 +181,9 @@ bool flecs_pipeline_check_term(
                 flecs_pipeline_set_write_state(write_state, id);
             }
             break;
-        default:
+        case EcsInOutDefault:
+        case EcsInOutNone:
+        case EcsIn:
             break;
         }
 
@@ -193,7 +195,10 @@ bool flecs_pipeline_check_term(
                  * the main store so it must be merged first */
                 return true;
             }
-        default:
+            /* fall through */
+        case EcsInOutDefault:
+        case EcsInOutNone:
+        case EcsOut:
             break;
         }
     }
@@ -514,7 +519,8 @@ void ecs_run_pipeline(
         flecs_create_worker_threads(world);
     }
 
-    EcsPipeline *p = (EcsPipeline*)ecs_get(world, pipeline, EcsPipeline);
+    EcsPipeline *p = 
+        ECS_CONST_CAST(EcsPipeline*, ecs_get(world, pipeline, EcsPipeline));
     flecs_workers_progress(world, p->state, delta_time);
 
     if (ecs_using_task_threads(world))
@@ -834,9 +840,9 @@ void FlecsPipelineFini(
 
 #define flecs_bootstrap_phase(world, phase, depends_on)\
     flecs_bootstrap_tag(world, phase);\
-    _flecs_bootstrap_phase(world, phase, depends_on)
+    flecs_bootstrap_phase_(world, phase, depends_on)
 static
-void _flecs_bootstrap_phase(
+void flecs_bootstrap_phase_(
     ecs_world_t *world,
     ecs_entity_t phase,
     ecs_entity_t depends_on)

--- a/src/addons/pipeline/worker.c
+++ b/src/addons/pipeline/worker.c
@@ -57,7 +57,8 @@ void* flecs_worker(void *arg) {
         ecs_entity_t old_scope = ecs_set_scope((ecs_world_t*)stage, 0);
 
         ecs_dbg_3("worker %d: run", stage->id);
-        flecs_run_pipeline_ops(world, stage, stage->id, world->stage_count, world->info.delta_time);
+        flecs_run_pipeline_ops(world, stage, stage->id, world->stage_count, 
+            world->info.delta_time);
 
         ecs_set_scope((ecs_world_t*)stage, old_scope);
 
@@ -88,13 +89,11 @@ void flecs_create_worker_threads(
         ecs_poly_assert(stage, ecs_stage_t);
 
         ecs_assert(stage->thread == 0, ECS_INTERNAL_ERROR, NULL);
-        if (ecs_using_task_threads(world))
-        {
-            /* workers are using tasks in an external task manager provided to the OS API */
+        if (ecs_using_task_threads(world)) {
+            /* workers are using tasks in an external task manager provided to 
+             * the OS API */
             stage->thread = ecs_os_task_new(flecs_worker, stage);
-        }
-        else
-        {
+        } else {
             /* workers are using long-running os threads */
             stage->thread = ecs_os_thread_new(flecs_worker, stage);
         }
@@ -111,8 +110,7 @@ void flecs_start_workers(
 
     ecs_assert(ecs_get_stage_count(world) == threads, ECS_INTERNAL_ERROR, NULL);
 
-    if (!ecs_using_task_threads(world))
-    {
+    if (!ecs_using_task_threads(world)) {
         flecs_create_worker_threads(world);
     }
 }
@@ -213,13 +211,10 @@ bool flecs_join_worker_threads(
 
     /* Join all threads with main */
     for (i = 1; i < count; i ++) {
-        if (ecs_using_task_threads(world))
-        {
+        if (ecs_using_task_threads(world)) {
             /* Join using the override provided */
             ecs_os_task_join(stages[i].thread);
-        }
-        else
-        {
+        } else {
             ecs_os_thread_join(stages[i].thread);
         }
         stages[i].thread = 0;
@@ -273,7 +268,10 @@ void flecs_set_threads_internal(
     int32_t threads,
     bool use_task_api)
 {
-    ecs_assert(threads <= 1 || (use_task_api ? ecs_os_has_task_support() : ecs_os_has_threading()), ECS_MISSING_OS_API, NULL);
+    ecs_assert(threads <= 1 || (use_task_api 
+        ? ecs_os_has_task_support() 
+        : ecs_os_has_threading()), 
+            ECS_MISSING_OS_API, NULL);
     
     int32_t stage_count = ecs_get_stage_count(world);
     bool worker_method_changed = (use_task_api != world->workers_use_task_api);

--- a/src/addons/plecs.c
+++ b/src/addons/plecs.c
@@ -582,7 +582,7 @@ static
 char* plecs_trim_annot(
     char *annot)
 {
-    annot = (char*)ecs_parse_ws(annot);
+    annot = ECS_CONST_CAST(char*, ecs_parse_ws(annot));
     int32_t len = ecs_os_strlen(annot) - 1;
     while (isspace(annot[len]) && (len > 0)) {
         annot[len] = '\0';
@@ -2167,14 +2167,14 @@ ecs_entity_t ecs_script_init(
 
     if (script != desc->str) {
         /* Safe cast, only happens when script is loaded from file */
-        ecs_os_free((char*)script);
+        ecs_os_free(ECS_CONST_CAST(char*, script));
     }
 
     return e;
 error:
     if (script != desc->str) {
         /* Safe cast, only happens when script is loaded from file */
-        ecs_os_free((char*)script);
+        ecs_os_free(ECS_CONST_CAST(char*, script));
     }
     if (!desc->entity) {
         ecs_delete(world, e);

--- a/src/addons/rules/api.c
+++ b/src/addons/rules/api.c
@@ -8,7 +8,7 @@
 
 #ifdef FLECS_RULES
 
-ecs_mixins_t ecs_rule_t_mixins = {
+static ecs_mixins_t ecs_rule_t_mixins = {
     .type_name = "ecs_rule_t",
     .elems = {
         [EcsMixinWorld] = offsetof(ecs_rule_t, filter.world),
@@ -67,10 +67,10 @@ void flecs_rule_iter_mixin_init(
     ecs_poly_assert(poly, ecs_rule_t);
 
     if (filter) {
-        iter[1] = ecs_rule_iter(world, (ecs_rule_t*)poly);
+        iter[1] = ecs_rule_iter(world, ECS_CONST_CAST(ecs_rule_t*, poly));
         iter[0] = ecs_term_chain_iter(&iter[1], filter);
     } else {
-        iter[0] = ecs_rule_iter(world, (ecs_rule_t*)poly);
+        iter[0] = ecs_rule_iter(world, ECS_CONST_CAST(ecs_rule_t*, poly));
     }
 }
 
@@ -268,6 +268,7 @@ char* ecs_rule_str_w_profile(
                 ecs_strbuf_appendstr(&buf, ", #[yellow]\"");
                 ecs_strbuf_appendstr(&buf, rule->filter.terms[term_index].second.name);
                 ecs_strbuf_appendstr(&buf, "\"#[reset]");
+                break;
             }
             default:
                 break;

--- a/src/addons/rules/compile.c
+++ b/src/addons/rules/compile.c
@@ -514,7 +514,7 @@ void flecs_rule_discover_vars(
     flecs_set_var_label(&rule_vars[0], NULL);
     rule_vars[0].id = 0;
     rule_vars[0].table_id = EcsVarNone;
-    var_names[0] = (char*)rule_vars[0].name;
+    var_names[0] = ECS_CONST_CAST(char*, rule_vars[0].name);
     rule_vars ++;
     var_names ++;
     var_count --;
@@ -523,7 +523,7 @@ void flecs_rule_discover_vars(
         ecs_rule_var_t *user_vars = ecs_vec_first_t(vars, ecs_rule_var_t);
         ecs_os_memcpy_n(rule_vars, user_vars, ecs_rule_var_t, var_count);
         for (i = 0; i < var_count; i ++) {
-            var_names[i] = (char*)rule_vars[i].name;
+            var_names[i] = ECS_CONST_CAST(char*, rule_vars[i].name);
         }
     }
 

--- a/src/addons/rules/engine.c
+++ b/src/addons/rules/engine.c
@@ -20,13 +20,13 @@ ecs_allocator_t* flecs_rule_get_allocator(
 }
 
 static
-ecs_rule_op_ctx_t* _flecs_op_ctx(
+ecs_rule_op_ctx_t* flecs_op_ctx_(
     const ecs_rule_run_ctx_t *ctx)
 {
     return &ctx->op_ctx[ctx->op_index];
 }
 
-#define flecs_op_ctx(ctx, op_kind) (&_flecs_op_ctx(ctx)->is.op_kind)
+#define flecs_op_ctx(ctx, op_kind) (&flecs_op_ctx_(ctx)->is.op_kind)
 
 static
 ecs_table_range_t flecs_range_from_entity(
@@ -557,7 +557,7 @@ bool flecs_rule_with_id(
         }
     }
 
-    const ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
+    ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
     if (!tr) {
         return false;
     }
@@ -1871,7 +1871,7 @@ ecs_iter_t ecs_rule_iter(
     ecs_run_aperiodic(rule->filter.world, EcsAperiodicEmptyTables);
 
     int32_t i, var_count = rule->var_count, op_count = rule->op_count;
-    it.world = (ecs_world_t*)world;
+    it.world = ECS_CONST_CAST(ecs_world_t*, world);
     it.real_world = rule->filter.world;
     it.terms = rule->filter.terms;
     it.next = ecs_rule_next;

--- a/src/addons/rules/trav_cache.c
+++ b/src/addons/rules/trav_cache.c
@@ -79,7 +79,7 @@ void flecs_rule_build_up_cache(
 
         ecs_record_t *r = flecs_entities_get_any(world, second);
         if (r->table) {
-            const ecs_table_record_t *r_tr = flecs_id_record_get_table(
+            ecs_table_record_t *r_tr = flecs_id_record_get_table(
                 cache->idr, r->table);
             if (!r_tr) {
                 return;
@@ -133,7 +133,7 @@ void flecs_rule_get_up_cache(
         }
     }
 
-    const ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
+    ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
     if (!tr) {
         ecs_vec_reset_t(a, &cache->entities, ecs_trav_elem_t);
         return;

--- a/src/addons/snapshot.c
+++ b/src/addons/snapshot.c
@@ -47,7 +47,7 @@ ecs_data_t* flecs_duplicate_data(
     /* Copy each column */
     for (i = 0; i < column_count; i ++) {
         ecs_vec_t *column = &result->columns[i];
-        ecs_type_info_t *ti = table->type_info[i];
+        const ecs_type_info_t *ti = table->type_info[i];
         int32_t size = ti->size;
         ecs_copy_t copy = ti->hooks.copy;
         if (copy) {
@@ -86,8 +86,10 @@ void snapshot_table(
     ecs_assert(l != NULL, ECS_INTERNAL_ERROR, NULL);
     
     l->table = table;
-    l->type = flecs_type_copy((ecs_world_t*)world, &table->type);
-    l->data = flecs_duplicate_data((ecs_world_t*)world, table, &table->data);
+    l->type = flecs_type_copy(
+        ECS_CONST_CAST(ecs_world_t*, world), &table->type);
+    l->data = flecs_duplicate_data(
+        ECS_CONST_CAST(ecs_world_t*, world), table, &table->data);
 }
 
 static
@@ -100,9 +102,9 @@ ecs_snapshot_t* snapshot_create(
     ecs_snapshot_t *result = ecs_os_calloc_t(ecs_snapshot_t);
     ecs_assert(result != NULL, ECS_OUT_OF_MEMORY, NULL);
 
-    ecs_run_aperiodic((ecs_world_t*)world, 0);
+    ecs_run_aperiodic(ECS_CONST_CAST(ecs_world_t*, world), 0);
 
-    result->world = (ecs_world_t*)world;
+    result->world = ECS_CONST_CAST(ecs_world_t*, world);
 
     /* If no iterator is provided, the snapshot will be taken of the entire
      * world, and we can simply copy the entity index as it will be restored

--- a/src/addons/stats.c
+++ b/src/addons/stats.c
@@ -271,7 +271,7 @@ void ecs_world_stats_get(
     ECS_COUNTER_RECORD(&s->performance.merge_time, t, world->info.merge_time_total);
     ECS_COUNTER_RECORD(&s->performance.rematch_time, t, world->info.rematch_time_total);
     ECS_GAUGE_RECORD(&s->performance.delta_time, t, delta_world_time);
-    if (delta_world_time != 0 && delta_frame_count != 0) {
+    if (ECS_NEQZERO(delta_world_time) && ECS_NEQZERO(delta_frame_count)) {
         ECS_GAUGE_RECORD(&s->performance.fps, t, (double)1 / (delta_world_time / (double)delta_frame_count));
     } else {
         ECS_GAUGE_RECORD(&s->performance.fps, t, 0);

--- a/src/addons/system/system.c
+++ b/src/addons/system/system.c
@@ -283,9 +283,11 @@ ecs_entity_t ecs_system_init(
         system->multi_threaded = desc->multi_threaded;
         system->no_readonly = desc->no_readonly;
 
-        if (desc->interval != 0 || desc->rate != 0 || desc->tick_source != 0) {
+        if (ECS_NEQZERO(desc->interval) || ECS_NEQZERO(desc->rate) || 
+            ECS_NEQZERO(desc->tick_source)) 
+        {
 #ifdef FLECS_TIMER
-            if (desc->interval != 0) {
+            if (ECS_NEQZERO(desc->interval)) {
                 ecs_set_interval(world, entity, desc->interval);
             }
 
@@ -348,9 +350,11 @@ ecs_entity_t ecs_system_init(
             system->no_readonly = desc->no_readonly;
         }
 
-        if (desc->interval != 0 || desc->rate != 0 || desc->tick_source != 0) {
+        if (ECS_NEQZERO(desc->interval) || desc->rate != 0 || 
+            desc->tick_source != 0) 
+        {
 #ifdef FLECS_TIMER
-            if (desc->interval != 0) {
+            if (ECS_NEQZERO(desc->interval)) {
                 ecs_set_interval(world, entity, desc->interval);
             }
             if (desc->rate != 0) {

--- a/src/datastructures/hash.c
+++ b/src/datastructures/hash.c
@@ -8,7 +8,7 @@
 
 /* quick example:
    string s="fjsakfdsjkf";
-   uint64_t hash=wyhash(s.c_str(), s.size(), 0, _wyp);
+   uint64_t hash=wyhash(s.c_str(), s.size(), 0, wyp_);
 */
 
 #include "../private_api.h"
@@ -36,15 +36,15 @@
 
 //likely and unlikely macros
 #if defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__clang__)
-  #define _likely_(x)  __builtin_expect(x,1)
-  #define _unlikely_(x)  __builtin_expect(x,0)
+  #define likely_(x)  __builtin_expect(x,1)
+  #define unlikely_(x)  __builtin_expect(x,0)
 #else
-  #define _likely_(x) (x)
-  #define _unlikely_(x) (x)
+  #define likely_(x) (x)
+  #define unlikely_(x) (x)
 #endif
 
 //128bit multiply function
-static inline void _wymum(uint64_t *A, uint64_t *B){
+static inline void wymum_(uint64_t *A, uint64_t *B){
 #if(WYHASH_32BIT_MUM)
   uint64_t hh=(*A>>32)*(*B>>32), hl=(*A>>32)*(uint32_t)*B, lh=(uint32_t)*A*(*B>>32), ll=(uint64_t)(uint32_t)*A*(uint32_t)*B;
   #if(WYHASH_CONDOM>1)
@@ -80,7 +80,7 @@ static inline void _wymum(uint64_t *A, uint64_t *B){
 }
 
 //multiply and xor mix function, aka MUM
-static inline uint64_t _wymix(uint64_t A, uint64_t B){ _wymum(&A,&B); return A^B; }
+static inline uint64_t wymix_(uint64_t A, uint64_t B){ wymum_(&A,&B); return A^B; }
 
 //endian macros
 #ifndef WYHASH_LITTLE_ENDIAN
@@ -96,59 +96,59 @@ static inline uint64_t _wymix(uint64_t A, uint64_t B){ _wymum(&A,&B); return A^B
 
 //read functions
 #if (WYHASH_LITTLE_ENDIAN)
-static inline uint64_t _wyr8(const uint8_t *p) { uint64_t v; memcpy(&v, p, 8); return v;}
-static inline uint64_t _wyr4(const uint8_t *p) { uint32_t v; memcpy(&v, p, 4); return v;}
+static inline uint64_t wyr8_(const uint8_t *p) { uint64_t v; memcpy(&v, p, 8); return v;}
+static inline uint64_t wyr4_(const uint8_t *p) { uint32_t v; memcpy(&v, p, 4); return v;}
 #elif defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__clang__)
-static inline uint64_t _wyr8(const uint8_t *p) { uint64_t v; memcpy(&v, p, 8); return __builtin_bswap64(v);}
-static inline uint64_t _wyr4(const uint8_t *p) { uint32_t v; memcpy(&v, p, 4); return __builtin_bswap32(v);}
+static inline uint64_t wyr8_(const uint8_t *p) { uint64_t v; memcpy(&v, p, 8); return __builtin_bswap64(v);}
+static inline uint64_t wyr4_(const uint8_t *p) { uint32_t v; memcpy(&v, p, 4); return __builtin_bswap32(v);}
 #elif defined(_MSC_VER)
-static inline uint64_t _wyr8(const uint8_t *p) { uint64_t v; memcpy(&v, p, 8); return _byteswap_uint64(v);}
-static inline uint64_t _wyr4(const uint8_t *p) { uint32_t v; memcpy(&v, p, 4); return _byteswap_ulong(v);}
+static inline uint64_t wyr8_(const uint8_t *p) { uint64_t v; memcpy(&v, p, 8); return _byteswap_uint64(v);}
+static inline uint64_t wyr4_(const uint8_t *p) { uint32_t v; memcpy(&v, p, 4); return _byteswap_ulong(v);}
 #else
-static inline uint64_t _wyr8(const uint8_t *p) {
+static inline uint64_t wyr8_(const uint8_t *p) {
   uint64_t v; memcpy(&v, p, 8);
   return (((v >> 56) & 0xff)| ((v >> 40) & 0xff00)| ((v >> 24) & 0xff0000)| ((v >>  8) & 0xff000000)| ((v <<  8) & 0xff00000000)| ((v << 24) & 0xff0000000000)| ((v << 40) & 0xff000000000000)| ((v << 56) & 0xff00000000000000));
 }
-static inline uint64_t _wyr4(const uint8_t *p) {
+static inline uint64_t wyr4_(const uint8_t *p) {
   uint32_t v; memcpy(&v, p, 4);
   return (((v >> 24) & 0xff)| ((v >>  8) & 0xff00)| ((v <<  8) & 0xff0000)| ((v << 24) & 0xff000000));
 }
 #endif
-static inline uint64_t _wyr3(const uint8_t *p, size_t k) { return (((uint64_t)p[0])<<16)|(((uint64_t)p[k>>1])<<8)|p[k-1];}
+static inline uint64_t wyr3_(const uint8_t *p, size_t k) { return (((uint64_t)p[0])<<16)|(((uint64_t)p[k>>1])<<8)|p[k-1];}
 
 //wyhash main function
 static inline uint64_t wyhash(const void *key, size_t len, uint64_t seed, const uint64_t *secret){
-  const uint8_t *p=(const uint8_t *)key; seed^=_wymix(seed^secret[0],secret[1]);	uint64_t	a,	b;
-  if(_likely_(len<=16)){
-    if(_likely_(len>=4)){ a=(_wyr4(p)<<32)|_wyr4(p+((len>>3)<<2)); b=(_wyr4(p+len-4)<<32)|_wyr4(p+len-4-((len>>3)<<2)); }
-    else if(_likely_(len>0)){ a=_wyr3(p,len); b=0;}
+  const uint8_t *p=(const uint8_t *)key; seed^=wymix_(seed^secret[0],secret[1]);	uint64_t	a,	b;
+  if(likely_(len<=16)){
+    if(likely_(len>=4)){ a=(wyr4_(p)<<32)|wyr4_(p+((len>>3)<<2)); b=(wyr4_(p+len-4)<<32)|wyr4_(p+len-4-((len>>3)<<2)); }
+    else if(likely_(len>0)){ a=wyr3_(p,len); b=0;}
     else a=b=0;
   }
   else{
     size_t i=len; 
-    if(_unlikely_(i>48)){
+    if(unlikely_(i>48)){
       uint64_t see1=seed, see2=seed;
       do{
-        seed=_wymix(_wyr8(p)^secret[1],_wyr8(p+8)^seed);
-        see1=_wymix(_wyr8(p+16)^secret[2],_wyr8(p+24)^see1);
-        see2=_wymix(_wyr8(p+32)^secret[3],_wyr8(p+40)^see2);
+        seed=wymix_(wyr8_(p)^secret[1],wyr8_(p+8)^seed);
+        see1=wymix_(wyr8_(p+16)^secret[2],wyr8_(p+24)^see1);
+        see2=wymix_(wyr8_(p+32)^secret[3],wyr8_(p+40)^see2);
         p+=48; i-=48;
-      }while(_likely_(i>48));
+      }while(likely_(i>48));
       seed^=see1^see2;
     }
-    while(_unlikely_(i>16)){  seed=_wymix(_wyr8(p)^secret[1],_wyr8(p+8)^seed);  i-=16; p+=16;  }
-    a=_wyr8(p+i-16);  b=_wyr8(p+i-8);
+    while(unlikely_(i>16)){  seed=wymix_(wyr8_(p)^secret[1],wyr8_(p+8)^seed);  i-=16; p+=16;  }
+    a=wyr8_(p+i-16);  b=wyr8_(p+i-8);
   }
-  a^=secret[1]; b^=seed;  _wymum(&a,&b);
-  return  _wymix(a^secret[0]^len,b^secret[1]);
+  a^=secret[1]; b^=seed;  wymum_(&a,&b);
+  return  wymix_(a^secret[0]^len,b^secret[1]);
 }
 
 //the default secret parameters
-static const uint64_t _wyp[4] = {0xa0761d6478bd642full, 0xe7037ed1a0b428dbull, 0x8ebc6af09c88c6e3ull, 0x589965cc75374cc3ull};
+static const uint64_t wyp_[4] = {0xa0761d6478bd642full, 0xe7037ed1a0b428dbull, 0x8ebc6af09c88c6e3ull, 0x589965cc75374cc3ull};
 
 uint64_t flecs_hash(
     const void *data,
     ecs_size_t length)
 {
-    return wyhash(data, flecs_ito(size_t, length), 0, _wyp);
+    return wyhash(data, flecs_ito(size_t, length), 0, wyp_);
 }

--- a/src/datastructures/hashmap.c
+++ b/src/datastructures/hashmap.c
@@ -27,7 +27,7 @@ int32_t flecs_hashmap_find_key(
     return -1;
 }
 
-void _flecs_hashmap_init(
+void flecs_hashmap_init_(
     ecs_hashmap_t *map,
     ecs_size_t key_size,
     ecs_size_t value_size,
@@ -68,7 +68,7 @@ void flecs_hashmap_copy(
 {
     ecs_assert(dst != src, ECS_INVALID_PARAMETER, NULL);
 
-    _flecs_hashmap_init(dst, src->key_size, src->value_size, src->hash, 
+    flecs_hashmap_init_(dst, src->key_size, src->value_size, src->hash, 
         src->compare, src->impl.allocator);
     ecs_map_copy(&dst->impl, &src->impl);
 
@@ -84,7 +84,7 @@ void flecs_hashmap_copy(
     }
 }
 
-void* _flecs_hashmap_get(
+void* flecs_hashmap_get_(
     const ecs_hashmap_t *map,
     ecs_size_t key_size,
     const void *key,
@@ -108,7 +108,7 @@ void* _flecs_hashmap_get(
     return ecs_vec_get(&bucket->values, value_size, index);
 }
 
-flecs_hashmap_result_t _flecs_hashmap_ensure(
+flecs_hashmap_result_t flecs_hashmap_ensure_(
     ecs_hashmap_t *map,
     ecs_size_t key_size,
     const void *key,
@@ -153,14 +153,14 @@ flecs_hashmap_result_t _flecs_hashmap_ensure(
     };
 }
 
-void _flecs_hashmap_set(
+void flecs_hashmap_set_(
     ecs_hashmap_t *map,
     ecs_size_t key_size,
     void *key,
     ecs_size_t value_size,
     const void *value)
 {
-    void *value_ptr = _flecs_hashmap_ensure(map, key_size, key, value_size).value;
+    void *value_ptr = flecs_hashmap_ensure_(map, key_size, key, value_size).value;
     ecs_assert(value_ptr != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_os_memcpy(value_ptr, value, value_size);
 }
@@ -192,7 +192,7 @@ void flecs_hm_bucket_remove(
     }
 }
 
-void _flecs_hashmap_remove_w_hash(
+void flecs_hashmap_remove_w_hash_(
     ecs_hashmap_t *map,
     ecs_size_t key_size,
     const void *key,
@@ -217,7 +217,7 @@ void _flecs_hashmap_remove_w_hash(
     flecs_hm_bucket_remove(map, bucket, hash, index);
 }
 
-void _flecs_hashmap_remove(
+void flecs_hashmap_remove_(
     ecs_hashmap_t *map,
     ecs_size_t key_size,
     const void *key,
@@ -227,7 +227,7 @@ void _flecs_hashmap_remove(
     ecs_assert(map->value_size == value_size, ECS_INVALID_PARAMETER, NULL);
 
     uint64_t hash = map->hash(key);
-    _flecs_hashmap_remove_w_hash(map, key_size, key, value_size, hash);
+    flecs_hashmap_remove_w_hash_(map, key_size, key, value_size, hash);
 }
 
 flecs_hashmap_iter_t flecs_hashmap_iter(
@@ -238,7 +238,7 @@ flecs_hashmap_iter_t flecs_hashmap_iter(
     };
 }
 
-void* _flecs_hashmap_next(
+void* flecs_hashmap_next_(
     flecs_hashmap_iter_t *it,
     ecs_size_t key_size,
     void *key_out,

--- a/src/datastructures/map.c
+++ b/src/datastructures/map.c
@@ -279,7 +279,7 @@ ecs_map_val_t* ecs_map_get(
     return flecs_map_bucket_get(flecs_map_get_bucket(map, key), key);
 }
 
-void* _ecs_map_get_deref(
+void* ecs_map_get_deref_(
     const ecs_map_t *map,
     ecs_map_key_t key)
 {

--- a/src/datastructures/name_index.c
+++ b/src/datastructures/name_index.c
@@ -34,7 +34,7 @@ void flecs_name_index_init(
     ecs_hashmap_t *hm,
     ecs_allocator_t *allocator) 
 {
-    _flecs_hashmap_init(hm, 
+    flecs_hashmap_init_(hm, 
         ECS_SIZEOF(ecs_hashed_string_t), ECS_SIZEOF(uint64_t), 
         flecs_name_index_hash, 
         flecs_name_index_compare,
@@ -108,7 +108,7 @@ ecs_hashed_string_t flecs_get_hashed_string(
     }
 
     return (ecs_hashed_string_t) {
-        .value = (char*)name,
+        .value = ECS_CONST_CAST(char*, name),
         .length = length,
         .hash = hash
     };
@@ -197,7 +197,7 @@ void flecs_name_index_update_name(
         if (ids[i] == e) {
             ecs_hashed_string_t *key = ecs_vec_get_t(
                 &b->keys, ecs_hashed_string_t, i);
-            key->value = (char*)name;
+            key->value = ECS_CONST_CAST(char*, name);
             ecs_assert(ecs_os_strlen(name) == key->length,
                 ECS_INTERNAL_ERROR, NULL);
             ecs_assert(flecs_hash(name, key->length) == key->hash,

--- a/src/datastructures/strbuf.c
+++ b/src/datastructures/strbuf.c
@@ -249,7 +249,7 @@ void flecs_strbuf_grow(
 static
 void flecs_strbuf_grow_str(
     ecs_strbuf_t *b,
-    char *str,
+    const char *str,
     char *alloc_str,
     int32_t size)
 {
@@ -262,7 +262,7 @@ void flecs_strbuf_grow_str(
     e->super.buffer_embedded = false;
     e->super.pos = size ? size : (int32_t)ecs_os_strlen(str);
     e->super.next = NULL;
-    e->super.buf = str;
+    e->super.buf = ECS_CONST_CAST(char*, str);
     e->alloc_str = alloc_str;
 }
 
@@ -572,7 +572,7 @@ bool ecs_strbuf_appendstr_zerocpy_const(
     ecs_assert(str != NULL, ECS_INVALID_PARAMETER, NULL);
     /* Removes const modifier, but logic prevents changing / delete string */
     flecs_strbuf_init(b);
-    flecs_strbuf_grow_str(b, (char*)str, NULL, 0);
+    flecs_strbuf_grow_str(b, str, NULL, 0);
     return true;
 }
 
@@ -585,7 +585,7 @@ bool ecs_strbuf_appendstr_zerocpyn_const(
     ecs_assert(str != NULL, ECS_INVALID_PARAMETER, NULL);
     /* Removes const modifier, but logic prevents changing / delete string */
     flecs_strbuf_init(b);
-    flecs_strbuf_grow_str(b, (char*)str, NULL, n);
+    flecs_strbuf_grow_str(b, str, NULL, n);
     return true;
 }
 

--- a/src/datastructures/switch_list.c
+++ b/src/datastructures/switch_list.c
@@ -328,7 +328,7 @@ uint64_t flecs_switch_get(
 ecs_vec_t* flecs_switch_values(
     const ecs_switch_t *sw)
 {
-    return (ecs_vec_t*)&sw->values;
+    return ECS_CONST_CAST(ecs_vec_t*, &sw->values);
 }
 
 int32_t flecs_switch_case_count(

--- a/src/datastructures/vec.c
+++ b/src/datastructures/vec.c
@@ -85,7 +85,7 @@ void ecs_vec_clear(
 
 ecs_vec_t ecs_vec_copy(
     ecs_allocator_t *allocator,
-    ecs_vec_t *v,
+    const ecs_vec_t *v,
     ecs_size_t size)
 {
     ecs_dbg_assert(size == v->elem_size, ECS_INVALID_PARAMETER, NULL);

--- a/src/entity_filter.c
+++ b/src/entity_filter.c
@@ -344,10 +344,10 @@ int32_t flecs_get_flattened_target(
         return -1;
     }
 
-    const ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
+    ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
     if (tr) {
         *src_out = ecs_record_get_entity(r);
-        *tr_out = (ecs_table_record_t*)tr;
+        *tr_out = tr;
         return tr->column;
     }
 

--- a/src/hierarchy.c
+++ b/src/hierarchy.c
@@ -404,8 +404,8 @@ ecs_entity_t ecs_lookup_path_w_sep(
     ecs_entity_t cur;
     bool lookup_path_search = false;
 
-    ecs_entity_t *lookup_path = ecs_get_lookup_path(stage);
-    ecs_entity_t *lookup_path_cur = lookup_path;
+    const ecs_entity_t *lookup_path = ecs_get_lookup_path(stage);
+    const ecs_entity_t *lookup_path_cur = lookup_path;
     while (lookup_path_cur && *lookup_path_cur) {
         lookup_path_cur ++;
     }
@@ -507,8 +507,9 @@ ecs_entity_t* ecs_set_lookup_path(
     ecs_check(world != NULL, ECS_INVALID_PARAMETER, NULL);
     ecs_stage_t *stage = flecs_stage_from_world(&world);
 
-    ecs_entity_t *cur = stage->lookup_path;
-    stage->lookup_path = (ecs_entity_t*)lookup_path;
+    /* Safe: application owns lookup path */
+    ecs_entity_t *cur = ECS_CONST_CAST(ecs_entity_t*, stage->lookup_path);
+    stage->lookup_path = lookup_path;
 
     return cur;
 error:
@@ -520,7 +521,8 @@ ecs_entity_t* ecs_get_lookup_path(
 {
     ecs_check(world != NULL, ECS_INVALID_PARAMETER, NULL);
     const ecs_stage_t *stage = flecs_stage_from_readonly_world(world);
-    return stage->lookup_path;
+    /* Safe: application owns lookup path */
+    return ECS_CONST_CAST(ecs_entity_t*, stage->lookup_path);
 error:
     return NULL;
 }

--- a/src/id_record.c
+++ b/src/id_record.c
@@ -585,7 +585,7 @@ ecs_table_record_t* flecs_table_record_get(
     return (ecs_table_record_t*)ecs_table_cache_get(&idr->cache, table);
 }
 
-const ecs_table_record_t* flecs_id_record_get_table(
+ecs_table_record_t* flecs_id_record_get_table(
     const ecs_id_record_t *idr,
     const ecs_table_t *table)
 {

--- a/src/id_record.h
+++ b/src/id_record.h
@@ -131,7 +131,7 @@ ecs_table_record_t* flecs_table_record_get(
     ecs_id_t id);
 
 /* Find table record for id record */
-const ecs_table_record_t* flecs_id_record_get_table(
+ecs_table_record_t* flecs_id_record_get_table(
     const ecs_id_record_t *idr,
     const ecs_table_t *table);
 

--- a/src/iter.c
+++ b/src/iter.c
@@ -53,7 +53,8 @@ void flecs_iter_init(
     ecs_assert(!ECS_BIT_IS_SET(it->flags, EcsIterIsValid), 
         ECS_INTERNAL_ERROR, NULL);
 
-    ecs_stage_t *stage = flecs_stage_from_world((ecs_world_t**)&world);
+    ecs_stage_t *stage = flecs_stage_from_world(
+        ECS_CONST_CAST(ecs_world_t**, &world));
     ecs_stack_t *stack = &stage->allocators.iter_stack;
 
     it->priv.cache.used = 0;
@@ -772,7 +773,7 @@ void ecs_iter_set_var_as_table(
     int32_t var_id,
     const ecs_table_t *table)
 {
-    ecs_table_range_t range = { .table = (ecs_table_t*)table };
+    ecs_table_range_t range = { .table = ECS_CONST_CAST(ecs_table_t*, table) };
     ecs_iter_set_var_as_range(it, var_id, &range);
 }
 
@@ -847,7 +848,7 @@ ecs_iter_t ecs_page_iter(
     };
     result.next = ecs_page_next;
     result.fini = ecs_chained_iter_fini;
-    result.chain_it = (ecs_iter_t*)it;
+    result.chain_it = ECS_CONST_CAST(ecs_iter_t*, it);
 
     return result;
 error:
@@ -997,7 +998,7 @@ ecs_iter_t ecs_worker_iter(
     };
     result.next = ecs_worker_next;
     result.fini = ecs_chained_iter_fini;
-    result.chain_it = (ecs_iter_t*)it;
+    result.chain_it = ECS_CONST_CAST(ecs_iter_t*, it);
 
     return result;
 error:

--- a/src/misc.c
+++ b/src/misc.c
@@ -15,7 +15,7 @@ static int64_t flecs_s_max[] = {
 static uint64_t flecs_u_max[] = { 
     [1] = UINT8_MAX, [2] = UINT16_MAX, [4] = UINT32_MAX, [8] = UINT64_MAX };
 
-uint64_t _flecs_ito(
+uint64_t flecs_ito_(
     size_t size,
     bool is_signed,
     bool lt_zero,

--- a/src/observable.c
+++ b/src/observable.c
@@ -55,11 +55,11 @@ ecs_event_record_t* flecs_event_record_get(
     ecs_assert(o != NULL, ECS_INTERNAL_ERROR, NULL);
     
     /* Builtin events*/
-    if      (event == EcsOnAdd)     return (ecs_event_record_t*)&o->on_add;
-    else if (event == EcsOnRemove)  return (ecs_event_record_t*)&o->on_remove;
-    else if (event == EcsOnSet)     return (ecs_event_record_t*)&o->on_set;
-    else if (event == EcsUnSet)     return (ecs_event_record_t*)&o->un_set;
-    else if (event == EcsWildcard)  return (ecs_event_record_t*)&o->on_wildcard;
+    if      (event == EcsOnAdd)     return ECS_CONST_CAST(ecs_event_record_t*, &o->on_add);
+    else if (event == EcsOnRemove)  return ECS_CONST_CAST(ecs_event_record_t*, &o->on_remove);
+    else if (event == EcsOnSet)     return ECS_CONST_CAST(ecs_event_record_t*, &o->on_set);
+    else if (event == EcsUnSet)     return ECS_CONST_CAST(ecs_event_record_t*, &o->un_set);
+    else if (event == EcsWildcard)  return ECS_CONST_CAST(ecs_event_record_t*, &o->on_wildcard);
 
     /* User events */
     return flecs_sparse_try_t(&o->events, ecs_event_record_t, event);
@@ -81,13 +81,13 @@ ecs_event_record_t* flecs_event_record_ensure(
 }
 
 static
-ecs_event_record_t* flecs_event_record_get_if(
+const ecs_event_record_t* flecs_event_record_get_if(
     const ecs_observable_t *o,
     ecs_entity_t event)
 {
     ecs_assert(o != NULL, ECS_INTERNAL_ERROR, NULL);
 
-    ecs_event_record_t *er = flecs_event_record_get(o, event);
+    const ecs_event_record_t *er = flecs_event_record_get(o, event);
     if (er) {
         if (ecs_map_is_init(&er->event_ids)) {
             return er;
@@ -226,7 +226,7 @@ bool flecs_observers_exist(
     ecs_id_t id,
     ecs_entity_t event)
 {
-    ecs_event_record_t *er = flecs_event_record_get_if(observable, event);
+    const ecs_event_record_t *er = flecs_event_record_get_if(observable, event);
     if (!er) {
         return false;
     }
@@ -272,7 +272,7 @@ void flecs_emit_propagate(
                 continue;
             }
 
-            bool owned = flecs_id_record_get_table(idr, table);
+            bool owned = flecs_id_record_get_table(idr, table) != NULL;
 
             int32_t e, entity_count = ecs_table_count(table);
             it->table = table;
@@ -457,7 +457,7 @@ void* flecs_override(
              * after it was inherited, as this does not change the actual value
              * of the component for the entity (it is copied from the existing
              * overridden component), and does not require an OnSet event. */
-            const ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
+            ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
             if (!tr) {
                 continue;
             }
@@ -480,8 +480,8 @@ void* flecs_override(
 static
 void flecs_emit_forward_up(
     ecs_world_t *world,
-    ecs_event_record_t *er,
-    ecs_event_record_t *er_onset,
+    const ecs_event_record_t *er,
+    const ecs_event_record_t *er_onset,
     const ecs_type_t *emit_ids,
     ecs_iter_t *it,
     ecs_table_t *table,
@@ -493,8 +493,8 @@ void flecs_emit_forward_up(
 static
 void flecs_emit_forward_id(
     ecs_world_t *world,
-    ecs_event_record_t *er,
-    ecs_event_record_t *er_onset,
+    const ecs_event_record_t *er,
+    const ecs_event_record_t *er_onset,
     const ecs_type_t *emit_ids,
     ecs_iter_t *it,
     ecs_table_t *table,
@@ -540,7 +540,7 @@ void flecs_emit_forward_id(
         it->sizes[0] = size;
     }
 
-    const ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
+    ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
     bool owned = tr != NULL;
 
     for (ider_i = 0; ider_i < ider_count; ider_i ++) {
@@ -595,8 +595,8 @@ void flecs_emit_forward_id(
 static
 void flecs_emit_forward_and_cache_id(
     ecs_world_t *world,
-    ecs_event_record_t *er,
-    ecs_event_record_t *er_onset,
+    const ecs_event_record_t *er,
+    const ecs_event_record_t *er_onset,
     const ecs_type_t *emit_ids,
     ecs_iter_t *it,
     ecs_table_t *table,
@@ -656,8 +656,8 @@ bool flecs_emit_stack_has(
 static
 void flecs_emit_forward_cached_ids(
     ecs_world_t *world,
-    ecs_event_record_t *er,
-    ecs_event_record_t *er_onset,
+    const ecs_event_record_t *er,
+    const ecs_event_record_t *er_onset,
     const ecs_type_t *emit_ids,
     ecs_iter_t *it,
     ecs_table_t *table,
@@ -721,8 +721,8 @@ void flecs_emit_dump_cache(
 static
 void flecs_emit_forward_table_up(
     ecs_world_t *world,
-    ecs_event_record_t *er,
-    ecs_event_record_t *er_onset,
+    const ecs_event_record_t *er,
+    const ecs_event_record_t *er_onset,
     const ecs_type_t *emit_ids,
     ecs_iter_t *it,
     ecs_table_t *table,
@@ -869,8 +869,8 @@ void flecs_emit_forward_table_up(
 static
 void flecs_emit_forward_up(
     ecs_world_t *world,
-    ecs_event_record_t *er,
-    ecs_event_record_t *er_onset,
+    const ecs_event_record_t *er,
+    const ecs_event_record_t *er_onset,
     const ecs_type_t *emit_ids,
     ecs_iter_t *it,
     ecs_table_t *table,
@@ -896,8 +896,8 @@ void flecs_emit_forward_up(
 static
 void flecs_emit_forward(
     ecs_world_t *world,
-    ecs_event_record_t *er,
-    ecs_event_record_t *er_onset,
+    const ecs_event_record_t *er,
+    const ecs_event_record_t *er_onset,
     const ecs_type_t *emit_ids,
     ecs_iter_t *it,
     ecs_table_t *table,
@@ -1036,7 +1036,7 @@ void flecs_emit(
         .other_table = other_table,
         .offset = offset,
         .count = count,
-        .param = (void*)desc->param,
+        .param = ECS_CONST_CAST(void*, desc->param),
         .flags = desc->flags | EcsIterIsValid
     };
 
@@ -1057,10 +1057,10 @@ void flecs_emit(
      * inherited components, for example when an IsA relationship is added to an
      * entity. This doesn't add much overhead, as fetching records is cheap for
      * builtin event types. */
-    ecs_event_record_t *er = flecs_event_record_get_if(observable, event);
-    ecs_event_record_t *wcer = flecs_event_record_get_if(observable, EcsWildcard);
-    ecs_event_record_t *er_onset = flecs_event_record_get_if(observable, EcsOnSet);
-    ecs_event_record_t *er_unset = flecs_event_record_get_if(observable, EcsUnSet);
+    const ecs_event_record_t *er = flecs_event_record_get_if(observable, event);
+    const ecs_event_record_t *wcer = flecs_event_record_get_if(observable, EcsWildcard);
+    const ecs_event_record_t *er_onset = flecs_event_record_get_if(observable, EcsOnSet);
+    const ecs_event_record_t *er_unset = flecs_event_record_get_if(observable, EcsUnSet);
 
     ecs_data_t *storage = NULL;
     ecs_vec_t *columns = NULL;
@@ -1127,7 +1127,7 @@ repeat_event:
             ecs_flags32_t idr_flags = idr->flags;
 
             if (is_pair && (idr_flags & EcsIdTraversable)) {
-                ecs_event_record_t *er_fwd = NULL;
+                const ecs_event_record_t *er_fwd = NULL;
                 if (ECS_PAIR_FIRST(id) == EcsIsA) {
                     if (event == EcsOnAdd) {
                         if (!world->stages[0].base) {
@@ -1205,7 +1205,7 @@ repeat_event:
         }
 
         ecs_assert(idr != NULL, ECS_INTERNAL_ERROR, NULL);
-        const ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
+        ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
         if (tr == NULL) {
             /* When a single batch contains multiple add's for an exclusive
              * relationship, it's possible that an id was in the added list
@@ -1352,7 +1352,7 @@ void ecs_emit(
     ecs_world_t *stage,
     ecs_event_desc_t *desc)
 {
-    ecs_world_t *world = (ecs_world_t*)ecs_get_world(stage);
+    ecs_world_t *world = ECS_CONST_CAST(ecs_world_t*, ecs_get_world(stage));
     if (desc->entity) {
         ecs_assert(desc->table == NULL, ECS_INVALID_PARAMETER, NULL);
         ecs_assert(desc->offset == 0, ECS_INVALID_PARAMETER, NULL);

--- a/src/poly.c
+++ b/src/poly.c
@@ -187,11 +187,11 @@ ecs_poly_t* ecs_poly_get_(
     return NULL;
 }
 
+#ifndef FLECS_NDEBUG
 #define assert_object(cond, file, line, type_name)\
     ecs_assert_((cond), ECS_INVALID_PARAMETER, #cond, file, line, type_name);\
     assert(cond)
 
-#ifndef FLECS_NDEBUG
 void* ecs_poly_assert_(
     const ecs_poly_t *poly,
     int32_t type,

--- a/src/poly.c
+++ b/src/poly.c
@@ -97,7 +97,7 @@ void* assert_mixin(
     return ECS_OFFSET(hdr, offset);
 }
 
-void* _ecs_poly_init(
+void* ecs_poly_init_(
     ecs_poly_t *poly,
     int32_t type,
     ecs_size_t size,
@@ -115,7 +115,7 @@ void* _ecs_poly_init(
     return poly;
 }
 
-void _ecs_poly_fini(
+void ecs_poly_fini_(
     ecs_poly_t *poly,
     int32_t type)
 {
@@ -130,7 +130,7 @@ void _ecs_poly_fini(
     hdr->magic = 0;
 }
 
-EcsPoly* _ecs_poly_bind(
+EcsPoly* ecs_poly_bind_(
     ecs_world_t *world,
     ecs_entity_t entity,
     ecs_entity_t tag)
@@ -159,7 +159,7 @@ EcsPoly* _ecs_poly_bind(
     return result;
 }
 
-void _ecs_poly_modified(
+void ecs_poly_modified_(
     ecs_world_t *world,
     ecs_entity_t entity,
     ecs_entity_t tag)
@@ -167,7 +167,7 @@ void _ecs_poly_modified(
     ecs_modified_pair(world, entity, ecs_id(EcsPoly), tag);
 }
 
-const EcsPoly* _ecs_poly_bind_get(
+const EcsPoly* ecs_poly_bind_get_(
     const ecs_world_t *world,
     ecs_entity_t entity,
     ecs_entity_t tag)
@@ -175,12 +175,12 @@ const EcsPoly* _ecs_poly_bind_get(
     return ecs_get_pair(world, entity, EcsPoly, tag);
 }
 
-ecs_poly_t* _ecs_poly_get(
+ecs_poly_t* ecs_poly_get_(
     const ecs_world_t *world,
     ecs_entity_t entity,
     ecs_entity_t tag)
 {
-    const EcsPoly *p = _ecs_poly_bind_get(world, entity, tag);
+    const EcsPoly *p = ecs_poly_bind_get_(world, entity, tag);
     if (p) {
         return p->poly;
     }
@@ -188,11 +188,11 @@ ecs_poly_t* _ecs_poly_get(
 }
 
 #define assert_object(cond, file, line, type_name)\
-    _ecs_assert((cond), ECS_INVALID_PARAMETER, #cond, file, line, type_name);\
+    ecs_assert_((cond), ECS_INVALID_PARAMETER, #cond, file, line, type_name);\
     assert(cond)
 
 #ifndef FLECS_NDEBUG
-void* _ecs_poly_assert(
+void* ecs_poly_assert_(
     const ecs_poly_t *poly,
     int32_t type,
     const char *file,
@@ -204,11 +204,11 @@ void* _ecs_poly_assert(
     const char *type_name = hdr->mixins->type_name;
     assert_object(hdr->magic == ECS_OBJECT_MAGIC, file, line, type_name);
     assert_object(hdr->type == type, file, line, type_name);
-    return (ecs_poly_t*)poly;
+    return ECS_CONST_CAST(ecs_poly_t*, poly);
 }
 #endif
 
-bool _ecs_poly_is(
+bool ecs_poly_is_(
     const ecs_poly_t *poly,
     int32_t type)
 {
@@ -234,7 +234,7 @@ ecs_observable_t* ecs_get_observable(
 const ecs_world_t* ecs_get_world(
     const ecs_poly_t *poly)
 {
-    if (((ecs_header_t*)poly)->type == ecs_world_t_magic) {
+    if (((const ecs_header_t*)poly)->type == ecs_world_t_magic) {
         return poly;
     }
     return *(ecs_world_t**)assert_mixin(poly, EcsMixinWorld);

--- a/src/poly.h
+++ b/src/poly.h
@@ -9,22 +9,22 @@
 #include <stddef.h>
 
 /* Initialize poly */
-void* _ecs_poly_init(
+void* ecs_poly_init_(
     ecs_poly_t *object,
     int32_t kind,
     ecs_size_t size,
     ecs_mixins_t *mixins);
 
 #define ecs_poly_init(object, type)\
-    _ecs_poly_init(object, type##_magic, sizeof(type), &type##_mixins)
+    ecs_poly_init_(object, type##_magic, sizeof(type), &type##_mixins)
 
 /* Deinitialize object for specified type */
-void _ecs_poly_fini(
+void ecs_poly_fini_(
     ecs_poly_t *object,
     int32_t kind);
 
 #define ecs_poly_fini(object, type)\
-    _ecs_poly_fini(object, type##_magic)
+    ecs_poly_fini_(object, type##_magic)
 
 /* Utility functions for creating an object on the heap */
 #define ecs_poly_new(type)\
@@ -35,49 +35,49 @@ void _ecs_poly_fini(
     ecs_os_free(obj)
 
 /* Get or create poly component for an entity */
-EcsPoly* _ecs_poly_bind(
+EcsPoly* ecs_poly_bind_(
     ecs_world_t *world,
     ecs_entity_t entity,
     ecs_entity_t tag);
 
 #define ecs_poly_bind(world, entity, T) \
-    _ecs_poly_bind(world, entity, T##_tag)
+    ecs_poly_bind_(world, entity, T##_tag)
 
-void _ecs_poly_modified(
+void ecs_poly_modified_(
     ecs_world_t *world,
     ecs_entity_t entity,
     ecs_entity_t tag);
 
 #define ecs_poly_modified(world, entity, T) \
-    _ecs_poly_modified(world, entity, T##_tag)
+    ecs_poly_modified_(world, entity, T##_tag)
 
 /* Get poly component for an entity */
-const EcsPoly* _ecs_poly_bind_get(
+const EcsPoly* ecs_poly_bind_get_(
     const ecs_world_t *world,
     ecs_entity_t entity,
     ecs_entity_t tag);
 
 #define ecs_poly_bind_get(world, entity, T) \
-    _ecs_poly_bind_get(world, entity, T##_tag)
+    ecs_poly_bind_get_(world, entity, T##_tag)
 
-ecs_poly_t* _ecs_poly_get(
+ecs_poly_t* ecs_poly_get_(
     const ecs_world_t *world,
     ecs_entity_t entity,
     ecs_entity_t tag);
 
 #define ecs_poly_get(world, entity, T) \
-    ((T*)_ecs_poly_get(world, entity, T##_tag))
+    ((T*)ecs_poly_get_(world, entity, T##_tag))
 
 /* Utilities for testing/asserting an object type */
 #ifndef FLECS_NDEBUG
-void* _ecs_poly_assert(
+void* ecs_poly_assert_(
     const ecs_poly_t *object,
     int32_t type,
     const char *file,
     int32_t line);
 
 #define ecs_poly_assert(object, type)\
-    _ecs_poly_assert(object, type##_magic, __FILE__, __LINE__)
+    ecs_poly_assert_(object, type##_magic, __FILE__, __LINE__)
 
 #define ecs_poly(object, T) ((T*)ecs_poly_assert(object, T))
 #else

--- a/src/private_api.h
+++ b/src/private_api.h
@@ -38,7 +38,7 @@ void flecs_bootstrap(
     ecs_add_id(world, name, EcsFinal);\
     ecs_add_pair(world, name, EcsChildOf, ecs_get_scope(world));\
     ecs_set(world, name, EcsComponent, {.size = 0});\
-    ecs_set_name(world, name, (char*)&#name[ecs_os_strlen(world->info.name_prefix)]);\
+    ecs_set_name(world, name, (const char*)&#name[ecs_os_strlen(world->info.name_prefix)]);\
     ecs_set_symbol(world, name, #name)
 
 /* Bootstrap functions for other parts in the code */
@@ -187,7 +187,7 @@ void flecs_filter_apply_iter_flags(
 #define flecs_signed_ecs_size_t__ true
 #define flecs_signed_ecs_entity_t__ false
 
-uint64_t _flecs_ito(
+uint64_t flecs_ito_(
     size_t dst_size,
     bool dst_signed,
     bool lt_zero,
@@ -196,7 +196,7 @@ uint64_t _flecs_ito(
 
 #ifndef FLECS_NDEBUG
 #define flecs_ito(T, value)\
-    (T)_flecs_ito(\
+    (T)flecs_ito_(\
         sizeof(T),\
         flecs_signed_##T##__,\
         (value) < 0,\
@@ -204,7 +204,7 @@ uint64_t _flecs_ito(
         FLECS_CONVERSION_ERR(T, (value)))
 
 #define flecs_uto(T, value)\
-    (T)_flecs_ito(\
+    (T)flecs_ito_(\
         sizeof(T),\
         flecs_signed_##T##__,\
         false,\
@@ -295,14 +295,6 @@ uint64_t flecs_string_hash(
 void flecs_table_hashmap_init(
     ecs_world_t *world,
     ecs_hashmap_t *hm);
-
-#define assert_func(cond) _assert_func(cond, #cond, __FILE__, __LINE__, __func__)
-void _assert_func(
-    bool cond,
-    const char *cond_str,
-    const char *file,
-    int32_t line,
-    const char *func);
 
 void flecs_dump_backtrace(
     FILE *stream);

--- a/src/private_types.h
+++ b/src/private_types.h
@@ -182,22 +182,22 @@ typedef struct ecs_table__t {
  * entity has a set of components not previously observed before. When a new
  * table is created, it is automatically matched with existing queries */
 struct ecs_table_t {
-    uint64_t id;                     /* Table id in sparse set */
-    ecs_flags32_t flags;             /* Flags for testing table properties */
-    uint16_t storage_count;          /* Number of components (excluding tags) */
-    ecs_type_t type;                 /* Identifies table type in type_index */
+    uint64_t id;                       /* Table id in sparse set */
+    ecs_flags32_t flags;               /* Flags for testing table properties */
+    uint16_t storage_count;            /* Number of components (excluding tags) */
+    ecs_type_t type;                   /* Identifies table type in type_index */
 
-    ecs_graph_node_t node;           /* Graph node */
-    ecs_data_t data;                 /* Component storage */
-    ecs_type_info_t **type_info;     /* Cached type info */
-    int32_t *dirty_state;            /* Keep track of changes in columns */
+    ecs_graph_node_t node;             /* Graph node */
+    ecs_data_t data;                   /* Component storage */
+    const ecs_type_info_t **type_info; /* Cached type info */
+    int32_t *dirty_state;              /* Keep track of changes in columns */
 
-    ecs_table_t *storage_table;      /* Table without tags */
-    ecs_id_t *storage_ids;           /* Component ids (prevent indirection) */
-    int32_t *storage_map;            /* Map type <-> data type
-                                      *  - 0..count(T):        type -> data_type
-                                      *  - count(T)..count(S): data_type -> type
-                                      */
+    ecs_table_t *storage_table;        /* Table without tags */
+    ecs_id_t *storage_ids;             /* Component ids (prevent indirection) */
+    int32_t *storage_map;              /* Map type <-> data type
+                                        *  - 0..count(T):        type -> data_type
+                                        *  - count(T)..count(S): data_type -> type
+                                        */
 
     ecs_table__t *_;                 /* Infrequently accessed table metadata */
 };
@@ -508,7 +508,7 @@ struct ecs_stage_t {
     ecs_entity_t scope;              /* Entity of current scope */
     ecs_entity_t with;               /* Id to add by default to new entities */
     ecs_entity_t base;               /* Currently instantiated top-level base */
-    ecs_entity_t *lookup_path;       /* Search path used by lookup operations */
+    const ecs_entity_t *lookup_path; /* Search path used by lookup operations */
 
     /* Properties */
     bool auto_merge;                 /* Should this stage automatically merge? */

--- a/src/query.c
+++ b/src/query.c
@@ -1017,7 +1017,7 @@ void flecs_query_sort_table(
     void *ptr = NULL;
     int32_t size = 0;
     if (column_index != -1) {
-        ecs_type_info_t *ti = table->type_info[column_index];
+        const ecs_type_info_t *ti = table->type_info[column_index];
         ecs_vec_t *column = &data->columns[column_index];
         size = ti->size;
         ptr = ecs_vec_first(column);
@@ -1790,10 +1790,10 @@ void flecs_query_iter_init(
     ecs_poly_assert(poly, ecs_query_t);
 
     if (filter) {
-        iter[1] = ecs_query_iter(world, (ecs_query_t*)poly);
+        iter[1] = ecs_query_iter(world, ECS_CONST_CAST(ecs_query_t*, poly));
         iter[0] = ecs_term_chain_iter(&iter[1], filter);
     } else {
-        iter[0] = ecs_query_iter(world, (ecs_query_t*)poly);
+        iter[0] = ecs_query_iter(world, ECS_CONST_CAST(ecs_query_t*, poly));
     }
 }
 
@@ -2168,7 +2168,7 @@ ecs_iter_t ecs_query_iter(
 
     ecs_iter_t result = {
         .real_world = world,
-        .world = (ecs_world_t*)stage,
+        .world = ECS_CONST_CAST(ecs_world_t*, stage),
         .terms = query->filter.terms,
         .field_count = query->filter.field_count,
         .table_count = table_count,
@@ -2183,8 +2183,8 @@ ecs_iter_t ecs_query_iter(
     if (!(query->flags & EcsQueryTrivialIter)) {
         /* Check if non-This terms (like singleton terms) still match */
         if (!(filter->flags & EcsFilterMatchOnlyThis)) {
-            fit = flecs_filter_iter_w_flags(
-                (ecs_world_t*)stage, &query->filter, EcsIterIgnoreThis);
+            fit = flecs_filter_iter_w_flags(ECS_CONST_CAST(ecs_world_t*, stage),
+                &query->filter, EcsIterIgnoreThis);
             if (!ecs_filter_next(&fit)) {
                 /* No match, so return nothing */
                 ecs_iter_fini(&fit);

--- a/src/search.c
+++ b/src/search.c
@@ -332,7 +332,7 @@ int32_t flecs_relation_depth_walk(
 {
     int32_t result = 0;
 
-    const ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
+    ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
     if (!tr) {
         return 0;
     }

--- a/src/stage.c
+++ b/src/stage.c
@@ -416,7 +416,7 @@ void* flecs_defer_set(
         ecs_record_t *r = flecs_entities_get(world, entity);
         table = r->table;
         if (r && table && (storage_table = table->storage_table)) {
-            const ecs_table_record_t *tr = flecs_id_record_get_table(
+            ecs_table_record_t *tr = flecs_id_record_get_table(
                 idr, storage_table);
             if (tr) {
                 /* Entity has the component */
@@ -610,7 +610,7 @@ void ecs_set_stage_count(
         ECS_INTERNAL_ERROR, NULL);
 
     bool auto_merge = true;
-    ecs_entity_t *lookup_path = NULL;
+    const ecs_entity_t *lookup_path = NULL;
     ecs_entity_t scope = 0;
     ecs_entity_t with = 0;
     if (world->stage_count >= 1) {
@@ -682,7 +682,7 @@ int32_t ecs_get_stage_id(
     ecs_check(world != NULL, ECS_INVALID_PARAMETER, NULL);
 
     if (ecs_poly_is(world, ecs_stage_t)) {
-        ecs_stage_t *stage = (ecs_stage_t*)world;
+        ecs_stage_t *stage = ECS_CONST_CAST(ecs_stage_t*, world);
 
         /* Index 0 is reserved for main stage */
         return stage->id;
@@ -803,7 +803,7 @@ bool ecs_stage_is_readonly(
     const ecs_world_t *world = ecs_get_world(stage);
 
     if (ecs_poly_is(stage, ecs_stage_t)) {
-        if (((ecs_stage_t*)stage)->async) {
+        if (((const ecs_stage_t*)stage)->async) {
             return false;
         }
     }

--- a/src/table_cache.c
+++ b/src/table_cache.c
@@ -114,7 +114,7 @@ void ecs_table_cache_insert(
     }
 
     result->cache = cache;
-    result->table = (ecs_table_t*)table;
+    result->table = ECS_CONST_CAST(ecs_table_t*, table);
     result->empty = empty;
 
     flecs_table_cache_list_insert(cache, result);
@@ -264,7 +264,7 @@ bool flecs_table_cache_all_iter(
     return out->next != NULL || out->next_list != NULL;
 }
 
-ecs_table_cache_hdr_t* _flecs_table_cache_next(
+ecs_table_cache_hdr_t* flecs_table_cache_next_(
     ecs_table_cache_iter_t *it)
 {
     ecs_table_cache_hdr_t *next = it->next;

--- a/src/table_cache.h
+++ b/src/table_cache.h
@@ -55,10 +55,10 @@ bool flecs_table_cache_all_iter(
     ecs_table_cache_t *cache,
     ecs_table_cache_iter_t *out);
 
-ecs_table_cache_hdr_t* _flecs_table_cache_next(
+ecs_table_cache_hdr_t* flecs_table_cache_next_(
     ecs_table_cache_iter_t *it);
 
 #define flecs_table_cache_next(it, T)\
-    (ECS_CAST(T*, _flecs_table_cache_next(it)))
+    (ECS_CAST(T*, flecs_table_cache_next_(it)))
 
 #endif

--- a/src/table_graph.c
+++ b/src/table_graph.c
@@ -772,7 +772,7 @@ void flecs_add_overrides_for_base(
     }
 
     if (flags & EcsTableHasIsA) {
-        const ecs_table_record_t *tr = flecs_id_record_get_table(
+        ecs_table_record_t *tr = flecs_id_record_get_table(
             world->idr_isa_wildcard, base_table);
         ecs_assert(tr != NULL, ECS_INTERNAL_ERROR, NULL);
         int32_t i = tr->column, end = i + tr->count;
@@ -799,7 +799,7 @@ void flecs_add_with_property(
         return;
     }
     
-    const ecs_table_record_t *tr = flecs_id_record_get_table(
+    ecs_table_record_t *tr = flecs_id_record_get_table(
         idr_with_wildcard, table);
     if (tr) {
         int32_t i = tr->column, end = i + tr->count;
@@ -848,7 +848,7 @@ ecs_table_t* flecs_find_table_with(
             return flecs_table_ensure(world, &dst_type, true, node);
         } else if (idr->flags & EcsIdExclusive) {
             /* Relationship is exclusive, check if table already has it */
-            const ecs_table_record_t *tr = flecs_id_record_get_table(idr, node);
+            ecs_table_record_t *tr = flecs_id_record_get_table(idr, node);
             if (tr) {
                 /* Table already has an instance of the relationship, create
                  * a new id sequence with the existing id replaced */
@@ -1214,7 +1214,7 @@ ecs_table_t* ecs_table_find(
     int32_t id_count)
 {
     ecs_type_t type = {
-        .array = (ecs_id_t*)ids,
+        .array = ECS_CONST_CAST(ecs_id_t*, ids),
         .count = id_count
     };
     return flecs_table_ensure(world, &type, false, NULL);

--- a/test/addons/src/RulesBasic.c
+++ b/test/addons/src/RulesBasic.c
@@ -1289,7 +1289,7 @@ void RulesBasic_1_this_src_w_component_pair_2_tables() {
     ecs_world_t *world = ecs_init();
 
     ECS_COMPONENT(world, Position);
-    ECS_TAG(world, TgtA)
+    ECS_TAG(world, TgtA);
     ECS_TAG(world, FragmentA);
     ECS_TAG(world, FragmentB);
 

--- a/test/addons/src/RulesTransitive.c
+++ b/test/addons/src/RulesTransitive.c
@@ -16,7 +16,7 @@ ECS_TAG_DECLARE(Amsterdam);
 static
 void populate_facts(ecs_world_t *world) {
     ECS_ENTITY_DEFINE(world, LocatedIn, Final, Transitive);
-    ECS_TAG_DEFINE(world, Location)
+    ECS_TAG_DEFINE(world, Location);
     ECS_ENTITY_DEFINE(world, Earth, Location);
     ECS_ENTITY_DEFINE(world, UnitedStates, Location, (LocatedIn, Earth));
     ECS_ENTITY_DEFINE(world, California, Location, (LocatedIn, UnitedStates));

--- a/test/api/src/Filter.c
+++ b/test/api/src/Filter.c
@@ -11466,7 +11466,7 @@ void Filter_oneof_w_mismatching_obj() {
     ECS_ENTITY(world, Rel, (OneOf, Parent));
     ECS_ENTITY(world, ObjA, (ChildOf, Parent));
     ECS_ENTITY(world, ObjB, (ChildOf, Parent));
-    ECS_TAG(world, ObjC)
+    ECS_TAG(world, ObjC);
 
     ecs_entity_t e1 = ecs_new_w_pair(world, Rel, ObjA);
     test_assert( ecs_has_pair(world, e1, Rel, ObjA));
@@ -11493,7 +11493,7 @@ void Filter_oneof_w_mismatching_obj_expr() {
     ECS_ENTITY(world, Rel, (OneOf, Parent));
     ECS_ENTITY(world, ObjA, (ChildOf, Parent));
     ECS_ENTITY(world, ObjB, (ChildOf, Parent));
-    ECS_TAG(world, ObjC)
+    ECS_TAG(world, ObjC);
 
     ecs_entity_t e1 = ecs_new_w_pair(world, Rel, ObjA);
     test_assert( ecs_has_pair(world, e1, Rel, ObjA));

--- a/test/api/src/Prefab.c
+++ b/test/api/src/Prefab.c
@@ -3576,7 +3576,7 @@ void Prefab_override_dont_inherit() {
 void Prefab_prefab_w_switch() {
     ecs_world_t *world = ecs_mini();
 
-    ECS_ENTITY(world, Movement, Union)
+    ECS_ENTITY(world, Movement, Union);
     ECS_TAG(world, Walking);
     ECS_TAG(world, Running);
 

--- a/test/cpp_api/src/main.cpp
+++ b/test/cpp_api/src/main.cpp
@@ -563,7 +563,6 @@ void Query_instanced_nested_query_w_world(void);
 void Query_captured_query(void);
 void Query_page_iter_captured_query(void);
 void Query_worker_iter_captured_query(void);
-void Query_iter_entities(void);
 
 // Testsuite 'QueryBuilder'
 void QueryBuilder_builder_assign_same_type(void);
@@ -3419,10 +3418,6 @@ bake_test_case Query_testcases[] = {
     {
         "worker_iter_captured_query",
         Query_worker_iter_captured_query
-    },
-    {
-        "iter_entities",
-        Query_iter_entities
     }
 };
 
@@ -6132,7 +6127,7 @@ static bake_test_suite suites[] = {
         "Query",
         NULL,
         NULL,
-        79,
+        78,
         Query_testcases
     },
     {

--- a/test/cpp_api/src/main.cpp
+++ b/test/cpp_api/src/main.cpp
@@ -563,6 +563,7 @@ void Query_instanced_nested_query_w_world(void);
 void Query_captured_query(void);
 void Query_page_iter_captured_query(void);
 void Query_worker_iter_captured_query(void);
+void Query_iter_entities(void);
 
 // Testsuite 'QueryBuilder'
 void QueryBuilder_builder_assign_same_type(void);
@@ -3418,6 +3419,10 @@ bake_test_case Query_testcases[] = {
     {
         "worker_iter_captured_query",
         Query_worker_iter_captured_query
+    },
+    {
+        "iter_entities",
+        Query_iter_entities
     }
 };
 
@@ -6127,7 +6132,7 @@ static bake_test_suite suites[] = {
         "Query",
         NULL,
         NULL,
-        78,
+        79,
         Query_testcases
     },
     {

--- a/test/custom_builds/c/pipeline/src/main.c
+++ b/test/custom_builds/c/pipeline/src/main.c
@@ -1,7 +1,7 @@
 #include <pipeline.h>
 
 typedef struct {
-    float x, y;
+    int32_t x, y;
 } Position, Velocity;
 
 void Move(ecs_iter_t *it) {

--- a/test/custom_builds/c/pipeline_w_system/src/main.c
+++ b/test/custom_builds/c/pipeline_w_system/src/main.c
@@ -1,7 +1,7 @@
 #include <pipeline_w_system.h>
 
 typedef struct {
-    float x, y;
+    int32_t x, y;
 } Position, Velocity;
 
 void Move(ecs_iter_t *it) {

--- a/test/custom_builds/c/system/src/main.c
+++ b/test/custom_builds/c/system/src/main.c
@@ -1,7 +1,7 @@
 #include <system.h>
 
 typedef struct {
-    float x, y;
+    int32_t x, y;
 } Position, Velocity;
 
 void Move(ecs_iter_t *it) {

--- a/test/custom_builds/c/timer/src/main.c
+++ b/test/custom_builds/c/timer/src/main.c
@@ -1,7 +1,7 @@
 #include <timer.h>
 
 typedef struct {
-    float x, y;
+    int32_t x, y;
 } Position, Velocity;
 
 void Move(ecs_iter_t *it) {

--- a/test/custom_builds/cpp/pipeline/src/main.cpp
+++ b/test/custom_builds/cpp/pipeline/src/main.cpp
@@ -2,11 +2,11 @@
 #include <iostream>
 
 struct Position { 
-    double x, y;
+    int32_t x, y;
 };
 
 struct Velocity { 
-    double x, y;
+    int32_t x, y;
 };
 
 int main(int, char *[]) {

--- a/test/custom_builds/cpp/system/src/main.cpp
+++ b/test/custom_builds/cpp/system/src/main.cpp
@@ -1,11 +1,11 @@
 #include <system.h>
 
 struct Position { 
-    double x, y;
+    int32_t x, y;
 };
 
 struct Velocity { 
-    double x, y;
+    int32_t x, y;
 };
 
 int main(int, char *[]) {

--- a/test/custom_builds/cpp/timer/src/main.cpp
+++ b/test/custom_builds/cpp/timer/src/main.cpp
@@ -2,11 +2,11 @@
 #include <iostream>
 
 struct Position { 
-    double x, y;
+    int32_t x, y;
 };
 
 struct Velocity { 
-    double x, y;
+    int32_t x, y;
 };
 
 int main(int, char *[]) {


### PR DESCRIPTION
This PR implements the following improvements and fixes:
- The code now compiles warning free with more clang/gcc warnings enabled, on Linux, macOS and Windows
- The code now compiles warning free with MSVC /W3
- Fixed incorrect threading abstraction in Windows OS API implementation
- Changed naming convention of id variables to prevent potential conflicts with reserved names
- Changed `ecs_term_id_t::name` to `const char*` which allows for warning-free assignments of string literals