### PR TITLE
match function parameter names across declaration and definition in entity view

### DIFF
--- a/include/flecs/addons/cpp/component.hpp
+++ b/include/flecs/addons/cpp/component.hpp
@@ -168,7 +168,7 @@ struct cpp_type_impl {
             // If no world was provided the component cannot be registered
             ecs_assert(world != nullptr, ECS_COMPONENT_NOT_REGISTERED, name);
         } else {
-            ecs_assert(!id || s_id == id, ECS_INCONSISTENT_COMPONENT_ID, NULL);
+            ecs_assert(!id, ECS_INCONSISTENT_COMPONENT_ID, NULL);
         }
 
         // If no id has been registered yet for the component (indicating the 

--- a/include/flecs/addons/cpp/entity_view.hpp
+++ b/include/flecs/addons/cpp/entity_view.hpp
@@ -51,7 +51,7 @@ struct entity_view : public id {
         return m_id;
     }
 
-    /** Check is entity is valid.
+    /** Check if entity is valid.
      *
      * @return True if the entity is alive, false otherwise.
      */
@@ -63,7 +63,7 @@ struct entity_view : public id {
         return is_valid();
     }
 
-    /** Check is entity is alive.
+    /** Check if entity is alive.
      *
      * @return True if the entity is alive, false otherwise.
      */

--- a/include/flecs/addons/cpp/entity_view.hpp
+++ b/include/flecs/addons/cpp/entity_view.hpp
@@ -154,7 +154,7 @@ struct entity_view : public id {
      * @param func The function invoked for each id.
      */
     template <typename Func>
-    void each(flecs::id_t first, flecs::id_t second, const Func& func) const;
+    void each(flecs::id_t pred, flecs::id_t obj, const Func& func) const;
 
     /** Iterate targets for a given relationship.
      * The function parameter must match the following signature:


### PR DESCRIPTION
match function parameter names across declaration and definition in entity view

removing the s_id == id -> we already know s_id is not 0, and if the first check (!id) passed, it's 0, so s_id will never match id and will always assert. Unless this is intended? If so we could put false down instead.

