### PR TITLE
Fix issues with (de)serializing large integers

### DIFF
--- a/src/addons/json/deserialize.c
+++ b/src/addons/json/deserialize.c
@@ -144,6 +144,11 @@ const char* ecs_ptr_from_json(
             if (ecs_meta_set_float(&cur, number) != 0) {
                 goto error;
             }
+        } else if (token_kind == JsonLargeInt) {
+            int64_t number = flecs_ito(int64_t, atoll(token));
+            if (ecs_meta_set_int(&cur, number) != 0) {
+                goto error;
+            }
         } else if (token_kind == JsonNull) {
             if (ecs_meta_set_null(&cur) != 0) {
                 goto error;

--- a/src/addons/json/json.h
+++ b/src/addons/json/json.h
@@ -20,6 +20,7 @@ typedef enum ecs_json_token_t {
     JsonTrue,
     JsonFalse,
     JsonNull,
+    JsonLargeInt,
     JsonLargeString,
     JsonInvalid
 } ecs_json_token_t;

--- a/src/addons/meta/cursor.c
+++ b/src/addons/meta/cursor.c
@@ -1303,11 +1303,11 @@ int ecs_meta_set_string(
         break;
     case EcsOpI64:
     case EcsOpU64:
-        set_T(ecs_i64_t, ptr, atol(value));
+        set_T(ecs_i64_t, ptr, atoll(value));
         break;
     case EcsOpIPtr:
     case EcsOpUPtr:
-        set_T(ecs_iptr_t, ptr, atol(value));
+        set_T(ecs_iptr_t, ptr, atoll(value));
         break;
     case EcsOpF32:
         set_T(ecs_f32_t, ptr, atof(value));

--- a/test/meta/project.json
+++ b/test/meta/project.json
@@ -321,6 +321,7 @@
                 "set_str_to_i16",
                 "set_str_to_i32",
                 "set_str_to_i64",
+                "set_str_to_u64",
                 "set_str_to_f32",
                 "set_str_to_f64",
                 "set_str_to_entity",

--- a/test/meta/src/Cursor.c
+++ b/test/meta/src/Cursor.c
@@ -146,12 +146,19 @@ void Cursor_set_u32(void) {
 void Cursor_set_u64(void) {
     ecs_world_t *world = ecs_init();
 
-    ecs_u64_t value = 10;
+    {
+        ecs_u64_t value = 10;
+        ecs_meta_cursor_t cur = ecs_meta_cursor(world, ecs_id(ecs_u64_t), &value);
+        test_ok( ecs_meta_set_uint(&cur, 20) );
+        test_uint(value, 20);
+    }
 
-    ecs_meta_cursor_t cur = ecs_meta_cursor(world, ecs_id(ecs_u64_t), &value);
-    test_ok( ecs_meta_set_uint(&cur, 20) );
-
-    test_uint(value, 20);
+    {
+        ecs_u64_t value = 10;
+        ecs_meta_cursor_t cur = ecs_meta_cursor(world, ecs_id(ecs_u64_t), &value);
+        test_ok( ecs_meta_set_uint(&cur, 2366700781656087864) );
+        test_uint(value, 2366700781656087864);
+    }
 
     ecs_fini(world);
 }
@@ -532,12 +539,39 @@ void Cursor_set_str_to_i32(void) {
 void Cursor_set_str_to_i64(void) {
     ecs_world_t *world = ecs_init();
 
-    ecs_i64_t value = 10;
+    {
+        ecs_i64_t value = 10;
+        ecs_meta_cursor_t cur = ecs_meta_cursor(world, ecs_id(ecs_i64_t), &value);
+        test_ok( ecs_meta_set_string(&cur, "20") );
+        test_int(value, 20);
+    }
 
-    ecs_meta_cursor_t cur = ecs_meta_cursor(world, ecs_id(ecs_i64_t), &value);
-    test_ok( ecs_meta_set_string(&cur, "20") );
+    {
+        ecs_i64_t value = 10;
+        ecs_meta_cursor_t cur = ecs_meta_cursor(world, ecs_id(ecs_i64_t), &value);
+        test_ok( ecs_meta_set_string(&cur, "2366700781656087864") );
+        test_int(value, 2366700781656087864);
+    }
 
-    test_int(value, 20);
+    ecs_fini(world);
+}
+
+void Cursor_set_str_to_u64(void) {
+    ecs_world_t *world = ecs_init();
+
+    {
+        ecs_u64_t value = 10;
+        ecs_meta_cursor_t cur = ecs_meta_cursor(world, ecs_id(ecs_u64_t), &value);
+        test_ok( ecs_meta_set_string(&cur, "20") );
+        test_uint(value, 20);
+    }
+
+    {
+        ecs_u64_t value = 10;
+        ecs_meta_cursor_t cur = ecs_meta_cursor(world, ecs_id(ecs_u64_t), &value);
+        test_ok( ecs_meta_set_string(&cur, "2366700781656087864") );
+        test_uint(value, 2366700781656087864);
+    }
 
     ecs_fini(world);
 }

--- a/test/meta/src/DeserializeFromExpr.c
+++ b/test/meta/src/DeserializeFromExpr.c
@@ -162,12 +162,29 @@ void DeserializeFromExpr_u32(void) {
 void DeserializeFromExpr_u64(void) {
     ecs_world_t *world = ecs_init();
 
-    ecs_u64_t value = 0;
+    {
+        ecs_u64_t value = 0;
+        const char *ptr = ecs_parse_expr(
+            world, "0", &ecs_value(ecs_u64_t, &value), NULL);
+        test_assert(ptr != NULL);
+        test_int(value, 0);
+    }
 
-    const char *ptr = ecs_parse_expr(world, "10", &ecs_value(ecs_u64_t, &value), NULL);
-    test_assert(ptr != NULL);
+    {
+        ecs_u64_t value = 0;
+        const char *ptr = ecs_parse_expr(
+            world, "10", &ecs_value(ecs_u64_t, &value), NULL);
+        test_assert(ptr != NULL);
+        test_int(value, 10);
+    }
 
-    test_int(value, 10);
+    {
+        ecs_u64_t value = 0;
+        const char *ptr = ecs_parse_expr(
+            world, "2366700781656087864", &ecs_value(ecs_u64_t, &value), NULL);
+        test_assert(ptr != NULL);
+        test_int(value, 2366700781656087864);
+    }
 
     ecs_fini(world);
 }

--- a/test/meta/src/DeserializeFromJson.c
+++ b/test/meta/src/DeserializeFromJson.c
@@ -340,13 +340,30 @@ void DeserializeFromJson_struct_u64(void) {
 
     test_assert(t != 0);
 
-    T value = {0};
+    {
+        T value = {0};
+        const char *ptr = ecs_ptr_from_json(world, t, &value, "{\"v\": 0}", NULL);
+        test_assert(ptr != NULL);
+        test_assert(ptr[0] == '\0');
+        test_uint(value.v, 0);
+    }
 
-    const char *ptr = ecs_ptr_from_json(world, t, &value, "{\"v\": 10}", NULL);
-    test_assert(ptr != NULL);
-    test_assert(ptr[0] == '\0');
+    {
+        T value = {0};
+        const char *ptr = ecs_ptr_from_json(world, t, &value, "{\"v\": 10}", NULL);
+        test_assert(ptr != NULL);
+        test_assert(ptr[0] == '\0');
+        test_uint(value.v, 10);
+    }
 
-    test_uint(value.v, 10);
+    {
+        T value = {0};
+        const char *ptr = ecs_ptr_from_json(
+            world, t, &value, "{\"v\": 2366700781656087864}", NULL);
+        test_assert(ptr != NULL);
+        test_assert(ptr[0] == '\0');
+        test_uint(value.v, 2366700781656087864);
+    }
 
     ecs_fini(world);
 }

--- a/test/meta/src/SerializeToExpr.c
+++ b/test/meta/src/SerializeToExpr.c
@@ -326,6 +326,14 @@ void SerializeToExpr_u64(void) {
     ecs_os_free(expr);
     }
 
+    {
+    ecs_u64_t value = 2366700781656087864;
+    char *expr = ecs_ptr_to_expr(world, ecs_id(ecs_u64_t), &value);
+    test_assert(expr != NULL);
+    test_str(expr, "2366700781656087864");
+    ecs_os_free(expr);
+    }
+
     ecs_fini(world);
 }
 

--- a/test/meta/src/SerializeToJson.c
+++ b/test/meta/src/SerializeToJson.c
@@ -280,11 +280,29 @@ void SerializeToJson_struct_u64(void) {
         }
     });
 
-    T value = {10};
-    char *expr = ecs_ptr_to_json(world, t, &value);
-    test_assert(expr != NULL);
-    test_str(expr, "{\"x\":10}");
-    ecs_os_free(expr);
+    {
+        T value = {0};
+        char *expr = ecs_ptr_to_json(world, t, &value);
+        test_assert(expr != NULL);
+        test_str(expr, "{\"x\":0}");
+        ecs_os_free(expr);
+    }
+
+    {
+        T value = {10};
+        char *expr = ecs_ptr_to_json(world, t, &value);
+        test_assert(expr != NULL);
+        test_str(expr, "{\"x\":10}");
+        ecs_os_free(expr);
+    }
+
+    {
+        T value = {2366700781656087864};
+        char *expr = ecs_ptr_to_json(world, t, &value);
+        test_assert(expr != NULL);
+        test_str(expr, "{\"x\":2366700781656087864}");
+        ecs_os_free(expr);
+    }
 
     ecs_fini(world);
 }

--- a/test/meta/src/main.c
+++ b/test/meta/src/main.c
@@ -298,6 +298,7 @@ void Cursor_set_str_to_i8(void);
 void Cursor_set_str_to_i16(void);
 void Cursor_set_str_to_i32(void);
 void Cursor_set_str_to_i64(void);
+void Cursor_set_str_to_u64(void);
 void Cursor_set_str_to_f32(void);
 void Cursor_set_str_to_f64(void);
 void Cursor_set_str_to_entity(void);
@@ -2139,6 +2140,10 @@ bake_test_case Cursor_testcases[] = {
     {
         "set_str_to_i64",
         Cursor_set_str_to_i64
+    },
+    {
+        "set_str_to_u64",
+        Cursor_set_str_to_u64
     },
     {
         "set_str_to_f32",
@@ -5066,7 +5071,7 @@ static bake_test_suite suites[] = {
         "Cursor",
         NULL,
         NULL,
-        123,
+        124,
         Cursor_testcases
     },
     {


### PR DESCRIPTION
This PR:
- Fixes a precision issue when parsing large (>32 bit) integers from JSON
- Fixes potential parsing issues on 32bit platforms (replaces `atol` with `atoll` where appropriate)
- Adds serialization/deserialization test cases for large ints