### PR TITLE
Add world::get_info and remove unneeded functions

### DIFF
--- a/flecs.h
+++ b/flecs.h
@@ -19827,6 +19827,13 @@ struct world {
         ecs_run_post_frame(m_world, action, ctx);
     }
 
+    /** Get the world info.
+     * @see ecs_get_world_info
+     */
+    const flecs::world_info_t* get_info() const{
+        return ecs_get_world_info(m_world);
+    }
+
 /**
  * @file addons/cpp/mixins/id/mixin.inl
  * @brief Id world mixin.
@@ -20216,11 +20223,6 @@ void run_pipeline(const flecs::entity_t pip, ecs_ftime_t delta_time = 0.0) const
  */
 template <typename Pipeline, if_not_t< is_enum<Pipeline>::value > = 0>
 void run_pipeline(ecs_ftime_t delta_time = 0.0) const;
-
-/** Get the world info.
- * @see ecs_get_world_info
- */
-const flecs::world_info_t* get_info() const;
 
 /** Set timescale.
  * @see ecs_set_time_scale
@@ -28450,10 +28452,6 @@ inline void world::run_pipeline(const flecs::entity_t pip, ecs_ftime_t delta_tim
 template <typename Pipeline, if_not_t< is_enum<Pipeline>::value >>
 inline void world::run_pipeline(ecs_ftime_t delta_time) const {
     return ecs_run_pipeline(m_world, _::cpp_type<Pipeline>::id(m_world), delta_time);
-}
-
-const flecs::world_info_t* world::get_info() const {
-    return ecs_get_world_info(m_world);
 }
 
 inline void world::set_time_scale(ecs_ftime_t mul) const {

--- a/flecs.h
+++ b/flecs.h
@@ -19022,27 +19022,6 @@ struct world {
         return m_world;
     }
 
-    /** Get last delta_time.
-     */
-    ecs_ftime_t delta_time() const {
-        const ecs_world_info_t *stats = ecs_get_world_info(m_world);
-        return stats->delta_time;
-    }
-
-    /** Get current tick.
-     */
-    int64_t tick() const {
-        const ecs_world_info_t *stats = ecs_get_world_info(m_world);
-        return stats->frame_count_total;
-    }
-
-    /** Get current simulation time.
-     */
-    ecs_ftime_t time() const {
-        const ecs_world_info_t *stats = ecs_get_world_info(m_world);
-        return stats->world_time_total;
-    }
-
     /** Signal application should quit.
      * After calling this operation, the next call to progress() returns false.
      */
@@ -20238,30 +20217,20 @@ void run_pipeline(const flecs::entity_t pip, ecs_ftime_t delta_time = 0.0) const
 template <typename Pipeline, if_not_t< is_enum<Pipeline>::value > = 0>
 void run_pipeline(ecs_ftime_t delta_time = 0.0) const;
 
+/** Get the world info.
+ * @see ecs_get_world_info
+ */
+const flecs::world_info_t* get_info() const;
+
 /** Set timescale.
  * @see ecs_set_time_scale
  */
 void set_time_scale(ecs_ftime_t mul) const;
 
-/** Get timescale.
- * @see ecs_get_time_scale
- */
-ecs_ftime_t get_time_scale() const;
-
-/** Get tick.
- * @return Monotonically increasing frame count.
- */
-int64_t get_tick() const;
-
 /** Set target FPS.
  * @see ecs_set_target_fps
  */
 void set_target_fps(ecs_ftime_t target_fps) const;
-
-/** Get target FPS.
- * @return Configured frames per second.
- */
-ecs_ftime_t get_target_fps() const;
 
 /** Reset simulation clock.
  * @see ecs_reset_clock
@@ -28483,24 +28452,13 @@ inline void world::run_pipeline(ecs_ftime_t delta_time) const {
     return ecs_run_pipeline(m_world, _::cpp_type<Pipeline>::id(m_world), delta_time);
 }
 
+const flecs::world_info_t* world::get_info() const {
+    return ecs_get_world_info(m_world);
+}
+
 inline void world::set_time_scale(ecs_ftime_t mul) const {
     ecs_set_time_scale(m_world, mul);
-}  
-
-inline ecs_ftime_t world::get_time_scale() const {
-    const ecs_world_info_t *stats = ecs_get_world_info(m_world);
-    return stats->time_scale;
 }
-
-inline int64_t world::get_tick() const {
-    const ecs_world_info_t *stats = ecs_get_world_info(m_world);
-    return stats->frame_count_total;
-}
-
-inline ecs_ftime_t world::get_target_fps() const {
-    const ecs_world_info_t *stats = ecs_get_world_info(m_world);
-    return stats->target_fps;
-} 
 
 inline void world::set_target_fps(ecs_ftime_t target_fps) const {
     ecs_set_target_fps(m_world, target_fps);

--- a/include/flecs/addons/cpp/mixins/pipeline/impl.hpp
+++ b/include/flecs/addons/cpp/mixins/pipeline/impl.hpp
@@ -61,10 +61,6 @@ inline void world::run_pipeline(ecs_ftime_t delta_time) const {
     return ecs_run_pipeline(m_world, _::cpp_type<Pipeline>::id(m_world), delta_time);
 }
 
-const flecs::world_info_t* world::get_info() const {
-    return ecs_get_world_info(m_world);
-}
-
 inline void world::set_time_scale(ecs_ftime_t mul) const {
     ecs_set_time_scale(m_world, mul);
 }

--- a/include/flecs/addons/cpp/mixins/pipeline/impl.hpp
+++ b/include/flecs/addons/cpp/mixins/pipeline/impl.hpp
@@ -61,24 +61,13 @@ inline void world::run_pipeline(ecs_ftime_t delta_time) const {
     return ecs_run_pipeline(m_world, _::cpp_type<Pipeline>::id(m_world), delta_time);
 }
 
+const flecs::world_info_t* world::get_info() const {
+    return ecs_get_world_info(m_world);
+}
+
 inline void world::set_time_scale(ecs_ftime_t mul) const {
     ecs_set_time_scale(m_world, mul);
-}  
-
-inline ecs_ftime_t world::get_time_scale() const {
-    const ecs_world_info_t *stats = ecs_get_world_info(m_world);
-    return stats->time_scale;
 }
-
-inline int64_t world::get_tick() const {
-    const ecs_world_info_t *stats = ecs_get_world_info(m_world);
-    return stats->frame_count_total;
-}
-
-inline ecs_ftime_t world::get_target_fps() const {
-    const ecs_world_info_t *stats = ecs_get_world_info(m_world);
-    return stats->target_fps;
-} 
 
 inline void world::set_target_fps(ecs_ftime_t target_fps) const {
     ecs_set_target_fps(m_world, target_fps);

--- a/include/flecs/addons/cpp/mixins/pipeline/mixin.inl
+++ b/include/flecs/addons/cpp/mixins/pipeline/mixin.inl
@@ -55,11 +55,6 @@ void run_pipeline(const flecs::entity_t pip, ecs_ftime_t delta_time = 0.0) const
 template <typename Pipeline, if_not_t< is_enum<Pipeline>::value > = 0>
 void run_pipeline(ecs_ftime_t delta_time = 0.0) const;
 
-/** Get the world info.
- * @see ecs_get_world_info
- */
-const flecs::world_info_t* get_info() const;
-
 /** Set timescale.
  * @see ecs_set_time_scale
  */

--- a/include/flecs/addons/cpp/mixins/pipeline/mixin.inl
+++ b/include/flecs/addons/cpp/mixins/pipeline/mixin.inl
@@ -55,30 +55,20 @@ void run_pipeline(const flecs::entity_t pip, ecs_ftime_t delta_time = 0.0) const
 template <typename Pipeline, if_not_t< is_enum<Pipeline>::value > = 0>
 void run_pipeline(ecs_ftime_t delta_time = 0.0) const;
 
+/** Get the world info.
+ * @see ecs_get_world_info
+ */
+const flecs::world_info_t* get_info() const;
+
 /** Set timescale.
  * @see ecs_set_time_scale
  */
 void set_time_scale(ecs_ftime_t mul) const;
 
-/** Get timescale.
- * @see ecs_get_time_scale
- */
-ecs_ftime_t get_time_scale() const;
-
-/** Get tick.
- * @return Monotonically increasing frame count.
- */
-int64_t get_tick() const;
-
 /** Set target FPS.
  * @see ecs_set_target_fps
  */
 void set_target_fps(ecs_ftime_t target_fps) const;
-
-/** Get target FPS.
- * @return Configured frames per second.
- */
-ecs_ftime_t get_target_fps() const;
 
 /** Reset simulation clock.
  * @see ecs_reset_clock

--- a/include/flecs/addons/cpp/world.hpp
+++ b/include/flecs/addons/cpp/world.hpp
@@ -987,6 +987,13 @@ struct world {
         ecs_run_post_frame(m_world, action, ctx);
     }
 
+    /** Get the world info.
+     * @see ecs_get_world_info
+     */
+    const flecs::world_info_t* get_info() const{
+        return ecs_get_world_info(m_world);
+    }
+
 #   include "mixins/id/mixin.inl"
 #   include "mixins/component/mixin.inl"
 #   include "mixins/entity/mixin.inl"

--- a/include/flecs/addons/cpp/world.hpp
+++ b/include/flecs/addons/cpp/world.hpp
@@ -182,27 +182,6 @@ struct world {
         return m_world;
     }
 
-    /** Get last delta_time.
-     */
-    ecs_ftime_t delta_time() const {
-        const ecs_world_info_t *stats = ecs_get_world_info(m_world);
-        return stats->delta_time;
-    }
-
-    /** Get current tick.
-     */
-    int64_t tick() const {
-        const ecs_world_info_t *stats = ecs_get_world_info(m_world);
-        return stats->frame_count_total;
-    }
-
-    /** Get current simulation time.
-     */
-    ecs_ftime_t time() const {
-        const ecs_world_info_t *stats = ecs_get_world_info(m_world);
-        return stats->world_time_total;
-    }
-
     /** Signal application should quit.
      * After calling this operation, the next call to progress() returns false.
      */

--- a/test/cpp_api/src/Misc.cpp
+++ b/test/cpp_api/src/Misc.cpp
@@ -224,7 +224,7 @@ void Misc_app_run_target_fps() {
     int32_t count = 0;
     ecs.system().iter([&](flecs::iter& it) {
         count ++;
-        test_int(it.world().get_target_fps(), 10);
+        test_int(it.world().get_info()->target_fps, 10);
         it.world().quit();
     });
 

--- a/test/cpp_api/src/World.cpp
+++ b/test/cpp_api/src/World.cpp
@@ -1546,15 +1546,15 @@ void World_reset_all() {
 void World_get_tick() {
     flecs::world ecs;
 
-    test_int(ecs.tick(), 0);
+    test_int(ecs.get_info()->frame_count_total, 0);
 
     ecs.progress();
 
-    test_int(ecs.tick(), 1);
+    test_int(ecs.get_info()->frame_count_total, 1);
 
     ecs.progress();
 
-    test_int(ecs.tick(), 2);
+    test_int(ecs.get_info()->frame_count_total, 2);
 }
 
 struct Scope { };


### PR DESCRIPTION
**Changelog**
- Removes
  - `ecs_ftime_t flecs::world::delta_time() const`
  - `int64_t flecs::world::tick() const`
  - `int64_t flecs::world::get_tick() const`
  - `ecs_ftime_t flecs::world::time() const`
  - `ecs_ftime_t flecs::world::get_time_scale() const`
  - `ecs_ftime_t flecs::world::get_target_fps() const`
- Adds `const flecs::world_info_t* flecs::world::get_info() const` which all the above information can still be retrieved from.
