### PR TITLE
Add template specialization to `function_traits_impl` to handle noexcept free functions. 

### DIFF
--- a/include/flecs/addons/cpp/utils/function_traits.hpp
+++ b/include/flecs/addons/cpp/utils/function_traits.hpp
@@ -76,6 +76,10 @@ template <typename ClassType, typename ReturnType, typename... Args>
 struct function_traits_impl<ReturnType(ClassType::*)(Args...) const volatile&&>
     : function_traits_defs<ReturnType, Args...> {};
 
+template <typename ReturnType, typename... Args>
+struct function_traits_impl<ReturnType(__cdecl *)(Args...) noexcept>
+    : function_traits_defs<ReturnType, Args...> {};
+
 // Primary template for function_traits_no_cv. If T is not a function, the
 // compiler will attempt to instantiate this template and fail, because its base
 // is undefined.

--- a/test/cpp_api/include/cpp_api.h
+++ b/test/cpp_api/include/cpp_api.h
@@ -361,6 +361,8 @@ struct Struct_w_vector {
     std::vector<int> value;
 };
 
+void Hooks_on_add(flecs::entity e, Position& p) noexcept;
+
 void install_test_abort(void);
 
 #endif

--- a/test/cpp_api/src/main.cpp
+++ b/test/cpp_api/src/main.cpp
@@ -6499,6 +6499,13 @@ bake_test_case Doc_testcases[] = {
     }
 };
 
+bake_test_case Hooks_testcases[] = {
+    {
+        "hook_noexcept",
+        Hooks_hook_noexcept
+    }
+}
+
 static bake_test_suite suites[] = {
     {
         "PrettyFunction",
@@ -6695,9 +6702,16 @@ static bake_test_suite suites[] = {
         NULL,
         5,
         Doc_testcases
+    },
+    {
+        "Hooks",
+        NULL,
+        NULL,
+        1,
+        Hooks_testcases
     }
 };
 
 int main(int argc, char *argv[]) {
-    return bake_test_run("cpp_api", argc, argv, suites, 28);
+    return bake_test_run("cpp_api", argc, argv, suites, 29);
 }


### PR DESCRIPTION
This seems to be working for the most part. However, a couple things of note: 
- the calling convention need to be specified, which could cause issues with other calling conventions
- this does not seem to work with `noexcept` lambdas

For lambdas, I'm not sure if there's a way to get the argument types or return types, or if we can assume a set of arguments for the lambda for this to work. I tried to think of a way to introduce this: `function_traits_impl<decltype(&Callable::operator())>` but I'm not sure how to go about this, lambdas are tricky. 

We could also just take the small win and add support for free floating `noexcept` functions and leave lambdas as is. However, that could introduce some confusion when it comes to using the API which doesn't seem ideal. 

As for the test, I have no idea if what I did was right, please do confirm I put everything in the right place. 