### PR TITLE
set name if alias is nullptr for use

### DIFF
--- a/flecs.h
+++ b/flecs.h
@@ -30535,9 +30535,9 @@ inline void world::use(flecs::entity e, const char *alias) const {
     const char *name = alias;
     if (!name) {
         // If no name is defined, use the entity name without the scope
-        ecs_get_name(m_world, eid);
+        name = ecs_get_name(m_world, eid);
     }
-    ecs_set_alias(m_world, eid, alias);
+    ecs_set_alias(m_world, eid, name);
 }
 
 inline flecs::entity world::set_scope(const flecs::entity_t s) const {

--- a/include/flecs/addons/cpp/impl/world.hpp
+++ b/include/flecs/addons/cpp/impl/world.hpp
@@ -51,9 +51,9 @@ inline void world::use(flecs::entity e, const char *alias) const {
     const char *name = alias;
     if (!name) {
         // If no name is defined, use the entity name without the scope
-        ecs_get_name(m_world, eid);
+        name = ecs_get_name(m_world, eid);
     }
-    ecs_set_alias(m_world, eid, alias);
+    ecs_set_alias(m_world, eid, name);
 }
 
 inline flecs::entity world::set_scope(const flecs::entity_t s) const {

--- a/test/collections/src/Map.c
+++ b/test/collections/src/Map.c
@@ -112,7 +112,7 @@ void *test_realloc(void *old_ptr, ecs_size_t size) {
 }
 
 
-void Map_setup() {
+void Map_setup(void) {
     ecs_os_set_api_defaults();
     ecs_os_api_t os_api = ecs_os_api;
     os_api.malloc_ = test_malloc;
@@ -121,7 +121,7 @@ void Map_setup() {
     ecs_os_set_api(&os_api);    
 }
 
-void Map_count() {
+void Map_count(void) {
     uint64_t *keys = generate_keys(4);
     ecs_map_t map = populate_map(keys, 4);
 
@@ -131,14 +131,14 @@ void Map_count() {
     ecs_map_fini(&map);
 }
 
-void Map_count_empty() {
+void Map_count_empty(void) {
     ecs_map_t map;
     ecs_map_init(&map, NULL);
     test_int(ecs_map_count(&map), 0);
     ecs_map_fini(&map);
 }
 
-void Map_set_overwrite() {
+void Map_set_overwrite(void) {
     uint64_t *keys = generate_keys(4);
     ecs_map_t map = populate_map(keys, 4);
 
@@ -153,7 +153,7 @@ void Map_set_overwrite() {
     ecs_map_fini(&map);
 }
 
-void Map_set_rehash() {
+void Map_set_rehash(void) {
     uint64_t *keys = generate_keys(4);
     ecs_map_t map = populate_map(keys, 4);
 
@@ -187,7 +187,7 @@ void Map_set_rehash() {
     ecs_map_fini(&map);
 }
 
-void Map_get() {
+void Map_get(void) {
     uint64_t *keys = generate_keys(4);
     ecs_map_t map = populate_map(keys, 4);
 
@@ -199,7 +199,7 @@ void Map_get() {
     ecs_map_fini(&map);
 }
 
-void Map_get_all() {
+void Map_get_all(void) {
     uint64_t *keys = generate_keys(4);
     ecs_map_t map = populate_map(keys, 4);
 
@@ -223,7 +223,7 @@ void Map_get_all() {
     ecs_map_fini(&map);
 }
 
-void Map_get_empty() {
+void Map_get_empty(void) {
     ecs_map_t map;
     ecs_map_init(&map, NULL);
     uint64_t *value = ecs_map_get(&map, 1);
@@ -231,7 +231,7 @@ void Map_get_empty() {
     ecs_map_fini(&map);
 }
 
-void Map_get_unknown() {
+void Map_get_unknown(void) {
     uint64_t *keys = generate_keys(4);
     ecs_map_t map = populate_map(keys, 4);
 
@@ -242,7 +242,7 @@ void Map_get_unknown() {
     ecs_map_fini(&map);
 }
 
-void Map_get_0_from_empty() {
+void Map_get_0_from_empty(void) {
     ecs_map_t map;
     ecs_map_init(&map, NULL);
     uint64_t *value = ecs_map_get(&map, 0);
@@ -250,7 +250,7 @@ void Map_get_0_from_empty() {
     ecs_map_fini(&map);
 }
 
-void Map_get_0_from_populated() {
+void Map_get_0_from_populated(void) {
     uint64_t *keys = generate_keys(32);
     ecs_map_t map = populate_map(keys, 32);
 
@@ -261,7 +261,7 @@ void Map_get_0_from_populated() {
     ecs_map_fini(&map);
 }
 
-void Map_get_0_after_insert() {
+void Map_get_0_after_insert(void) {
     ecs_map_t map;
     ecs_map_init(&map, NULL);
     ecs_map_insert(&map, 0, 10);
@@ -271,7 +271,7 @@ void Map_get_0_after_insert() {
     ecs_map_fini(&map);
 }
 
-void Map_get_0_after_ensure() {
+void Map_get_0_after_ensure(void) {
     ecs_map_t map;
     ecs_map_init(&map, NULL);
     ecs_map_ensure(&map, 0)[0] = 10;
@@ -281,7 +281,7 @@ void Map_get_0_after_ensure() {
     ecs_map_fini(&map);
 }
 
-void Map_iter() {
+void Map_iter(void) {
     uint64_t *keys = generate_keys(4);
     ecs_map_t map = populate_map(keys, 4);
     
@@ -300,7 +300,7 @@ void Map_iter() {
     ecs_map_fini(&map);
 }
 
-void Map_iter_empty() {
+void Map_iter_empty(void) {
     ecs_map_t map;
     ecs_map_init(&map, NULL);
     ecs_map_iter_t it = ecs_map_iter(&map);
@@ -308,12 +308,12 @@ void Map_iter_empty() {
     ecs_map_fini(&map);
 }
 
-void Map_iter_null() {
+void Map_iter_null(void) {
     ecs_map_iter_t it = ecs_map_iter(NULL);
     test_assert(!ecs_map_next(&it));
 }
 
-void Map_remove() {
+void Map_remove(void) {
     uint64_t *keys = generate_keys(4);
     ecs_map_t map = populate_map(keys, 4);
 
@@ -327,7 +327,7 @@ void Map_remove() {
     ecs_map_fini(&map);
 }
 
-void Map_remove_empty() {
+void Map_remove_empty(void) {
     ecs_map_t map;
     ecs_map_init(&map, NULL);
     ecs_map_remove(&map, 3);
@@ -335,7 +335,7 @@ void Map_remove_empty() {
     ecs_map_fini(&map);
 }
 
-void Map_remove_unknown() {
+void Map_remove_unknown(void) {
     uint64_t *keys = generate_keys(4);
     ecs_map_t map = populate_map(keys, 4);
 
@@ -352,7 +352,7 @@ void Map_remove_unknown() {
     ecs_map_fini(&map);
 }
 
-void Map_remove_twice() {
+void Map_remove_twice(void) {
     uint64_t *keys = generate_keys(4);
     ecs_map_t map = populate_map(keys, 4);
 
@@ -369,7 +369,7 @@ void Map_remove_twice() {
     ecs_map_fini(&map);
 }
 
-void Map_clear_empty() {
+void Map_clear_empty(void) {
     ecs_map_t map;
     ecs_map_init(&map, NULL);
     ecs_map_clear(&map);
@@ -377,7 +377,7 @@ void Map_clear_empty() {
     ecs_map_fini(&map);
 }
 
-void Map_clear_populated() {
+void Map_clear_populated(void) {
     uint64_t *keys = generate_keys(4);
     ecs_map_t map = populate_map(keys, 4);
 
@@ -389,7 +389,7 @@ void Map_clear_populated() {
     ecs_map_fini(&map);
 }
 
-void Map_clear_empty_twice() {
+void Map_clear_empty_twice(void) {
     ecs_map_t map;
     ecs_map_init(&map, NULL);
     ecs_map_clear(&map);
@@ -399,7 +399,7 @@ void Map_clear_empty_twice() {
     ecs_map_fini(&map);
 }
 
-void Map_clear_populated_twice() {
+void Map_clear_populated_twice(void) {
     uint64_t *keys = generate_keys(4);
     ecs_map_t map = populate_map(keys, 4);
 
@@ -413,7 +413,7 @@ void Map_clear_populated_twice() {
     ecs_map_fini(&map);
 }
 
-void Map_populate_after_clear() {
+void Map_populate_after_clear(void) {
     uint64_t *keys = generate_keys(4);
     ecs_map_t map = populate_map(keys, 4);
 
@@ -430,7 +430,7 @@ void Map_populate_after_clear() {
     ecs_map_fini(&map);
 }
 
-void Map_randomized_insert() {
+void Map_randomized_insert(void) {
     uint64_t *keys = generate_random_keys(100);
 
     for (int count = 0; count < 100; count ++) {
@@ -442,7 +442,7 @@ void Map_randomized_insert() {
     ecs_os_free(keys);
 }
 
-void Map_randomized_remove() {
+void Map_randomized_remove(void) {
     uint64_t *keys = generate_random_keys(100);
 
     for (int count = 0; count < 100; count ++) {
@@ -456,7 +456,7 @@ void Map_randomized_remove() {
     ecs_os_free(keys);
 }
 
-void Map_randomized_insert_large() {
+void Map_randomized_insert_large(void) {
     uint64_t *keys = generate_random_keys(1000);
 
     for (int count = 0; count < 1000; count += 27) {
@@ -468,7 +468,7 @@ void Map_randomized_insert_large() {
     ecs_os_free(keys);
 }
 
-void Map_randomized_remove_large() {
+void Map_randomized_remove_large(void) {
     uint64_t *keys = generate_random_keys(1000);
 
     for (int count = 0; count < 1000; count += 50) {
@@ -482,7 +482,7 @@ void Map_randomized_remove_large() {
     ecs_os_free(keys);
 }
 
-void Map_randomized_after_clear() {
+void Map_randomized_after_clear(void) {
     uint64_t *keys = generate_random_keys(1000);
 
     for (int count = 0; count < 1000; count += 50) {

--- a/test/collections/src/Sparse.c
+++ b/test/collections/src/Sparse.c
@@ -1,7 +1,7 @@
 #include <collections.h>
 #include <flecs/private/sparse.h>
 
-void Sparse_setup() {
+void Sparse_setup(void) {
     ecs_os_set_api_defaults();
 }
 
@@ -37,7 +37,7 @@ void populate(ecs_sparse_t *sp, int count) {
     test_int(flecs_sparse_count(sp), count + prev_count);
 }
 
-void Sparse_add_1() {
+void Sparse_add_1(void) {
     ecs_sparse_t *sp = flecs_sparse_new(NULL, NULL, int);
     test_assert(sp != NULL);
     test_int(flecs_sparse_count(sp), 0);
@@ -53,7 +53,7 @@ void Sparse_add_1() {
     flecs_sparse_free(sp);
 }
 
-void Sparse_add_1_to_empty() {
+void Sparse_add_1_to_empty(void) {
     ecs_sparse_t *sp = flecs_sparse_new(NULL, NULL, int);
     test_assert(sp != NULL);
     test_int(flecs_sparse_count(sp), 0);
@@ -69,7 +69,7 @@ void Sparse_add_1_to_empty() {
     flecs_sparse_free(sp);
 }
 
-void Sparse_add_1_chunk_size_1() {
+void Sparse_add_1_chunk_size_1(void) {
     ecs_sparse_t *sp = flecs_sparse_new(NULL, NULL, int);
     test_assert(sp != NULL);
     test_int(flecs_sparse_count(sp), 0);
@@ -85,7 +85,7 @@ void Sparse_add_1_chunk_size_1() {
     flecs_sparse_free(sp);
 }
 
-void Sparse_add_n() {
+void Sparse_add_n(void) {
     ecs_sparse_t *sp = flecs_sparse_new(NULL, NULL, int);
     test_assert(sp != NULL);
     test_int(flecs_sparse_count(sp), 0);
@@ -109,7 +109,7 @@ void Sparse_add_n() {
     flecs_sparse_free(sp);
 }
 
-void Sparse_add_n_chunk_size_1() {
+void Sparse_add_n_chunk_size_1(void) {
     ecs_sparse_t *sp = flecs_sparse_new(NULL, NULL, int);
     test_assert(sp != NULL);
     test_int(flecs_sparse_count(sp), 0);
@@ -133,7 +133,7 @@ void Sparse_add_n_chunk_size_1() {
     flecs_sparse_free(sp);
 }
 
-void Sparse_remove() {
+void Sparse_remove(void) {
     ecs_sparse_t *sp = flecs_sparse_new(NULL, NULL, int);
     test_assert(sp != NULL);
     test_int(flecs_sparse_count(sp), 0);
@@ -153,7 +153,7 @@ void Sparse_remove() {
     flecs_sparse_free(sp);
 }
 
-void Sparse_remove_first() {
+void Sparse_remove_first(void) {
     ecs_sparse_t *sp = flecs_sparse_new(NULL, NULL, int);
     test_assert(sp != NULL);
     test_int(flecs_sparse_count(sp), 0);
@@ -173,7 +173,7 @@ void Sparse_remove_first() {
     flecs_sparse_free(sp);
 }
 
-void Sparse_remove_last() {
+void Sparse_remove_last(void) {
     ecs_sparse_t *sp = flecs_sparse_new(NULL, NULL, int);
     test_assert(sp != NULL);
     test_int(flecs_sparse_count(sp), 0);
@@ -193,7 +193,7 @@ void Sparse_remove_last() {
     flecs_sparse_free(sp);
 }
 
-void Sparse_remove_all() {
+void Sparse_remove_all(void) {
     ecs_sparse_t *sp = flecs_sparse_new(NULL, NULL, int);
     test_assert(sp != NULL);
     test_int(flecs_sparse_count(sp), 0);
@@ -224,7 +224,7 @@ void Sparse_remove_all() {
     flecs_sparse_free(sp);
 }
 
-void Sparse_remove_all_n_chunks() {
+void Sparse_remove_all_n_chunks(void) {
     ecs_sparse_t *sp = flecs_sparse_new(NULL, NULL, int);
     test_assert(sp != NULL);
     test_int(flecs_sparse_count(sp), 0);
@@ -240,7 +240,7 @@ void Sparse_remove_all_n_chunks() {
     flecs_sparse_free(sp);
 }
 
-void Sparse_clear_1() {
+void Sparse_clear_1(void) {
     ecs_sparse_t *sp = flecs_sparse_new(NULL, NULL, int);
     test_assert(sp != NULL);
     test_int(flecs_sparse_count(sp), 0);
@@ -253,7 +253,7 @@ void Sparse_clear_1() {
     flecs_sparse_free(sp);
 }
 
-void Sparse_clear_empty() {
+void Sparse_clear_empty(void) {
     ecs_sparse_t *sp = flecs_sparse_new(NULL, NULL, int);
     test_assert(sp != NULL);
     test_int(flecs_sparse_count(sp), 0);
@@ -264,7 +264,7 @@ void Sparse_clear_empty() {
     flecs_sparse_free(sp);
 }
 
-void Sparse_clear_n() {
+void Sparse_clear_n(void) {
     ecs_sparse_t *sp = flecs_sparse_new(NULL, NULL, int);
     test_assert(sp != NULL);
     test_int(flecs_sparse_count(sp), 0);
@@ -277,7 +277,7 @@ void Sparse_clear_n() {
     flecs_sparse_free(sp);
 }
 
-void Sparse_clear_n_chunks() {
+void Sparse_clear_n_chunks(void) {
     ecs_sparse_t *sp = flecs_sparse_new(NULL, NULL, int);
     test_assert(sp != NULL);
     test_int(flecs_sparse_count(sp), 0);
@@ -290,7 +290,7 @@ void Sparse_clear_n_chunks() {
     flecs_sparse_free(sp);
 }
 
-void Sparse_add_after_clear() {
+void Sparse_add_after_clear(void) {
     ecs_sparse_t *sp = flecs_sparse_new(NULL, NULL, int);
     test_assert(sp != NULL);
     test_int(flecs_sparse_count(sp), 0);
@@ -315,7 +315,7 @@ void Sparse_add_after_clear() {
     flecs_sparse_free(sp);
 }
 
-void Sparse_create_delete() {
+void Sparse_create_delete(void) {
     ecs_sparse_t *sp = flecs_sparse_new(NULL, NULL, int);
     test_assert(sp != NULL);
     test_int(flecs_sparse_count(sp), 0);
@@ -330,7 +330,7 @@ void Sparse_create_delete() {
     flecs_sparse_free(sp);
 }
 
-void Sparse_create_delete_2() {
+void Sparse_create_delete_2(void) {
     ecs_sparse_t *sp = flecs_sparse_new(NULL, NULL, int);
     test_assert(sp != NULL);
     test_int(flecs_sparse_count(sp), 0);
@@ -354,11 +354,11 @@ void Sparse_create_delete_2() {
     flecs_sparse_free(sp);
 }
 
-void Sparse_count_of_null() {
+void Sparse_count_of_null(void) {
     test_int(flecs_sparse_count(NULL), 0);
 }
 
-void Sparse_try_low_after_ensure_high() {
+void Sparse_try_low_after_ensure_high(void) {
     ecs_sparse_t *sp = flecs_sparse_new(NULL, NULL, int);
 
     int *ptr_1 = flecs_sparse_ensure_t(sp, int, 5000);
@@ -370,7 +370,7 @@ void Sparse_try_low_after_ensure_high() {
     flecs_sparse_free(sp);
 }
 
-void Sparse_is_alive_low_after_ensure_high() {
+void Sparse_is_alive_low_after_ensure_high(void) {
     ecs_sparse_t *sp = flecs_sparse_new(NULL, NULL, int);
 
     int *ptr_1 = flecs_sparse_ensure_t(sp, int, 5000);
@@ -382,7 +382,7 @@ void Sparse_is_alive_low_after_ensure_high() {
     flecs_sparse_free(sp);
 }
 
-void Sparse_remove_low_after_ensure_high() {
+void Sparse_remove_low_after_ensure_high(void) {
     ecs_sparse_t *sp = flecs_sparse_new(NULL, NULL, int);
 
     int *ptr_1 = flecs_sparse_ensure_t(sp, int, 5000);

--- a/test/collections/src/Strbuf.c
+++ b/test/collections/src/Strbuf.c
@@ -1,11 +1,11 @@
 #include <collections.h>
 #include <math.h>
 
-void Strbuf_setup() {
+void Strbuf_setup(void) {
     ecs_os_set_api_defaults();
 }
 
-void Strbuf_append() {
+void Strbuf_append(void) {
     ecs_strbuf_t b = ECS_STRBUF_INIT;
     ecs_strbuf_append(&b, "Foo");
     ecs_strbuf_append(&b, "Bar %d", 10);
@@ -15,7 +15,7 @@ void Strbuf_append() {
     ecs_os_free(str);
 }
 
-void Strbuf_appendstr() {
+void Strbuf_appendstr(void) {
     ecs_strbuf_t b = ECS_STRBUF_INIT;
     ecs_strbuf_appendstr(&b, "Foo");
     ecs_strbuf_appendstr(&b, "Bar");
@@ -25,7 +25,7 @@ void Strbuf_appendstr() {
     ecs_os_free(str);
 }
 
-void Strbuf_appendstrn() {
+void Strbuf_appendstrn(void) {
     ecs_strbuf_t b = ECS_STRBUF_INIT;
     ecs_strbuf_append(&b, "Foo");
     ecs_strbuf_appendstrn(&b, "Bar", 1);
@@ -35,7 +35,7 @@ void Strbuf_appendstrn() {
     ecs_os_free(str);
 }
 
-void Strbuf_appendstr_null() {
+void Strbuf_appendstr_null(void) {
     install_test_abort();
     ecs_strbuf_t b = ECS_STRBUF_INIT;
     ecs_strbuf_append(&b, "Foo");
@@ -43,7 +43,7 @@ void Strbuf_appendstr_null() {
     ecs_strbuf_appendstr(&b, NULL);
 }
 
-void Strbuf_append_list() {
+void Strbuf_append_list(void) {
     ecs_strbuf_t b = ECS_STRBUF_INIT;
     ecs_strbuf_append(&b, "Foo");
     ecs_strbuf_list_push(&b, "{", ",");
@@ -56,7 +56,7 @@ void Strbuf_append_list() {
     ecs_os_free(str);
 }
 
-void Strbuf_append_nested_list() {
+void Strbuf_append_nested_list(void) {
     ecs_strbuf_t b = ECS_STRBUF_INIT;
     ecs_strbuf_append(&b, "Foo");
     ecs_strbuf_list_push(&b, "{", ",");
@@ -81,7 +81,7 @@ void Strbuf_append_nested_list() {
     ecs_os_free(str);
 }
 
-void Strbuf_large_str() {
+void Strbuf_large_str(void) {
     ecs_strbuf_t b = ECS_STRBUF_INIT;
     ecs_strbuf_append(&b, "Foo");
 
@@ -100,13 +100,13 @@ void Strbuf_large_str() {
     ecs_os_free(str);
 }
 
-void Strbuf_empty_str() {
+void Strbuf_empty_str(void) {
     ecs_strbuf_t b = ECS_STRBUF_INIT;
     char *str = ecs_strbuf_get(&b);
     test_assert(str == NULL);
 }
 
-void Strbuf_append_zerocopy() {
+void Strbuf_append_zerocopy(void) {
     ecs_strbuf_t b = ECS_STRBUF_INIT;
     ecs_strbuf_appendstr(&b, "Foo");
     ecs_strbuf_appendstr_zerocpy(&b, ecs_os_strdup("Bar"));
@@ -116,7 +116,7 @@ void Strbuf_append_zerocopy() {
     ecs_os_free(str);
 }
 
-void Strbuf_append_zerocopy_const() {
+void Strbuf_append_zerocopy_const(void) {
     ecs_strbuf_t b = ECS_STRBUF_INIT;
     ecs_strbuf_appendstr(&b, "Foo");
     ecs_strbuf_appendstr_zerocpy_const(&b, "Bar");
@@ -126,7 +126,7 @@ void Strbuf_append_zerocopy_const() {
     ecs_os_free(str);
 }
 
-void Strbuf_append_zerocopy_only() {
+void Strbuf_append_zerocopy_only(void) {
     ecs_strbuf_t b = ECS_STRBUF_INIT;
     ecs_strbuf_appendstr_zerocpy(&b, ecs_os_strdup("Bar"));
     char *str = ecs_strbuf_get(&b);
@@ -135,7 +135,7 @@ void Strbuf_append_zerocopy_only() {
     ecs_os_free(str);
 }
 
-void Strbuf_reset() {
+void Strbuf_reset(void) {
     ecs_strbuf_t b = ECS_STRBUF_INIT;
     ecs_strbuf_appendstr(&b, "Foo");
     ecs_strbuf_appendstr(&b, "Bar");
@@ -144,7 +144,7 @@ void Strbuf_reset() {
     test_assert(str == NULL);
 }
 
-void Strbuf_merge() {
+void Strbuf_merge(void) {
     ecs_strbuf_t b1 = ECS_STRBUF_INIT;
     ecs_strbuf_appendstr(&b1, "Foo");
     ecs_strbuf_appendstr(&b1, "Bar");
@@ -162,7 +162,7 @@ void Strbuf_merge() {
     test_assert(str == NULL);
 }
 
-void Strbuf_app_buffer() {
+void Strbuf_app_buffer(void) {
     char buf[256];
     ecs_strbuf_t b = ECS_STRBUF_INIT;
     b.buf = buf;
@@ -176,7 +176,7 @@ void Strbuf_app_buffer() {
     ecs_os_free(str);
 }
 
-void Strbuf_append_char() {
+void Strbuf_append_char(void) {
     ecs_strbuf_t b = ECS_STRBUF_INIT;
     ecs_strbuf_appendch(&b, 'a');
     ecs_strbuf_appendch(&b, 'b');
@@ -188,7 +188,7 @@ void Strbuf_append_char() {
     ecs_os_free(str);
 }
 
-void Strbuf_append_511_chars() {
+void Strbuf_append_511_chars(void) {
     ecs_strbuf_t b = ECS_STRBUF_INIT;
 
     for (int i = 0; i < 511; i ++) {
@@ -203,7 +203,7 @@ void Strbuf_append_511_chars() {
     ecs_os_free(str);
 }
 
-void Strbuf_append_512_chars() {
+void Strbuf_append_512_chars(void) {
     ecs_strbuf_t b = ECS_STRBUF_INIT;
 
     for (int i = 0; i < 512; i ++) {
@@ -218,7 +218,7 @@ void Strbuf_append_512_chars() {
     ecs_os_free(str);
 }
 
-void Strbuf_append_513_chars() {
+void Strbuf_append_513_chars(void) {
     ecs_strbuf_t b = ECS_STRBUF_INIT;
 
     for (int i = 0; i < 513; i ++) {
@@ -233,7 +233,7 @@ void Strbuf_append_513_chars() {
     ecs_os_free(str);
 }
 
-void Strbuf_append_flt() {
+void Strbuf_append_flt(void) {
     ecs_strbuf_t b = ECS_STRBUF_INIT;
     ecs_strbuf_appendflt(&b, 10.5, 0);
 
@@ -243,7 +243,7 @@ void Strbuf_append_flt() {
     ecs_os_free(str);
 }
 
-void Strbuf_append_nan() {
+void Strbuf_append_nan(void) {
     ecs_strbuf_t b = ECS_STRBUF_INIT;
     ecs_strbuf_appendflt(&b, NAN, 0);
 
@@ -253,7 +253,7 @@ void Strbuf_append_nan() {
     ecs_os_free(str);
 }
 
-void Strbuf_append_inf() {
+void Strbuf_append_inf(void) {
     {
         ecs_strbuf_t b = ECS_STRBUF_INIT;
         ecs_strbuf_appendflt(&b, INFINITY, 0);
@@ -274,7 +274,7 @@ void Strbuf_append_inf() {
     }
 }
 
-void Strbuf_append_nan_delim() {
+void Strbuf_append_nan_delim(void) {
     ecs_strbuf_t b = ECS_STRBUF_INIT;
     ecs_strbuf_appendflt(&b, NAN, '"');
 
@@ -284,7 +284,7 @@ void Strbuf_append_nan_delim() {
     ecs_os_free(str);
 }
 
-void Strbuf_append_inf_delim() {
+void Strbuf_append_inf_delim(void) {
     {
         ecs_strbuf_t b = ECS_STRBUF_INIT;
         ecs_strbuf_appendflt(&b, INFINITY, '"');

--- a/test/cpp_api/project.json
+++ b/test/cpp_api/project.json
@@ -409,7 +409,8 @@
                 "alias_scoped_component_w_name",
                 "alias_entity",
                 "alias_entity_by_name",
-                "alias_entity_by_scoped_name"
+                "alias_entity_by_scoped_name",
+                "alias_entity_empty"
             ]
         }, {
             "id": "System",

--- a/test/cpp_api/src/Paths.cpp
+++ b/test/cpp_api/src/Paths.cpp
@@ -176,19 +176,9 @@ void Paths_alias_entity(void) {
 
     ecs.use(e, "FooAlias");
 
-    auto original = ecs.lookup("Foo");
-    auto alias = ecs.lookup("FooAlias");
+    auto a = ecs.lookup("FooAlias");
 
-    test_assert(e.id() == alias.id());
-    test_assert(e.id() == original.id());
-
-    ecs.use(e);
-
-    original = ecs.lookup("Foo");
-    alias = ecs.lookup("FooAlias");
-
-    test_assert(e.id() == original.id());
-    test_assert(e.id() != alias.id());
+    test_assert(e.id() == a.id());
 }
 
 void Paths_alias_entity_by_name(void) {
@@ -215,3 +205,31 @@ void Paths_alias_entity_by_scoped_name(void) {
     test_assert(e.id() == a.id());
     test_assert(e.id() == l.id());
 }
+
+void Paths_alias_entity_empty(void) {
+    flecs::world ecs;
+
+    auto parent = ecs.entity("parent");
+    auto child = ecs.entity("child").child_of(parent);
+
+    auto e = ecs.lookup("child");
+
+    test_assert(e.id() == 0);
+
+    ecs.use(child); // alias being nullptr
+
+    e = ecs.lookup("child");
+
+    test_assert(e.id() != 0);
+
+    ecs.use(child, "FooAlias");
+
+    e = ecs.lookup("child");
+
+    test_assert(e.id() == 0);
+
+    e = ecs.lookup("FooAlias");
+
+    test_assert(e.id() != 0);
+}
+

--- a/test/cpp_api/src/Paths.cpp
+++ b/test/cpp_api/src/Paths.cpp
@@ -176,9 +176,19 @@ void Paths_alias_entity(void) {
 
     ecs.use(e, "FooAlias");
 
-    auto a = ecs.lookup("FooAlias");
+    auto original = ecs.lookup("Foo");
+    auto alias = ecs.lookup("FooAlias");
 
-    test_assert(e.id() == a.id());
+    test_assert(e.id() == alias.id());
+    test_assert(e.id() == original.id());
+
+    ecs.use(e);
+
+    original = ecs.lookup("Foo");
+    alias = ecs.lookup("FooAlias");
+
+    test_assert(e.id() == original.id());
+    test_assert(e.id() != alias.id());
 }
 
 void Paths_alias_entity_by_name(void) {

--- a/test/cpp_api/src/main.cpp
+++ b/test/cpp_api/src/main.cpp
@@ -394,6 +394,7 @@ void Paths_alias_scoped_component_w_name(void);
 void Paths_alias_entity(void);
 void Paths_alias_entity_by_name(void);
 void Paths_alias_entity_by_scoped_name(void);
+void Paths_alias_entity_empty(void);
 
 // Testsuite 'System'
 void System_iter(void);
@@ -2808,6 +2809,10 @@ bake_test_case Paths_testcases[] = {
     {
         "alias_entity_by_scoped_name",
         Paths_alias_entity_by_scoped_name
+    },
+    {
+        "alias_entity_empty",
+        Paths_alias_entity_empty
     }
 };
 
@@ -6329,7 +6334,7 @@ static bake_test_suite suites[] = {
         "Paths",
         NULL,
         NULL,
-        14,
+        15,
         Paths_testcases
     },
     {


### PR DESCRIPTION
it's worth considering if there should be a default parameter value for alias, which is set to nullptr.

In case you agree to remove it, I'll update the PR and 
`set ecs_check(entity != 0 || name != NULL, ECS_INVALID_PARAMETER, NULL); `
to
`ecs_check(entity != 0 && name != NULL, ECS_INVALID_PARAMETER, NULL);`
in
`flecs_set_identifier` function

In case we do, then the `if(!name)` check in `use` function is quite redundant and we could optionally remove it since flecs_set_identifier already deals will nullptr name where it just removes the previous alias and sets no new (as far as I understand)