### PR TITLE
Remove redundant comment terminators.

### DIFF
--- a/examples/c/queries/sorting/src/main.c
+++ b/examples/c/queries/sorting/src/main.c
@@ -5,7 +5,7 @@ typedef struct {
     double x, y;
 } Position;
 
-// Order by x member of Position */
+// Order by x member of Position
 int compare_position(
     ecs_entity_t e1,
     const Position *p1,

--- a/examples/cpp/queries/sorting/src/main.cpp
+++ b/examples/cpp/queries/sorting/src/main.cpp
@@ -5,7 +5,7 @@ struct Position {
     double x, y;
 };
 
-// Order by x member of Position */
+// Order by x member of Position
 int compare_position(
     flecs::entity_t e1,
     const Position *p1,

--- a/flecs.h
+++ b/flecs.h
@@ -25611,7 +25611,7 @@ struct cpp_type_impl {
         // If no id has been registered yet for the component (indicating the 
         // component has not yet been registered, or the component is used
         // across more than one binary), or if the id does not exists in the 
-        // world (indicating a multi-world application), register it. */
+        // world (indicating a multi-world application), register it.
         if (!s_id || (world && !ecs_exists(world, s_id))) {
             init(s_id ? s_id : id, allow_tag);
 
@@ -25670,7 +25670,7 @@ struct cpp_type_impl {
 
             // Register lifecycle callbacks, but only if the component has a
             // size. Components that don't have a size are tags, and tags don't
-            // require construction/destruction/copy/move's. */
+            // require construction/destruction/copy/move's.
             if (size() && !existing) {
                 register_lifecycle_actions<T>(world, s_id);
             }

--- a/include/flecs/addons/cpp/component.hpp
+++ b/include/flecs/addons/cpp/component.hpp
@@ -174,7 +174,7 @@ struct cpp_type_impl {
         // If no id has been registered yet for the component (indicating the 
         // component has not yet been registered, or the component is used
         // across more than one binary), or if the id does not exists in the 
-        // world (indicating a multi-world application), register it. */
+        // world (indicating a multi-world application), register it.
         if (!s_id || (world && !ecs_exists(world, s_id))) {
             init(s_id ? s_id : id, allow_tag);
 
@@ -233,7 +233,7 @@ struct cpp_type_impl {
 
             // Register lifecycle callbacks, but only if the component has a
             // size. Components that don't have a size are tags, and tags don't
-            // require construction/destruction/copy/move's. */
+            // require construction/destruction/copy/move's.
             if (size() && !existing) {
                 register_lifecycle_actions<T>(world, s_id);
             }


### PR DESCRIPTION
Since these are using single line comments, don't need to have `*/` at the end.