### PR TITLE
remove redundant get_ref component registration ensure

### DIFF
--- a/flecs.h
+++ b/flecs.h
@@ -23679,16 +23679,12 @@ struct entity : entity_builder<entity>
      */
     template <typename T>
     ref<T> get_ref() const {
-        // Ensure component is registered
-        _::cpp_type<T>::id(m_world);
-        return ref<T>(m_world, m_id);
+        return ref<T>(m_world, m_id, _::cpp_type<T>::id(m_world));
     }
 
     template <typename First, typename Second, typename P = flecs::pair<First, Second>, 
         typename A = actual_type_t<P>>
     ref<A> get_ref() const {
-        // Ensure component is registered
-        _::cpp_type<A>::id(m_world);
         return ref<A>(m_world, m_id, 
             ecs_pair(_::cpp_type<First>::id(m_world),
                 _::cpp_type<Second>::id(m_world)));
@@ -23696,16 +23692,12 @@ struct entity : entity_builder<entity>
 
     template <typename First>
     ref<First> get_ref(flecs::entity_t second) const {
-        // Ensure component is registered
-        _::cpp_type<First>::id(m_world);
         return ref<First>(m_world, m_id, 
             ecs_pair(_::cpp_type<First>::id(m_world), second));
     }
 
     template <typename Second>
     ref<Second> get_ref_second(flecs::entity_t first) const {
-        // Ensure component is registered
-        _::cpp_type<Second>::id(m_world);
         return ref<Second>(m_world, m_id, 
             ecs_pair(first, _::cpp_type<Second>::id(m_world)));
     }

--- a/include/flecs/addons/cpp/entity.hpp
+++ b/include/flecs/addons/cpp/entity.hpp
@@ -223,16 +223,12 @@ struct entity : entity_builder<entity>
      */
     template <typename T>
     ref<T> get_ref() const {
-        // Ensure component is registered
-        _::cpp_type<T>::id(m_world);
-        return ref<T>(m_world, m_id);
+        return ref<T>(m_world, m_id, _::cpp_type<T>::id(m_world));
     }
 
     template <typename First, typename Second, typename P = flecs::pair<First, Second>, 
         typename A = actual_type_t<P>>
     ref<A> get_ref() const {
-        // Ensure component is registered
-        _::cpp_type<A>::id(m_world);
         return ref<A>(m_world, m_id, 
             ecs_pair(_::cpp_type<First>::id(m_world),
                 _::cpp_type<Second>::id(m_world)));
@@ -240,16 +236,12 @@ struct entity : entity_builder<entity>
 
     template <typename First>
     ref<First> get_ref(flecs::entity_t second) const {
-        // Ensure component is registered
-        _::cpp_type<First>::id(m_world);
         return ref<First>(m_world, m_id, 
             ecs_pair(_::cpp_type<First>::id(m_world), second));
     }
 
     template <typename Second>
     ref<Second> get_ref_second(flecs::entity_t first) const {
-        // Ensure component is registered
-        _::cpp_type<Second>::id(m_world);
         return ref<Second>(m_world, m_id, 
             ecs_pair(first, _::cpp_type<Second>::id(m_world)));
     }


### PR DESCRIPTION
for the standard get_ref I'm passing it as a parameter, which should ensure registration too

for the other get_refs, it's already being registered in the function parameter passthrough too.