### PR TITLE
Improve assert performance

### DIFF
--- a/include/flecs/addons/log.h
+++ b/include/flecs/addons/log.h
@@ -155,8 +155,7 @@ void ecs_abort_(
     ...);
 
 FLECS_API
-bool ecs_assert_(
-    bool condition,
+void ecs_assert_log_(
     int32_t error_code,
     const char *condition_str,
     const char *file,
@@ -350,7 +349,8 @@ void ecs_parser_errorv_(
 #define ecs_assert(condition, error_code, ...)
 #else
 #define ecs_assert(condition, error_code, ...)\
-    if (!ecs_assert_(condition, error_code, #condition, __FILE__, __LINE__, __VA_ARGS__)) {\
+    if (!(condition)) {\
+        ecs_assert_log_(error_code, #condition, __FILE__, __LINE__, __VA_ARGS__);\
         ecs_os_abort();\
     }\
     assert(condition) /* satisfy compiler/static analyzers */
@@ -390,7 +390,8 @@ void ecs_parser_errorv_(
 #else
 #ifdef FLECS_SOFT_ASSERT
 #define ecs_check(condition, error_code, ...)\
-    if (!ecs_assert_(condition, error_code, #condition, __FILE__, __LINE__, __VA_ARGS__)) {\
+    if (!(condition)) {\
+        ecs_assert_log_(error_code, #condition, __FILE__, __LINE__, __VA_ARGS__);\
         goto error;\
     }
 #else // FLECS_SOFT_ASSERT

--- a/src/addons/log.c
+++ b/src/addons/log.c
@@ -326,8 +326,7 @@ void ecs_abort_(
     ecs_os_api.log_last_error_ = err;
 }
 
-bool ecs_assert_(
-    bool condition,
+void ecs_assert_log_(
     int32_t err,
     const char *cond_str,
     const char *file,
@@ -335,23 +334,19 @@ bool ecs_assert_(
     const char *fmt,
     ...)
 {
-    if (!condition) {
-        if (fmt) {
-            va_list args;
-            va_start(args, fmt);
-            char *msg = ecs_vasprintf(fmt, args);
-            va_end(args);            
-            ecs_fatal_(file, line, "assert: %s %s (%s)", 
-                cond_str, msg, ecs_strerror(err));
-            ecs_os_free(msg);
-        } else {
-            ecs_fatal_(file, line, "assert: %s %s", 
-                cond_str, ecs_strerror(err));
-        }
-        ecs_os_api.log_last_error_ = err;
+    if (fmt) {
+        va_list args;
+        va_start(args, fmt);
+        char *msg = ecs_vasprintf(fmt, args);
+        va_end(args);
+        ecs_fatal_(file, line, "assert: %s %s (%s)",
+            cond_str, msg, ecs_strerror(err));
+        ecs_os_free(msg);
+    } else {
+        ecs_fatal_(file, line, "assert: %s %s",
+            cond_str, ecs_strerror(err));
     }
-
-    return condition;
+    ecs_os_api.log_last_error_ = err;
 }
 
 void ecs_deprecated_(
@@ -484,8 +479,7 @@ void ecs_abort_(
     (void)fmt;
 }
 
-bool ecs_assert_(
-    bool condition,
+void ecs_assert_log_(
     int32_t error_code,
     const char *condition_str,
     const char *file,
@@ -493,13 +487,11 @@ bool ecs_assert_(
     const char *fmt,
     ...)
 {
-    (void)condition;
     (void)error_code;
     (void)condition_str;
     (void)file;
     (void)line;
     (void)fmt;
-    return true;
 }
 
 #endif

--- a/src/addons/pipeline/pipeline.c
+++ b/src/addons/pipeline/pipeline.c
@@ -285,7 +285,8 @@ bool flecs_pipeline_build(
 
         int32_t i;
         for (i = 0; i < it.count; i ++) {
-            ecs_system_t *sys = ecs_poly(poly[i].poly, ecs_system_t);
+            ecs_poly_assert(poly[i].poly, ecs_system_t);
+            ecs_system_t *sys = (ecs_system_t*)poly[i].poly;
             ecs_query_t *q = sys->query;
 
             bool needs_merge = false;
@@ -391,8 +392,8 @@ bool flecs_pipeline_build(
         for (i = 0; i < count; i ++) {
             ecs_entity_t system = systems[i];
             const EcsPoly *poly = ecs_get_pair(world, system, EcsPoly, EcsSystem);
-            ecs_assert(poly != NULL, ECS_INTERNAL_ERROR, NULL);
-            ecs_system_t *sys = ecs_poly(poly->poly, ecs_system_t);
+            ecs_poly_assert(poly->poly, ecs_system_t);
+            ecs_system_t *sys = (ecs_system_t*)poly->poly;
 
 #ifdef FLECS_LOG_1
             char *path = ecs_get_fullpath(world, system);
@@ -550,8 +551,8 @@ int32_t flecs_run_pipeline_ops(
     for (; i < count; i++) {
         ecs_entity_t system = systems[i];
         const EcsPoly* poly = ecs_get_pair(world, system, EcsPoly, EcsSystem);
-        ecs_assert(poly != NULL, ECS_INTERNAL_ERROR, NULL);
-        ecs_system_t* sys = ecs_poly(poly->poly, ecs_system_t);
+        ecs_poly_assert(poly->poly, ecs_system_t);
+        ecs_system_t* sys = (ecs_system_t*)poly->poly;
 
         /* Keep track of the last frame for which the system has ran, so we
         * know from where to resume the schedule in case the schedule

--- a/src/addons/system/system.c
+++ b/src/addons/system/system.c
@@ -322,7 +322,8 @@ ecs_entity_t ecs_system_init(
 
         ecs_defer_end(world);            
     } else {
-        ecs_system_t *system = ecs_poly(poly->poly, ecs_system_t);
+        ecs_poly_assert(poly->poly, ecs_system_t);
+        ecs_system_t *system = (ecs_system_t*)poly->poly;
 
         if (desc->run) {
             system->run = desc->run;

--- a/src/observer.c
+++ b/src/observer.c
@@ -928,7 +928,8 @@ ecs_entity_t ecs_observer_init(
                 ecs_get_name(world, entity));
         }
     } else {
-        ecs_observer_t *observer = ecs_poly(poly->poly, ecs_observer_t);
+        ecs_poly_assert(poly->poly, ecs_observer_t);
+        ecs_observer_t *observer = (ecs_observer_t*)poly->poly;
 
         if (desc->run) {
             observer->run = desc->run;

--- a/src/poly.c
+++ b/src/poly.c
@@ -187,26 +187,6 @@ ecs_poly_t* ecs_poly_get_(
     return NULL;
 }
 
-#ifndef FLECS_NDEBUG
-#define assert_object(cond, file, line, type_name)\
-    ecs_assert((cond), ECS_INVALID_PARAMETER, #cond, file, line, type_name)
-
-void* ecs_poly_assert_(
-    const ecs_poly_t *poly,
-    int32_t type,
-    const char *file,
-    int32_t line)
-{
-    assert_object(poly != NULL, file, line, 0);
-    
-    const ecs_header_t *hdr = poly;
-    const char *type_name = hdr->mixins->type_name;
-    assert_object(hdr->magic == ECS_OBJECT_MAGIC, file, line, type_name);
-    assert_object(hdr->type == type, file, line, type_name);
-    return ECS_CONST_CAST(ecs_poly_t*, poly);
-}
-#endif
-
 bool ecs_poly_is_(
     const ecs_poly_t *poly,
     int32_t type)

--- a/src/poly.c
+++ b/src/poly.c
@@ -189,8 +189,7 @@ ecs_poly_t* ecs_poly_get_(
 
 #ifndef FLECS_NDEBUG
 #define assert_object(cond, file, line, type_name)\
-    ecs_assert_((cond), ECS_INVALID_PARAMETER, #cond, file, line, type_name);\
-    assert(cond)
+    ecs_assert((cond), ECS_INVALID_PARAMETER, #cond, file, line, type_name)
 
 void* ecs_poly_assert_(
     const ecs_poly_t *poly,

--- a/src/poly.h
+++ b/src/poly.h
@@ -70,19 +70,16 @@ ecs_poly_t* ecs_poly_get_(
 
 /* Utilities for testing/asserting an object type */
 #ifndef FLECS_NDEBUG
-void* ecs_poly_assert_(
-    const ecs_poly_t *object,
-    int32_t type,
-    const char *file,
-    int32_t line);
-
-#define ecs_poly_assert(object, type)\
-    ecs_poly_assert_(object, type##_magic, __FILE__, __LINE__)
-
-#define ecs_poly(object, T) ((T*)ecs_poly_assert(object, T))
+#define ecs_poly_assert(object, ty)\
+    do {\
+        ecs_assert(object != NULL, ECS_INVALID_PARAMETER, NULL);\
+        const ecs_header_t *hdr = (const ecs_header_t *)object;\
+        const char *type_name = hdr->mixins->type_name;\
+        ecs_assert(hdr->magic == ECS_OBJECT_MAGIC, ECS_INVALID_PARAMETER, type_name);\
+        ecs_assert(hdr->type == ty##_magic, ECS_INVALID_PARAMETER, type_name);\
+    } while (0)
 #else
-#define ecs_poly_assert(object, type)
-#define ecs_poly(object, T) ((T*)object)
+#define ecs_poly_assert(object, ty)
 #endif
 
 /* Utility functions for getting a mixin from an object */


### PR DESCRIPTION
As discussed on discord, moving the condition outside of `ecs_assert` improves debug performance. Now I also tested on ecs_benchmark and got ~1.4x speedups. 

For further work I need your opinion on 2 things:
1. The same could be done to `ecs_poly_assert`, but `ecs_poly` casts the return value from `ecs_poly_assert`. My suggestion is to do the check separately: [Example in my fork](https://github.com/jbarthelmes/flecs/commit/e00a9c15dbc549b34299d0162d12a353f9793206#diff-227b94484bf9df7691c3995c506646ee41f49e57356d50db1b55e00131767d15). Those 5 were the only callsites 2 weeks ago. Can you live with that?
2. Performance could be further improved (I measured ~1.3x) by removing the calls to `ecs_os_abort` and `assert`. This can be done by making the fail handler noreturn and moving the call to abort inside. However, adding noreturn requires some `#if`s because the C standard changed on how to use it: [cppreference](https://en.cppreference.com/w/c/language/_Noreturn). So I'd add a `#define FLECS_NORETURN` depending on std(/compiler?) version. Do you want that?

[My benchmark results are attached](https://github.com/SanderMertens/flecs/files/12857299/assert-bench.ods).
You'll have to amalgamate yourself.