### PR TITLE
Reduce complexity of table data structures

### DIFF
--- a/flecs.h
+++ b/flecs.h
@@ -7746,15 +7746,6 @@ int32_t ecs_table_get_depth(
     const ecs_table_t *table,
     ecs_entity_t rel);
 
-/** Get storage type for table.
- *
- * @param table The table.
- * @return The storage type of the table (components only).
- */
-FLECS_API
-ecs_table_t* ecs_table_get_storage_table(
-    const ecs_table_t *table);
-
 /** Convert index in table type to index in table storage type. */
 FLECS_API
 int32_t ecs_table_type_to_storage_index(

--- a/flecs.h
+++ b/flecs.h
@@ -25479,11 +25479,11 @@ struct table {
 
     /** Get pointer to component array by column index. 
      * 
-     * @param column_index The column index.
+     * @param index The column index.
      * @return Pointer to the column, NULL if not a component.
      */
-    virtual void* get_column(int32_t column_index) const {
-        return ecs_table_get_column(m_table, column_index, 0);
+    virtual void* get_column(int32_t index) const {
+        return ecs_table_get_column(m_table, index, 0);
     }
 
     /** Get pointer to component array by component.
@@ -25554,8 +25554,8 @@ struct table {
     }
 
     /** Get column size */
-    size_t column_size(int32_t column_index) {
-        return ecs_table_get_column_size(m_table, column_index);
+    size_t column_size(int32_t index) {
+        return ecs_table_get_column_size(m_table, index);
     }
 
     /** Get depth for given relationship.

--- a/flecs.h
+++ b/flecs.h
@@ -7653,6 +7653,7 @@ char* ecs_iter_str(
  */
 
 /** Get type for table.
+ * The table type is a vector that contains all component, tag and pair ids.
  *
  * @param table The table.
  * @return The type of the table.
@@ -7661,44 +7662,7 @@ FLECS_API
 const ecs_type_t* ecs_table_get_type(
     const ecs_table_t *table);
 
-/** Return number of columns in table. 
- * This is the same as ecs_table_get_type(table)->count, except that it excludes
- * tags, and only counts components in a table.
- * 
- * @param table The table.
- * @return The number of columns in the table.
- */
-FLECS_API
-int32_t ecs_table_column_count(
-    const ecs_table_t *table);
-
-/** Get column from table.
- * This operation returns the component array for the provided index.
- * 
- * @param table The table.
- * @param index The index of the column (corresponds with element in type).
- * @param offset The index of the first row to return (0 for entire column).
- * @return The component array, or NULL if the index is not a component.
- */
-FLECS_API
-void* ecs_table_get_column(
-    const ecs_table_t *table,
-    int32_t index,
-    int32_t offset);
-
-/** Get column size from table.
- * This operation returns the component size for the provided index.
- * 
- * @param table The table.
- * @param index The index of the column (corresponds with element in type).
- * @return The component size, or 0 if the index is not a component.
- */
-FLECS_API
-size_t ecs_table_get_column_size(
-    const ecs_table_t *table,
-    int32_t index);
-
-/** Get column index for id.
+/** Get type index for id.
  * This operation returns the index for an id in the table's type.
  * 
  * @param world The world.
@@ -7712,19 +7676,74 @@ int32_t ecs_table_get_type_index(
     const ecs_table_t *table,
     ecs_id_t id);
 
-/** Test if table has id.
- * Same as ecs_table_get_type_index(world, table, id) != -1.
+/** Get column index for id.
+ * This operation returns the column index for an id in the table's type. If the
+ * id is not a component, the function will return -1.
  * 
  * @param world The world.
  * @param table The table.
- * @param id The id.
- * @return True if the table has the id, false if the table doesn't.
+ * @param id The component id.
+ * @return The column index of the id, or -1 if not found/not a component.
  */
 FLECS_API
-bool ecs_table_has_id(
+int32_t ecs_table_get_column_index(
     const ecs_world_t *world,
     const ecs_table_t *table,
     ecs_id_t id);
+
+/** Return number of columns in table. 
+ * Similar to ecs_table_get_type(table)->count, except that the column count 
+ * only counts the number of components in a table.
+ * 
+ * @param table The table.
+ * @return The number of columns in the table.
+ */
+FLECS_API
+int32_t ecs_table_column_count(
+    const ecs_table_t *table);
+
+/** Convert type index to column index. 
+ * Tables have an array of columns for each component in the table. This array
+ * does not include elements for tags, which means that the index for a 
+ * component in the table type is not necessarily the same as the index in the
+ * column array. This operation converts from an index in the table type to an
+ * index in the column array.
+ * 
+ * @param table The table.
+ * @param index The index in the table type.
+ * @return The index in the table column array.
+ */
+FLECS_API
+int32_t ecs_table_type_to_column_index(
+    const ecs_table_t *table,
+    int32_t index);
+
+/** Convert column index to type index.
+ * Same as ecs_table_type_to_column_index, but converts from an index in the
+ * column array to an index in the table type.
+ * 
+ * @param table The table.
+ * @param index The column index.
+ * @return The index in the table type.
+ */
+FLECS_API
+int32_t ecs_table_column_to_type_index(
+    const ecs_table_t *table,
+    int32_t index);
+
+/** Get column from table by column index.
+ * This operation returns the component array for the provided index.
+ * 
+ * @param table The table.
+ * @param index The column index.
+ * @param offset The index of the first row to return (0 for entire column).
+ * @return The component array, or NULL if the index is not a component.
+ */
+FLECS_API
+void* ecs_table_get_column(
+    const ecs_table_t *table,
+    int32_t index,
+    int32_t offset);
 
 /** Get column from table by component id.
  * This operation returns the component array for the provided component  id.
@@ -7741,6 +7760,44 @@ void* ecs_table_get_id(
     ecs_id_t id,
     int32_t offset);
 
+/** Get column size from table.
+ * This operation returns the component size for the provided index.
+ * 
+ * @param table The table.
+ * @param index The column index.
+ * @return The component size, or 0 if the index is not a component.
+ */
+FLECS_API
+size_t ecs_table_get_column_size(
+    const ecs_table_t *table,
+    int32_t index);
+
+/** Returns the number of records in the table. 
+ * This operation returns the number of records that have been populated through
+ * the regular (entity) API as well as the number of records that have been
+ * inserted using the direct access API.
+ *
+ * @param table The table.
+ * @return The number of records in a table.
+ */
+FLECS_API
+int32_t ecs_table_count(
+    const ecs_table_t *table);
+
+/** Test if table has id.
+ * Same as ecs_table_get_type_index(world, table, id) != -1.
+ * 
+ * @param world The world.
+ * @param table The table.
+ * @param id The id.
+ * @return True if the table has the id, false if the table doesn't.
+ */
+FLECS_API
+bool ecs_table_has_id(
+    const ecs_world_t *world,
+    const ecs_table_t *table,
+    ecs_id_t id);
+
 /** Return depth for table in tree for relationship rel.
  * Depth is determined by counting the number of targets encountered while 
  * traversing up the relationship tree for rel. Only acyclic relationships are
@@ -7756,30 +7813,6 @@ int32_t ecs_table_get_depth(
     const ecs_world_t *world,
     const ecs_table_t *table,
     ecs_entity_t rel);
-
-/** Convert index in table type to index in table storage type. */
-FLECS_API
-int32_t ecs_table_type_to_column_index(
-    const ecs_table_t *table,
-    int32_t index);
-
-/** Convert index in table storage type to index in table type. */
-FLECS_API
-int32_t ecs_table_column_to_type_index(
-    const ecs_table_t *table,
-    int32_t index);
-
-/** Returns the number of records in the table. 
- * This operation returns the number of records that have been populated through
- * the regular (entity) API as well as the number of records that have been
- * inserted using the direct access API.
- *
- * @param table The table.
- * @return The number of records in a table.
- */
-FLECS_API
-int32_t ecs_table_count(
-    const ecs_table_t *table);
 
 /** Get table that has all components of current table plus the specified id.
  * If the provided table already has the provided id, the operation will return
@@ -7858,16 +7891,19 @@ void ecs_table_unlock(
     ecs_world_t *world,
     ecs_table_t *table);    
 
-/** Returns whether table is a module or contains module contents
- * Returns true for tables that have module contents. Can be used to filter out
- * tables that do not contain application data.
+/** Test table for flags.
+ * Test if table has all of the provided flags. See 
+ * include/flecs/private/api_flags.h for a list of table flags that can be used 
+ * with this function.
  *
  * @param table The table.
- * @return true if table contains module contents, false if not.
+ * @param flags The flags to test for.
+ * @return Whether the specified flags are set for the table.
  */
 FLECS_API
-bool ecs_table_has_module(
-    ecs_table_t *table);
+bool ecs_table_has_flags(
+    ecs_table_t *table,
+    ecs_flags32_t flags);
 
 /** Swaps two elements inside the table. This is useful for implementing custom
  * table sorting algorithms.
@@ -20860,11 +20896,6 @@ public:
 
     flecs::table_range range() const;
 
-    /** Is current type a module or does it contain module contents? */
-    bool has_module() const {
-        return ecs_table_has_module(m_iter->table);
-    }
-
     /** Access ctx. 
      * ctx contains the context pointer assigned to a system.
      */
@@ -23841,8 +23872,8 @@ struct entity_with_invoker_impl<arg_list<Args ...>> {
 
         /* Get column indices for components */
         ColumnArray columns ({
-            ecs_search_offset(real_world, table, 0, 
-                _::cpp_type<Args>().id(world), 0)...
+            ecs_table_get_column_index(real_world, table, 
+                _::cpp_type<Args>().id(world))...
         });
 
         /* Get pointers for columns for entity */
@@ -23851,8 +23882,6 @@ struct entity_with_invoker_impl<arg_list<Args ...>> {
             if (column == -1) {
                 return false;
             }
-
-            column = ecs_table_type_to_column_index(table, column);
 
             ptrs[i ++] = ecs_record_get_column(r, column, 0);
         }
@@ -25301,52 +25330,100 @@ struct table {
         return ecs_table_count(m_table);
     }
 
-    /** Find index for (component) id. 
+    /** Find type index for (component) id. 
      * 
      * @param id The (component) id.
      * @return The index of the id in the table type, -1 if not found/
      */
-    int32_t search(flecs::id_t id) const {
-        return ecs_search(m_world, m_table, id, 0);
+    int32_t type_index(flecs::id_t id) const {
+        return ecs_table_get_type_index(m_world, m_table, id);
     }
 
-    /** Find index for type. 
+    /** Find type index for type. 
      * 
      * @tparam T The type.
      * @return True if the table has the type, false if not.
      */
     template <typename T>
-    int32_t search() const {
-        return search(_::cpp_type<T>::id(m_world));
+    int32_t type_index() const {
+        return type_index(_::cpp_type<T>::id(m_world));
     }
 
-    /** Find index for pair. 
+    /** Find type index for pair. 
      * @param first First element of pair.
      * @param second Second element of pair.
      * @return True if the table has the pair, false if not.
      */
-    int32_t search(flecs::entity_t first, flecs::entity_t second) const {
-        return search(ecs_pair(first, second));
+    int32_t type_index(flecs::entity_t first, flecs::entity_t second) const {
+        return type_index(ecs_pair(first, second));
     }
 
-    /** Find index for pair. 
+    /** Find type index for pair. 
      * @tparam First First element of pair.
      * @param second Second element of pair.
      * @return True if the table has the pair, false if not.
      */
     template <typename First>
-    int32_t search(flecs::entity_t second) const {
-        return search(_::cpp_type<First>::id(m_world), second);
+    int32_t type_index(flecs::entity_t second) const {
+        return type_index(_::cpp_type<First>::id(m_world), second);
     }
 
-    /** Find index for pair. 
+    /** Find type index for pair. 
      * @tparam First First element of pair.
      * @tparam Second Second element of pair.
      * @return True if the table has the pair, false if not.
      */
     template <typename First, typename Second>
-    int32_t search() const {
-        return search<First>(_::cpp_type<Second>::id(m_world));
+    int32_t type_index() const {
+        return type_index<First>(_::cpp_type<Second>::id(m_world));
+    }
+
+    /** Find column index for (component) id. 
+     * 
+     * @param id The (component) id.
+     * @return The index of the id in the table type, -1 if not found/
+     */
+    int32_t column_index(flecs::id_t id) const {
+        return ecs_table_get_column_index(m_world, m_table, id);
+    }
+
+    /** Find column index for type. 
+     * 
+     * @tparam T The type.
+     * @return True if the table has the type, false if not.
+     */
+    template <typename T>
+    int32_t column_index() const {
+        return column_index(_::cpp_type<T>::id(m_world));
+    }
+
+    /** Find column index for pair. 
+     * @param first First element of pair.
+     * @param second Second element of pair.
+     * @return True if the table has the pair, false if not.
+     */
+    int32_t column_index(flecs::entity_t first, flecs::entity_t second) const {
+        return column_index(ecs_pair(first, second));
+    }
+
+    /** Find column index for pair. 
+     * @tparam First First element of pair.
+     * @param second Second element of pair.
+     * @return True if the table has the pair, false if not.
+     */
+    template <typename First>
+    int32_t column_index(flecs::entity_t second) const {
+        return column_index(_::cpp_type<First>::id(m_world), second);
+    }
+
+    /** Find column index for pair. 
+     * @tparam First First element of pair.
+     * @tparam Second Second element of pair.
+     * @return True if the table has the pair, false if not.
+     */
+    template <typename First, typename Second>
+    int32_t column_index() const {
+        return column_index<First>(_::cpp_type<Second>::id(m_world));
     }
 
     /** Test if table has (component) id. 
@@ -25355,7 +25432,7 @@ struct table {
      * @return True if the table has the id, false if not.
      */
     bool has(flecs::id_t id) const {
-        return search(id) != -1;
+        return type_index(id) != -1;
     }
 
     /** Test if table has the type. 
@@ -25365,7 +25442,7 @@ struct table {
      */
     template <typename T>
     bool has() const {
-        return search<T>() != -1;
+        return type_index<T>() != -1;
     }
 
     /** Test if table has the pair.
@@ -25375,7 +25452,7 @@ struct table {
      * @return True if the table has the pair, false if not.
      */
     bool has(flecs::entity_t first, flecs::entity_t second) const {
-        return search(first, second) != -1;
+        return type_index(first, second) != -1;
     }
 
     /** Test if table has the pair.
@@ -25386,7 +25463,7 @@ struct table {
      */
     template <typename First>
     bool has(flecs::entity_t second) const {
-        return search<First>(second) != -1;
+        return type_index<First>(second) != -1;
     }
 
     /** Test if table has the pair.
@@ -25397,16 +25474,16 @@ struct table {
      */
     template <typename First, typename Second>
     bool has() const {
-        return search<First, Second>() != -1;
+        return type_index<First, Second>() != -1;
     }
 
     /** Get pointer to component array by column index. 
      * 
-     * @param index The column index.
+     * @param column_index The column index.
      * @return Pointer to the column, NULL if not a component.
      */
-    virtual void* get_by_index(int32_t index) const {
-        return ecs_table_get_column(m_table, index, 0);
+    virtual void* get_column(int32_t column_index) const {
+        return ecs_table_get_column(m_table, column_index, 0);
     }
 
     /** Get pointer to component array by component.
@@ -25415,11 +25492,11 @@ struct table {
      * @return Pointer to the column, NULL if not found.
      */
     void* get(flecs::id_t id) const {
-        int32_t index = search(id);
+        int32_t index = column_index(id);
         if (index == -1) {
             return NULL;
         }
-        return get_by_index(index);
+        return get_column(index);
     }
 
     /** Get pointer to component array by pair.
@@ -25534,7 +25611,7 @@ struct table_range : table {
      * @param index The column index.
      * @return Pointer to the column, NULL if not a component.
      */
-    void* get_by_index(int32_t index) const override {
+    void* get_column(int32_t index) const override {
         return ecs_table_get_column(m_table, index, m_offset);
     }
 

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -4958,15 +4958,6 @@ int32_t ecs_table_get_depth(
     const ecs_table_t *table,
     ecs_entity_t rel);
 
-/** Get storage type for table.
- *
- * @param table The table.
- * @return The storage type of the table (components only).
- */
-FLECS_API
-ecs_table_t* ecs_table_get_storage_table(
-    const ecs_table_t *table);
-
 /** Convert index in table type to index in table storage type. */
 FLECS_API
 int32_t ecs_table_type_to_storage_index(

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -4865,6 +4865,7 @@ char* ecs_iter_str(
  */
 
 /** Get type for table.
+ * The table type is a vector that contains all component, tag and pair ids.
  *
  * @param table The table.
  * @return The type of the table.
@@ -4873,7 +4874,61 @@ FLECS_API
 const ecs_type_t* ecs_table_get_type(
     const ecs_table_t *table);
 
-/** Get column from table.
+/** Get type index for id.
+ * This operation returns the index for an id in the table's type.
+ * 
+ * @param world The world.
+ * @param table The table.
+ * @param id The id.
+ * @return The index of the id in the table type, or -1 if not found.
+ */
+FLECS_API
+int32_t ecs_table_get_type_index(
+    const ecs_world_t *world,
+    const ecs_table_t *table,
+    ecs_id_t id);
+
+/** Return number of columns in table. 
+ * Similar to ecs_table_get_type(table)->count, except that the column count 
+ * only counts the number of components in a table.
+ * 
+ * @param table The table.
+ * @return The number of columns in the table.
+ */
+FLECS_API
+int32_t ecs_table_column_count(
+    const ecs_table_t *table);
+
+/** Convert type index to column index. 
+ * Tables have an array of columns for each component in the table. This array
+ * does not include elements for tags, which means that the index for a 
+ * component in the table type is not necessarily the same as the index in the
+ * column array. This operation converts from an index in the table type to an
+ * index in the column array.
+ * 
+ * @param table The table.
+ * @param index The index in the table type.
+ * @return The index in the table column array.
+ */
+FLECS_API
+int32_t ecs_table_type_to_column_index(
+    const ecs_table_t *table,
+    int32_t index);
+
+/** Convert column index to type index.
+ * Same as ecs_table_type_to_column_index, but converts from an index in the
+ * column array to an index in the table type.
+ * 
+ * @param table The table.
+ * @param index The index in the table column array.
+ * @return The index in the table type.
+ */
+FLECS_API
+int32_t ecs_table_column_to_type_index(
+    const ecs_table_t *table,
+    int32_t index);
+
+/** Get column from table by column index.
  * This operation returns the component array for the provided index.
  * 
  * @param table The table.
@@ -4886,46 +4941,6 @@ void* ecs_table_get_column(
     const ecs_table_t *table,
     int32_t index,
     int32_t offset);
-
-/** Get column size from table.
- * This operation returns the component size for the provided index.
- * 
- * @param table The table.
- * @param index The index of the column (corresponds with element in type).
- * @return The component size, or 0 if the index is not a component.
- */
-FLECS_API
-size_t ecs_table_get_column_size(
-    const ecs_table_t *table,
-    int32_t index);
-
-/** Get column index for id.
- * This operation returns the index for an id in the table's type.
- * 
- * @param world The world.
- * @param table The table.
- * @param id The id.
- * @return The index of the id in the table type, or -1 if not found.
- */
-FLECS_API
-int32_t ecs_table_get_index(
-    const ecs_world_t *world,
-    const ecs_table_t *table,
-    ecs_id_t id);
-
-/** Test if table has id.
- * Same as ecs_table_get_index(world, table, id) != -1.
- * 
- * @param world The world.
- * @param table The table.
- * @param id The id.
- * @return True if the table has the id, false if the table doesn't.
- */
-FLECS_API
-bool ecs_table_has_id(
-    const ecs_world_t *world,
-    const ecs_table_t *table,
-    ecs_id_t id);
 
 /** Get column from table by component id.
  * This operation returns the component array for the provided component  id.
@@ -4942,6 +4957,32 @@ void* ecs_table_get_id(
     ecs_id_t id,
     int32_t offset);
 
+/** Get column size from table.
+ * This operation returns the component size for the provided index.
+ * 
+ * @param table The table.
+ * @param index The index of the column (corresponds with element in type).
+ * @return The component size, or 0 if the index is not a component.
+ */
+FLECS_API
+size_t ecs_table_get_column_size(
+    const ecs_table_t *table,
+    int32_t index);
+
+/** Test if table has id.
+ * Same as ecs_table_get_type_index(world, table, id) != -1.
+ * 
+ * @param world The world.
+ * @param table The table.
+ * @param id The id.
+ * @return True if the table has the id, false if the table doesn't.
+ */
+FLECS_API
+bool ecs_table_has_id(
+    const ecs_world_t *world,
+    const ecs_table_t *table,
+    ecs_id_t id);
+
 /** Return depth for table in tree for relationship rel.
  * Depth is determined by counting the number of targets encountered while 
  * traversing up the relationship tree for rel. Only acyclic relationships are
@@ -4957,18 +4998,6 @@ int32_t ecs_table_get_depth(
     const ecs_world_t *world,
     const ecs_table_t *table,
     ecs_entity_t rel);
-
-/** Convert index in table type to index in table storage type. */
-FLECS_API
-int32_t ecs_table_type_to_storage_index(
-    const ecs_table_t *table,
-    int32_t index);
-
-/** Convert index in table storage type to index in table type. */
-FLECS_API
-int32_t ecs_table_storage_to_type_index(
-    const ecs_table_t *table,
-    int32_t index);
 
 /** Returns the number of records in the table. 
  * This operation returns the number of records that have been populated through

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -4888,6 +4888,21 @@ int32_t ecs_table_get_type_index(
     const ecs_table_t *table,
     ecs_id_t id);
 
+/** Get column index for id.
+ * This operation returns the column index for an id in the table's type. If the
+ * id is not a component, the function will return -1.
+ * 
+ * @param world The world.
+ * @param table The table.
+ * @param id The component id.
+ * @return The column index of the id, or -1 if not found/not a component.
+ */
+FLECS_API
+int32_t ecs_table_get_column_index(
+    const ecs_world_t *world,
+    const ecs_table_t *table,
+    ecs_id_t id);
+
 /** Return number of columns in table. 
  * Similar to ecs_table_get_type(table)->count, except that the column count 
  * only counts the number of components in a table.
@@ -4920,7 +4935,7 @@ int32_t ecs_table_type_to_column_index(
  * column array to an index in the table type.
  * 
  * @param table The table.
- * @param index The index in the table column array.
+ * @param index The column index.
  * @return The index in the table type.
  */
 FLECS_API
@@ -4932,7 +4947,7 @@ int32_t ecs_table_column_to_type_index(
  * This operation returns the component array for the provided index.
  * 
  * @param table The table.
- * @param index The index of the column (corresponds with element in type).
+ * @param index The column index.
  * @param offset The index of the first row to return (0 for entire column).
  * @return The component array, or NULL if the index is not a component.
  */
@@ -4961,13 +4976,25 @@ void* ecs_table_get_id(
  * This operation returns the component size for the provided index.
  * 
  * @param table The table.
- * @param index The index of the column (corresponds with element in type).
+ * @param index The column index.
  * @return The component size, or 0 if the index is not a component.
  */
 FLECS_API
 size_t ecs_table_get_column_size(
     const ecs_table_t *table,
     int32_t index);
+
+/** Returns the number of records in the table. 
+ * This operation returns the number of records that have been populated through
+ * the regular (entity) API as well as the number of records that have been
+ * inserted using the direct access API.
+ *
+ * @param table The table.
+ * @return The number of records in a table.
+ */
+FLECS_API
+int32_t ecs_table_count(
+    const ecs_table_t *table);
 
 /** Test if table has id.
  * Same as ecs_table_get_type_index(world, table, id) != -1.
@@ -4998,18 +5025,6 @@ int32_t ecs_table_get_depth(
     const ecs_world_t *world,
     const ecs_table_t *table,
     ecs_entity_t rel);
-
-/** Returns the number of records in the table. 
- * This operation returns the number of records that have been populated through
- * the regular (entity) API as well as the number of records that have been
- * inserted using the direct access API.
- *
- * @param table The table.
- * @return The number of records in a table.
- */
-FLECS_API
-int32_t ecs_table_count(
-    const ecs_table_t *table);
 
 /** Get table that has all components of current table plus the specified id.
  * If the provided table already has the provided id, the operation will return
@@ -5088,16 +5103,19 @@ void ecs_table_unlock(
     ecs_world_t *world,
     ecs_table_t *table);    
 
-/** Returns whether table is a module or contains module contents
- * Returns true for tables that have module contents. Can be used to filter out
- * tables that do not contain application data.
+/** Test table for flags.
+ * Test if table has all of the provided flags. See 
+ * include/flecs/private/api_flags.h for a list of table flags that can be used 
+ * with this function.
  *
  * @param table The table.
- * @return true if table contains module contents, false if not.
+ * @param flags The flags to test for.
+ * @return Whether the specified flags are set for the table.
  */
 FLECS_API
-bool ecs_table_has_module(
-    ecs_table_t *table);
+bool ecs_table_has_flags(
+    ecs_table_t *table,
+    ecs_flags32_t flags);
 
 /** Swaps two elements inside the table. This is useful for implementing custom
  * table sorting algorithms.

--- a/include/flecs/addons/cpp/invoker.hpp
+++ b/include/flecs/addons/cpp/invoker.hpp
@@ -460,8 +460,8 @@ struct entity_with_invoker_impl<arg_list<Args ...>> {
 
         /* Get column indices for components */
         ColumnArray columns ({
-            ecs_search_offset(real_world, table, 0, 
-                _::cpp_type<Args>().id(world), 0)...
+            ecs_table_get_column_index(real_world, table, 
+                _::cpp_type<Args>().id(world))...
         });
 
         /* Get pointers for columns for entity */
@@ -470,8 +470,6 @@ struct entity_with_invoker_impl<arg_list<Args ...>> {
             if (column == -1) {
                 return false;
             }
-
-            column = ecs_table_type_to_column_index(table, column);
 
             ptrs[i ++] = ecs_record_get_column(r, column, 0);
         }

--- a/include/flecs/addons/cpp/invoker.hpp
+++ b/include/flecs/addons/cpp/invoker.hpp
@@ -446,13 +446,12 @@ struct entity_with_invoker_impl<arg_list<Args ...>> {
         return true;
     }
 
-    static bool get_ptrs(world_t *world, const ecs_record_t *r, ecs_table_t *table,
+    static 
+    bool get_ptrs(world_t *world, const ecs_record_t *r, ecs_table_t *table,
         ArrayType& ptrs) 
     {
         ecs_assert(table != NULL, ECS_INTERNAL_ERROR, NULL);
-
-        ecs_table_t *storage_table = ecs_table_get_storage_table(table);
-        if (!storage_table) {
+        if (!ecs_table_column_count(table)) {
             return false;
         }
 
@@ -461,7 +460,7 @@ struct entity_with_invoker_impl<arg_list<Args ...>> {
 
         /* Get column indices for components */
         ColumnArray columns ({
-            ecs_search_offset(real_world, storage_table, 0, 
+            ecs_search_offset(real_world, table, 0, 
                 _::cpp_type<Args>().id(world), 0)...
         });
 
@@ -471,6 +470,8 @@ struct entity_with_invoker_impl<arg_list<Args ...>> {
             if (column == -1) {
                 return false;
             }
+
+            column = ecs_table_type_to_column_index(table, column);
 
             ptrs[i ++] = ecs_record_get_column(r, column, 0);
         }

--- a/include/flecs/addons/cpp/iter.hpp
+++ b/include/flecs/addons/cpp/iter.hpp
@@ -219,11 +219,6 @@ public:
 
     flecs::table_range range() const;
 
-    /** Is current type a module or does it contain module contents? */
-    bool has_module() const {
-        return ecs_table_has_module(m_iter->table);
-    }
-
     /** Access ctx. 
      * ctx contains the context pointer assigned to a system.
      */

--- a/include/flecs/addons/cpp/table.hpp
+++ b/include/flecs/addons/cpp/table.hpp
@@ -39,52 +39,100 @@ struct table {
         return ecs_table_count(m_table);
     }
 
-    /** Find index for (component) id. 
+    /** Find type index for (component) id. 
      * 
      * @param id The (component) id.
      * @return The index of the id in the table type, -1 if not found/
      */
-    int32_t search(flecs::id_t id) const {
-        return ecs_search(m_world, m_table, id, 0);
+    int32_t type_index(flecs::id_t id) const {
+        return ecs_table_get_type_index(m_world, m_table, id);
     }
 
-    /** Find index for type. 
+    /** Find type index for type. 
      * 
      * @tparam T The type.
      * @return True if the table has the type, false if not.
      */
     template <typename T>
-    int32_t search() const {
-        return search(_::cpp_type<T>::id(m_world));
+    int32_t type_index() const {
+        return type_index(_::cpp_type<T>::id(m_world));
     }
 
-    /** Find index for pair. 
+    /** Find type index for pair. 
      * @param first First element of pair.
      * @param second Second element of pair.
      * @return True if the table has the pair, false if not.
      */
-    int32_t search(flecs::entity_t first, flecs::entity_t second) const {
-        return search(ecs_pair(first, second));
+    int32_t type_index(flecs::entity_t first, flecs::entity_t second) const {
+        return type_index(ecs_pair(first, second));
     }
 
-    /** Find index for pair. 
+    /** Find type index for pair. 
      * @tparam First First element of pair.
      * @param second Second element of pair.
      * @return True if the table has the pair, false if not.
      */
     template <typename First>
-    int32_t search(flecs::entity_t second) const {
-        return search(_::cpp_type<First>::id(m_world), second);
+    int32_t type_index(flecs::entity_t second) const {
+        return type_index(_::cpp_type<First>::id(m_world), second);
     }
 
-    /** Find index for pair. 
+    /** Find type index for pair. 
      * @tparam First First element of pair.
      * @tparam Second Second element of pair.
      * @return True if the table has the pair, false if not.
      */
     template <typename First, typename Second>
-    int32_t search() const {
-        return search<First>(_::cpp_type<Second>::id(m_world));
+    int32_t type_index() const {
+        return type_index<First>(_::cpp_type<Second>::id(m_world));
+    }
+
+    /** Find column index for (component) id. 
+     * 
+     * @param id The (component) id.
+     * @return The index of the id in the table type, -1 if not found/
+     */
+    int32_t column_index(flecs::id_t id) const {
+        return ecs_table_get_column_index(m_world, m_table, id);
+    }
+
+    /** Find column index for type. 
+     * 
+     * @tparam T The type.
+     * @return True if the table has the type, false if not.
+     */
+    template <typename T>
+    int32_t column_index() const {
+        return column_index(_::cpp_type<T>::id(m_world));
+    }
+
+    /** Find column index for pair. 
+     * @param first First element of pair.
+     * @param second Second element of pair.
+     * @return True if the table has the pair, false if not.
+     */
+    int32_t column_index(flecs::entity_t first, flecs::entity_t second) const {
+        return column_index(ecs_pair(first, second));
+    }
+
+    /** Find column index for pair. 
+     * @tparam First First element of pair.
+     * @param second Second element of pair.
+     * @return True if the table has the pair, false if not.
+     */
+    template <typename First>
+    int32_t column_index(flecs::entity_t second) const {
+        return column_index(_::cpp_type<First>::id(m_world), second);
+    }
+
+    /** Find column index for pair. 
+     * @tparam First First element of pair.
+     * @tparam Second Second element of pair.
+     * @return True if the table has the pair, false if not.
+     */
+    template <typename First, typename Second>
+    int32_t column_index() const {
+        return column_index<First>(_::cpp_type<Second>::id(m_world));
     }
 
     /** Test if table has (component) id. 
@@ -93,7 +141,7 @@ struct table {
      * @return True if the table has the id, false if not.
      */
     bool has(flecs::id_t id) const {
-        return search(id) != -1;
+        return type_index(id) != -1;
     }
 
     /** Test if table has the type. 
@@ -103,7 +151,7 @@ struct table {
      */
     template <typename T>
     bool has() const {
-        return search<T>() != -1;
+        return type_index<T>() != -1;
     }
 
     /** Test if table has the pair.
@@ -113,7 +161,7 @@ struct table {
      * @return True if the table has the pair, false if not.
      */
     bool has(flecs::entity_t first, flecs::entity_t second) const {
-        return search(first, second) != -1;
+        return type_index(first, second) != -1;
     }
 
     /** Test if table has the pair.
@@ -124,7 +172,7 @@ struct table {
      */
     template <typename First>
     bool has(flecs::entity_t second) const {
-        return search<First>(second) != -1;
+        return type_index<First>(second) != -1;
     }
 
     /** Test if table has the pair.
@@ -135,16 +183,16 @@ struct table {
      */
     template <typename First, typename Second>
     bool has() const {
-        return search<First, Second>() != -1;
+        return type_index<First, Second>() != -1;
     }
 
     /** Get pointer to component array by column index. 
      * 
-     * @param index The column index.
+     * @param column_index The column index.
      * @return Pointer to the column, NULL if not a component.
      */
-    virtual void* get_by_index(int32_t index) const {
-        return ecs_table_get_column(m_table, index, 0);
+    virtual void* get_column(int32_t column_index) const {
+        return ecs_table_get_column(m_table, column_index, 0);
     }
 
     /** Get pointer to component array by component.
@@ -153,11 +201,11 @@ struct table {
      * @return Pointer to the column, NULL if not found.
      */
     void* get(flecs::id_t id) const {
-        int32_t index = search(id);
+        int32_t index = column_index(id);
         if (index == -1) {
             return NULL;
         }
-        return get_by_index(index);
+        return get_column(index);
     }
 
     /** Get pointer to component array by pair.
@@ -272,7 +320,7 @@ struct table_range : table {
      * @param index The column index.
      * @return Pointer to the column, NULL if not a component.
      */
-    void* get_by_index(int32_t index) const override {
+    void* get_column(int32_t index) const override {
         return ecs_table_get_column(m_table, index, m_offset);
     }
 

--- a/include/flecs/addons/cpp/table.hpp
+++ b/include/flecs/addons/cpp/table.hpp
@@ -188,11 +188,11 @@ struct table {
 
     /** Get pointer to component array by column index. 
      * 
-     * @param column_index The column index.
+     * @param index The column index.
      * @return Pointer to the column, NULL if not a component.
      */
-    virtual void* get_column(int32_t column_index) const {
-        return ecs_table_get_column(m_table, column_index, 0);
+    virtual void* get_column(int32_t index) const {
+        return ecs_table_get_column(m_table, index, 0);
     }
 
     /** Get pointer to component array by component.
@@ -263,8 +263,8 @@ struct table {
     }
 
     /** Get column size */
-    size_t column_size(int32_t column_index) {
-        return ecs_table_get_column_size(m_table, column_index);
+    size_t column_size(int32_t index) {
+        return ecs_table_get_column_size(m_table, index);
     }
 
     /** Get depth for given relationship.

--- a/src/addons/json/deserialize.c
+++ b/src/addons/json/deserialize.c
@@ -659,7 +659,7 @@ const char* flecs_json_parse_column(
     ecs_vec_t *records,
     const ecs_from_json_desc_t *desc)
 {
-    if (!table->storage_table) {
+    if (!table->storage_count) {
         ecs_parser_error(desc->name, desc->expr, json - desc->expr, 
             "table has no components");
         goto error;

--- a/src/addons/json/deserialize.c
+++ b/src/addons/json/deserialize.c
@@ -671,7 +671,7 @@ const char* flecs_json_parse_column(
         goto error;
     }
 
-    int32_t data_column = table->storage_map[index];
+    int32_t data_column = table->column_map[index];
     if (data_column == -1) {
         char *table_str = ecs_table_str(world, table);
         ecs_parser_error(desc->name, desc->expr, json - desc->expr, 

--- a/src/addons/json/deserialize.c
+++ b/src/addons/json/deserialize.c
@@ -659,7 +659,7 @@ const char* flecs_json_parse_column(
     ecs_vec_t *records,
     const ecs_from_json_desc_t *desc)
 {
-    if (!table->storage_count) {
+    if (!table->column_count) {
         ecs_parser_error(desc->name, desc->expr, json - desc->expr, 
             "table has no components");
         goto error;

--- a/src/addons/json/serialize.c
+++ b/src/addons/json/serialize.c
@@ -1839,7 +1839,7 @@ int flecs_json_serialize_iter_result_columns(
     ecs_strbuf_t *buf)
 {
     ecs_table_t *table = it->table;
-    if (!table || !table->storage_table) {
+    if (!table || !table->storage_count) {
         return 0;
     }
 

--- a/src/addons/json/serialize.c
+++ b/src/addons/json/serialize.c
@@ -1848,13 +1848,13 @@ int flecs_json_serialize_iter_result_columns(
     flecs_json_array_push(buf);
 
     ecs_type_t *type = &table->type;
-    int32_t *storage_map = table->storage_map;
-    ecs_assert(storage_map != NULL, ECS_INTERNAL_ERROR, NULL);
+    int32_t *column_map = table->column_map;
+    ecs_assert(column_map != NULL, ECS_INTERNAL_ERROR, NULL);
 
     for (int i = 0; i < type->count; i ++) {
         int32_t storage_column = -1;
-        if (storage_map) {
-            storage_column = storage_map[i];
+        if (column_map) {
+            storage_column = column_map[i];
         }
 
         ecs_strbuf_list_next(buf);

--- a/src/addons/json/serialize.c
+++ b/src/addons/json/serialize.c
@@ -1683,14 +1683,15 @@ void flecs_json_serialize_iter_result_entity_labels(
     }
 
 #ifdef FLECS_DOC
+    ecs_table_t *table = it->table;
     ecs_table_record_t *tr = flecs_id_record_get_table(
-        ser_idr->idr_doc_name, it->table);
+        ser_idr->idr_doc_name, table);
     if (tr == NULL) {
         return;
     }
 
     EcsDocDescription *labels = ecs_table_get_column(
-        it->table, tr->column, it->offset);
+        table, tr->storage, it->offset);
     ecs_assert(labels != NULL, ECS_INTERNAL_ERROR, NULL);
 
     flecs_json_memberl(buf, "entity_labels");
@@ -1731,7 +1732,7 @@ void flecs_json_serialize_iter_result_colors(
     }
 
     EcsDocDescription *colors = ecs_table_get_column(
-        it->table, tr->column, it->offset);
+        it->table, tr->storage, it->offset);
     ecs_assert(colors != NULL, ECS_INTERNAL_ERROR, NULL);
 
     flecs_json_memberl(buf, "colors");

--- a/src/addons/json/serialize.c
+++ b/src/addons/json/serialize.c
@@ -1839,7 +1839,7 @@ int flecs_json_serialize_iter_result_columns(
     ecs_strbuf_t *buf)
 {
     ecs_table_t *table = it->table;
-    if (!table || !table->storage_count) {
+    if (!table || !table->column_count) {
         return 0;
     }
 

--- a/src/addons/json/serialize.c
+++ b/src/addons/json/serialize.c
@@ -1863,7 +1863,7 @@ int flecs_json_serialize_iter_result_columns(
             continue;
         }
 
-        ecs_entity_t typeid = table->type_info[storage_column]->component;
+        ecs_entity_t typeid = table->data.columns[storage_column].ti->component;
         if (!typeid) {
             ecs_strbuf_appendch(buf, '0');
             continue;
@@ -1882,7 +1882,7 @@ int flecs_json_serialize_iter_result_columns(
             continue;
         }
 
-        void *ptr = ecs_vec_first(&table->data.columns[storage_column]);
+        void *ptr = ecs_vec_first(&table->data.columns[storage_column].data);
         if (array_to_json_buf_w_type_data(world, ptr, it->count, buf, comp, ser)) {
             return -1;
         }

--- a/src/addons/json/serialize.c
+++ b/src/addons/json/serialize.c
@@ -1630,7 +1630,7 @@ void flecs_json_serialize_iter_result_parent(
         return;
     }
 
-    ecs_id_t id = table->type.array[tr->column];
+    ecs_id_t id = table->type.array[tr->index];
     ecs_entity_t parent = ecs_pair_second(world, id);
     char *path = ecs_get_fullpath(world, parent);
     flecs_json_memberl(buf, "parent");
@@ -1691,7 +1691,7 @@ void flecs_json_serialize_iter_result_entity_labels(
     }
 
     EcsDocDescription *labels = ecs_table_get_column(
-        table, tr->storage, it->offset);
+        table, tr->column, it->offset);
     ecs_assert(labels != NULL, ECS_INTERNAL_ERROR, NULL);
 
     flecs_json_memberl(buf, "entity_labels");
@@ -1732,7 +1732,7 @@ void flecs_json_serialize_iter_result_colors(
     }
 
     EcsDocDescription *colors = ecs_table_get_column(
-        it->table, tr->storage, it->offset);
+        it->table, tr->column, it->offset);
     ecs_assert(colors != NULL, ECS_INTERNAL_ERROR, NULL);
 
     flecs_json_memberl(buf, "colors");

--- a/src/addons/metrics.c
+++ b/src/addons/metrics.c
@@ -327,7 +327,9 @@ static void UpdateCounterIdInstance(ecs_iter_t *it) {
 /** Update oneof metric */
 static void UpdateOneOfInstance(ecs_iter_t *it, bool counter) {
     ecs_world_t *world = it->real_world;
-    void *m = ecs_table_get_column(it->table, it->columns[0] - 1, it->offset);
+    ecs_table_t *table = it->table;
+    void *m = ecs_table_get_column(table, 
+        ecs_table_type_to_column_index(table, it->columns[0] - 1), it->offset);
     EcsMetricOneOfInstance *mi = ecs_field(it, EcsMetricOneOfInstance, 2);
     ecs_ftime_t dt = it->delta_time;
 

--- a/src/addons/metrics.c
+++ b/src/addons/metrics.c
@@ -336,21 +336,21 @@ static void UpdateOneOfInstance(ecs_iter_t *it, bool counter) {
     int32_t i, count = it->count;
     for (i = 0; i < count; i ++) {
         ecs_oneof_metric_ctx_t *ctx = mi[i].ctx;
-        ecs_table_t *table = mi[i].r->table;
+        ecs_table_t *mtable = mi[i].r->table;
 
         double *value = ECS_ELEM(m, ctx->size, i);
         if (!counter) {
             ecs_os_memset(value, 0, ctx->size);
         }
 
-        if (!table) {
+        if (!mtable) {
             ecs_delete(it->world, it->entities[i]);
             continue;
         }
 
         ecs_id_record_t *idr = ctx->idr;
         ecs_id_t id;
-        if (flecs_search_w_idr(world, table, idr->id, &id, idr) == -1) {
+        if (flecs_search_w_idr(world, mtable, idr->id, &id, idr) == -1) {
             ecs_delete(it->world, it->entities[i]);
             continue;
         }

--- a/src/addons/pipeline/pipeline.c
+++ b/src/addons/pipeline/pipeline.c
@@ -281,7 +281,7 @@ bool flecs_pipeline_build(
     /* Iterate systems in pipeline, add ops for running / merging */
     while (ecs_query_next(&it)) {
         EcsPoly *poly = flecs_pipeline_term_system(&it);
-        bool is_active = ecs_table_get_index(world, it.table, EcsEmpty) == -1;
+        bool is_active = ecs_table_get_type_index(world, it.table, EcsEmpty) == -1;
 
         int32_t i;
         for (i = 0; i < it.count; i ++) {

--- a/src/addons/pipeline/pipeline.c
+++ b/src/addons/pipeline/pipeline.c
@@ -241,8 +241,8 @@ static
 EcsPoly* flecs_pipeline_term_system(
     ecs_iter_t *it)
 {
-    int32_t index = ecs_search(it->real_world, it->table, 
-        ecs_poly_id(EcsSystem), 0);
+    int32_t index = ecs_table_get_column_index(
+        it->real_world, it->table, ecs_poly_id(EcsSystem));
     ecs_assert(index != -1, ECS_INTERNAL_ERROR, NULL);
     EcsPoly *poly = ecs_table_get_column(it->table, index, it->offset);
     ecs_assert(poly != NULL, ECS_INTERNAL_ERROR, NULL);

--- a/src/addons/rest.c
+++ b/src/addons/rest.c
@@ -840,12 +840,11 @@ void flecs_rest_reply_table_append_memory(
     allocated += table->data.records.size * ECS_SIZEOF(ecs_record_t*);
 
     int32_t i, storage_count = table->storage_count;
-    const ecs_type_info_t **ti = table->type_info;
-    ecs_vec_t *storages = table->data.columns;
+    ecs_column_t *columns = table->data.columns;
 
     for (i = 0; i < storage_count; i ++) {
-        used += storages[i].count * ti[i]->size;
-        allocated += storages[i].size * ti[i]->size;
+        used += columns[i].data.count * columns[i].ti->size;
+        allocated += columns[i].data.size * columns[i].ti->size;
     }
 
     ecs_strbuf_list_push(reply, "{", ",");

--- a/src/addons/rest.c
+++ b/src/addons/rest.c
@@ -868,7 +868,6 @@ void flecs_rest_reply_table_append(
     ecs_strbuf_list_append(reply, "\"count\":%d", ecs_table_count(table));
     ecs_strbuf_list_append(reply, "\"memory\":");
     flecs_rest_reply_table_append_memory(reply, table);
-    ecs_strbuf_list_append(reply, "\"refcount\":%d", table->_->refcount);
     ecs_strbuf_list_pop(reply, "}");
 }
 

--- a/src/addons/rest.c
+++ b/src/addons/rest.c
@@ -839,7 +839,7 @@ void flecs_rest_reply_table_append_memory(
     allocated += table->data.entities.size * ECS_SIZEOF(ecs_entity_t);
     allocated += table->data.records.size * ECS_SIZEOF(ecs_record_t*);
 
-    int32_t i, storage_count = table->storage_count;
+    int32_t i, storage_count = table->column_count;
     ecs_column_t *columns = table->data.columns;
 
     for (i = 0; i < storage_count; i ++) {

--- a/src/addons/rules/engine.c
+++ b/src/addons/rules/engine.c
@@ -1357,7 +1357,7 @@ bool flecs_rule_pred_match(
             return is_neq;
         }
         op_ctx->name_col = flecs_ito(int16_t, 
-            l.table->storage_map[op_ctx->name_col]);
+            l.table->column_map[op_ctx->name_col]);
         ecs_assert(op_ctx->name_col != -1, ECS_INTERNAL_ERROR, NULL);
     } else {
         if (op_ctx->name_col == -1) {

--- a/src/addons/rules/engine.c
+++ b/src/addons/rules/engine.c
@@ -1368,7 +1368,7 @@ bool flecs_rule_pred_match(
         l = op_ctx->range;
     }
 
-    const EcsIdentifier *names = l.table->data.columns[op_ctx->name_col].array;
+    const EcsIdentifier *names = l.table->data.columns[op_ctx->name_col].data.array;
     int32_t count = l.offset + l.count, offset = -1;
     for (; op_ctx->index < count; op_ctx->index ++) {
         const char *name = names[op_ctx->index].value;

--- a/src/addons/rules/engine.c
+++ b/src/addons/rules/engine.c
@@ -1351,7 +1351,7 @@ bool flecs_rule_pred_match(
         op_ctx->range = l;
         op_ctx->index = l.offset;
         op_ctx->name_col = flecs_ito(int16_t,   
-            ecs_table_get_index(ctx->world, l.table, 
+            ecs_table_get_type_index(ctx->world, l.table, 
                 ecs_pair(ecs_id(EcsIdentifier), EcsName)));
         if (op_ctx->name_col == -1) {
             return is_neq;

--- a/src/addons/rules/engine.c
+++ b/src/addons/rules/engine.c
@@ -403,7 +403,7 @@ bool flecs_rule_select_w_id(
             return false;
         }
 
-        op_ctx->column = flecs_ito(int16_t, tr->column);
+        op_ctx->column = flecs_ito(int16_t, tr->index);
         op_ctx->remaining = flecs_ito(int16_t, tr->count - 1);
         table = tr->hdr.table;
         flecs_rule_var_set_table(op, op->src.var, table, 0, 0, ctx);
@@ -461,7 +461,7 @@ bool flecs_rule_with(
             return false;
         }
 
-        op_ctx->column = flecs_ito(int16_t, tr->column);
+        op_ctx->column = flecs_ito(int16_t, tr->index);
         op_ctx->remaining = flecs_ito(int16_t, tr->count);
     } else {
         if (--op_ctx->remaining <= 0) {
@@ -524,7 +524,7 @@ bool flecs_rule_select_id(
 
     ecs_table_t *table = tr->hdr.table;
     flecs_rule_var_set_table(op, op->src.var, table, 0, 0, ctx);
-    flecs_rule_it_set_column(it, field, tr->column);
+    flecs_rule_it_set_column(it, field, tr->index);
     return true;
 }
 
@@ -562,7 +562,7 @@ bool flecs_rule_with_id(
         return false;
     }
 
-    flecs_rule_it_set_column(it, field, tr->column);
+    flecs_rule_it_set_column(it, field, tr->index);
     return true;
 }
 

--- a/src/addons/rules/trav_cache.c
+++ b/src/addons/rules/trav_cache.c
@@ -62,7 +62,7 @@ void flecs_rule_build_up_cache(
     int32_t root_column)
 {
     ecs_id_t *ids = table->type.array;
-    int32_t i = tr->column, end = i + tr->count;
+    int32_t i = tr->index, end = i + tr->count;
     bool is_root = root_column == -1;
 
     for (; i < end; i ++) {
@@ -139,7 +139,7 @@ void flecs_rule_get_up_cache(
         return;
     }
 
-    ecs_id_t id = table->type.array[tr->column];
+    ecs_id_t id = table->type.array[tr->index];
 
     if (cache->id != id || !cache->up) {
         ecs_vec_reset_t(a, &cache->entities, ecs_trav_elem_t);

--- a/src/addons/snapshot.c
+++ b/src/addons/snapshot.c
@@ -263,7 +263,14 @@ void restore_unfiltered(
 
         int32_t tcount = ecs_table_count(table);
         if (tcount) {
-            flecs_notify_on_set(world, table, 0, tcount, NULL, true);
+            int32_t j, storage_count = table->storage_count;
+            for (j = 0; j < storage_count; j ++) {
+                ecs_type_t type = {
+                    .array = &table->data.columns[j].id,
+                    .count = 1
+                };
+                flecs_notify_on_set(world, table, 0, tcount, &type, true);
+            }
         }
     }
 }
@@ -317,8 +324,15 @@ void restore_filtered(
 
         /* Run OnSet systems for merged entities */
         if (new_count) {
-            flecs_notify_on_set(
-                world, table, old_count, new_count, NULL, true);
+            int32_t j, storage_count = table->storage_count;
+            for (j = 0; j < storage_count; j ++) {
+                ecs_type_t type = {
+                    .array = &table->data.columns[j].id,
+                    .count = 1
+                };
+                flecs_notify_on_set(
+                    world, table, old_count, new_count, &type, true);
+            }
         }
 
         flecs_wfree_n(world, ecs_vec_t, table->storage_count,

--- a/src/addons/snapshot.c
+++ b/src/addons/snapshot.c
@@ -215,7 +215,7 @@ void restore_unfiltered(
             if (snapshot_table->data) {
                 flecs_table_replace_data(world, table, snapshot_table->data);
             }
-        
+
         /* If the world table still exists, replace its data */
         } else if (world_table && snapshot_table) {
             ecs_assert(snapshot_table->table == world_table, 
@@ -335,7 +335,7 @@ void restore_filtered(
             }
         }
 
-        flecs_wfree_n(world, ecs_vec_t, table->column_count,
+        flecs_wfree_n(world, ecs_column_t, table->column_count,
             snapshot_table->data->columns);
         ecs_os_free(snapshot_table->data);
         flecs_type_free(world, &snapshot_table->type);

--- a/src/addons/snapshot.c
+++ b/src/addons/snapshot.c
@@ -35,7 +35,7 @@ ecs_data_t* flecs_duplicate_data(
     }
 
     ecs_data_t *result = ecs_os_calloc_t(ecs_data_t);
-    int32_t i, column_count = table->storage_count;
+    int32_t i, column_count = table->column_count;
     result->columns = flecs_wdup_n(world, ecs_column_t, column_count, 
         main_data->columns);
 
@@ -263,7 +263,7 @@ void restore_unfiltered(
 
         int32_t tcount = ecs_table_count(table);
         if (tcount) {
-            int32_t j, storage_count = table->storage_count;
+            int32_t j, storage_count = table->column_count;
             for (j = 0; j < storage_count; j ++) {
                 ecs_type_t type = {
                     .array = &table->data.columns[j].id,
@@ -324,7 +324,7 @@ void restore_filtered(
 
         /* Run OnSet systems for merged entities */
         if (new_count) {
-            int32_t j, storage_count = table->storage_count;
+            int32_t j, storage_count = table->column_count;
             for (j = 0; j < storage_count; j ++) {
                 ecs_type_t type = {
                     .array = &table->data.columns[j].id,
@@ -335,7 +335,7 @@ void restore_filtered(
             }
         }
 
-        flecs_wfree_n(world, ecs_vec_t, table->storage_count,
+        flecs_wfree_n(world, ecs_vec_t, table->column_count,
             snapshot_table->data->columns);
         ecs_os_free(snapshot_table->data);
         flecs_type_free(world, &snapshot_table->type);

--- a/src/bootstrap.c
+++ b/src/bootstrap.c
@@ -478,7 +478,7 @@ void flecs_bootstrap_builtin(
 {
     ecs_assert(table != NULL, ECS_INTERNAL_ERROR, NULL);
 
-    ecs_vec_t *columns = table->data.columns;
+    ecs_column_t *columns = table->data.columns;
     ecs_assert(columns != NULL, ECS_INTERNAL_ERROR, NULL);
 
     ecs_record_t *record = flecs_entities_ensure(world, entity);
@@ -487,7 +487,7 @@ void flecs_bootstrap_builtin(
     int32_t index = flecs_table_append(world, table, entity, record, false, false);
     record->row = ECS_ROW_TO_RECORD(index, 0);
 
-    EcsComponent *component = ecs_vec_first(&columns[0]);
+    EcsComponent *component = ecs_vec_first(&columns[0].data);
     component[index].size = size;
     component[index].alignment = alignment;
 
@@ -495,7 +495,7 @@ void flecs_bootstrap_builtin(
     ecs_size_t symbol_length = ecs_os_strlen(symbol);
     ecs_size_t name_length = symbol_length - 3;
 
-    EcsIdentifier *name_col = ecs_vec_first(&columns[1]);
+    EcsIdentifier *name_col = ecs_vec_first(&columns[1].data);
     uint64_t name_hash = flecs_hash(name, name_length);
     name_col[index].value = ecs_os_strdup(name);
     name_col[index].length = name_length;
@@ -505,7 +505,7 @@ void flecs_bootstrap_builtin(
     flecs_name_index_ensure(
         table->_->name_index, entity, name, name_length, name_hash);
 
-    EcsIdentifier *symbol_col = ecs_vec_first(&columns[2]);
+    EcsIdentifier *symbol_col = ecs_vec_first(&columns[2].data);
     symbol_col[index].value = ecs_os_strdup(symbol);
     symbol_col[index].length = symbol_length;
     symbol_col[index].hash = flecs_hash(symbol, symbol_length);    
@@ -562,9 +562,9 @@ ecs_table_t* flecs_bootstrap_component_table(
     ecs_allocator_t *a = &world->allocator;
     ecs_vec_init_t(a, &data->entities, ecs_entity_t, EcsFirstUserComponentId);
     ecs_vec_init_t(a, &data->records, ecs_record_t*, EcsFirstUserComponentId);
-    ecs_vec_init_t(a, &data->columns[0], EcsComponent, EcsFirstUserComponentId);
-    ecs_vec_init_t(a, &data->columns[1], EcsIdentifier, EcsFirstUserComponentId);
-    ecs_vec_init_t(a, &data->columns[2], EcsIdentifier, EcsFirstUserComponentId);
+    ecs_vec_init_t(a, &data->columns[0].data, EcsComponent, EcsFirstUserComponentId);
+    ecs_vec_init_t(a, &data->columns[1].data, EcsIdentifier, EcsFirstUserComponentId);
+    ecs_vec_init_t(a, &data->columns[2].data, EcsIdentifier, EcsFirstUserComponentId);
     
     return result;
 }

--- a/src/datastructures/block_allocator.c
+++ b/src/datastructures/block_allocator.c
@@ -86,7 +86,8 @@ void flecs_ballocator_fini(
     ecs_assert(ba != NULL, ECS_INTERNAL_ERROR, NULL);
 
 #ifdef FLECS_SANITIZE
-    ecs_assert(ba->alloc_count == 0, ECS_LEAK_DETECTED, NULL);
+    ecs_assert(ba->alloc_count == 0, ECS_LEAK_DETECTED, 
+        "(size = %u)", (uint32_t)ba->data_size);
 #endif
 
     ecs_block_allocator_block_t *block;

--- a/src/entity.c
+++ b/src/entity.c
@@ -36,7 +36,7 @@ flecs_component_ptr_t flecs_get_component_w_index(
     int32_t column_index,
     int32_t row)
 {
-    ecs_check(column_index < table->storage_count, ECS_NOT_A_COMPONENT, NULL);
+    ecs_check(column_index < table->column_count, ECS_NOT_A_COMPONENT, NULL);
     ecs_column_t *column = &table->data.columns[column_index];
     return (flecs_component_ptr_t){
         .ti = column->ti,
@@ -323,7 +323,7 @@ void flecs_instantiate_children(
             childof_base_index = pos;
         }
 
-        int32_t storage_index = ecs_table_type_to_storage_index(child_table, i);
+        int32_t storage_index = ecs_table_type_to_column_index(child_table, i);
         if (storage_index != -1) {
             ecs_vec_t *column = &child_data->columns[storage_index].data;
             component_data[pos] = ecs_vec_first(column);
@@ -894,7 +894,7 @@ const ecs_entity_t* flecs_bulk_new(
             } 
         };
 
-        int32_t j, storage_count = table->storage_count;
+        int32_t j, storage_count = table->column_count;
         for (j = 0; j < storage_count; j ++) {
             ecs_type_t set_type = {
                 .array = &table->data.columns[j].id,
@@ -1014,7 +1014,7 @@ flecs_component_ptr_t flecs_get_mut(
     flecs_defer_begin(world, &world->stages[0]);
 
     ecs_assert(r->table != NULL, ECS_INTERNAL_ERROR, NULL);
-    ecs_assert(r->table->storage_count != 0, ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(r->table->column_count != 0, ECS_INTERNAL_ERROR, NULL);
     dst = flecs_get_component_ptr(
         world, r->table, ECS_RECORD_TO_ROW(r->row), id);
 error:
@@ -2677,7 +2677,7 @@ ecs_entity_t ecs_clone(
     if (copy_value) {
         flecs_table_move(world, dst, src, src_table,
             row, src_table, ECS_RECORD_TO_ROW(src_r->row), true);
-        int32_t i, count = src_table->storage_count;
+        int32_t i, count = src_table->column_count;
         for (i = 0; i < count; i ++) {
             ecs_type_t type = {
                 .array = &src_table->data.columns[i].id,
@@ -2966,7 +2966,7 @@ void* ecs_ref_get_id(
         ecs_assert(tr->hdr.table == r->table, ECS_INTERNAL_ERROR, NULL);
     }
 
-    int32_t column = ecs_table_type_to_storage_index(table, tr->column);
+    int32_t column = ecs_table_type_to_column_index(table, tr->column);
     ecs_assert(column != -1, ECS_INTERNAL_ERROR, NULL);
     return flecs_get_component_w_index(table, column, row).ptr;
 error:

--- a/src/entity.c
+++ b/src/entity.c
@@ -40,7 +40,7 @@ flecs_component_ptr_t flecs_get_component_w_index(
     ecs_column_t *column = &table->data.columns[column_index];
     return (flecs_component_ptr_t){
         .ti = column->ti,
-        .ptr = ecs_vec_get(&column->data, column->ti->size, row)
+        .ptr = ecs_vec_get(&column->data, column->size, row)
     };
 error:
     return (flecs_component_ptr_t){0};
@@ -879,7 +879,7 @@ const ecs_entity_t* flecs_bulk_new(
             int32_t index = tr->storage;
             ecs_column_t *column = &table->data.columns[index];
             ecs_type_info_t *ti = column->ti;
-            int32_t size = ti->size;
+            int32_t size = column->size;
             ecs_assert(size != 0, ECS_INTERNAL_ERROR, NULL);
             void *ptr = ecs_vec_get(&column->data, size, row);
 
@@ -1033,8 +1033,6 @@ void flecs_invoke_hook(
     ecs_entity_t event,
     ecs_iter_action_t hook)
 {
-    ecs_assert(ti->size != 0, ECS_INVALID_PARAMETER, NULL);
-
     ecs_iter_t it = { .field_count = 1};
     it.entities = entities;
     
@@ -1089,7 +1087,7 @@ void flecs_notify_on_set(
             ecs_iter_action_t on_set = ti->hooks.on_set;
             if (on_set) {
                 ecs_vec_t *c = &column->data;
-                void *ptr = ecs_vec_get(c, ti->size, row);
+                void *ptr = ecs_vec_get(c, column->size, row);
                 flecs_invoke_hook(world, table, count, row, entities, ptr, id, 
                     ti, EcsOnSet, on_set);
             }

--- a/src/entity.c
+++ b/src/entity.c
@@ -3217,7 +3217,7 @@ void ecs_enable_id(
     ecs_table_t *table = r->table;
     int32_t index = -1;
     if (table) {
-        index = ecs_search(world, table, bs_id, 0);
+        index = ecs_table_get_type_index(world, table, bs_id);
     }
 
     if (index == -1) {
@@ -3259,7 +3259,7 @@ bool ecs_is_enabled_id(
     }
 
     ecs_entity_t bs_id = id | ECS_TOGGLE;
-    int32_t index = ecs_search(world, table, bs_id, 0);
+    int32_t index = ecs_table_get_type_index(world, table, bs_id);
     if (index == -1) {
         /* If table does not have TOGGLE column for component, component is
          * always enabled, if the entity has it */

--- a/src/entity.c
+++ b/src/entity.c
@@ -57,21 +57,13 @@ flecs_component_ptr_t flecs_get_component_ptr(
     ecs_assert(table != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(id != 0, ECS_INVALID_PARAMETER, NULL);
 
-    if (!table->storage_table) {
-        ecs_check(ecs_search(world, table, id, 0) == -1, 
-            ECS_NOT_A_COMPONENT, NULL);
+    ecs_table_record_t *tr = flecs_table_record_get(world, table, id);
+    if (!tr || (tr->storage == -1)) {
+        ecs_check(tr == NULL, ECS_NOT_A_COMPONENT, NULL);
         return (flecs_component_ptr_t){0};
     }
 
-    ecs_table_record_t *tr = flecs_table_record_get(
-        world, table->storage_table, id);
-    if (!tr) {
-        ecs_check(ecs_search(world, table, id, 0) == -1, 
-            ECS_NOT_A_COMPONENT, NULL);
-       return (flecs_component_ptr_t){0};
-    }
-
-    return flecs_get_component_w_index(table, tr->column, row);
+    return flecs_get_component_w_index(table, tr->storage, row);
 error:
     return (flecs_component_ptr_t){0};
 }
@@ -129,22 +121,14 @@ void* flecs_get_base_component(
             continue;
         }
 
-        const ecs_table_record_t *tr = NULL;
-
-        ecs_table_t *storage_table = table->storage_table;
-        if (storage_table) {
-            tr = flecs_id_record_get_table(table_index, storage_table);
-        } else {
-            ecs_check(!ecs_owns_id(world, base, id), 
-                ECS_NOT_A_COMPONENT, NULL);
-        }
-
-        if (!tr) {
+        const ecs_table_record_t *tr = 
+            flecs_id_record_get_table(table_index, table);
+        if (!tr || tr->storage == -1) {
             ptr = flecs_get_base_component(world, table, id, table_index, 
                 recur_depth + 1);
         } else {
             int32_t row = ECS_RECORD_TO_ROW(r->row);
-            ptr = flecs_get_component_w_index(table, tr->column, row).ptr;
+            ptr = flecs_get_component_w_index(table, tr->storage, row).ptr;
         }
     } while (!ptr && (i < end));
 
@@ -876,7 +860,6 @@ const ecs_entity_t* flecs_bulk_new(
 
     if (component_data) {
         int32_t c_i;
-        ecs_table_t *storage_table = table->storage_table;
         for (c_i = 0; c_i < component_ids->count; c_i ++) {
             void *src_ptr = component_data[c_i];
             if (!src_ptr) {
@@ -886,14 +869,16 @@ const ecs_entity_t* flecs_bulk_new(
             /* Find component in storage type */
             ecs_entity_t id = component_ids->array[c_i];
             const ecs_table_record_t *tr = flecs_table_record_get(
-                world, storage_table, id);
+                world, table, id);
             ecs_assert(tr != NULL, ECS_INVALID_PARAMETER, 
+                "id is not a component");
+            ecs_assert(tr->storage != -1, ECS_INVALID_PARAMETER, 
                 "id is not a component");
             ecs_assert(tr->count == 1, ECS_INVALID_PARAMETER,
                 "ids cannot be wildcards");
 
-            int32_t index = tr->column;
-            const ecs_type_info_t *ti = table->type_info[index];
+            int32_t index = tr->storage;
+            ecs_type_info_t *ti = table->type_info[index];
             ecs_vec_t *column = &table->data.columns[index];
             int32_t size = ti->size;
             ecs_assert(size != 0, ECS_INTERNAL_ERROR, NULL);
@@ -1023,7 +1008,7 @@ flecs_component_ptr_t flecs_get_mut(
     flecs_defer_begin(world, &world->stages[0]);
 
     ecs_assert(r->table != NULL, ECS_INTERNAL_ERROR, NULL);
-    ecs_assert(r->table->storage_table != NULL, ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(r->table->storage_count != 0, ECS_INTERNAL_ERROR, NULL);
     dst = flecs_get_component_ptr(
         world, r->table, ECS_RECORD_TO_ROW(r->row), id);
 error:
@@ -1089,15 +1074,16 @@ void flecs_notify_on_set(
     }
 
     if (owned) {
-        ecs_table_t *storage_table = table->storage_table;
         int i;
         for (i = 0; i < ids->count; i ++) {
             ecs_id_t id = ids->array[i];
             const ecs_table_record_t *tr = flecs_table_record_get(world, 
-                storage_table, id);
+                table, id);
             ecs_assert(tr != NULL, ECS_INTERNAL_ERROR, NULL);
+            ecs_assert(tr->storage != -1, ECS_INTERNAL_ERROR, NULL);
             ecs_assert(tr->count == 1, ECS_INTERNAL_ERROR, NULL);
-            int32_t column = tr->column;
+
+            int32_t column = tr->storage;
             const ecs_type_info_t *ti = table->type_info[column];
             ecs_iter_action_t on_set = ti->hooks.on_set;
             if (on_set) {
@@ -2727,22 +2713,15 @@ const void* ecs_get_id(
         return NULL;
     }
 
-    const ecs_table_record_t *tr = NULL;
-    ecs_table_t *storage_table = table->storage_table;
-    if (storage_table) {
-        tr = flecs_id_record_get_table(idr, storage_table);
-    } else {
-        /* If the entity does not have a storage table (has no data) but it does
-         * have the id, the id must be a tag, and getting a tag is illegal. */
-        ecs_check(!ecs_owns_id(world, entity, id), ECS_NOT_A_COMPONENT, NULL);
-    }
-
+    const ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
     if (!tr) {
        return flecs_get_base_component(world, table, id, idr, 0);
+    } else {
+        ecs_assert(tr->storage != -1, ECS_NOT_A_COMPONENT, NULL);
     }
 
     int32_t row = ECS_RECORD_TO_ROW(r->row);
-    return flecs_get_component_w_index(table, tr->column, row).ptr;
+    return flecs_get_component_w_index(table, tr->storage, row).ptr;
 error:
     return NULL;
 }

--- a/src/entity.c
+++ b/src/entity.c
@@ -2723,7 +2723,7 @@ const void* ecs_get_id(
     if (!tr) {
        return flecs_get_base_component(world, table, id, idr, 0);
     } else {
-        ecs_assert(tr->column != -1, ECS_NOT_A_COMPONENT, NULL);
+        ecs_check(tr->column != -1, ECS_NOT_A_COMPONENT, NULL);
     }
 
     int32_t row = ECS_RECORD_TO_ROW(r->row);
@@ -2966,7 +2966,7 @@ void* ecs_ref_get_id(
         ecs_assert(tr->hdr.table == r->table, ECS_INTERNAL_ERROR, NULL);
     }
 
-    int32_t column = ecs_table_type_to_column_index(table, tr->index);
+    int32_t column = tr->column;
     ecs_assert(column != -1, ECS_INTERNAL_ERROR, NULL);
     return flecs_get_component_w_index(table, column, row).ptr;
 error:

--- a/src/entity_filter.c
+++ b/src/entity_filter.c
@@ -354,7 +354,7 @@ int32_t flecs_get_flattened_target(
     if (table->flags & EcsTableHasTarget) {
         int32_t col = table->storage_map[table->_->ft_offset];
         ecs_assert(col != -1, ECS_INTERNAL_ERROR, NULL);
-        EcsTarget *next = table->data.columns[col].array;
+        EcsTarget *next = table->data.columns[col].data.array;
         next = ECS_ELEM_T(next, EcsTarget, ECS_RECORD_TO_ROW(r->row));
         return flecs_get_flattened_target(
             world, next, rel, id, src_out, tr_out);
@@ -562,7 +562,7 @@ int flecs_entity_filter_next(
             bool first_for_table = it->prev != table;
             ecs_iter_t *iter = it->it;
             ecs_world_t *world = iter->real_world;
-            EcsTarget *ft = table->data.columns[flat_tree_column].array;
+            EcsTarget *ft = table->data.columns[flat_tree_column].data.array;
             int32_t ft_offset;
             int32_t ft_count;
 

--- a/src/entity_filter.c
+++ b/src/entity_filter.c
@@ -348,7 +348,7 @@ int32_t flecs_get_flattened_target(
     if (tr) {
         *src_out = ecs_record_get_entity(r);
         *tr_out = tr;
-        return tr->column;
+        return tr->index;
     }
 
     if (table->flags & EcsTableHasTarget) {
@@ -457,7 +457,7 @@ void flecs_entity_filter_init(
         const ecs_table_record_t *tr = flecs_table_record_get(world, table, 
             ecs_pair_t(EcsTarget, EcsWildcard));
         ecs_assert(tr != NULL, ECS_INTERNAL_ERROR, NULL);
-        int32_t column = tr->column;
+        int32_t column = tr->index;
         ecs_assert(column != -1, ECS_INTERNAL_ERROR, NULL);
         ecs_entity_t rel = ecs_pair_second(world, table->type.array[column]);
 

--- a/src/entity_filter.c
+++ b/src/entity_filter.c
@@ -352,7 +352,7 @@ int32_t flecs_get_flattened_target(
     }
 
     if (table->flags & EcsTableHasTarget) {
-        int32_t col = table->storage_map[table->_->ft_offset];
+        int32_t col = table->column_map[table->_->ft_offset];
         ecs_assert(col != -1, ECS_INTERNAL_ERROR, NULL);
         EcsTarget *next = table->data.columns[col].data.array;
         next = ECS_ELEM_T(next, EcsTarget, ECS_RECORD_TO_ROW(r->row));
@@ -467,7 +467,7 @@ void flecs_entity_filter_init(
             }
 
             if (terms[i].src.trav == rel) {
-                ef.flat_tree_column = table->storage_map[column];
+                ef.flat_tree_column = table->column_map[column];
                 ecs_assert(ef.flat_tree_column != -1, 
                     ECS_INTERNAL_ERROR, NULL);
                 has_filter = true;

--- a/src/entity_filter.c
+++ b/src/entity_filter.c
@@ -440,7 +440,7 @@ void flecs_entity_filter_init(
             int32_t field = terms[i].field_index;
             ecs_id_t id = ids[field];
             ecs_id_t bs_id = ECS_TOGGLE | id;
-            int32_t bs_index = ecs_search(world, table, bs_id, 0);
+            int32_t bs_index = ecs_table_get_type_index(world, table, bs_id);
 
             if (bs_index != -1) {
                 flecs_bitset_term_t *bc = ecs_vec_append_t(a, bs_terms, 

--- a/src/filter.c
+++ b/src/filter.c
@@ -2411,9 +2411,9 @@ bool flecs_term_iter_next(
             }
 
             iter->cur_match = 0;
-            iter->last_column = tr->column;
-            iter->column = tr->column + 1;
-            iter->id = flecs_to_public_id(table->type.array[tr->column]);
+            iter->last_column = tr->index;
+            iter->column = tr->index + 1;
+            iter->id = flecs_to_public_id(table->type.array[tr->index]);
         }
 
         if (iter->cur == iter->set_index) {
@@ -2457,9 +2457,9 @@ bool flecs_term_iter_set_table(
         tr = ecs_table_cache_get(&idr->cache, table);
         if (tr) {
             iter->match_count = tr->count;
-            iter->last_column = tr->column;
-            iter->column = tr->column + 1;
-            iter->id = flecs_to_public_id(table->type.array[tr->column]);
+            iter->last_column = tr->index;
+            iter->column = tr->index + 1;
+            iter->id = flecs_to_public_id(table->type.array[tr->index]);
         }
     }
 

--- a/src/id_record.c
+++ b/src/id_record.c
@@ -481,27 +481,8 @@ void flecs_id_record_release_tables(
     if (flecs_table_cache_empty_iter(&idr->cache, &it)) {
         ecs_table_record_t *tr;
         while ((tr = flecs_table_cache_next(&it, ecs_table_record_t))) {
-            /* Tables can hold claims on each other, so releasing a table can
-             * cause the next element to get invalidated. Claim the next table
-             * so that we can safely iterate. */
-            ecs_table_t *next = NULL;
-            if (it.next) {
-                next = it.next->table;
-                flecs_table_claim(world, next);
-            }
-
             /* Release current table */
-            flecs_table_release(world, tr->hdr.table);
-
-            /* Check if the only thing keeping the next table alive is our
-             * claim. If so, move to the next record before releasing */
-            if (next) {
-                if (next->_->refcount == 1) {
-                    it.next = it.next->next;
-                }
-
-                flecs_table_release(world, next);
-            }
+            flecs_table_free(world, tr->hdr.table);
         }
     }
 }

--- a/src/id_record.h
+++ b/src/id_record.h
@@ -11,6 +11,7 @@ struct ecs_table_record_t {
     ecs_table_cache_hdr_t hdr;  /* Table cache header */
     int32_t column;             /* First column where id occurs in table */
     int32_t count;              /* Number of times id occurs in table */
+    int32_t storage;            /* Storage index of id in table */
 };
 
 /* Linked list of id records */

--- a/src/id_record.h
+++ b/src/id_record.h
@@ -9,9 +9,9 @@
 /* Payload for id cache */
 struct ecs_table_record_t {
     ecs_table_cache_hdr_t hdr;  /* Table cache header */
-    int32_t column;             /* First column where id occurs in table */
-    int32_t count;              /* Number of times id occurs in table */
-    int32_t storage;            /* Storage index of id in table */
+    int16_t column;             /* First column where id occurs in table */
+    int16_t count;              /* Number of times id occurs in table */
+    int16_t storage;            /* Storage index of id in table */
 };
 
 /* Linked list of id records */

--- a/src/id_record.h
+++ b/src/id_record.h
@@ -9,9 +9,9 @@
 /* Payload for id cache */
 struct ecs_table_record_t {
     ecs_table_cache_hdr_t hdr;  /* Table cache header */
-    int16_t column;             /* First column where id occurs in table */
+    int16_t index;              /* First type index where id occurs in table */
     int16_t count;              /* Number of times id occurs in table */
-    int16_t storage;            /* Storage index of id in table */
+    int16_t column;             /* First column index where id occurs */
 };
 
 /* Linked list of id records */

--- a/src/iter.c
+++ b/src/iter.c
@@ -209,7 +209,7 @@ bool flecs_iter_populate_term_data(
 
         row = it->offset;
 
-        int32_t storage_column = ecs_table_type_to_storage_index(
+        int32_t storage_column = ecs_table_type_to_column_index(
             table, column - 1);
         if (storage_column == -1) {
             u_index = flecs_table_column_to_union_index(table, column - 1);

--- a/src/iter.c
+++ b/src/iter.c
@@ -197,8 +197,8 @@ bool flecs_iter_populate_term_data(
 
             /* We now have row and column, so we can get the storage for the id
              * which gives us the pointer and size */
-            column = tr->column;
-            ecs_vec_t *s = &table->data.columns[column];
+            column = tr->storage;
+            ecs_vec_t *s = &table->data.columns[column].data;
             data = ecs_vec_first(s);
             /* Fallthrough to has_data */
         }
@@ -223,7 +223,7 @@ bool flecs_iter_populate_term_data(
             goto no_data;
         }
 
-        ecs_vec_t *s = &table->data.columns[storage_column];
+        ecs_vec_t *s = &table->data.columns[storage_column].data;
         data = ecs_vec_first(s);
 
         /* Fallthrough to has_data */

--- a/src/iter.c
+++ b/src/iter.c
@@ -185,10 +185,9 @@ bool flecs_iter_populate_term_data(
             table = r->table;
 
             ecs_id_t id = it->ids[t];
-            ecs_table_t *s_table = table->storage_table;
             ecs_table_record_t *tr;
 
-            if (!s_table || !(tr = flecs_table_record_get(world, s_table, id))){
+            if (!(tr = flecs_table_record_get(world, table, id)) || (tr->storage == -1)) {
                 u_index = flecs_table_column_to_union_index(table, -column - 1);
                 if (u_index != -1) {
                     goto has_union;

--- a/src/iter.c
+++ b/src/iter.c
@@ -187,7 +187,7 @@ bool flecs_iter_populate_term_data(
             ecs_id_t id = it->ids[t];
             ecs_table_record_t *tr;
 
-            if (!(tr = flecs_table_record_get(world, table, id)) || (tr->storage == -1)) {
+            if (!(tr = flecs_table_record_get(world, table, id)) || (tr->column == -1)) {
                 u_index = flecs_table_column_to_union_index(table, -column - 1);
                 if (u_index != -1) {
                     goto has_union;
@@ -197,7 +197,7 @@ bool flecs_iter_populate_term_data(
 
             /* We now have row and column, so we can get the storage for the id
              * which gives us the pointer and size */
-            column = tr->storage;
+            column = tr->column;
             ecs_vec_t *s = &table->data.columns[column].data;
             data = ecs_vec_first(s);
             /* Fallthrough to has_data */

--- a/src/observable.c
+++ b/src/observable.c
@@ -462,15 +462,12 @@ void* flecs_override(
                 continue;
             }
 
-            int32_t column = tr->column;
-            column = ecs_table_type_to_storage_index(table, column);
-            ecs_assert(column != -1, ECS_INTERNAL_ERROR, NULL);
+            int32_t index = tr->storage;
+            ecs_assert(index != -1, ECS_INTERNAL_ERROR, NULL);
 
-            const ecs_type_info_t *ti = idr->type_info;
-            ecs_assert(ti != NULL, ECS_INTERNAL_ERROR, NULL);
-            ecs_size_t size = ti->size;
-            ecs_vec_t *vec = &table->data.columns[column];
-            return ecs_vec_get(vec, size, it->offset);
+            ecs_column_t *column = &table->data.columns[index];
+            ecs_size_t size = column->ti->size;
+            return ecs_vec_get(&column->data, size, it->offset);
         }
     }
 
@@ -534,10 +531,9 @@ void flecs_emit_forward_id(
     int32_t storage_i = ecs_table_type_to_storage_index(tgt_table, column);
     if (storage_i != -1) {
         ecs_assert(idr->type_info != NULL, ECS_INTERNAL_ERROR, NULL);
-        ecs_vec_t *vec = &tgt_table->data.columns[storage_i];
-        ecs_size_t size = idr->type_info->size;
-        it->ptrs[0] = ecs_vec_get(vec, size, offset);
-        it->sizes[0] = size;
+        ecs_column_t *c = &tgt_table->data.columns[storage_i];
+        it->ptrs[0] = ecs_vec_get(&c->data, c->ti->size, offset);
+        it->sizes[0] = c->ti->size;
     }
 
     ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
@@ -1063,7 +1059,7 @@ void flecs_emit(
     const ecs_event_record_t *er_unset = flecs_event_record_get_if(observable, EcsUnSet);
 
     ecs_data_t *storage = NULL;
-    ecs_vec_t *columns = NULL;
+    ecs_column_t *columns = NULL;
     if (count) {
         storage = &table->data;
         columns = storage->columns;
@@ -1174,7 +1170,7 @@ repeat_event:
                         ecs_record_t *base_r = flecs_entities_get(world, base);
                         ecs_assert(base_r != NULL, ECS_INTERNAL_ERROR, NULL);
                         int32_t base_row = ECS_RECORD_TO_ROW(base_r->row);
-                        ecs_vec_t *base_v = &base_table->data.columns[base_column];
+                        ecs_vec_t *base_v = &base_table->data.columns[base_column].data;
                         override_ptr = ecs_vec_get(base_v, ti->size, base_row);
                     }
                 }
@@ -1213,7 +1209,7 @@ repeat_event:
             continue;
         }
 
-        int32_t column = tr->column, storage_i = -1;
+        int32_t column = tr->column, storage_i;
         it.columns[0] = column + 1;
         it.ptrs[0] = NULL;
         it.sizes[0] = 0;
@@ -1221,13 +1217,13 @@ repeat_event:
         it.ids[0] = id;
 
         if (count) {
-            storage_i = ecs_table_type_to_storage_index(table, column);
+            storage_i = tr->storage;
             if (storage_i != -1) {
                 /* If this is a component, fetch pointer & size */
                 ecs_assert(idr->type_info != NULL, ECS_INTERNAL_ERROR, NULL);
-                ecs_vec_t *vec = &columns[storage_i];
-                ecs_size_t size = idr->type_info->size;
-                void *ptr = ecs_vec_get(vec, size, offset);
+                ecs_column_t *c = &columns[storage_i];
+                ecs_size_t size = c->ti->size;
+                void *ptr = ecs_vec_get(&c->data, size, offset);
                 it.sizes[0] = size;
 
                 if (override_ptr) {

--- a/src/observable.c
+++ b/src/observable.c
@@ -528,7 +528,7 @@ void flecs_emit_forward_id(
     it->ptrs[0] = NULL;
     it->sizes[0] = 0;
 
-    int32_t storage_i = ecs_table_type_to_storage_index(tgt_table, column);
+    int32_t storage_i = ecs_table_type_to_column_index(tgt_table, column);
     if (storage_i != -1) {
         ecs_assert(idr->type_info != NULL, ECS_INTERNAL_ERROR, NULL);
         ecs_column_t *c = &tgt_table->data.columns[storage_i];
@@ -1164,7 +1164,7 @@ repeat_event:
                     if (base_column != -1) {
                         /* Base found with component */
                         ecs_table_t *base_table = base_tr->hdr.table;
-                        base_column = ecs_table_type_to_storage_index(
+                        base_column = ecs_table_type_to_column_index(
                             base_table, base_tr->column);
                         ecs_assert(base_column != -1, ECS_INTERNAL_ERROR, NULL);
                         ecs_record_t *base_r = flecs_entities_get(world, base);

--- a/src/observable.c
+++ b/src/observable.c
@@ -462,7 +462,7 @@ void* flecs_override(
                 continue;
             }
 
-            int32_t index = tr->storage;
+            int32_t index = tr->column;
             ecs_assert(index != -1, ECS_INTERNAL_ERROR, NULL);
 
             ecs_column_t *column = &table->data.columns[index];
@@ -687,7 +687,7 @@ void flecs_emit_forward_cached_ids(
         int32_t rc_offset = ECS_RECORD_TO_ROW(rc_record->row);
         flecs_emit_forward_and_cache_id(world, er, er_onset, emit_ids,
             it, table, rc_idr, rc_elem->src,
-                rc_record, rc_record->table, rc_tr, rc_tr->column,
+                rc_record, rc_record->table, rc_tr, rc_tr->index,
                     rc_offset, reachable_ids, trav, evtx);
     }
 }
@@ -963,7 +963,7 @@ void flecs_emit_forward(
 
             int32_t offset = ECS_RECORD_TO_ROW(r->row);
             flecs_emit_forward_id(world, er, er_onset, emit_ids, it, table,
-                rc_idr, elem->src, r->table, tr->column, offset, trav, evtx);
+                rc_idr, elem->src, r->table, tr->index, offset, trav, evtx);
         }
     }
 }
@@ -1165,7 +1165,7 @@ repeat_event:
                         /* Base found with component */
                         ecs_table_t *base_table = base_tr->hdr.table;
                         base_column = ecs_table_type_to_column_index(
-                            base_table, base_tr->column);
+                            base_table, base_tr->index);
                         ecs_assert(base_column != -1, ECS_INTERNAL_ERROR, NULL);
                         ecs_record_t *base_r = flecs_entities_get(world, base);
                         ecs_assert(base_r != NULL, ECS_INTERNAL_ERROR, NULL);
@@ -1209,7 +1209,7 @@ repeat_event:
             continue;
         }
 
-        int32_t column = tr->column, storage_i;
+        int32_t column = tr->index, storage_i;
         it.columns[0] = column + 1;
         it.ptrs[0] = NULL;
         it.sizes[0] = 0;
@@ -1217,7 +1217,7 @@ repeat_event:
         it.ids[0] = id;
 
         if (count) {
-            storage_i = tr->storage;
+            storage_i = tr->column;
             if (storage_i != -1) {
                 /* If this is a component, fetch pointer & size */
                 ecs_assert(idr->type_info != NULL, ECS_INTERNAL_ERROR, NULL);

--- a/src/observable.c
+++ b/src/observable.c
@@ -1164,8 +1164,7 @@ repeat_event:
                     if (base_column != -1) {
                         /* Base found with component */
                         ecs_table_t *base_table = base_tr->hdr.table;
-                        base_column = ecs_table_type_to_column_index(
-                            base_table, base_tr->index);
+                        base_column = base_tr->column;
                         ecs_assert(base_column != -1, ECS_INTERNAL_ERROR, NULL);
                         ecs_record_t *base_r = flecs_entities_get(world, base);
                         ecs_assert(base_r != NULL, ECS_INTERNAL_ERROR, NULL);

--- a/src/observer.c
+++ b/src/observer.c
@@ -821,6 +821,7 @@ ecs_entity_t ecs_observer_init(
     if (!entity) {
         entity = ecs_new(world, 0);
     }
+
     EcsPoly *poly = ecs_poly_bind(world, entity, ecs_observer_t);
     if (!poly->poly) {
         ecs_check(desc->callback != NULL || desc->run != NULL, 

--- a/src/private_types.h
+++ b/src/private_types.h
@@ -190,10 +190,11 @@ struct ecs_data_t {
 struct ecs_table_t {
     uint64_t id;                     /* Table id in sparse set */
     ecs_flags32_t flags;             /* Flags for testing table properties */
-    int16_t storage_count;           /* Number of components (excluding tags) */
+    int16_t column_count;            /* Number of components (excluding tags) */
     ecs_type_t type;                 /* Identifies table type in type_index */
 
     ecs_data_t data;                 /* Component storage */
+    ecs_graph_node_t node;           /* Graph node */
     
     int32_t *dirty_state;            /* Keep track of changes in columns */
     int32_t *storage_map;            /* Map type <-> data type
@@ -205,7 +206,7 @@ struct ecs_table_t {
 };
 
 typedef struct ecs_archetype_t {
-    ecs_graph_node_t node;           /* Graph node */
+    
     ecs_table_t *table;
 } ecs_archetype_t;
 

--- a/src/private_types.h
+++ b/src/private_types.h
@@ -171,8 +171,9 @@ typedef struct ecs_table__t {
 
 typedef struct ecs_column_t {
     ecs_vec_t data;
-    ecs_type_info_t *ti;
     ecs_id_t id;
+    ecs_size_t size;
+    ecs_type_info_t *ti;
 } ecs_column_t;
 
 /** Table storage */
@@ -192,10 +193,9 @@ struct ecs_table_t {
     int16_t storage_count;           /* Number of components (excluding tags) */
     ecs_type_t type;                 /* Identifies table type in type_index */
 
-    ecs_graph_node_t node;           /* Graph node */
     ecs_data_t data;                 /* Component storage */
+    
     int32_t *dirty_state;            /* Keep track of changes in columns */
-
     int32_t *storage_map;            /* Map type <-> data type
                                       *  - 0..count(T):        type -> data_type
                                       *  - count(T)..count(S): data_type -> type
@@ -203,6 +203,11 @@ struct ecs_table_t {
 
     ecs_table__t *_;                 /* Infrequently accessed table metadata */
 };
+
+typedef struct ecs_archetype_t {
+    ecs_graph_node_t node;           /* Graph node */
+    ecs_table_t *table;
+} ecs_archetype_t;
 
 /** Must appear as first member in payload of table cache */
 typedef struct ecs_table_cache_hdr_t {

--- a/src/private_types.h
+++ b/src/private_types.h
@@ -155,7 +155,7 @@ typedef struct ecs_table__t {
     int32_t lock;                    /* Prevents modifications */
     int32_t traversable_count;       /* Number of observed entities in table */
     uint16_t generation;             /* Used for table cleanup */
-    uint16_t record_count;           /* Table record count including wildcards */
+    int16_t record_count;            /* Table record count including wildcards */
     
     struct ecs_table_record_t *records; /* Array with table records */
     ecs_hashmap_t *name_index;       /* Cached pointer to name index */
@@ -172,6 +172,7 @@ typedef struct ecs_table__t {
 typedef struct ecs_column_t {
     ecs_vec_t data;
     ecs_type_info_t *ti;
+    ecs_id_t id;
 } ecs_column_t;
 
 /** Table storage */
@@ -188,14 +189,13 @@ struct ecs_data_t {
 struct ecs_table_t {
     uint64_t id;                     /* Table id in sparse set */
     ecs_flags32_t flags;             /* Flags for testing table properties */
-    uint16_t storage_count;          /* Number of components (excluding tags) */
+    int16_t storage_count;           /* Number of components (excluding tags) */
     ecs_type_t type;                 /* Identifies table type in type_index */
 
     ecs_graph_node_t node;           /* Graph node */
     ecs_data_t data;                 /* Component storage */
     int32_t *dirty_state;            /* Keep track of changes in columns */
 
-    ecs_id_t *storage_ids;           /* Component ids (prevent indirection) */
     int32_t *storage_map;            /* Map type <-> data type
                                       *  - 0..count(T):        type -> data_type
                                       *  - count(T)..count(S): data_type -> type

--- a/src/private_types.h
+++ b/src/private_types.h
@@ -169,11 +169,16 @@ typedef struct ecs_table__t {
     int16_t ft_offset;
 } ecs_table__t;
 
-/** Stage-specific component data */
+typedef struct ecs_column_t {
+    ecs_vec_t data;
+    ecs_type_info_t *ti;
+} ecs_column_t;
+
+/** Table storage */
 struct ecs_data_t {
     ecs_vec_t entities;              /* Entity identifiers */
     ecs_vec_t records;               /* Ptrs to records in main entity index */
-    ecs_vec_t *columns;               /* Component columns */
+    ecs_column_t *columns;           /* Component vectors */
 };
 
 /** A table is the Flecs equivalent of an archetype. Tables store all entities
@@ -188,7 +193,6 @@ struct ecs_table_t {
 
     ecs_graph_node_t node;           /* Graph node */
     ecs_data_t data;                 /* Component storage */
-    ecs_type_info_t **type_info;     /* Cached type info */
     int32_t *dirty_state;            /* Keep track of changes in columns */
 
     ecs_id_t *storage_ids;           /* Component ids (prevent indirection) */

--- a/src/private_types.h
+++ b/src/private_types.h
@@ -102,13 +102,6 @@ typedef struct ecs_table_event_t {
      * initializing an event a bit simpler. */
 } ecs_table_event_t;
 
-/** Stage-specific component data */
-struct ecs_data_t {
-    ecs_vec_t entities;              /* Entity identifiers */
-    ecs_vec_t records;               /* Ptrs to records in main entity index */
-    ecs_vec_t *columns;              /* Component columns */
-};
-
 /** Cache of added/removed components for non-trivial edges between tables */
 #define ECS_TABLE_DIFF_INIT { .added = {0}}
 
@@ -160,7 +153,6 @@ typedef struct ecs_graph_node_t {
 typedef struct ecs_table__t {
     uint64_t hash;                   /* Type hash */
     int32_t lock;                    /* Prevents modifications */
-    int32_t refcount;                /* Increased when used as storage table */
     int32_t traversable_count;       /* Number of observed entities in table */
     uint16_t generation;             /* Used for table cleanup */
     uint16_t record_count;           /* Table record count including wildcards */
@@ -177,27 +169,33 @@ typedef struct ecs_table__t {
     int16_t ft_offset;
 } ecs_table__t;
 
+/** Stage-specific component data */
+struct ecs_data_t {
+    ecs_vec_t entities;              /* Entity identifiers */
+    ecs_vec_t records;               /* Ptrs to records in main entity index */
+    ecs_vec_t *columns;               /* Component columns */
+};
+
 /** A table is the Flecs equivalent of an archetype. Tables store all entities
  * with a specific set of components. Tables are automatically created when an
  * entity has a set of components not previously observed before. When a new
  * table is created, it is automatically matched with existing queries */
 struct ecs_table_t {
-    uint64_t id;                       /* Table id in sparse set */
-    ecs_flags32_t flags;               /* Flags for testing table properties */
-    uint16_t storage_count;            /* Number of components (excluding tags) */
-    ecs_type_t type;                   /* Identifies table type in type_index */
+    uint64_t id;                     /* Table id in sparse set */
+    ecs_flags32_t flags;             /* Flags for testing table properties */
+    uint16_t storage_count;          /* Number of components (excluding tags) */
+    ecs_type_t type;                 /* Identifies table type in type_index */
 
-    ecs_graph_node_t node;             /* Graph node */
-    ecs_data_t data;                   /* Component storage */
-    const ecs_type_info_t **type_info; /* Cached type info */
-    int32_t *dirty_state;              /* Keep track of changes in columns */
+    ecs_graph_node_t node;           /* Graph node */
+    ecs_data_t data;                 /* Component storage */
+    ecs_type_info_t **type_info;     /* Cached type info */
+    int32_t *dirty_state;            /* Keep track of changes in columns */
 
-    ecs_table_t *storage_table;        /* Table without tags */
-    ecs_id_t *storage_ids;             /* Component ids (prevent indirection) */
-    int32_t *storage_map;              /* Map type <-> data type
-                                        *  - 0..count(T):        type -> data_type
-                                        *  - count(T)..count(S): data_type -> type
-                                        */
+    ecs_id_t *storage_ids;           /* Component ids (prevent indirection) */
+    int32_t *storage_map;            /* Map type <-> data type
+                                      *  - 0..count(T):        type -> data_type
+                                      *  - count(T)..count(S): data_type -> type
+                                      */
 
     ecs_table__t *_;                 /* Infrequently accessed table metadata */
 };

--- a/src/private_types.h
+++ b/src/private_types.h
@@ -153,7 +153,7 @@ typedef struct ecs_graph_node_t {
 typedef struct ecs_table__t {
     uint64_t hash;                   /* Type hash */
     int32_t lock;                    /* Prevents modifications */
-    int32_t traversable_count;       /* Number of observed entities in table */
+    int32_t traversable_count;       /* Traversable relationship targets in table */
     uint16_t generation;             /* Used for table cleanup */
     int16_t record_count;            /* Table record count including wildcards */
     
@@ -172,8 +172,8 @@ typedef struct ecs_table__t {
 typedef struct ecs_column_t {
     ecs_vec_t data;
     ecs_id_t id;
-    ecs_size_t size;
     ecs_type_info_t *ti;
+    ecs_size_t size;
 } ecs_column_t;
 
 /** Table storage */
@@ -191,24 +191,19 @@ struct ecs_table_t {
     uint64_t id;                     /* Table id in sparse set */
     ecs_flags32_t flags;             /* Flags for testing table properties */
     int16_t column_count;            /* Number of components (excluding tags) */
-    ecs_type_t type;                 /* Identifies table type in type_index */
+    ecs_type_t type;                 /* Vector with component ids */
 
     ecs_data_t data;                 /* Component storage */
     ecs_graph_node_t node;           /* Graph node */
     
     int32_t *dirty_state;            /* Keep track of changes in columns */
-    int32_t *storage_map;            /* Map type <-> data type
-                                      *  - 0..count(T):        type -> data_type
-                                      *  - count(T)..count(S): data_type -> type
+    int32_t *column_map;             /* Map type index <-> column
+                                      *  - 0..count(T):        type index -> column
+                                      *  - count(T)..count(C): column -> type index
                                       */
 
     ecs_table__t *_;                 /* Infrequently accessed table metadata */
 };
-
-typedef struct ecs_archetype_t {
-    
-    ecs_table_t *table;
-} ecs_archetype_t;
 
 /** Must appear as first member in payload of table cache */
 typedef struct ecs_table_cache_hdr_t {

--- a/src/query.c
+++ b/src/query.c
@@ -441,7 +441,7 @@ void flecs_query_get_column_for_term(
                 ecs_ref_t *ref = ecs_vec_get_t(&match->refs, ecs_ref_t, ref_index);
                 if (ref->id != 0) {
                     ecs_ref_update(world, ref);
-                    column = ref->tr->column;
+                    column = ref->tr->index;
                     column = ecs_table_type_to_column_index(table, column);
                 }
             } else {
@@ -706,7 +706,7 @@ bool flecs_query_check_match_monitor(
                     ecs_ref_update(world, ref);
                     ecs_table_record_t *tr = ref->tr;
                     ecs_table_t *src_table = tr->hdr.table;
-                    column = tr->column;
+                    column = tr->index;
                     column = ecs_table_type_to_column_index(src_table, column);
                     int32_t *src_dirty_state = flecs_table_get_dirty_state(
                         world, src_table);
@@ -1318,7 +1318,7 @@ void flecs_query_sort_tables(
                 const ecs_table_record_t *tr = flecs_id_record_get_table(
                     idr, table);
                 if (tr) {
-                    column = tr->storage;
+                    column = tr->column;
                 }
 
                 if (column == -1) {

--- a/src/query.c
+++ b/src/query.c
@@ -1293,6 +1293,7 @@ void flecs_query_sort_tables(
 
     bool tables_sorted = false;
 
+    ecs_id_record_t *idr = flecs_id_record_get(world, order_by_component);
     ecs_table_cache_iter_t it;
     ecs_query_table_t *qt;
     flecs_table_cache_iter(&query->cache, &it);
@@ -1314,10 +1315,10 @@ void flecs_query_sort_tables(
             if (dirty) {
                 column = -1;
 
-                ecs_table_t *storage_table = table->storage_table;
-                if (storage_table) {
-                    column = ecs_search(world, storage_table, 
-                        order_by_component, 0);
+                const ecs_table_record_t *tr = flecs_id_record_get_table(
+                    idr, table);
+                if (tr) {
+                    column = tr->storage;
                 }
 
                 if (column == -1) {

--- a/src/query.c
+++ b/src/query.c
@@ -1054,10 +1054,10 @@ void flecs_query_sort_table(
     void *ptr = NULL;
     int32_t size = 0;
     if (column_index != -1) {
-        const ecs_type_info_t *ti = table->type_info[column_index];
-        ecs_vec_t *column = &data->columns[column_index];
+        ecs_column_t *column = &data->columns[column_index];
+        ecs_type_info_t *ti = column->ti;
         size = ti->size;
-        ptr = ecs_vec_first(column);
+        ptr = ecs_vec_first(&column->data);
     }
 
     if (sort) {
@@ -1140,7 +1140,7 @@ void flecs_query_build_sorted_table_range(
             ecs_assert(column != 0, ECS_INTERNAL_ERROR, NULL);
             if (column >= 0) {
                 column = table->storage_map[column - 1];
-                ecs_vec_t *vec = &data->columns[column];
+                ecs_vec_t *vec = &data->columns[column].data;
                 helper[to_sort].ptr = ecs_vec_first(vec);
                 helper[to_sort].elem_size = size;
                 helper[to_sort].shared = false;
@@ -2441,7 +2441,7 @@ void flecs_query_populate_trivial(
                     continue;
                 }
 
-                it->ptrs[i] = ecs_vec_get(&data->columns[column], 
+                it->ptrs[i] = ecs_vec_get(&data->columns[column].data,
                     it->sizes[i], 0);
             }
         }

--- a/src/query.c
+++ b/src/query.c
@@ -441,8 +441,7 @@ void flecs_query_get_column_for_term(
                 ecs_ref_t *ref = ecs_vec_get_t(&match->refs, ecs_ref_t, ref_index);
                 if (ref->id != 0) {
                     ecs_ref_update(world, ref);
-                    column = ref->tr->index;
-                    column = ecs_table_type_to_column_index(table, column);
+                    column = ref->tr->column;
                 }
             } else {
                 column = -(match->columns[field] + 1);
@@ -1139,7 +1138,7 @@ void flecs_query_build_sorted_table_range(
             ecs_size_t size = query->filter.sizes[field];
             ecs_assert(column != 0, ECS_INTERNAL_ERROR, NULL);
             if (column >= 0) {
-                column = table->storage_map[column - 1];
+                column = table->column_map[column - 1];
                 ecs_vec_t *vec = &data->columns[column].data;
                 helper[to_sort].ptr = ecs_vec_first(vec);
                 helper[to_sort].elem_size = size;

--- a/src/query.c
+++ b/src/query.c
@@ -442,7 +442,7 @@ void flecs_query_get_column_for_term(
                 if (ref->id != 0) {
                     ecs_ref_update(world, ref);
                     column = ref->tr->column;
-                    column = ecs_table_type_to_storage_index(table, column);
+                    column = ecs_table_type_to_column_index(table, column);
                 }
             } else {
                 column = -(match->columns[field] + 1);
@@ -707,7 +707,7 @@ bool flecs_query_check_match_monitor(
                     ecs_table_record_t *tr = ref->tr;
                     ecs_table_t *src_table = tr->hdr.table;
                     column = tr->column;
-                    column = ecs_table_type_to_storage_index(src_table, column);
+                    column = ecs_table_type_to_column_index(src_table, column);
                     int32_t *src_dirty_state = flecs_table_get_dirty_state(
                         world, src_table);
                     if (mon != src_dirty_state[column + 1]) {
@@ -719,7 +719,7 @@ bool flecs_query_check_match_monitor(
                 ecs_entity_t src = match->sources[i];
                 ecs_table_t *src_table = ecs_get_table(world, src);
                 ecs_assert(src_table != NULL, ECS_INTERNAL_ERROR, NULL);
-                column = ecs_table_type_to_storage_index(src_table, column - 1);
+                column = ecs_table_type_to_column_index(src_table, column - 1);
                 int32_t *src_dirty_state = flecs_table_get_dirty_state(
                     world, src_table);
                 if (mon != src_dirty_state[column + 1]) {
@@ -900,7 +900,7 @@ void flecs_query_set_table_match(
 
             int32_t column = qm->columns[i];
             if (column > 0) {
-                qm->storage_columns[i] = ecs_table_type_to_storage_index(table,
+                qm->storage_columns[i] = ecs_table_type_to_column_index(table,
                     qm->columns[i] - 1);
             } else {
                 /* Shared field (not from table) */

--- a/src/search.c
+++ b/src/search.c
@@ -369,7 +369,7 @@ int32_t flecs_relation_depth(
 
     int32_t depth_offset = 0;
     if (table->flags & EcsTableHasTarget) {
-        if (ecs_table_get_index(world, table, 
+        if (ecs_table_get_type_index(world, table, 
             ecs_pair_t(EcsTarget, r)) != -1)
         {
             ecs_id_t id;

--- a/src/search.c
+++ b/src/search.c
@@ -20,7 +20,7 @@ int32_t flecs_type_search(
 {    
     ecs_table_record_t *tr = ecs_table_cache_get(&idr->cache, table);
     if (tr) {
-        int32_t r = tr->column;
+        int32_t r = tr->index;
         if (tr_out) tr_out[0] = tr;
         if (id_out) {
             if (ECS_PAIR_FIRST(search_id) == EcsUnion) {
@@ -337,7 +337,7 @@ int32_t flecs_relation_depth_walk(
         return 0;
     }
 
-    int32_t i = tr->column, end = i + tr->count;
+    int32_t i = tr->index, end = i + tr->count;
     for (; i != end; i ++) {
         ecs_entity_t o = ecs_pair_second(world, table->type.array[i]);
         ecs_assert(o != 0, ECS_INTERNAL_ERROR, NULL);

--- a/src/stage.c
+++ b/src/stage.c
@@ -421,7 +421,7 @@ void* flecs_defer_set(
             if (tr) {
                 ecs_assert(tr->storage != -1, ECS_NOT_A_COMPONENT, NULL);
                 /* Entity has the component */
-                ecs_vec_t *column = &table->data.columns[tr->storage];
+                ecs_vec_t *column = &table->data.columns[tr->storage].data;
                 existing = ecs_vec_get(column, size, ECS_RECORD_TO_ROW(r->row));
             }
         }

--- a/src/stage.c
+++ b/src/stage.c
@@ -410,17 +410,18 @@ void* flecs_defer_set(
     /* Find existing component. Make sure it's owned, so that we won't use the
      * component of a prefab. */
     void *existing = NULL;
-    ecs_table_t *table = NULL, *storage_table;
+    ecs_table_t *table = NULL;
     if (idr) {
         /* Entity can only have existing component if id record exists */
         ecs_record_t *r = flecs_entities_get(world, entity);
         table = r->table;
-        if (r && table && (storage_table = table->storage_table)) {
-            ecs_table_record_t *tr = flecs_id_record_get_table(
-                idr, storage_table);
+        if (r && table) {
+            const ecs_table_record_t *tr = flecs_id_record_get_table(
+                idr, table);
             if (tr) {
+                ecs_assert(tr->storage != -1, ECS_NOT_A_COMPONENT, NULL);
                 /* Entity has the component */
-                ecs_vec_t *column = &table->data.columns[tr->column];
+                ecs_vec_t *column = &table->data.columns[tr->storage];
                 existing = ecs_vec_get(column, size, ECS_RECORD_TO_ROW(r->row));
             }
         }

--- a/src/stage.c
+++ b/src/stage.c
@@ -419,9 +419,9 @@ void* flecs_defer_set(
             const ecs_table_record_t *tr = flecs_id_record_get_table(
                 idr, table);
             if (tr) {
-                ecs_assert(tr->storage != -1, ECS_NOT_A_COMPONENT, NULL);
+                ecs_assert(tr->column != -1, ECS_NOT_A_COMPONENT, NULL);
                 /* Entity has the component */
-                ecs_vec_t *column = &table->data.columns[tr->storage].data;
+                ecs_vec_t *column = &table->data.columns[tr->column].data;
                 existing = ecs_vec_get(column, size, ECS_RECORD_TO_ROW(r->row));
             }
         }

--- a/src/table.c
+++ b/src/table.c
@@ -163,7 +163,7 @@ void flecs_table_init_columns(
 
         t2s[i] = cur;
         s2t[cur] = i;
-        tr->storage = flecs_ito(int16_t, cur);
+        tr->column = flecs_ito(int16_t, cur);
 
         columns[cur].ti = ECS_CONST_CAST(ecs_type_info_t*, ti);
         columns[cur].id = ids[i];
@@ -306,7 +306,7 @@ void flecs_table_append_to_records(
             idr, table);
     if (!tr) {
         tr = ecs_vec_append_t(&world->allocator, records, ecs_table_record_t);
-        tr->column = flecs_ito(int16_t, column);
+        tr->index = flecs_ito(int16_t, column);
         tr->count = 1;
 
         ecs_table_cache_insert(&idr->cache, table, &tr->hdr);
@@ -387,7 +387,7 @@ void flecs_table_init(
         if (idr) {
             tr = ecs_vec_append_t(a, records, ecs_table_record_t);
             tr->hdr.cache = (ecs_table_cache_t*)idr;
-            tr->column = flecs_ito(int16_t, dst_i);
+            tr->index = flecs_ito(int16_t, dst_i);
             tr->count = 1;
         }
 
@@ -402,7 +402,7 @@ void flecs_table_init(
         idr = flecs_id_record_ensure(world, dst_id);
         tr->hdr.cache = (ecs_table_cache_t*)idr;
         ecs_assert(tr->hdr.cache != NULL, ECS_INTERNAL_ERROR, NULL);
-        tr->column = flecs_ito(int16_t, dst_i);
+        tr->index = flecs_ito(int16_t, dst_i);
         tr->count = 1;
     }
 
@@ -476,7 +476,7 @@ void flecs_table_init(
 
                 tr = ecs_vec_append_t(a, records, ecs_table_record_t);
                 tr->hdr.cache = (ecs_table_cache_t*)idr;
-                tr->column = flecs_ito(int16_t, dst_i);
+                tr->index = flecs_ito(int16_t, dst_i);
                 tr->count = 0;
             }
 
@@ -502,26 +502,26 @@ void flecs_table_init(
     if (last_id >= 0) {
         tr = ecs_vec_append_t(a, records, ecs_table_record_t);
         tr->hdr.cache = (ecs_table_cache_t*)world->idr_wildcard;
-        tr->column = 0;
+        tr->index = 0;
         tr->count = flecs_ito(int16_t, last_id + 1);
     }
     if (last_pair - first_pair) {
         tr = ecs_vec_append_t(a, records, ecs_table_record_t);
         tr->hdr.cache = (ecs_table_cache_t*)world->idr_wildcard_wildcard;
-        tr->column = flecs_ito(int16_t, first_pair);
+        tr->index = flecs_ito(int16_t, first_pair);
         tr->count = flecs_ito(int16_t, last_pair - first_pair);
     }
     if (dst_count) {
         tr = ecs_vec_append_t(a, records, ecs_table_record_t);
         tr->hdr.cache = (ecs_table_cache_t*)world->idr_any;
-        tr->column = 0;
+        tr->index = 0;
         tr->count = 1;
     }
     if (dst_count && !has_childof) {
         tr = ecs_vec_append_t(a, records, ecs_table_record_t);
         childof_idr = world->idr_childof_0;
         tr->hdr.cache = (ecs_table_cache_t*)childof_idr;
-        tr->column = 0;
+        tr->index = 0;
         tr->count = 1;
     }
 
@@ -557,7 +557,7 @@ void flecs_table_init(
         table->flags |= idr->flags & EcsIdEventMask;
 
         /* Initialize column index (will be overwritten by init_storage) */
-        tr->storage = -1;
+        tr->column = -1;
 
         if (idr->flags & EcsIdAlwaysOverride) {
             table->flags |= EcsTableHasOverrides;
@@ -1125,11 +1125,11 @@ void flecs_table_mark_dirty(
         }
 
         const ecs_table_record_t *tr = flecs_id_record_get_table(idr, table);
-        if (!tr || tr->storage == -1) {
+        if (!tr || tr->column == -1) {
             return;
         }
 
-        table->dirty_state[tr->storage + 1] ++;
+        table->dirty_state[tr->column + 1] ++;
     }
 }
 
@@ -2415,7 +2415,7 @@ int32_t ecs_table_get_type_index(
         return -1;
     }
 
-    return tr->column;
+    return tr->index;
 error:
     return -1;
 }
@@ -2439,7 +2439,7 @@ int32_t ecs_table_get_column_index(
         return -1;
     }
 
-    return tr->storage;
+    return tr->column;
 error:
     return -1;
 }

--- a/src/table.h
+++ b/src/table.h
@@ -192,16 +192,6 @@ int32_t flecs_table_column_to_union_index(
     const ecs_table_t *table,
     int32_t column);
 
-/* Increase refcount of table (prevents deletion) */
-void flecs_table_claim(
-    ecs_world_t *world, 
-    ecs_table_t *table);
-
-/* Decreases refcount of table (may delete) */
-bool flecs_table_release(
-    ecs_world_t *world, 
-    ecs_table_t *table);
-
 /* Increase observer count of table */
 void flecs_table_traversable_add(
     ecs_table_t *table,

--- a/src/table.h
+++ b/src/table.h
@@ -183,11 +183,6 @@ void flecs_table_delete_entities(
     ecs_world_t *world,
     ecs_table_t *table);
 
-ecs_vec_t *ecs_table_column_for_id(
-    const ecs_world_t *world,
-    const ecs_table_t *table,
-    ecs_id_t id);
-
 int32_t flecs_table_column_to_union_index(
     const ecs_table_t *table,
     int32_t column);

--- a/src/table_graph.c
+++ b/src/table_graph.c
@@ -567,11 +567,11 @@ ecs_table_t *flecs_create_table(
     /* Update counters */
     world->info.table_count ++;
     world->info.table_record_count += result->_->record_count;
-    world->info.table_storage_count += result->storage_count;
+    world->info.table_storage_count += result->column_count;
     world->info.empty_table_count ++;
     world->info.table_create_total ++;
     
-    if (!result->storage_count) {
+    if (!result->column_count) {
         world->info.tag_table_count ++;
     } else {
         world->info.trivial_table_count += !(result->flags & EcsTableIsComplex);

--- a/src/table_graph.c
+++ b/src/table_graph.c
@@ -773,7 +773,7 @@ void flecs_add_overrides_for_base(
         ecs_table_record_t *tr = flecs_id_record_get_table(
             world->idr_isa_wildcard, base_table);
         ecs_assert(tr != NULL, ECS_INTERNAL_ERROR, NULL);
-        int32_t i = tr->column, end = i + tr->count;
+        int32_t i = tr->index, end = i + tr->count;
         for (; i != end; i ++) {
             flecs_add_overrides_for_base(world, dst_type, ids[i]);
         }
@@ -800,7 +800,7 @@ void flecs_add_with_property(
     ecs_table_record_t *tr = flecs_id_record_get_table(
         idr_with_wildcard, table);
     if (tr) {
-        int32_t i = tr->column, end = i + tr->count;
+        int32_t i = tr->index, end = i + tr->count;
         ecs_id_t *ids = table->type.array;
 
         for (; i < end; i ++) {
@@ -852,7 +852,7 @@ ecs_table_t* flecs_find_table_with(
                  * a new id sequence with the existing id replaced */
                 ecs_type_t dst_type = flecs_type_copy(world, &node->type);
                 ecs_assert(dst_type.array != NULL, ECS_INTERNAL_ERROR, NULL);
-                dst_type.array[tr->column] = with;
+                dst_type.array[tr->index] = with;
                 return flecs_table_ensure(world, &dst_type, true, node);
             }
         }

--- a/src/table_graph.c
+++ b/src/table_graph.c
@@ -524,7 +524,6 @@ void flecs_init_table(
     table->flags = 0;
     table->dirty_state = NULL;
     table->_->lock = 0;
-    table->_->refcount = 1;
     table->_->generation = 0;
 
     flecs_table_init_node(&table->node);

--- a/src/table_graph.c
+++ b/src/table_graph.c
@@ -520,7 +520,6 @@ void flecs_init_table(
     ecs_table_t *table,
     ecs_table_t *prev)
 {
-    table->type_info = NULL;
     table->flags = 0;
     table->dirty_state = NULL;
     table->_->lock = 0;

--- a/src/world.c
+++ b/src/world.c
@@ -1879,7 +1879,7 @@ void flecs_process_empty_queries(
     if (flecs_table_cache_iter(&idr->cache, &it)) {
         while ((tr = flecs_table_cache_next(&it, ecs_table_record_t))) {
             ecs_table_t *table = tr->hdr.table;
-            EcsPoly *queries = ecs_table_get_column(table, tr->column, 0);
+            EcsPoly *queries = ecs_table_get_column(table, tr->storage, 0);
             int32_t i, count = ecs_table_count(table);
 
             for (i = 0; i < count; i ++) {

--- a/src/world.c
+++ b/src/world.c
@@ -1879,7 +1879,7 @@ void flecs_process_empty_queries(
     if (flecs_table_cache_iter(&idr->cache, &it)) {
         while ((tr = flecs_table_cache_next(&it, ecs_table_record_t))) {
             ecs_table_t *table = tr->hdr.table;
-            EcsPoly *queries = ecs_table_get_column(table, tr->storage, 0);
+            EcsPoly *queries = ecs_table_get_column(table, tr->column, 0);
             int32_t i, count = ecs_table_count(table);
 
             for (i = 0; i < count; i ++) {

--- a/test/addons/src/System_w_FromEntity.c
+++ b/test/addons/src/System_w_FromEntity.c
@@ -79,7 +79,7 @@ static ecs_entity_t dummy_component = 0;
 static ecs_entity_t dummy_source = 0;
 
 static
-void dummy_reset() {
+void dummy_reset(void) {
     dummy_invoked = false;
     dummy_component = 0;
     dummy_source = 0;

--- a/test/api/project.json
+++ b/test/api/project.json
@@ -593,6 +593,8 @@
                 "has_in_progress",
                 "has_of_zero",
                 "owns",
+                "owns_wildcard",
+                "owns_wildcard_pair",
                 "has_entity",
                 "has_entity_0",
                 "has_entity_0_component",

--- a/test/api/src/Has.c
+++ b/test/api/src/Has.c
@@ -122,6 +122,53 @@ void Has_owns(void) {
     ecs_fini(world);
 }
 
+void Has_owns_wildcard(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, Tag_1);
+    ECS_TAG(world, Tag_2);
+
+    ecs_entity_t e1 = ecs_new_id(world);
+    test_assert(e1 != 0);
+
+    ecs_entity_t e2 = ecs_new_id(world);
+    test_assert(e2 != 0);    
+
+    ecs_add_id(world, e1, Tag_1);
+
+    test_bool(ecs_owns_id(world, e1, Tag_1), true);
+    test_bool(ecs_owns_id(world, e1, Tag_2), false);
+    test_bool(ecs_owns_id(world, e1, EcsWildcard), true);
+ 
+    test_bool(ecs_owns_id(world, e2, Tag_1), false);
+    test_bool(ecs_owns_id(world, e2, Tag_2), false);
+    test_bool(ecs_owns_id(world, e2, EcsWildcard), false);
+
+    ecs_fini(world);
+}
+
+void Has_owns_wildcard_pair(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, Rel);
+    ECS_TAG(world, Obj_1);
+    ECS_TAG(world, Obj_2);
+
+    ecs_entity_t e = ecs_new_id(world);
+    test_assert(e != 0);
+
+    ecs_add_pair(world, e, Rel, Obj_1);
+
+    test_bool(ecs_owns_pair(world, e, Rel, Obj_1), true);
+    test_bool(ecs_owns_pair(world, e, Rel, Obj_2), false);
+    test_bool(ecs_owns_pair(world, e, Rel, EcsWildcard), true);
+    test_bool(ecs_owns_pair(world, e, EcsWildcard, Obj_1), true);
+    test_bool(ecs_owns_pair(world, e, EcsWildcard, Obj_2), false);
+    test_bool(ecs_owns_pair(world, e, EcsWildcard, EcsWildcard), true);
+ 
+    ecs_fini(world);
+}
+
 void Has_has_entity(void) {
     ecs_world_t *world = ecs_mini();
 

--- a/test/api/src/Table.c
+++ b/test/api/src/Table.c
@@ -54,16 +54,18 @@ void Table_get_column(void) {
 
     ecs_table_t *table = ecs_get_table(world, e1);
     test_assert(table != NULL);
-    int32_t pos_id = ecs_table_get_type_index(world, table, ecs_id(Position));
-    int32_t vel_id = ecs_table_get_type_index(world, table, ecs_id(Velocity));
+    int32_t pos_id = ecs_table_get_column_index(world, table, ecs_id(Position));
+    int32_t vel_id = ecs_table_get_column_index(world, table, ecs_id(Velocity));
 
     Position *p = ecs_table_get_column(table, pos_id, 0);
+    test_assert(p != NULL);
     test_int(p[0].x, 10);
     test_int(p[0].y, 20);
     test_int(p[1].x, 20);
     test_int(p[1].y, 30);
 
     Velocity *v = ecs_table_get_column(table, vel_id, 0);
+    test_assert(v != NULL);
     test_int(v[0].x, 1);
     test_int(v[0].y, 2);
     test_int(v[1].x, 2);
@@ -73,6 +75,8 @@ void Table_get_column(void) {
 }
 
 void Table_get_column_for_tag(void) {
+    install_test_abort();
+
     ecs_world_t *world = ecs_mini();
 
     ECS_COMPONENT(world, Position);
@@ -84,11 +88,12 @@ void Table_get_column_for_tag(void) {
 
     ecs_table_t *table = ecs_get_table(world, e1);
     test_assert(table != NULL);
+
+    test_expect_abort();
     int32_t tag_id = ecs_table_get_type_index(world, table, Tag);
 
-    test_assert(ecs_table_get_column(table, tag_id, 0) == NULL);
-
-    ecs_fini(world);
+    test_expect_abort();
+    ecs_table_get_column(table, tag_id, 0);
 }
 
 void Table_get_column_for_component_after_tag(void) {
@@ -114,16 +119,21 @@ void Table_get_column_for_component_after_tag(void) {
 
     ecs_table_t *table = ecs_get_table(world, e1);
     test_assert(table != NULL);
-    int32_t pos_id = ecs_table_get_type_index(world, table, ecs_id(Position));
-    int32_t vel_id = ecs_table_get_type_index(world, table, ecs_id(Velocity));
+    int32_t pos_id = ecs_table_get_column_index(world, table, ecs_id(Position));
+    int32_t vel_id = ecs_table_get_column_index(world, table, ecs_id(Velocity));
+
+    test_assert(pos_id != -1);
+    test_assert(vel_id != -1);
 
     Position *p = ecs_table_get_column(table, pos_id, 0);
+    test_assert(p != NULL);
     test_int(p[0].x, 10);
     test_int(p[0].y, 20);
     test_int(p[1].x, 20);
     test_int(p[1].y, 30);
 
     Velocity *v = ecs_table_get_column(table, vel_id, 0);
+    test_assert(v != NULL);
     test_int(v[0].x, 1);
     test_int(v[0].y, 2);
     test_int(v[1].x, 2);
@@ -148,14 +158,16 @@ void Table_get_column_w_offset(void) {
 
     ecs_table_t *table = ecs_get_table(world, e1);
     test_assert(table != NULL);
-    int32_t pos_id = ecs_table_get_type_index(world, table, ecs_id(Position));
-    int32_t vel_id = ecs_table_get_type_index(world, table, ecs_id(Velocity));
+    int32_t pos_id = ecs_table_get_column_index(world, table, ecs_id(Position));
+    int32_t vel_id = ecs_table_get_column_index(world, table, ecs_id(Velocity));
 
     Position *p = ecs_table_get_column(table, pos_id, 1);
+    test_assert(p != NULL);
     test_int(p[0].x, 20);
     test_int(p[0].y, 30);
 
     Velocity *v = ecs_table_get_column(table, vel_id, 1);
+    test_assert(v != NULL);
     test_int(v[0].x, 2);
     test_int(v[0].y, 3);
 
@@ -357,4 +369,8 @@ void Table_get_column_size(void) {
     test_uint(0, ecs_table_get_column_size(table, 1));
 
     ecs_fini(world);
+}
+
+void Table_get_column_index(void) {
+    // Implement testcase
 }

--- a/test/api/src/Table.c
+++ b/test/api/src/Table.c
@@ -12,8 +12,8 @@ void Table_get_index(void) {
 
     ecs_table_t *table = ecs_get_table(world, e);
     test_assert(table != NULL);
-    test_int(ecs_table_get_index(world, table, ecs_id(Position)), 0);
-    test_int(ecs_table_get_index(world, table, ecs_id(Velocity)), 1);
+    test_int(ecs_table_get_type_index(world, table, ecs_id(Position)), 0);
+    test_int(ecs_table_get_type_index(world, table, ecs_id(Velocity)), 1);
 
     ecs_fini(world);
 }
@@ -31,9 +31,9 @@ void Table_get_index_not_in_table(void) {
 
     ecs_table_t *table = ecs_get_table(world, e);
     test_assert(table != NULL);
-    test_int(ecs_table_get_index(world, table, ecs_id(Position)), 0);
-    test_int(ecs_table_get_index(world, table, ecs_id(Velocity)), 1);
-    test_int(ecs_table_get_index(world, table, ecs_id(Mass)), -1);
+    test_int(ecs_table_get_type_index(world, table, ecs_id(Position)), 0);
+    test_int(ecs_table_get_type_index(world, table, ecs_id(Velocity)), 1);
+    test_int(ecs_table_get_type_index(world, table, ecs_id(Mass)), -1);
 
     ecs_fini(world);
 }
@@ -54,8 +54,8 @@ void Table_get_column(void) {
 
     ecs_table_t *table = ecs_get_table(world, e1);
     test_assert(table != NULL);
-    int32_t pos_id = ecs_table_get_index(world, table, ecs_id(Position));
-    int32_t vel_id = ecs_table_get_index(world, table, ecs_id(Velocity));
+    int32_t pos_id = ecs_table_get_type_index(world, table, ecs_id(Position));
+    int32_t vel_id = ecs_table_get_type_index(world, table, ecs_id(Velocity));
 
     Position *p = ecs_table_get_column(table, pos_id, 0);
     test_int(p[0].x, 10);
@@ -84,7 +84,7 @@ void Table_get_column_for_tag(void) {
 
     ecs_table_t *table = ecs_get_table(world, e1);
     test_assert(table != NULL);
-    int32_t tag_id = ecs_table_get_index(world, table, Tag);
+    int32_t tag_id = ecs_table_get_type_index(world, table, Tag);
 
     test_assert(ecs_table_get_column(table, tag_id, 0) == NULL);
 
@@ -114,8 +114,8 @@ void Table_get_column_for_component_after_tag(void) {
 
     ecs_table_t *table = ecs_get_table(world, e1);
     test_assert(table != NULL);
-    int32_t pos_id = ecs_table_get_index(world, table, ecs_id(Position));
-    int32_t vel_id = ecs_table_get_index(world, table, ecs_id(Velocity));
+    int32_t pos_id = ecs_table_get_type_index(world, table, ecs_id(Position));
+    int32_t vel_id = ecs_table_get_type_index(world, table, ecs_id(Velocity));
 
     Position *p = ecs_table_get_column(table, pos_id, 0);
     test_int(p[0].x, 10);
@@ -148,8 +148,8 @@ void Table_get_column_w_offset(void) {
 
     ecs_table_t *table = ecs_get_table(world, e1);
     test_assert(table != NULL);
-    int32_t pos_id = ecs_table_get_index(world, table, ecs_id(Position));
-    int32_t vel_id = ecs_table_get_index(world, table, ecs_id(Velocity));
+    int32_t pos_id = ecs_table_get_type_index(world, table, ecs_id(Position));
+    int32_t vel_id = ecs_table_get_type_index(world, table, ecs_id(Velocity));
 
     Position *p = ecs_table_get_column(table, pos_id, 1);
     test_int(p[0].x, 20);

--- a/test/api/src/WorldInfo.c
+++ b/test/api/src/WorldInfo.c
@@ -171,10 +171,10 @@ void WorldInfo_table_storage_count(void) {
     test_delta(&prev, cur, table_storage_count, 0);
 
     ecs_add(world, e, Position);
-    test_delta(&prev, cur, table_storage_count, 2);
+    test_delta(&prev, cur, table_storage_count, 1);
 
     ecs_delete(world, c_1);
-    test_delta(&prev, cur, table_storage_count, -1);
+    test_delta(&prev, cur, table_storage_count, 0);
 
     ecs_delete(world, ecs_id(Position));
     test_delta(&prev, cur, table_storage_count, -1);

--- a/test/api/src/main.c
+++ b/test/api/src/main.c
@@ -562,6 +562,8 @@ void Has_1_of_empty(void);
 void Has_has_in_progress(void);
 void Has_has_of_zero(void);
 void Has_owns(void);
+void Has_owns_wildcard(void);
+void Has_owns_wildcard_pair(void);
 void Has_has_entity(void);
 void Has_has_entity_0(void);
 void Has_has_entity_0_component(void);
@@ -4735,6 +4737,14 @@ bake_test_case Has_testcases[] = {
     {
         "owns",
         Has_owns
+    },
+    {
+        "owns_wildcard",
+        Has_owns_wildcard
+    },
+    {
+        "owns_wildcard_pair",
+        Has_owns_wildcard_pair
     },
     {
         "has_entity",
@@ -12729,7 +12739,7 @@ static bake_test_suite suites[] = {
         "Has",
         NULL,
         NULL,
-        16,
+        18,
         Has_testcases
     },
     {


### PR DESCRIPTION
This PR includes a number of changes that reduces complexity of the table data structures:
- Remove the storage table mechanism. Tables used to store a reference to a table with the same type except stripped from all tags, which was used in functions that only operated on components (like `ecs_get`). In practice this mechanism required tables to store a refcount to track usage, which increased complexity and table size.
- Combine the type_info and columns arrays. Tables used to have two separate arrays for component columns and type information (like size, alignment, hooks). In practice these two are almost always accessed together by the table however, and combining them in a single array reduces table footprint and improves cache utilization.
- Combine the storage_ids and columns arrays. Tables used to store a pointer to the type of the storage table for quick access to component ids. Component ids are now stored in the columns array.
- The component size is now cached on the columns array, which prevents cache misses from having to access the type_info data
- Rename `ecs_table_record_t::column` to `ecs_table_record_t::index` and add `ecs_table_record_t::column` member that stores the index in the columns array. This reduces the need for converting between type indices and column indices.

The PR introduces a number of changes to the table API:
- Functions that operate on table columns now always accept a column index (vs. a type index). This improves consistency of the API, and also removes the need for converting between type indices and column indices.
- Replace `flecs::table::search` with `flecs::table::type_index`, add `flecs::table::column_index` to find the type index/column index respectively.
- Add `ecs_table_column_count`
- Replace `ecs_table_has_module` with `ecs_table_has_flags`