### PR TITLE
get flecs::scoped_world by name

### DIFF
--- a/include/flecs/addons/cpp/impl/world.hpp
+++ b/include/flecs/addons/cpp/impl/world.hpp
@@ -280,4 +280,8 @@ inline flecs::scoped_world world::scope() const {
     return scoped_world(m_world, parent);
 }
 
+inline flecs::scoped_world world::scope(const char* name) const {
+  return scope(entity(name));
+}
+
 } // namespace flecs

--- a/include/flecs/addons/cpp/world.hpp
+++ b/include/flecs/addons/cpp/world.hpp
@@ -868,6 +868,8 @@ struct world {
     template <typename T>
     flecs::scoped_world scope() const;
 
+    flecs::scoped_world scope(const char* name) const;
+
     /** Delete all entities with specified id. */
     void delete_with(id_t the_id) const {
         ecs_delete_with(m_world, the_id);


### PR DESCRIPTION
# Changelog

- added a method to get `flecs::scoped_world` by name