### PR TITLE
Allow for optional pairs in C++ systems

### DIFF
--- a/include/flecs/addons/cpp/delegate.hpp
+++ b/include/flecs/addons/cpp/delegate.hpp
@@ -139,7 +139,7 @@ struct each_column<T, if_t< is_pointer<T>::value &&
     each_column(const _::term_ptr& term, size_t row) 
         : each_column_base(term, row) { }
 
-    T get_row() {
+    actual_type_t<T> get_row() {
         if (this->m_term.ptr) {
             return &static_cast<actual_type_t<T>>(this->m_term.ptr)[this->m_row];
         } else {

--- a/include/flecs/addons/cpp/pair.hpp
+++ b/include/flecs/addons/cpp/pair.hpp
@@ -74,25 +74,26 @@ private:
 template <typename First, typename Second, if_t<is_empty<First>::value> = 0>
 using pair_object = pair<First, Second>;
 
+template <typename T>
+using raw_type_t = remove_pointer_t<remove_reference_t<T>>;
 
 /** Test if type is a pair. */
 template <typename T>
 struct is_pair {
-    static constexpr bool value = is_base_of<_::pair_base, remove_reference_t<T> >::value;
+    static constexpr bool value = is_base_of<_::pair_base, raw_type_t<T> >::value;
 };
-
 
 /** Get pair::first from pair while preserving cv qualifiers. */
 template <typename P>
-using pair_first_t = transcribe_cv_t<remove_reference_t<P>, typename remove_reference_t<P>::first>;
+using pair_first_t = transcribe_cv_t<remove_reference_t<P>, typename raw_type_t<P>::first>;
 
 /** Get pair::second from pair while preserving cv qualifiers. */
 template <typename P>
-using pair_second_t = transcribe_cv_t<remove_reference_t<P>, typename remove_reference_t<P>::second>;
+using pair_second_t = transcribe_cv_t<remove_reference_t<P>, typename raw_type_t<P>::second>;
 
-/** Get pair::type type from pair while preserving cv qualifiers. */
+/** Get pair::type type from pair while preserving cv qualifiers and pointer type. */
 template <typename P>
-using pair_type_t = transcribe_cv_t<remove_reference_t<P>, typename remove_reference_t<P>::type>;
+using pair_type_t = transcribe_cvp_t<remove_reference_t<P>, typename raw_type_t<P>::type>;
 
 /** Get actual type from a regular type or pair. */
 template <typename T, typename U = int>

--- a/include/flecs/addons/cpp/utils/utils.hpp
+++ b/include/flecs/addons/cpp/utils/utils.hpp
@@ -109,6 +109,12 @@ using transcribe_volatile_t = conditional_t<is_volatile<Src>::value, Dst volatil
 template<class Src, class Dst>
 using transcribe_cv_t = transcribe_const_t< Src, transcribe_volatile_t< Src, Dst> >;
 
+template<class Src, class Dst>
+using transcribe_pointer_t = conditional_t<is_pointer<Src>::value, Dst*, Dst>;
+
+template<class Src, class Dst>
+using transcribe_cvp_t = transcribe_cv_t< Src, transcribe_pointer_t< Src, Dst> >;
+
 
 // More convenience templates. The if_*_t templates use int as default type
 // instead of void. This enables writing code that's a bit less cluttered when

--- a/test/cpp_api/project.json
+++ b/test/cpp_api/project.json
@@ -162,7 +162,7 @@
                 "with_scope_nested",
                 "with_scope_nested_same_name_as_parent",
                 "scope_after_builder_method",
-                "scope_before_builder_method",                
+                "scope_before_builder_method",
                 "no_recursive_lookup",
                 "defer_new_w_name",
                 "defer_new_w_nested_name",
@@ -277,7 +277,7 @@
                 "add_tag_pair_to_tag",
                 "remove_component_pair",
                 "remove_tag_pair",
-                "remove_tag_pair_to_tag",                
+                "remove_tag_pair_to_tag",
                 "set_component_pair",
                 "set_tag_pair",
                 "system_1_pair_instance",
@@ -482,7 +482,8 @@
                 "nested_rate_tick_source",
                 "table_get",
                 "range_get",
-                "randomize_timers"
+                "randomize_timers",
+                "optional_pair_term"
             ]
         }, {
             "id": "Event",
@@ -823,7 +824,7 @@
                 "inspect_terms_w_expr",
                 "find",
                 "find_not_found",
-                "find_w_entity"                
+                "find_w_entity"
             ]
         }, {
             "id": "SystemBuilder",
@@ -850,7 +851,7 @@
                 "create_w_no_template_args",
                 "write_annotation",
                 "name_from_root"
-            ]  
+            ]
         }, {
             "id": "Observer",
             "testcases": [

--- a/test/cpp_api/src/System.cpp
+++ b/test/cpp_api/src/System.cpp
@@ -23,7 +23,7 @@ void System_iter(void) {
 
     const Velocity *v = entity.get<Velocity>();
     test_int(v->x, 1);
-    test_int(v->y, 2);       
+    test_int(v->y, 2);
 }
 
 void System_iter_const(void) {
@@ -79,7 +79,7 @@ void System_iter_shared(void) {
                 for (auto i : it) {
                     p[i].x += v[i].x;
                     p[i].y += v[i].y;
-                }                
+                }
             }
         });
 
@@ -91,7 +91,7 @@ void System_iter_shared(void) {
 
     p = e2.get<Position>();
     test_int(p->x, 13);
-    test_int(p->y, 24);   
+    test_int(p->y, 24);
 }
 
 void System_iter_optional(void) {
@@ -106,7 +106,7 @@ void System_iter_optional(void) {
     auto e2 = world.entity()
         .set<Position>({30, 40})
         .set<Velocity>({3, 4})
-        .set<Mass>({1});        
+        .set<Mass>({1});
 
     auto e3 = world.entity()
         .set<Position>({50, 60});
@@ -216,7 +216,7 @@ void System_each_shared(void) {
 
     p = e2.get<Position>();
     test_int(p->x, 13);
-    test_int(p->y, 24); 
+    test_int(p->y, 24);
 }
 
 void System_each_optional(void) {
@@ -231,7 +231,7 @@ void System_each_optional(void) {
     auto e2 = world.entity()
         .set<Position>({30, 40})
         .set<Velocity>({3, 4})
-        .set<Mass>({1});        
+        .set<Mass>({1});
 
     auto e3 = world.entity()
         .set<Position>({50, 60});
@@ -296,7 +296,7 @@ void System_signature(void) {
 
     const Velocity *v = entity.get<Velocity>();
     test_int(v->x, 1);
-    test_int(v->y, 2); 
+    test_int(v->y, 2);
 }
 
 void System_signature_const(void) {
@@ -325,7 +325,7 @@ void System_signature_const(void) {
 
     const Velocity *v = entity.get<Velocity>();
     test_int(v->x, 1);
-    test_int(v->y, 2); 
+    test_int(v->y, 2);
 }
 
 void System_signature_shared(void) {
@@ -356,7 +356,7 @@ void System_signature_shared(void) {
                 for (auto i : it) {
                     p[i].x += v[i].x;
                     p[i].y += v[i].y;
-                }                
+                }
             }
         });
 
@@ -368,7 +368,7 @@ void System_signature_shared(void) {
 
     p = e2.get<Position>();
     test_int(p->x, 13);
-    test_int(p->y, 24); 
+    test_int(p->y, 24);
 }
 
 void System_signature_optional(void) {
@@ -383,7 +383,7 @@ void System_signature_optional(void) {
     auto e2 = world.entity()
         .set<Position>({30, 40})
         .set<Velocity>({3, 4})
-        .set<Mass>({1});        
+        .set<Mass>({1});
 
     auto e3 = world.entity()
         .set<Position>({50, 60});
@@ -406,7 +406,7 @@ void System_signature_optional(void) {
                 for (auto i : it) {
                     p[i].x ++;
                     p[i].y ++;
-                }            
+                }
             }
         });
 
@@ -475,7 +475,7 @@ void System_empty_signature(void) {
 
     world.progress();
 
-    test_int(count, 1); 
+    test_int(count, 1);
 }
 
 struct MyTag { };
@@ -547,7 +547,7 @@ void System_order_by_type(void) {
 
     auto sys = world.system<const Position>()
         .order_by<Position>(
-            [](flecs::entity_t e1, const Position *p1, 
+            [](flecs::entity_t e1, const Position *p1,
                flecs::entity_t e2, const Position *p2) {
                 return (p1->x > p2->x) - (p1->x < p2->x);
             })
@@ -577,12 +577,12 @@ void System_order_by_id(void) {
     int32_t count = 0;
 
     auto sys = world.system<const Position>()
-        .order_by(pos, [](flecs::entity_t e1, const void *p1, 
-                          flecs::entity_t e2, const void *p2) 
+        .order_by(pos, [](flecs::entity_t e1, const void *p1,
+                          flecs::entity_t e2, const void *p2)
             {
-                return (static_cast<const Position*>(p1)->x > 
-                            static_cast<const Position*>(p2)->x) - 
-                       (static_cast<const Position*>(p1)->x < 
+                return (static_cast<const Position*>(p1)->x >
+                            static_cast<const Position*>(p2)->x) -
+                       (static_cast<const Position*>(p1)->x <
                             static_cast<const Position*>(p2)->x);
             })
         .each([&](flecs::entity e, const Position& p) {
@@ -609,7 +609,7 @@ void System_order_by_type_after_create(void) {
     int32_t count = 0;
 
     auto sys = world.system<const Position>()
-        .order_by<Position>([](flecs::entity_t e1, const Position *p1, 
+        .order_by<Position>([](flecs::entity_t e1, const Position *p1,
             flecs::entity_t e2, const Position *p2) {
             return (p1->x > p2->x) - (p1->x < p2->x);
         })
@@ -640,7 +640,7 @@ void System_order_by_id_after_create(void) {
 
     auto sys = world.system<const Position>()
         .order_by(pos, [](flecs::entity_t e1, const void *p1, flecs::entity_t e2, const void *p2) {
-            return (static_cast<const Position*>(p1)->x > static_cast<const Position*>(p2)->x) - 
+            return (static_cast<const Position*>(p1)->x > static_cast<const Position*>(p2)->x) -
                 (static_cast<const Position*>(p1)->x < static_cast<const Position*>(p2)->x);
         })
         .each([&](flecs::entity e, const Position& p) {
@@ -911,9 +911,9 @@ void System_readonly_children_iter(void) {
                     // Dummy code to ensure we can access the entity
                     const Position *p = child.get<Position>();
                     test_int(p->x, 1);
-                    test_int(p->y, 0);    
+                    test_int(p->y, 0);
 
-                    count ++;                
+                    count ++;
                 });
             }
         });
@@ -926,10 +926,10 @@ void System_readonly_children_iter(void) {
 void System_rate_filter(void) {
     flecs::world world;
 
-    int32_t 
-    root_count = 0, root_mult = 1, 
-    l1_a_count = 0, l1_a_mult = 1, 
-    l1_b_count = 0, l1_b_mult = 2, 
+    int32_t
+    root_count = 0, root_mult = 1,
+    l1_a_count = 0, l1_a_mult = 1,
+    l1_b_count = 0, l1_b_mult = 2,
     l1_c_count = 0, l1_c_mult = 3,
     l2_a_count = 0, l2_a_mult = 2,
     l2_b_count = 0, l2_b_mult = 4,
@@ -944,7 +944,7 @@ void System_rate_filter(void) {
         .rate(root, 1)
         .iter([&](flecs::iter& it) {
             l1_a_count ++;
-        });  
+        });
 
     auto l1_b = world.system<>("l1_b")
         .rate(root, 2)
@@ -956,7 +956,7 @@ void System_rate_filter(void) {
         .rate(root, 3)
         .iter([&](flecs::iter& it) {
             l1_c_count ++;
-        });        
+        });
 
     world.system<>("l2_a")
         .rate(l1_a, 2)
@@ -978,15 +978,15 @@ void System_rate_filter(void) {
         test_int(l1_c_count, frame_count / l1_c_mult);
         test_int(l2_a_count, frame_count / l2_a_mult);
         test_int(l2_b_count, frame_count / l2_b_mult);
-    }    
+    }
 }
 
 void System_update_rate_filter(void) {
     flecs::world world;
 
-    int32_t 
-    root_count = 0, root_mult = 1, 
-    l1_count = 0, l1_mult = 2, 
+    int32_t
+    root_count = 0, root_mult = 1,
+    l1_count = 0, l1_mult = 2,
     l2_count = 0, l2_mult = 6,
     frame_count = 0;
 
@@ -999,13 +999,13 @@ void System_update_rate_filter(void) {
         .rate(root, 2)
         .iter([&](flecs::iter& it) {
             l1_count ++;
-        });  
+        });
 
     world.system<>("l2")
         .rate(l1, 3)
         .iter([&](flecs::iter& it) {
             l2_count ++;
-        }); 
+        });
 
     for (int i = 0; i < 12; i ++) {
         world.progress(); frame_count ++;
@@ -1028,7 +1028,7 @@ void System_update_rate_filter(void) {
         test_int(root_count, frame_count / root_mult);
         test_int(l1_count, frame_count / l1_mult);
         test_int(l2_count, frame_count / l2_mult);
-    }      
+    }
 }
 
 void System_test_auto_defer_each(void) {
@@ -1452,7 +1452,7 @@ void System_instanced_query_w_singleton_iter(void) {
                 count ++;
             }
         });
-    
+
     s.run();
 
     test_int(count, 5);
@@ -1745,7 +1745,7 @@ void System_system_w_type_kind_type_pipeline(void) {
         });
 
     world.progress();
-    
+
     test_int(s1_count, 1);
     test_int(s2_count, 1);
 }
@@ -2230,4 +2230,37 @@ void System_randomize_timers(void) {
         test_assert(t != nullptr);
         test_assert(t->time != 0);
     }
+}
+
+void System_optional_pair_term(void) {
+    flecs::world ecs;
+
+    ecs.entity()
+        .add<TagA>()
+        .emplace<Position, Tag>(1.0f, 2.0f);
+    ecs.entity()
+        .add<TagA>();
+
+    int32_t with_pair = 0, without_pair = 0;
+
+    ecs.system<flecs::pair<Position, Tag>*>()
+        .with<TagA>()
+        .each([&](flecs::entity e, Position* p)
+        {
+            if (p)
+            {
+                with_pair++;
+                test_flt(1.0f, p->x);
+                test_flt(2.0f, p->y);
+            }
+            else
+            {
+                without_pair++;
+            }
+        });
+
+    ecs.progress(1.0);
+
+    test_int(1, with_pair);
+    test_int(1, without_pair);
 }

--- a/test/cpp_api/src/main.cpp
+++ b/test/cpp_api/src/main.cpp
@@ -465,6 +465,7 @@ void System_nested_rate_tick_source(void);
 void System_table_get(void);
 void System_range_get(void);
 void System_randomize_timers(void);
+void System_optional_pair_term(void);
 
 // Testsuite 'Event'
 void Event_evt_1_id_entity(void);
@@ -3108,6 +3109,10 @@ bake_test_case System_testcases[] = {
     {
         "randomize_timers",
         System_randomize_timers
+    },
+    {
+        "optional_pair_term",
+        System_optional_pair_term
     }
 };
 
@@ -6441,7 +6446,7 @@ static bake_test_suite suites[] = {
         "System",
         NULL,
         NULL,
-        67,
+        68,
         System_testcases
     },
     {


### PR DESCRIPTION
Modifies the templates for pairs in order to allow them to handle being used as an optional term in a system. It does this by adding `raw_type_t` to strip both pointers and references for most operations but adding `transcribe_pointer_t` to put them back when needed. This means that most of the code should end up handling this transparently without many changes but I've only tested systems right now.

Only tested with gcc currently as its all I had on me at the time.