### PR TITLE
make the hello world example optional when building via meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -111,14 +111,18 @@ flecs_dep = declare_dependency(
     include_directories : flecs_inc
 )
 
-helloworld_inc = include_directories('examples/c/hello_world/include')
+opt_helloworld = get_option('build_example').disable_auto_if(meson.is_subproject())
 
-helloworld_exe = executable('helloworld',
-    'examples/c/hello_world/src/main.c',
-    include_directories : helloworld_inc,
-    implicit_include_directories : false,
-    dependencies : flecs_dep
+if opt_helloworld.allowed()
+    helloworld_inc = include_directories('examples/c/hello_world/include')
+
+    helloworld_exe = executable('helloworld',
+        'examples/c/hello_world/src/main.c',
+        include_directories : helloworld_inc,
+        implicit_include_directories : false,
+        dependencies : flecs_dep
 )
+endif
 
 if meson.version().version_compare('>= 0.54.0')
     meson.override_dependency('flecs', flecs_dep)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('build_example', description : 'build the helloworld example', type : 'feature', value : 'auto')


### PR DESCRIPTION
prevents the hello world example from being built by default when consumed as a subproject