### PR TITLE
Fix for temp iterator erroneously freeing returned iterator

### DIFF
--- a/src/iter.c
+++ b/src/iter.c
@@ -71,6 +71,27 @@ void flecs_iter_init(
     INIT_CACHE(it, stack, fields, ptrs, void*, it->field_count);
 }
 
+void flecs_iter_deinit(
+    ecs_iter_t* it)
+{
+    ecs_world_t* world = it->world;
+    if (!world) {
+        return;
+    }
+
+    FINI_CACHE(it, ids, ecs_id_t, it->field_count);
+    FINI_CACHE(it, sources, ecs_entity_t, it->field_count);
+    FINI_CACHE(it, match_indices, int32_t, it->field_count);
+    FINI_CACHE(it, columns, int32_t, it->field_count);
+    FINI_CACHE(it, variables, ecs_var_t, it->variable_count);
+    FINI_CACHE(it, ptrs, void*, it->field_count);
+    flecs_stack_free_t(it->priv.entity_iter, ecs_entity_filter_iter_t);
+
+    ecs_stage_t* stage = flecs_stage_from_world(&world);
+    flecs_stack_restore_cursor(&stage->allocators.iter_stack,
+        &it->priv.cache.stack_cursor);
+}
+
 void flecs_iter_validate(
     ecs_iter_t *it)
 {
@@ -96,22 +117,7 @@ void ecs_iter_fini(
         it->fini(it);
     }
 
-    ecs_world_t *world = it->world;
-    if (!world) {
-        return;
-    }
-
-    FINI_CACHE(it, ids, ecs_id_t, it->field_count);
-    FINI_CACHE(it, sources, ecs_entity_t, it->field_count);
-    FINI_CACHE(it, match_indices, int32_t, it->field_count);
-    FINI_CACHE(it, columns, int32_t, it->field_count);
-    FINI_CACHE(it, variables, ecs_var_t, it->variable_count);
-    FINI_CACHE(it, ptrs, void*, it->field_count);
-    flecs_stack_free_t(it->priv.entity_iter, ecs_entity_filter_iter_t);
-
-    ecs_stage_t *stage = flecs_stage_from_world(&world);
-    flecs_stack_restore_cursor(&stage->allocators.iter_stack, 
-        &it->priv.cache.stack_cursor);
+    flecs_iter_deinit(it);
 }
 
 static

--- a/src/iter.h
+++ b/src/iter.h
@@ -11,6 +11,9 @@ void flecs_iter_init(
     ecs_iter_t *it,
     ecs_flags8_t fields);
 
+void flecs_iter_deinit(
+    ecs_iter_t* it);
+
 void flecs_iter_validate(
     ecs_iter_t *it);
 

--- a/src/query.c
+++ b/src/query.c
@@ -2227,6 +2227,8 @@ ecs_iter_t ecs_query_iter(
     ecs_filter_t *filter = &query->filter;
     ecs_iter_t fit;
     if (!(query->flags & EcsQueryTrivialIter)) {
+        flecs_iter_init(stage, &result, flecs_iter_cache_all);
+
         /* Check if non-This terms (like singleton terms) still match */
         if (!(filter->flags & EcsFilterMatchOnlyThis)) {
             fit = flecs_filter_iter_w_flags(ECS_CONST_CAST(ecs_world_t*, stage),
@@ -2234,11 +2236,10 @@ ecs_iter_t ecs_query_iter(
             if (!ecs_filter_next(&fit)) {
                 /* No match, so return nothing */
                 ecs_iter_fini(&fit);
+                flecs_iter_deinit(&result);
                 goto noresults;
             }
         }
-
-        flecs_iter_init(stage, &result, flecs_iter_cache_all);
 
         /* Copy the data */
         if (!(filter->flags & EcsFilterMatchOnlyThis)) {

--- a/test/addons/src/SystemMisc.c
+++ b/test/addons/src/SystemMisc.c
@@ -977,6 +977,7 @@ void SystemMisc_rw_in_implicit_from_empty() {
     test_assert(ecs_query_next(&it) == true);
     test_assert(ecs_field_is_readonly(&it, 1) == false);
     test_assert(ecs_field_is_readonly(&it, 2) == true);
+    test_assert(ecs_query_next(&it) == false);
 
     ecs_fini(world);
 }
@@ -997,6 +998,7 @@ void SystemMisc_rw_in_implicit_from_entity() {
     test_assert(ecs_query_next(&it) == true);
     test_assert(ecs_field_is_readonly(&it, 1) == false);
     test_assert(ecs_field_is_readonly(&it, 2) == true);
+    test_assert(ecs_query_next(&it) == false);
 
     ecs_fini(world);
 }
@@ -1057,6 +1059,7 @@ void SystemMisc_rw_out_explicit_from_empty() {
     test_assert(ecs_query_next(&it) == true);
     test_assert(ecs_field_is_readonly(&it, 1) == false);
     test_assert(ecs_field_is_readonly(&it, 2) == false);
+    test_assert(ecs_query_next(&it) == false);
 
     ecs_fini(world);
 }
@@ -1077,6 +1080,7 @@ void SystemMisc_rw_out_explicit_from_entity() {
     test_assert(ecs_query_next(&it) == true);
     test_assert(ecs_field_is_readonly(&it, 1) == false);
     test_assert(ecs_field_is_readonly(&it, 2) == false);
+    test_assert(ecs_query_next(&it) == false);
 
     ecs_fini(world);
 }

--- a/test/api/src/Iter.c
+++ b/test/api/src/Iter.c
@@ -1228,6 +1228,7 @@ void Iter_worker_iter_w_singleton() {
     test_int(p[1].y, 50);
 
     test_bool(ecs_worker_next(&wit_2), false);
+    test_bool(ecs_worker_next(&wit_1), false);
 
     ecs_fini(world);
 }

--- a/test/api/src/Query.c
+++ b/test/api/src/Query.c
@@ -4735,6 +4735,7 @@ void Query_only_not_from_entity() {
     test_assert(ecs_query_next(&it));
     test_assert(ecs_field_src(&it, 1) == e);
     test_assert(ecs_field_id(&it, 1) == Tag);
+    test_assert(!ecs_query_next(&it));
 
     ecs_add(world, e, Tag);
 
@@ -4756,6 +4757,7 @@ void Query_only_not_from_singleton() {
     test_assert(ecs_query_next(&it));
     test_assert(ecs_field_src(&it, 1) == e);
     test_assert(ecs_field_id(&it, 1) == e);
+    test_assert(!ecs_query_next(&it));
 
     ecs_add_id(world, e, e);
 


### PR DESCRIPTION
This fixes the problem we were debugging in Discord. All tests now pass.

Turns out that there were iterators that were not being cleaned up because the test wasn't running the iterator to completion. But the memory leaks were being masked by the stack-allocator problem.

So fixing the problem caused the three tests to fail. Adding the additional `ecs_*_next()` calls fixed the tests.