### PR TITLE
fix/improve some comments, group add and remove functions

### DIFF
--- a/flecs.h
+++ b/flecs.h
@@ -19784,34 +19784,9 @@ struct world {
     template <typename T>
     flecs::entity set_scope() const;
 
-    /**
-    * @brief Sets the search path for entity lookup operations.
-    *
-    * This function configures the search path used for looking up entities. The search path is an array of entity IDs that define the scopes within which lookup operations will search for entities.
-    *
-    * @section Best Practices
-    * - It's advisable to restore the previous search path after making temporary changes.
-    *
-    * @section Search Path Evaluation
-    * - The search path is evaluated starting from the last element of the array.
-    *
-    * @section Default Behavior
-    * - The default search path includes `flecs.core`.
-    *
-    * @section Overwriting
-    * - Providing a custom search path will overwrite the existing search path.
-    *
-    * @section Considerations
-    * - If the custom search path doesn't include `flecs.core`, operations that rely on looking up names from `flecs.core` may fail.
-    * - The search path array is not managed by the C++ runtime. Ensure the array remains valid for as long as it is used as the search path.
-    *
-    * @section Array Termination
-    * - The provided array must be terminated with a 0 element. This allows for pushing/popping elements onto/from an existing array without needing to call `ecs_set_lookup_path` again.
-    *
-    * @param search_path A 0-terminated array of entity IDs defining the new search path.
-    *
-    * @return Returns the current search path after the operation.
-    */
+    /** Set search path.
+     *  @see ecs_set_lookup_path
+     */
     flecs::entity_t* set_lookup_path(const flecs::entity_t *search_path) const {
         return ecs_set_lookup_path(m_world, search_path);
     }

--- a/include/flecs/addons/cpp/entity.hpp
+++ b/include/flecs/addons/cpp/entity.hpp
@@ -122,7 +122,7 @@ struct entity : entity_builder<entity>
             _::cpp_type<Second>::id(m_world))));
     }
 
-    /** Get mutable pointer for a pair.
+    /** Get mutable pointer for the first element of a pair.
      * This operation gets the value for a pair from the entity.
      *
      * @tparam First The first part of the pair.

--- a/include/flecs/addons/cpp/mixins/entity/builder.hpp
+++ b/include/flecs/addons/cpp/mixins/entity/builder.hpp
@@ -29,6 +29,23 @@ struct entity_builder : entity_view {
         return to_base();
     }
 
+     /** Add pair for enum constant.
+     * This operation will add a pair to the entity where the first element is
+     * the enumeration type, and the second element the enumeration constant.
+     * 
+     * The operation may be used with regular (C style) enumerations as well as
+     * enum classes.
+     * 
+     * @param value The enumeration value.
+     */
+    template <typename E, if_t< is_enum<E>::value > = 0>
+    Self& add(E value) {
+        flecs::entity_t first = _::cpp_type<E>::id(this->m_world);
+        const auto& et = enum_type<E>(this->m_world);
+        flecs::entity_t second = et.entity(value);
+        return this->add(first, second);
+    }
+
     /** Add an entity to an entity.
      * Add an entity to the entity. This is typically used for tagging.
      *
@@ -275,6 +292,17 @@ struct entity_builder : entity_view {
         return to_base();
     }
 
+     /** Remove pair for enum.
+     * This operation will remove any (Enum, *) pair from the entity.
+     * 
+     * @tparam E The enumeration type.
+     */
+    template <typename E, if_t< is_enum<E>::value > = 0>
+    Self& remove() {
+        flecs::entity_t first = _::cpp_type<E>::id(this->m_world);
+        return this->remove(first, flecs::Wildcard);
+    }
+
     /** Remove an entity from an entity.
      *
      * @param entity The entity to remove.
@@ -307,7 +335,7 @@ struct entity_builder : entity_view {
     }
 
     /** Remove a pair.
-     * This operation adds a pair to the entity.
+     * This operation removes the pair from the entity.
      *
      * @tparam First The first element of the pair
      * @param second The second element of the pair.
@@ -329,7 +357,7 @@ struct entity_builder : entity_view {
     }
 
     /** Remove a pair.
-     * This operation adds a pair to the entity.
+     * This operation removes the pair from the entity.
      *
      * @tparam First The first element of the pair
      * @param constant the enum constant.
@@ -499,34 +527,6 @@ struct entity_builder : entity_view {
                     FLECS_FWD(args)...);
 
         return to_base();  
-    }
-
-    /** Add pair for enum constant.
-     * This operation will add a pair to the entity where the first element is
-     * the enumeration type, and the second element the enumeration constant.
-     * 
-     * The operation may be used with regular (C style) enumerations as well as
-     * enum classes.
-     * 
-     * @param value The enumeration value.
-     */
-    template <typename E, if_t< is_enum<E>::value > = 0>
-    Self& add(E value) {
-        flecs::entity_t first = _::cpp_type<E>::id(this->m_world);
-        const auto& et = enum_type<E>(this->m_world);
-        flecs::entity_t second = et.entity(value);
-        return this->add(first, second);
-    }
-
-    /** Remove pair for enum.
-     * This operation will remove any (Enum, *) pair from the entity.
-     * 
-     * @tparam E The enumeration type.
-     */
-    template <typename E, if_t< is_enum<E>::value > = 0>
-    Self& remove() {
-        flecs::entity_t first = _::cpp_type<E>::id(this->m_world);
-        return this->remove(first, flecs::Wildcard);
     }
 
     /** Enable an entity.
@@ -881,6 +881,7 @@ struct entity_builder : entity_view {
     }
 
     /** Entities created in function will have the current entity.
+     * This operation is thread safe.
      *
      * @param func The function to call.
      */
@@ -905,6 +906,7 @@ struct entity_builder : entity_view {
     }
 
     /** Entities created in function will have (first, this).
+     * This operation is thread safe.
      *
      * @param first The first element of the pair.
      * @param func The function to call.

--- a/include/flecs/addons/cpp/world.hpp
+++ b/include/flecs/addons/cpp/world.hpp
@@ -542,34 +542,9 @@ struct world {
     template <typename T>
     flecs::entity set_scope() const;
 
-    /**
-    * @brief Sets the search path for entity lookup operations.
-    *
-    * This function configures the search path used for looking up entities. The search path is an array of entity IDs that define the scopes within which lookup operations will search for entities.
-    *
-    * @section Best Practices
-    * - It's advisable to restore the previous search path after making temporary changes.
-    *
-    * @section Search Path Evaluation
-    * - The search path is evaluated starting from the last element of the array.
-    *
-    * @section Default Behavior
-    * - The default search path includes `flecs.core`.
-    *
-    * @section Overwriting
-    * - Providing a custom search path will overwrite the existing search path.
-    *
-    * @section Considerations
-    * - If the custom search path doesn't include `flecs.core`, operations that rely on looking up names from `flecs.core` may fail.
-    * - The search path array is not managed by the C++ runtime. Ensure the array remains valid for as long as it is used as the search path.
-    *
-    * @section Array Termination
-    * - The provided array must be terminated with a 0 element. This allows for pushing/popping elements onto/from an existing array without needing to call `ecs_set_lookup_path` again.
-    *
-    * @param search_path A 0-terminated array of entity IDs defining the new search path.
-    *
-    * @return Returns the current search path after the operation.
-    */
+    /** Set search path.
+     *  @see ecs_set_lookup_path
+     */
     flecs::entity_t* set_lookup_path(const flecs::entity_t *search_path) const {
         return ecs_set_lookup_path(m_world, search_path);
     }

--- a/include/flecs/addons/cpp/world.hpp
+++ b/include/flecs/addons/cpp/world.hpp
@@ -542,8 +542,34 @@ struct world {
     template <typename T>
     flecs::entity set_scope() const;
 
-    /** Set search path.
-     */
+    /**
+    * @brief Sets the search path for entity lookup operations.
+    *
+    * This function configures the search path used for looking up entities. The search path is an array of entity IDs that define the scopes within which lookup operations will search for entities.
+    *
+    * @section Best Practices
+    * - It's advisable to restore the previous search path after making temporary changes.
+    *
+    * @section Search Path Evaluation
+    * - The search path is evaluated starting from the last element of the array.
+    *
+    * @section Default Behavior
+    * - The default search path includes `flecs.core`.
+    *
+    * @section Overwriting
+    * - Providing a custom search path will overwrite the existing search path.
+    *
+    * @section Considerations
+    * - If the custom search path doesn't include `flecs.core`, operations that rely on looking up names from `flecs.core` may fail.
+    * - The search path array is not managed by the C++ runtime. Ensure the array remains valid for as long as it is used as the search path.
+    *
+    * @section Array Termination
+    * - The provided array must be terminated with a 0 element. This allows for pushing/popping elements onto/from an existing array without needing to call `ecs_set_lookup_path` again.
+    *
+    * @param search_path A 0-terminated array of entity IDs defining the new search path.
+    *
+    * @return Returns the current search path after the operation.
+    */
     flecs::entity_t* set_lookup_path(const flecs::entity_t *search_path) const {
         return ecs_set_lookup_path(m_world, search_path);
     }
@@ -706,7 +732,7 @@ struct world {
     template <typename T>
     void remove() const;
 
-    /** Adds a pair to the singleton component.
+    /** Removes the pair singleton component.
      * 
      * @tparam First The first element of the pair
      * @tparam Second The second element of the pair
@@ -714,7 +740,7 @@ struct world {
     template <typename First, typename Second>
     void remove() const;
 
-    /** Adds a pair to the singleton component.
+    /** Removes the pair singleton component.
      * 
      * @tparam First The first element of the pair
      * @param second The second element of the pair.
@@ -722,7 +748,7 @@ struct world {
     template <typename First>
     void remove(flecs::entity_t second) const;
 
-    /** Adds a pair to the singleton entity.
+    /** Removes the pair singleton component.
      * 
      * @param first The first element of the pair
      * @param second The second element of the pair


### PR DESCRIPTION
~~I changed the comment of set_lookup_path dramatically to be aligned with the comment on the C function lookup_path, as it was a lot more descriptive. However, I used the @ parameters more heavily to split it up into sections.~~

after discussion with Sander, he instead suggested to use @see so there's no comment duplication across CPP/C API so @see has been added to set_lookup_path cpp function

I relocated the add enum function to be grouped with the other add functions. Same with Remove. 

The rest is quite minor.