### PR TITLE
Don't use flecs_sparse_clear before executing command queue

### DIFF
--- a/src/addons/pipeline/pipeline.c
+++ b/src/addons/pipeline/pipeline.c
@@ -656,7 +656,7 @@ void flecs_run_pipeline(
             int32_t si;
             for (si = 0; si < stage_count; si ++) {
                 ecs_stage_t *s = &world->stages[si];
-                pq->cur_op->commands_enqueued += ecs_vec_count(&s->commands);
+                pq->cur_op->commands_enqueued += ecs_vec_count(&s->cmd->queue);
             }
 
             ecs_readonly_end(world);

--- a/src/stage.h
+++ b/src/stage.h
@@ -99,4 +99,10 @@ bool flecs_defer_purge(
     ecs_world_t *world,
     ecs_stage_t *stage);
 
+void flecs_commands_push(
+    ecs_stage_t *stage);
+
+void flecs_commands_pop(
+    ecs_stage_t *stage);
+
 #endif

--- a/src/world.c
+++ b/src/world.c
@@ -382,13 +382,13 @@ ecs_world_t* flecs_suspend_readonly(
 
     /* Hack around safety checks (this ought to look ugly) */
     state->defer_count = stage->defer;
-    state->commands = stage->commands;
-    state->defer_stack = stage->defer_stack;
-    flecs_stack_init(&stage->defer_stack);
+    state->commands = stage->cmd->queue;
+    state->defer_stack = stage->cmd->stack;
+    flecs_stack_init(&stage->cmd->stack);
     state->scope = stage->scope;
     state->with = stage->with;
     stage->defer = 0;
-    ecs_vec_init_t(NULL, &stage->commands, ecs_cmd_t, 0);
+    ecs_vec_init_t(NULL, &stage->cmd->queue, ecs_cmd_t, 0);
     
     return world;
 }
@@ -411,10 +411,10 @@ void flecs_resume_readonly(
         /* Restore readonly state / defer count */
         ECS_BIT_COND(world->flags, EcsWorldReadonly, state->is_readonly);
         stage->defer = state->defer_count;
-        ecs_vec_fini_t(&stage->allocator, &stage->commands, ecs_cmd_t);
-        stage->commands = state->commands;
-        flecs_stack_fini(&stage->defer_stack);
-        stage->defer_stack = state->defer_stack;
+        ecs_vec_fini_t(&stage->allocator, &stage->cmd->queue, ecs_cmd_t);
+        stage->cmd->queue = state->commands;
+        flecs_stack_fini(&stage->cmd->stack);
+        stage->cmd->stack = state->defer_stack;
         stage->scope = state->scope;
         stage->with = state->with;
     }

--- a/test/api/src/Commands.c
+++ b/test/api/src/Commands.c
@@ -1469,7 +1469,7 @@ void Commands_defer_return_value(void) {
 
     ecs_fini(world);
 }
- 
+
 void Commands_defer_get_mut_pair(void) {
     ecs_world_t *world = ecs_mini();
 
@@ -2269,8 +2269,6 @@ void Commands_defer_while_suspend_readonly_w_existing_commands(void) {
 
     test_int(3, ecs_count(world, Position));
 
-    ecs_log_set_level(-1);
-
     ecs_fini(world);
 }
 
@@ -2520,6 +2518,8 @@ void Commands_add_in_observer_during_merge_2_commands(void) {
 
     ecs_entity_t e = ecs_new_id(world);
 
+    ecs_log_set_level(0);
+
     ecs_defer_begin(world);
     ecs_add(world, e, TagA);
     ecs_add(world, e, TagB);
@@ -2536,6 +2536,8 @@ void Commands_add_in_observer_during_merge_2_commands(void) {
     test_assert(ptr != NULL);
     test_int(ptr->x, 10);
     test_int(ptr->y, 20);
+
+    ecs_log_set_level(-1);
 
     ecs_fini(world);
 }


### PR DESCRIPTION
Fixes issue that can severely degrade performance of executing commands, particularly from observers in applications with lots of entities.

The issue was caused by a `flecs_sparse_clear` function that was used to clear the index used to track the start/end of command batches before executing commands in the queue. This function iterates all pages in the sparse set and memsets them to 0. For applications with large numbers of entities the number of pages could be a few dozen.

This added lots of relative overhead especially when small/empty command buffers which is typical for commands enqueued by observers.

In a local test with ~1 million entities, this fix reduced the time to create the entities from ~30 seconds to 0.2 seconds.