### PR TITLE
bump cmake_minimum_required version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 cmake_policy(SET CMP0063 NEW)
 
 project(flecs LANGUAGES C)


### PR DESCRIPTION
Minor change to CMakelists.

versions before 3.5 are deprecated in latest CMake versions and causes a warning:
```
CMake Deprecation Warning at flecs/CMakeLists.txt:1 (cmake_minimum_required):Compatibility with CMake < 3.5 will be removed from a future version of
CMake.

Update the VERSION argument <min> value or use a ...<max> suffix to tell
CMake that the project does not need compatibility with older versions.
```