### PR TITLE
Add pointer-to-member member function overload

### DIFF
--- a/include/flecs/addons/cpp/mixins/meta/untyped_component.inl
+++ b/include/flecs/addons/cpp/mixins/meta/untyped_component.inl
@@ -10,25 +10,6 @@
  * @{
  */
 
-/** Add member. */
-untyped_component& member(flecs::entity_t type_id, const char *name, int32_t count = 0, size_t offset = 0) {
-    ecs_entity_desc_t desc = {};
-    desc.name = name;
-    desc.add[0] = ecs_pair(flecs::ChildOf, m_id);
-    ecs_entity_t eid = ecs_entity_init(m_world, &desc);
-    ecs_assert(eid != 0, ECS_INTERNAL_ERROR, NULL);
-
-    flecs::entity e(m_world, eid);
-
-    Member m = {};
-    m.type = type_id;
-    m.count = count;
-    m.offset = static_cast<int32_t>(offset);
-    e.set<Member>(m);
-
-    return *this;
-}
-
 /** Add member with unit. */
 untyped_component& member(flecs::entity_t type_id, flecs::entity_t unit, const char *name, int32_t count = 0, size_t offset = 0) {
     ecs_entity_desc_t desc = {};
@@ -47,6 +28,11 @@ untyped_component& member(flecs::entity_t type_id, flecs::entity_t unit, const c
     e.set<Member>(m);
 
     return *this;
+}
+
+/** Add member. */
+untyped_component& member(flecs::entity_t type_id, const char* name, int32_t count = 0, size_t offset = 0) {
+    return member(type_id, 0, name, count, offset);
 }
 
 /** Add member. */
@@ -69,6 +55,31 @@ untyped_component& member(const char *name, int32_t count = 0, size_t offset = 0
     flecs::entity_t type_id = _::cpp_type<MemberType>::id(m_world);
     flecs::entity_t unit_id = _::cpp_type<UnitType>::id(m_world);
     return member(type_id, unit_id, name, count, offset);
+}
+
+/** Add member using pointer-to-member. */
+template <typename MemberType, typename ComponentType, typename RealType = typename std::remove_extent<MemberType>::type>
+untyped_component& member(const char* name, const MemberType ComponentType::* ptr) {
+    flecs::entity_t type_id = _::cpp_type<RealType>::id(m_world);
+    size_t offset = reinterpret_cast<size_t>(&(static_cast<ComponentType*>(nullptr)->*ptr));
+    return member(type_id, name, std::extent<MemberType>::value, offset);
+}
+
+/** Add member with unit using pointer-to-member. */
+template <typename MemberType, typename ComponentType, typename RealType = typename std::remove_extent<MemberType>::type>
+untyped_component& member(flecs::entity_t unit, const char* name, const MemberType ComponentType::* ptr) {
+    flecs::entity_t type_id = _::cpp_type<RealType>::id(m_world);
+    size_t offset = reinterpret_cast<size_t>(&(static_cast<ComponentType*>(nullptr)->*ptr));
+    return member(type_id, unit, name, std::extent<MemberType>::value, offset);
+}
+
+/** Add member with unit using pointer-to-member. */
+template <typename UnitType, typename MemberType, typename ComponentType, typename RealType = typename std::remove_extent<MemberType>::type>
+untyped_component& member(const char* name, const MemberType ComponentType::* ptr) {
+    flecs::entity_t type_id = _::cpp_type<RealType>::id(m_world);
+    flecs::entity_t unit_id = _::cpp_type<UnitType>::id(m_world);
+    size_t offset = reinterpret_cast<size_t>(&(static_cast<ComponentType*>(nullptr)->*ptr));
+    return member(type_id, unit_id, name, std::extent<MemberType>::value, offset);
 }
 
 /** Add constant. */

--- a/include/flecs/addons/meta.h
+++ b/include/flecs/addons/meta.h
@@ -154,8 +154,6 @@ typedef struct EcsMetaType {
     ecs_type_kind_t kind;
     bool existing;         /**< Did the type exist or is it populated from reflection */
     bool partial;          /**< Is the reflection data a partial type description */
-    ecs_size_t size;       /**< Computed size */
-    ecs_size_t alignment;  /**< Computed alignment */
 } EcsMetaType;
 
 /** Primitive type kinds supported by meta addon */

--- a/src/addons/meta/meta.c
+++ b/src/addons/meta/meta.c
@@ -299,10 +299,6 @@ int flecs_init_type(
                 ecs_err("computed size for '%s' matches with actual type but "
                     "alignment is different (%d vs. %d)", ecs_get_name(world, type),
                         alignment, comp->alignment);
-            } else {
-                /* If this is an existing type, the alignment can be larger but
-                 * not smaller than the computed alignment. */
-                alignment = comp->alignment;
             }
         }
         
@@ -310,8 +306,6 @@ int flecs_init_type(
     }
 
     meta_type->kind = kind;
-    meta_type->size = size;
-    meta_type->alignment = alignment;
     ecs_modified(world, type, EcsMetaType);
 
     return 0;
@@ -457,7 +451,7 @@ int flecs_add_member_to_struct(
             /* Get component of member type to get its size & alignment */
             const EcsComponent *mbr_comp = ecs_get(world, elem->type, EcsComponent);
             if (!mbr_comp) {
-                char *path = ecs_get_fullpath(world, member);
+                char *path = ecs_get_fullpath(world, elem->type);
                 ecs_err("member '%s' is not a type", path);
                 ecs_os_free(path);
                 return -1;
@@ -467,7 +461,7 @@ int flecs_add_member_to_struct(
             ecs_size_t member_alignment = mbr_comp->alignment;
 
             if (!member_size || !member_alignment) {
-                char *path = ecs_get_fullpath(world, member);
+                char *path = ecs_get_fullpath(world, elem->type);
                 ecs_err("member '%s' has 0 size/alignment");
                 ecs_os_free(path);
                 return -1;
@@ -494,14 +488,42 @@ int flecs_add_member_to_struct(
         }
     } else {
         /* If members have explicit offsets, we can't rely on computed 
-         * size/alignment values. Grab size of just added member instead. It
-         * doesn't matter if the size doesn't correspond to the actual struct
-         * size. The flecs_init_type function compares computed size with actual
+         * size/alignment values. Calculate size as if this is the last member
+         * instead, since this will validate if the member fits in the struct.
+         * It doesn't matter if the size is smaller than the actual struct size
+         * because flecs_init_type function compares computed size with actual
          * (component) size to determine if the type is partial. */
-        const EcsComponent *cptr = ecs_get(world, m->type, EcsComponent);
-        ecs_assert(cptr != NULL, ECS_INTERNAL_ERROR, NULL);
-        size = cptr->size;
-        alignment = cptr->alignment;
+        ecs_member_t *elem = &members[i];
+
+        ecs_assert(elem->name != NULL, ECS_INTERNAL_ERROR, NULL);
+        ecs_assert(elem->type != 0, ECS_INTERNAL_ERROR, NULL);
+
+        /* Get component of member type to get its size & alignment */
+        const EcsComponent *mbr_comp = ecs_get(world, elem->type, EcsComponent);
+        if (!mbr_comp) {
+            char *path = ecs_get_fullpath(world, elem->type);
+            ecs_err("member '%s' is not a type", path);
+            ecs_os_free(path);
+            return -1;
+        }
+
+        ecs_size_t member_size = mbr_comp->size;
+        ecs_size_t member_alignment = mbr_comp->alignment;
+
+        if (!member_size || !member_alignment) {
+            char *path = ecs_get_fullpath(world, elem->type);
+            ecs_err("member '%s' has 0 size/alignment");
+            ecs_os_free(path);
+            return -1;
+        }
+
+        member_size *= elem->count;
+        elem->size = member_size;
+
+        size = elem->offset + member_size;
+
+        const EcsComponent* comp = ecs_get(world, type, EcsComponent);
+        alignment = comp->alignment;
     }
 
     if (size == 0) {

--- a/test/cpp_api/project.json
+++ b/test/cpp_api/project.json
@@ -1267,7 +1267,9 @@
                 "enum_w_bits",
                 "value_range",
                 "warning_range",
-                "error_range"
+                "error_range",
+                "struct_member_ptr",
+                "struct_member_ptr_packed_struct"
             ]
         }, {
             "id": "Table",

--- a/test/cpp_api/src/main.cpp
+++ b/test/cpp_api/src/main.cpp
@@ -1212,6 +1212,8 @@ void Meta_enum_w_bits(void);
 void Meta_value_range(void);
 void Meta_warning_range(void);
 void Meta_error_range(void);
+void Meta_struct_member_ptr(void);
+void Meta_struct_member_ptr_packed_struct(void);
 
 // Testsuite 'Table'
 void Table_each(void);
@@ -5936,6 +5938,14 @@ bake_test_case Meta_testcases[] = {
     {
         "error_range",
         Meta_error_range
+    },
+    {
+        "struct_member_ptr",
+        Meta_struct_member_ptr
+    },
+    {
+        "struct_member_ptr_packed_struct",
+        Meta_struct_member_ptr_packed_struct
     }
 };
 
@@ -6269,7 +6279,7 @@ static bake_test_suite suites[] = {
         "Meta",
         NULL,
         NULL,
-        45,
+        47,
         Meta_testcases
     },
     {

--- a/test/meta/include/meta.h
+++ b/test/meta/include/meta.h
@@ -55,6 +55,10 @@ typedef struct {
     Point start, stop;
 } Line;
 
+typedef struct {
+    int32_t x, y, z;
+} Vec3;
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/meta/src/StructTypes.c
+++ b/test/meta/src/StructTypes.c
@@ -402,7 +402,7 @@ void StructTypes_partial_type() {
 
     ecs_entity_t s = ecs_struct_init(world, &(ecs_struct_desc_t){
         .entity = ecs_id(Position),
-        .members = {{ .name = "x", .type = ecs_id(ecs_f32_t) }}
+        .members = {{ .name = "x", .type = ecs_id(ecs_i32_t) }}
     });
 
     test_assert(s == ecs_id(Position));
@@ -418,7 +418,7 @@ void StructTypes_partial_type() {
     test_bool(mptr->existing, true);
 
     meta_test_struct(world, s, Position);
-    meta_test_member(world, s, Position, x, ecs_id(ecs_f32_t), 1);
+    meta_test_member(world, s, Position, x, ecs_id(ecs_i32_t), 1);
 
     ecs_fini(world);
 }
@@ -426,31 +426,31 @@ void StructTypes_partial_type() {
 void StructTypes_partial_type_custom_offset() {
     ecs_world_t *world = ecs_init();
 
-    ECS_COMPONENT(world, Position);
+    ECS_COMPONENT(world, Vec3);
 
     ecs_entity_t s = ecs_struct_init(world, &(ecs_struct_desc_t){
-        .entity = ecs_id(Position),
+        .entity = ecs_id(Vec3),
         .members = {{ 
-            .name = "y", 
-            .type = ecs_id(ecs_f32_t), 
-            .offset = offsetof(Position, y) 
+            .name = "y",
+            .type = ecs_id(ecs_i32_t),
+            .offset = offsetof(Vec3, y)
         }}
     });
 
-    test_assert(s == ecs_id(Position));
+    test_assert(s == ecs_id(Vec3));
 
     const EcsComponent *cptr = ecs_get(world, s, EcsComponent);
     test_assert(cptr != NULL);
-    test_int(cptr->size, sizeof(Position));
-    test_int(cptr->alignment, ECS_ALIGNOF(Position));
+    test_int(cptr->size, sizeof(Vec3));
+    test_int(cptr->alignment, ECS_ALIGNOF(Vec3));
 
     const EcsMetaType *mptr = ecs_get(world, s, EcsMetaType);
     test_assert(mptr != NULL);
     test_bool(mptr->partial, true);
     test_bool(mptr->existing, true);
 
-    meta_test_struct(world, s, Position);
-    meta_test_member(world, s, Position, y, ecs_id(ecs_f32_t), 1);
+    meta_test_struct(world, s, Vec3);
+    meta_test_member(world, s, Vec3, y, ecs_id(ecs_i32_t), 1);
 
     ecs_fini(world);
 }
@@ -817,8 +817,6 @@ void StructTypes_struct_w_16_alignment() {
     test_assert(mptr != NULL);
     test_bool(mptr->partial, false);
     test_bool(mptr->existing, true);
-    test_int(mptr->size, sizeof(T));
-    test_int(mptr->alignment, 16);
 
     ecs_fini(world);
 }


### PR DESCRIPTION
## Changelog
- Added new pointer-to-member member function overload to `untyped_component`.
- Added support for packed structs in flecs meta.
- Removed unused `size` and `alignment` from `EcsMetaType`.
- Fixed bug where member count was ignored if an explicit offset was provided.

## Details
### Pointer-to-member Member Function
This new overload simplifies adding members with offsets and also helps ensure the offset is correct even if the structure changes or padding is inserted before/after fields, it also helps deal with offsets caused by inheritance with members or virtual functions.
<br/>

Using the example struct. I've included how this would usually be laid out in memory.
```cpp
struct SomeData {
        char a;      // (Size: 1, Align: 1, Offset: 0)
        int b;       // (Size: 4, Align: 4, Offset: 4)
        char pad[2]; // (Size: 2, Align: 1, Offset: 8)
        double c;    // (Size: 8, Align: 8, Offset: 16)
};                   // (Size: 24, Align: 8)
```

You can register the component with the padding included like this:
```cpp
ecs.component<SomeData>()
	.member<char>("a")
	.member<int>("b")
	.member<char>("pad", 2)
	.member<double>("c");
```

Or if you wanted to ignore the padding you would need to add the members with their offsets for every member.
```cpp
ecs.component<SomeData>()
	.member<char>("a", 0, offsetof(SomeData, a))
	.member<int>("b", 0, offsetof(SomeData, b))
	.member<double>("c", 0, offsetof(SomeData, c));
```

With this change, this becomes simplified to the following:
```cpp
ecs.component<SomeData>()
	.member("a", &SomeData::a)
	.member("b", &SomeData::b)
	.member("c", &SomeData::c);
```

The pointer-to-member overload also supports fixed-size arrays so you could register the padding like the following and it will be registered the same as doing `.member<char>("pad", 2, offsetof(SomeData, pad))`.
```cpp
ecs.component<SomeData>()
	.member("a", &SomeData::a)
	.member("b", &SomeData::b)
	.member("pad", &SomeData::pad)
	.member("c", &SomeData::c);
```

### Packed Structs
I've modified the case when an explicit offset is provided to use the `alignment` already stored in `EcsComponent` for the `EcsStruct`, this allows for the alignment of the struct to differ from the alignment of the members.

During this change I also noticed that the member count was being ignored in this case so I also updated the code to correctly calculate the size for `ecs_member_t`.
From this, I then calculate the expected minimum size of the struct using the member offset and the member size calculated by the size and count, this will now provide an error if a member is added with an offset and size that would exceed the size of the struct.

Because of this change, I had to adjust the test case `StructTypes_partial_type_custom_offset` because `partial` is set to true if the last member of the field is added with an offset because the expected size and actual size matches.

So with this change using the same example struct from before but this time packed. (Using MSVC)
```cpp
#pragma pack(push, 1)
struct SomeData {
        char a;      // (Size: 1, Align: 1, Offset: 0)
        int b;       // (Size: 4, Align: 4, Offset: 1)
        char pad[2]; // (Size: 2, Align: 1, Offset: 5)
        double c;    // (Size: 8, Align: 8, Offset: 7)
};                   // (Size: 15, Align: 1)
#pragma pack(pop)

ecs.component<SomeData>()
	.member("a", &SomeData::a)
	.member("b", &SomeData::b)
	.member("c", &SomeData::c);

flecs::entity_to_json_desc_t desc = {
	.serialize_path = true,
	.serialize_values = true,
};
auto str = ecs.entity("e1")
	.set<SomeData>({ '-', 1, {0}, 2.1 })
	.to_json(&desc);
printf("%s\n", str.c_str());
```
This produces the output:
```json
{"path":"e1", "ids":[["SomeData"]], "values":[{"a":"-", "b":1, "c":2.1}]}
```