### PR TITLE
Overhaul control flow instructions of rule engine

### DIFF
--- a/src/addons/rules/api.c
+++ b/src/addons/rules/api.c
@@ -18,46 +18,45 @@ static ecs_mixins_t ecs_rule_t_mixins = {
     }
 };
 
-static
 const char* flecs_rule_op_str(
     uint16_t kind)
 {
     switch(kind) {
-    case EcsRuleAnd:          return "and     ";
-    case EcsRuleAndId:        return "and_id  ";
-    case EcsRuleAndAny:       return "and_any ";
-    case EcsRuleSelectAny:    return "any     ";
-    case EcsRuleUp:           return "up      ";
-    case EcsRuleSelfUp:       return "selfup  ";
-    case EcsRuleWith:         return "with    ";
-    case EcsRuleTrav:         return "trav    ";
-    case EcsRuleIdsRight:     return "idsr    ";
-    case EcsRuleIdsLeft:      return "idsl    ";
-    case EcsRuleEach:         return "each    ";
-    case EcsRuleStore:        return "store   ";
-    case EcsRuleReset:        return "reset   ";
-    case EcsRuleOr:           return "or      ";
-    case EcsRuleEnd:          return "end     ";
-    case EcsRuleNot:          return "not     ";
-    case EcsRulePredEq:       return "eq      ";
-    case EcsRulePredNeq:      return "neq     ";
-    case EcsRulePredEqName:   return "eq_nm   ";
-    case EcsRulePredNeqName:  return "neq_nm  ";
-    case EcsRulePredEqMatch:  return "eq_m    ";
-    case EcsRulePredNeqMatch: return "neq_m   ";
-    case EcsRuleLookup:       return "lookup  ";
-    case EcsRuleSetVars:      return "setvars ";
-    case EcsRuleSetThis:      return "setthis ";
-    case EcsRuleSetFixed:     return "setfix  ";
-    case EcsRuleSetIds:       return "setids  ";
-    case EcsRuleContain:      return "contain ";
-    case EcsRulePairEq:       return "pair_eq ";
-    case EcsRuleSetCond:      return "setcond ";
-    case EcsRuleJmpCondFalse: return "jfalse  ";
-    case EcsRuleJmpNotSet:    return "jnotset ";
-    case EcsRuleYield:        return "yield   ";
-    case EcsRuleNothing:      return "nothing ";
-    default: return "!invalid";
+    case EcsRuleAnd:           return "and     ";
+    case EcsRuleAndId:         return "and_id  ";
+    case EcsRuleAndAny:        return "and_any ";
+    case EcsRuleSelectAny:     return "any     ";
+    case EcsRuleUp:            return "up      ";
+    case EcsRuleSelfUp:        return "selfup  ";
+    case EcsRuleWith:          return "with    ";
+    case EcsRuleTrav:          return "trav    ";
+    case EcsRuleIdsRight:      return "idsr    ";
+    case EcsRuleIdsLeft:       return "idsl    ";
+    case EcsRuleEach:          return "each    ";
+    case EcsRuleStore:         return "store   ";
+    case EcsRuleReset:         return "reset   ";
+    case EcsRuleOr:            return "or      ";
+    case EcsRuleOptional:      return "option  ";
+    case EcsRuleIf:            return "if      ";
+    case EcsRuleEnd:           return "end     ";
+    case EcsRuleNot:           return "not     ";
+    case EcsRulePredEq:        return "eq      ";
+    case EcsRulePredNeq:       return "neq     ";
+    case EcsRulePredEqName:    return "eq_nm   ";
+    case EcsRulePredNeqName:   return "neq_nm  ";
+    case EcsRulePredEqMatch:   return "eq_m    ";
+    case EcsRulePredNeqMatch:  return "neq_m   ";
+    case EcsRuleLookup:        return "lookup  ";
+    case EcsRuleSetVars:       return "setvars ";
+    case EcsRuleSetThis:       return "setthis ";
+    case EcsRuleSetFixed:      return "setfix  ";
+    case EcsRuleSetIds:        return "setids  ";
+    case EcsRuleSetId:         return "setid   ";
+    case EcsRuleContain:       return "contain ";
+    case EcsRulePairEq:        return "pair_eq ";
+    case EcsRuleYield:         return "yield   ";
+    case EcsRuleNothing:       return "nothing ";
+    default:                   return "!invalid";
     }
 }
 
@@ -230,20 +229,17 @@ char* ecs_rule_str_w_profile(
         ecs_strbuf_appendstr(&buf, " ");
 
         int32_t written = ecs_strbuf_written(&buf);
-        for (int32_t j = 0; j < (10 - (written - start)); j ++) {
-            ecs_strbuf_appendch(&buf, ' ');
-        }
-
-        if (op->kind == EcsRuleJmpCondFalse || op->kind == EcsRuleSetCond ||
-            op->kind == EcsRuleJmpNotSet) 
-        {
-            ecs_strbuf_appendint(&buf, op->other);
+        for (int32_t j = 0; j < (12 - (written - start)); j ++) {
             ecs_strbuf_appendch(&buf, ' ');
         }
     
         hidden_chars = flecs_rule_op_ref_str(rule, &op->src, src_flags, &buf);
 
-        if (op->kind == EcsRuleOr) {
+        if (op->kind == EcsRuleNot || 
+            op->kind == EcsRuleOr || 
+            op->kind == EcsRuleOptional || 
+            op->kind == EcsRuleIf) 
+        {
             indent ++;
         }
 
@@ -255,6 +251,11 @@ char* ecs_rule_str_w_profile(
         written = ecs_strbuf_written(&buf) - hidden_chars;
         for (int32_t j = 0; j < (30 - (written - start)); j ++) {
             ecs_strbuf_appendch(&buf, ' ');
+        }
+
+        if (!first_flags && !second_flags) {
+            ecs_strbuf_appendstr(&buf, "\n");
+            continue;
         }
 
         ecs_strbuf_appendstr(&buf, "(");

--- a/test/addons/project.json
+++ b/test/addons/project.json
@@ -762,7 +762,16 @@
                 "iter_empty_source_2_terms_mixed",
                 "iter_empty_source_2_terms_mixed_pair",
                 "iter_empty_source_2_terms_mixed_pair_wildcard",
-                "this_var_w_empty_entity"
+                "this_var_w_empty_entity",
+                "match_disabled",
+                "match_prefab",
+                "match_disabled_prefab",
+                "match_disabled_this_tgt",
+                "match_prefab_this_tgt",
+                "match_disabled_prefab_this_tgt",
+                "match_self_disabled",
+                "match_self_prefab",
+                "match_self_disabled_prefab"
             ]
         }, {
             "id": "RulesVariables",

--- a/test/addons/src/RulesBasic.c
+++ b/test/addons/src/RulesBasic.c
@@ -4280,3 +4280,666 @@ void RulesBasic_this_var_w_empty_entity(void) {
 
     ecs_fini(world);
 }
+
+void RulesBasic_match_disabled(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, TagA);
+
+    ecs_entity_t e_1 = ecs_new(world, TagA);
+    ecs_entity_t e_2 = ecs_new(world, TagA);
+    ecs_add_id(world, e_2, EcsDisabled);
+    ecs_entity_t e_3 = ecs_new(world, TagA);
+    ecs_add_id(world, e_3, EcsPrefab);
+
+    ecs_rule_t *r_1 = ecs_rule(world, {
+        .expr = "TagA"
+    });
+
+    ecs_rule_t *r_2 = ecs_rule(world, {
+        .expr = "TagA, ?Disabled"
+    });
+
+    test_assert(r_1 != NULL);
+    test_assert(r_2 != NULL);
+
+    test_bool(ecs_rule_get_filter(r_1)->flags & EcsFilterMatchDisabled, false);
+    test_bool(ecs_rule_get_filter(r_2)->flags & EcsFilterMatchDisabled, true);
+
+    ecs_iter_t it = ecs_rule_iter(world, r_1);
+    test_assert(ecs_rule_next(&it));
+    test_int(it.count, 1);
+    test_int(it.entities[0], e_1);
+    test_int(ecs_field_id(&it, 1), TagA);
+    test_assert(!ecs_rule_next(&it));
+
+    it = ecs_rule_iter(world, r_2);
+
+    test_assert(ecs_rule_next(&it));
+    test_int(it.count, 1);
+    test_int(it.entities[0], e_1);
+    test_int(ecs_field_id(&it, 1), TagA);
+
+    test_assert(ecs_rule_next(&it));
+    test_int(it.count, 1);
+    test_int(it.entities[0], e_2);
+    test_int(ecs_field_id(&it, 1), TagA);
+
+    test_assert(!ecs_rule_next(&it));
+
+    ecs_rule_fini(r_1);
+    ecs_rule_fini(r_2);
+
+    ecs_fini(world);
+}
+
+void RulesBasic_match_prefab(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, TagA);
+
+    ecs_entity_t e_1 = ecs_new(world, TagA);
+    ecs_entity_t e_2 = ecs_new(world, TagA);
+    ecs_add_id(world, e_2, EcsDisabled);
+    ecs_entity_t e_3 = ecs_new(world, TagA);
+    ecs_add_id(world, e_3, EcsPrefab);
+
+    ecs_rule_t *r_1 = ecs_rule(world, {
+        .expr = "TagA"
+    });
+
+    ecs_rule_t *r_2 = ecs_rule(world, {
+        .expr = "TagA, ?Prefab"
+    });
+
+    test_assert(r_1 != NULL);
+    test_assert(r_2 != NULL);
+
+    test_bool(ecs_rule_get_filter(r_1)->flags & EcsFilterMatchPrefab, false);
+    test_bool(ecs_rule_get_filter(r_2)->flags & EcsFilterMatchPrefab, true);
+
+    ecs_iter_t it = ecs_rule_iter(world, r_1);
+    test_assert(ecs_rule_next(&it));
+    test_int(it.count, 1);
+    test_int(it.entities[0], e_1);
+    test_int(ecs_field_id(&it, 1), TagA);
+    test_assert(!ecs_rule_next(&it));
+
+    it = ecs_rule_iter(world, r_2);
+
+    test_assert(ecs_rule_next(&it));
+    test_int(it.count, 1);
+    test_int(it.entities[0], e_1);
+    test_int(ecs_field_id(&it, 1), TagA);
+
+    test_assert(ecs_rule_next(&it));
+    test_int(it.count, 1);
+    test_int(it.entities[0], e_3);
+    test_int(ecs_field_id(&it, 1), TagA);
+
+    test_assert(!ecs_rule_next(&it));
+
+    ecs_rule_fini(r_1);
+    ecs_rule_fini(r_2);
+
+    ecs_fini(world);
+}
+
+void RulesBasic_match_disabled_prefab(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, TagA);
+
+    ecs_entity_t e_1 = ecs_new(world, TagA);
+    ecs_entity_t e_2 = ecs_new(world, TagA);
+    ecs_add_id(world, e_2, EcsDisabled);
+    ecs_entity_t e_3 = ecs_new(world, TagA);
+    ecs_add_id(world, e_3, EcsPrefab);
+    ecs_entity_t e_4 = ecs_new(world, TagA);
+    ecs_add_id(world, e_4, EcsPrefab);
+    ecs_add_id(world, e_4, EcsDisabled);
+
+    ecs_rule_t *r_1 = ecs_rule(world, {
+        .expr = "TagA"
+    });
+
+    ecs_rule_t *r_2 = ecs_rule(world, {
+        .expr = "TagA, ?Disabled"
+    });
+
+    ecs_rule_t *r_3 = ecs_rule(world, {
+        .expr = "TagA, ?Prefab"
+    });
+
+    ecs_rule_t *r_4 = ecs_rule(world, {
+        .expr = "TagA, ?Prefab, ?Disabled"
+    });
+
+    test_assert(r_1 != NULL);
+    test_assert(r_2 != NULL);
+    test_assert(r_3 != NULL);
+    test_assert(r_4 != NULL);
+
+    test_bool(ecs_rule_get_filter(r_1)->flags & EcsFilterMatchDisabled, false);
+    test_bool(ecs_rule_get_filter(r_2)->flags & EcsFilterMatchDisabled, true);
+    test_bool(ecs_rule_get_filter(r_3)->flags & EcsFilterMatchDisabled, false);
+    test_bool(ecs_rule_get_filter(r_4)->flags & EcsFilterMatchDisabled, true);
+
+    test_bool(ecs_rule_get_filter(r_1)->flags & EcsFilterMatchPrefab, false);
+    test_bool(ecs_rule_get_filter(r_2)->flags & EcsFilterMatchPrefab, false);
+    test_bool(ecs_rule_get_filter(r_3)->flags & EcsFilterMatchPrefab, true);
+    test_bool(ecs_rule_get_filter(r_4)->flags & EcsFilterMatchPrefab, true);
+
+    ecs_iter_t it = ecs_rule_iter(world, r_1);
+    test_assert(ecs_rule_next(&it));
+    test_int(it.count, 1);
+    test_int(it.entities[0], e_1);
+    test_int(ecs_field_id(&it, 1), TagA);
+    test_assert(!ecs_rule_next(&it));
+
+    {
+        it = ecs_rule_iter(world, r_2);
+        test_assert(ecs_rule_next(&it));
+        test_int(it.count, 1);
+        test_int(it.entities[0], e_1);
+        test_int(ecs_field_id(&it, 1), TagA);
+
+        test_assert(ecs_rule_next(&it));
+        test_int(it.count, 1);
+        test_int(it.entities[0], e_2);
+        test_int(ecs_field_id(&it, 1), TagA);
+        test_assert(!ecs_rule_next(&it));
+    }
+
+    {
+        it = ecs_rule_iter(world, r_3);
+        test_assert(ecs_rule_next(&it));
+        test_int(it.count, 1);
+        test_int(it.entities[0], e_1);
+        test_int(ecs_field_id(&it, 1), TagA);
+
+        test_assert(ecs_rule_next(&it));
+        test_int(it.count, 1);
+        test_int(it.entities[0], e_3);
+        test_int(ecs_field_id(&it, 1), TagA);
+        test_assert(!ecs_rule_next(&it));
+    }
+
+    {
+        it = ecs_rule_iter(world, r_4);
+        test_assert(ecs_rule_next(&it));
+        test_int(it.count, 1);
+        test_int(it.entities[0], e_1);
+        test_int(ecs_field_id(&it, 1), TagA);
+
+        test_assert(ecs_rule_next(&it));
+        test_int(it.count, 1);
+        test_int(it.entities[0], e_2);
+        test_int(ecs_field_id(&it, 1), TagA);
+
+        test_assert(ecs_rule_next(&it));
+        test_int(it.count, 1);
+        test_int(it.entities[0], e_3);
+        test_int(ecs_field_id(&it, 1), TagA);
+
+        test_assert(ecs_rule_next(&it));
+        test_int(it.count, 1);
+        test_int(it.entities[0], e_4);
+        test_int(ecs_field_id(&it, 1), TagA);
+
+        test_assert(!ecs_rule_next(&it));
+    }
+
+    ecs_rule_fini(r_1);
+    ecs_rule_fini(r_2);
+    ecs_rule_fini(r_3);
+    ecs_rule_fini(r_4);
+
+    ecs_fini(world);
+}
+
+void RulesBasic_match_disabled_this_tgt(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, TagA);
+
+    ecs_entity_t e_1 = ecs_new(world, TagA);
+    ecs_entity_t e_2 = ecs_new(world, TagA);
+    ecs_add_id(world, e_2, EcsDisabled);
+    ecs_entity_t e_3 = ecs_new(world, TagA);
+    ecs_add_id(world, e_3, EcsPrefab);
+
+    ecs_new_w_pair(world, EcsChildOf, e_1);
+    ecs_new_w_pair(world, EcsChildOf, e_2);
+    ecs_new_w_pair(world, EcsChildOf, e_3);
+
+    ecs_rule_t *r_1 = ecs_rule(world, {
+        .expr = "TagA, ChildOf($child, $this)"
+    });
+
+    ecs_rule_t *r_2 = ecs_rule(world, {
+        .expr = "TagA, ChildOf($child, $this), ?Disabled"
+    });
+
+    test_assert(r_1 != NULL);
+    test_assert(r_2 != NULL);
+
+    test_bool(ecs_rule_get_filter(r_1)->flags & EcsFilterMatchDisabled, false);
+    test_bool(ecs_rule_get_filter(r_2)->flags & EcsFilterMatchDisabled, true);
+
+    ecs_iter_t it = ecs_rule_iter(world, r_1);
+    test_assert(ecs_rule_next(&it));
+    test_int(it.count, 1);
+    test_int(it.entities[0], e_1);
+    test_int(ecs_field_id(&it, 1), TagA);
+    test_assert(!ecs_rule_next(&it));
+
+    it = ecs_rule_iter(world, r_2);
+
+    test_assert(ecs_rule_next(&it));
+    test_int(it.count, 1);
+    test_int(it.entities[0], e_1);
+    test_int(ecs_field_id(&it, 1), TagA);
+
+    test_assert(ecs_rule_next(&it));
+    test_int(it.count, 1);
+    test_int(it.entities[0], e_2);
+    test_int(ecs_field_id(&it, 1), TagA);
+
+    test_assert(!ecs_rule_next(&it));
+
+    ecs_rule_fini(r_1);
+    ecs_rule_fini(r_2);
+
+    ecs_fini(world);
+}
+
+void RulesBasic_match_prefab_this_tgt(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, TagA);
+
+    ecs_entity_t e_1 = ecs_new(world, TagA);
+    ecs_entity_t e_2 = ecs_new(world, TagA);
+    ecs_add_id(world, e_2, EcsDisabled);
+    ecs_entity_t e_3 = ecs_new(world, TagA);
+    ecs_add_id(world, e_3, EcsPrefab);
+
+    ecs_new_w_pair(world, EcsChildOf, e_1);
+    ecs_new_w_pair(world, EcsChildOf, e_2);
+    ecs_new_w_pair(world, EcsChildOf, e_3);
+
+    ecs_rule_t *r_1 = ecs_rule(world, {
+        .expr = "TagA, ChildOf($child, $this)"
+    });
+
+    ecs_rule_t *r_2 = ecs_rule(world, {
+        .expr = "TagA, ChildOf($child, $this), ?Prefab"
+    });
+
+    test_assert(r_1 != NULL);
+    test_assert(r_2 != NULL);
+
+    test_bool(ecs_rule_get_filter(r_1)->flags & EcsFilterMatchPrefab, false);
+    test_bool(ecs_rule_get_filter(r_2)->flags & EcsFilterMatchPrefab, true);
+
+    ecs_iter_t it = ecs_rule_iter(world, r_1);
+    test_assert(ecs_rule_next(&it));
+    test_int(it.count, 1);
+    test_int(it.entities[0], e_1);
+    test_int(ecs_field_id(&it, 1), TagA);
+    test_assert(!ecs_rule_next(&it));
+
+    it = ecs_rule_iter(world, r_2);
+
+    test_assert(ecs_rule_next(&it));
+    test_int(it.count, 1);
+    test_int(it.entities[0], e_1);
+    test_int(ecs_field_id(&it, 1), TagA);
+
+    test_assert(ecs_rule_next(&it));
+    test_int(it.count, 1);
+    test_int(it.entities[0], e_3);
+    test_int(ecs_field_id(&it, 1), TagA);
+    test_assert(!ecs_rule_next(&it));
+
+    ecs_rule_fini(r_1);
+    ecs_rule_fini(r_2);
+
+    ecs_fini(world);
+}
+
+void RulesBasic_match_disabled_prefab_this_tgt(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, TagA);
+
+    ecs_entity_t e_1 = ecs_new(world, TagA);
+    ecs_entity_t e_2 = ecs_new(world, TagA);
+    ecs_add_id(world, e_2, EcsDisabled);
+    ecs_entity_t e_3 = ecs_new(world, TagA);
+    ecs_add_id(world, e_3, EcsPrefab);
+    ecs_entity_t e_4 = ecs_new(world, TagA);
+    ecs_add_id(world, e_4, EcsPrefab);
+    ecs_add_id(world, e_4, EcsDisabled);
+
+    ecs_new_w_pair(world, EcsChildOf, e_1);
+    ecs_new_w_pair(world, EcsChildOf, e_2);
+    ecs_new_w_pair(world, EcsChildOf, e_3);
+    ecs_new_w_pair(world, EcsChildOf, e_4);
+
+    ecs_rule_t *r_1 = ecs_rule(world, {
+        .expr = "TagA, ChildOf($child, $this)"
+    });
+
+    ecs_rule_t *r_2 = ecs_rule(world, {
+        .expr = "TagA, ChildOf($child, $this), ?Disabled"
+    });
+
+    ecs_rule_t *r_3 = ecs_rule(world, {
+        .expr = "TagA, ChildOf($child, $this), ?Prefab"
+    });
+
+    ecs_rule_t *r_4 = ecs_rule(world, {
+        .expr = "TagA, ChildOf($child, $this), ?Prefab, ?Disabled"
+    });
+
+    test_assert(r_1 != NULL);
+    test_assert(r_2 != NULL);
+    test_assert(r_3 != NULL);
+    test_assert(r_4 != NULL);
+
+    test_bool(ecs_rule_get_filter(r_1)->flags & EcsFilterMatchDisabled, false);
+    test_bool(ecs_rule_get_filter(r_2)->flags & EcsFilterMatchDisabled, true);
+    test_bool(ecs_rule_get_filter(r_3)->flags & EcsFilterMatchDisabled, false);
+    test_bool(ecs_rule_get_filter(r_4)->flags & EcsFilterMatchDisabled, true);
+
+    test_bool(ecs_rule_get_filter(r_1)->flags & EcsFilterMatchPrefab, false);
+    test_bool(ecs_rule_get_filter(r_2)->flags & EcsFilterMatchPrefab, false);
+    test_bool(ecs_rule_get_filter(r_3)->flags & EcsFilterMatchPrefab, true);
+    test_bool(ecs_rule_get_filter(r_4)->flags & EcsFilterMatchPrefab, true);
+
+    ecs_iter_t it = ecs_rule_iter(world, r_1);
+    test_assert(ecs_rule_next(&it));
+    test_int(it.count, 1);
+    test_int(it.entities[0], e_1);
+    test_int(ecs_field_id(&it, 1), TagA);
+    test_assert(!ecs_rule_next(&it));
+
+    {
+        it = ecs_rule_iter(world, r_2);
+        test_assert(ecs_rule_next(&it));
+        test_int(it.count, 1);
+        test_int(it.entities[0], e_1);
+        test_int(ecs_field_id(&it, 1), TagA);
+
+        test_assert(ecs_rule_next(&it));
+        test_int(it.count, 1);
+        test_int(it.entities[0], e_2);
+        test_int(ecs_field_id(&it, 1), TagA);
+        test_assert(!ecs_rule_next(&it));
+    }
+
+    {
+        it = ecs_rule_iter(world, r_3);
+        test_assert(ecs_rule_next(&it));
+        test_int(it.count, 1);
+        test_int(it.entities[0], e_1);
+        test_int(ecs_field_id(&it, 1), TagA);
+
+        test_assert(ecs_rule_next(&it));
+        test_int(it.count, 1);
+        test_int(it.entities[0], e_3);
+        test_int(ecs_field_id(&it, 1), TagA);
+        test_assert(!ecs_rule_next(&it));
+    }
+
+    {
+        it = ecs_rule_iter(world, r_4);
+        test_assert(ecs_rule_next(&it));
+        test_int(it.count, 1);
+        test_int(it.entities[0], e_1);
+        test_int(ecs_field_id(&it, 1), TagA);
+
+        test_assert(ecs_rule_next(&it));
+        test_int(it.count, 1);
+        test_int(it.entities[0], e_2);
+        test_int(ecs_field_id(&it, 1), TagA);
+
+        test_assert(ecs_rule_next(&it));
+        test_int(it.count, 1);
+        test_int(it.entities[0], e_3);
+        test_int(ecs_field_id(&it, 1), TagA);
+
+        test_assert(ecs_rule_next(&it));
+        test_int(it.count, 1);
+        test_int(it.entities[0], e_4);
+        test_int(ecs_field_id(&it, 1), TagA);
+
+        test_assert(!ecs_rule_next(&it));
+    }
+
+    ecs_rule_fini(r_1);
+    ecs_rule_fini(r_2);
+    ecs_rule_fini(r_3);
+    ecs_rule_fini(r_4);
+
+    ecs_fini(world);
+}
+
+void RulesBasic_match_self_disabled(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, TagA);
+
+    ecs_entity_t e_1 = ecs_new(world, TagA);
+    ecs_entity_t e_2 = ecs_new(world, TagA);
+    ecs_add_id(world, e_2, EcsDisabled);
+    ecs_entity_t e_3 = ecs_new(world, TagA);
+    ecs_add_id(world, e_3, EcsPrefab);
+
+    ecs_rule_t *r_1 = ecs_rule(world, {
+        .expr = "TagA(self)"
+    });
+
+    ecs_rule_t *r_2 = ecs_rule(world, {
+        .expr = "TagA(self), ?Disabled(self)"
+    });
+
+    test_assert(r_1 != NULL);
+    test_assert(r_2 != NULL);
+
+    test_bool(ecs_rule_get_filter(r_1)->flags & EcsFilterMatchDisabled, false);
+    test_bool(ecs_rule_get_filter(r_2)->flags & EcsFilterMatchDisabled, true);
+
+    ecs_iter_t it = ecs_rule_iter(world, r_1);
+    test_assert(ecs_rule_next(&it));
+    test_int(it.count, 1);
+    test_int(it.entities[0], e_1);
+    test_int(ecs_field_id(&it, 1), TagA);
+    test_assert(!ecs_rule_next(&it));
+
+    it = ecs_rule_iter(world, r_2);
+
+    test_assert(ecs_rule_next(&it));
+    test_int(it.count, 1);
+    test_int(it.entities[0], e_1);
+    test_int(ecs_field_id(&it, 1), TagA);
+
+    test_assert(ecs_rule_next(&it));
+    test_int(it.count, 1);
+    test_int(it.entities[0], e_2);
+    test_int(ecs_field_id(&it, 1), TagA);
+
+    test_assert(!ecs_rule_next(&it));
+
+    ecs_rule_fini(r_1);
+    ecs_rule_fini(r_2);
+
+    ecs_fini(world);
+}
+
+void RulesBasic_match_self_prefab(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, TagA);
+
+    ecs_entity_t e_1 = ecs_new(world, TagA);
+    ecs_entity_t e_2 = ecs_new(world, TagA);
+    ecs_add_id(world, e_2, EcsDisabled);
+    ecs_entity_t e_3 = ecs_new(world, TagA);
+    ecs_add_id(world, e_3, EcsPrefab);
+
+    ecs_rule_t *r_1 = ecs_rule(world, {
+        .expr = "TagA(self)"
+    });
+
+    ecs_rule_t *r_2 = ecs_rule(world, {
+        .expr = "TagA(self), ?Prefab(self)"
+    });
+
+    test_assert(r_1 != NULL);
+    test_assert(r_2 != NULL);
+
+    test_bool(ecs_rule_get_filter(r_1)->flags & EcsFilterMatchPrefab, false);
+    test_bool(ecs_rule_get_filter(r_2)->flags & EcsFilterMatchPrefab, true);
+
+    ecs_iter_t it = ecs_rule_iter(world, r_1);
+    test_assert(ecs_rule_next(&it));
+    test_int(it.count, 1);
+    test_int(it.entities[0], e_1);
+    test_int(ecs_field_id(&it, 1), TagA);
+    test_assert(!ecs_rule_next(&it));
+
+    it = ecs_rule_iter(world, r_2);
+
+    test_assert(ecs_rule_next(&it));
+    test_int(it.count, 1);
+    test_int(it.entities[0], e_1);
+    test_int(ecs_field_id(&it, 1), TagA);
+
+    test_assert(ecs_rule_next(&it));
+    test_int(it.count, 1);
+    test_int(it.entities[0], e_3);
+    test_int(ecs_field_id(&it, 1), TagA);
+
+    test_assert(!ecs_rule_next(&it));
+
+    ecs_rule_fini(r_1);
+    ecs_rule_fini(r_2);
+
+    ecs_fini(world);
+}
+
+void RulesBasic_match_self_disabled_prefab(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, TagA);
+
+    ecs_entity_t e_1 = ecs_new(world, TagA);
+    ecs_entity_t e_2 = ecs_new(world, TagA);
+    ecs_add_id(world, e_2, EcsDisabled);
+    ecs_entity_t e_3 = ecs_new(world, TagA);
+    ecs_add_id(world, e_3, EcsPrefab);
+    ecs_entity_t e_4 = ecs_new(world, TagA);
+    ecs_add_id(world, e_4, EcsPrefab);
+    ecs_add_id(world, e_4, EcsDisabled);
+
+    ecs_rule_t *r_1 = ecs_rule(world, {
+        .expr = "TagA(self)"
+    });
+
+    ecs_rule_t *r_2 = ecs_rule(world, {
+        .expr = "TagA(self), ?Disabled(self)"
+    });
+
+    ecs_rule_t *r_3 = ecs_rule(world, {
+        .expr = "TagA(self), ?Prefab(self)"
+    });
+
+    ecs_rule_t *r_4 = ecs_rule(world, {
+        .expr = "TagA(self), ?Prefab(self), ?Disabled(self)"
+    });
+
+    test_assert(r_1 != NULL);
+    test_assert(r_2 != NULL);
+    test_assert(r_3 != NULL);
+    test_assert(r_4 != NULL);
+
+    test_bool(ecs_rule_get_filter(r_1)->flags & EcsFilterMatchDisabled, false);
+    test_bool(ecs_rule_get_filter(r_2)->flags & EcsFilterMatchDisabled, true);
+    test_bool(ecs_rule_get_filter(r_3)->flags & EcsFilterMatchDisabled, false);
+    test_bool(ecs_rule_get_filter(r_4)->flags & EcsFilterMatchDisabled, true);
+
+    test_bool(ecs_rule_get_filter(r_1)->flags & EcsFilterMatchPrefab, false);
+    test_bool(ecs_rule_get_filter(r_2)->flags & EcsFilterMatchPrefab, false);
+    test_bool(ecs_rule_get_filter(r_3)->flags & EcsFilterMatchPrefab, true);
+    test_bool(ecs_rule_get_filter(r_4)->flags & EcsFilterMatchPrefab, true);
+
+    ecs_iter_t it = ecs_rule_iter(world, r_1);
+    test_assert(ecs_rule_next(&it));
+    test_int(it.count, 1);
+    test_int(it.entities[0], e_1);
+    test_int(ecs_field_id(&it, 1), TagA);
+    test_assert(!ecs_rule_next(&it));
+
+    {
+        it = ecs_rule_iter(world, r_2);
+        test_assert(ecs_rule_next(&it));
+        test_int(it.count, 1);
+        test_int(it.entities[0], e_1);
+        test_int(ecs_field_id(&it, 1), TagA);
+
+        test_assert(ecs_rule_next(&it));
+        test_int(it.count, 1);
+        test_int(it.entities[0], e_2);
+        test_int(ecs_field_id(&it, 1), TagA);
+        test_assert(!ecs_rule_next(&it));
+    }
+
+    {
+        it = ecs_rule_iter(world, r_3);
+        test_assert(ecs_rule_next(&it));
+        test_int(it.count, 1);
+        test_int(it.entities[0], e_1);
+        test_int(ecs_field_id(&it, 1), TagA);
+
+        test_assert(ecs_rule_next(&it));
+        test_int(it.count, 1);
+        test_int(it.entities[0], e_3);
+        test_int(ecs_field_id(&it, 1), TagA);
+        test_assert(!ecs_rule_next(&it));
+    }
+
+    {
+        it = ecs_rule_iter(world, r_4);
+        test_assert(ecs_rule_next(&it));
+        test_int(it.count, 1);
+        test_int(it.entities[0], e_1);
+        test_int(ecs_field_id(&it, 1), TagA);
+
+        test_assert(ecs_rule_next(&it));
+        test_int(it.count, 1);
+        test_int(it.entities[0], e_2);
+        test_int(ecs_field_id(&it, 1), TagA);
+
+        test_assert(ecs_rule_next(&it));
+        test_int(it.count, 1);
+        test_int(it.entities[0], e_3);
+        test_int(ecs_field_id(&it, 1), TagA);
+
+        test_assert(ecs_rule_next(&it));
+        test_int(it.count, 1);
+        test_int(it.entities[0], e_4);
+        test_int(ecs_field_id(&it, 1), TagA);
+
+        test_assert(!ecs_rule_next(&it));
+    }
+
+    ecs_rule_fini(r_1);
+    ecs_rule_fini(r_2);
+    ecs_rule_fini(r_3);
+    ecs_rule_fini(r_4);
+
+    ecs_fini(world);
+}

--- a/test/addons/src/RulesComponentInheritance.c
+++ b/test/addons/src/RulesComponentInheritance.c
@@ -2214,43 +2214,44 @@ void RulesComponentInheritance_1_this_src_not_written(void) {
             ecs_iter_t it = ecs_rule_iter(world, r);
             test_bool(true, ecs_rule_next(&it));
             test_uint(1, it.count);
-            test_uint(Tag, ecs_field_id(&it, 1));
-            test_uint(MeleeUnit, ecs_field_id(&it, 2));
-            test_uint(0, ecs_field_src(&it, 1));
-            test_uint(0, ecs_field_src(&it, 2));
-            test_bool(true, ecs_field_is_set(&it, 1));
-            test_bool(false, ecs_field_is_set(&it, 2));
             test_uint(e1, it.entities[0]);
-
-            test_bool(true, ecs_rule_next(&it));
-            test_uint(1, it.count);
             test_uint(Tag, ecs_field_id(&it, 1));
+
             test_uint(MeleeUnit, ecs_field_id(&it, 2));
             test_uint(0, ecs_field_src(&it, 1));
             test_uint(0, ecs_field_src(&it, 2));
             test_bool(true, ecs_field_is_set(&it, 1));
             test_bool(false, ecs_field_is_set(&it, 2));
+
+            test_bool(true, ecs_rule_next(&it));
+            test_uint(1, it.count);
             test_uint(e3, it.entities[0]);
-
-            test_bool(true, ecs_rule_next(&it));
-            test_uint(1, it.count);
             test_uint(Tag, ecs_field_id(&it, 1));
             test_uint(MeleeUnit, ecs_field_id(&it, 2));
             test_uint(0, ecs_field_src(&it, 1));
             test_uint(0, ecs_field_src(&it, 2));
             test_bool(true, ecs_field_is_set(&it, 1));
             test_bool(false, ecs_field_is_set(&it, 2));
+
+            test_bool(true, ecs_rule_next(&it));
+            test_uint(1, it.count);
             test_uint(e5, it.entities[0]);
-
-            test_bool(true, ecs_rule_next(&it));
-            test_uint(1, it.count);
             test_uint(Tag, ecs_field_id(&it, 1));
             test_uint(MeleeUnit, ecs_field_id(&it, 2));
             test_uint(0, ecs_field_src(&it, 1));
             test_uint(0, ecs_field_src(&it, 2));
             test_bool(true, ecs_field_is_set(&it, 1));
             test_bool(false, ecs_field_is_set(&it, 2));
+
+            test_bool(true, ecs_rule_next(&it));
+            test_uint(1, it.count);
             test_uint(e6, it.entities[0]);
+            test_uint(Tag, ecs_field_id(&it, 1));
+            test_uint(MeleeUnit, ecs_field_id(&it, 2));
+            test_uint(0, ecs_field_src(&it, 1));
+            test_uint(0, ecs_field_src(&it, 2));
+            test_bool(true, ecs_field_is_set(&it, 1));
+            test_bool(false, ecs_field_is_set(&it, 2));
 
             test_bool(false, ecs_rule_next(&it));
         }

--- a/test/addons/src/RulesOperators.c
+++ b/test/addons/src/RulesOperators.c
@@ -1693,6 +1693,7 @@ void RulesOperators_2_and_optional_pair_rel_tgt_same_var(void) {
 
         test_bool(true, ecs_rule_next(&it));
         test_uint(1, it.count);
+        test_uint(e1, it.entities[0]);
         test_uint(RelA, ecs_field_id(&it, 1));
         test_uint(ecs_pair(EcsWildcard, EcsWildcard), ecs_field_id(&it, 2));
         test_uint(0, ecs_field_src(&it, 1));
@@ -1700,10 +1701,10 @@ void RulesOperators_2_and_optional_pair_rel_tgt_same_var(void) {
         test_bool(true, ecs_field_is_set(&it, 1));
         test_bool(false, ecs_field_is_set(&it, 2));
         test_uint(EcsWildcard, ecs_iter_get_var(&it, x_var));
-        test_uint(e1, it.entities[0]);
 
         test_bool(true, ecs_rule_next(&it));
         test_uint(1, it.count);
+        test_uint(e2, it.entities[0]);
         test_uint(RelA, ecs_field_id(&it, 1));
         test_uint(ecs_pair(TgtA, TgtA), ecs_field_id(&it, 2));
         test_uint(0, ecs_field_src(&it, 1));
@@ -1711,10 +1712,10 @@ void RulesOperators_2_and_optional_pair_rel_tgt_same_var(void) {
         test_bool(true, ecs_field_is_set(&it, 1));
         test_bool(true, ecs_field_is_set(&it, 2));
         test_uint(TgtA, ecs_iter_get_var(&it, x_var));
-        test_uint(e2, it.entities[0]);
 
         test_bool(true, ecs_rule_next(&it));
         test_uint(1, it.count);
+        test_uint(e3, it.entities[0]);
         test_uint(RelA, ecs_field_id(&it, 1));
         test_uint(ecs_pair(RelA, RelA), ecs_field_id(&it, 2));
         test_uint(0, ecs_field_src(&it, 1));
@@ -1722,10 +1723,10 @@ void RulesOperators_2_and_optional_pair_rel_tgt_same_var(void) {
         test_bool(true, ecs_field_is_set(&it, 1));
         test_bool(true, ecs_field_is_set(&it, 2));
         test_uint(RelA, ecs_iter_get_var(&it, x_var));
-        test_uint(e3, it.entities[0]);
 
         test_bool(true, ecs_rule_next(&it));
         test_uint(1, it.count);
+        test_uint(e3, it.entities[0]);
         test_uint(RelA, ecs_field_id(&it, 1));
         test_uint(ecs_pair(TgtA, TgtA), ecs_field_id(&it, 2));
         test_uint(0, ecs_field_src(&it, 1));
@@ -1733,7 +1734,6 @@ void RulesOperators_2_and_optional_pair_rel_tgt_same_var(void) {
         test_bool(true, ecs_field_is_set(&it, 1));
         test_bool(true, ecs_field_is_set(&it, 2));
         test_uint(TgtA, ecs_iter_get_var(&it, x_var));
-        test_uint(e3, it.entities[0]);
 
         test_bool(false, ecs_rule_next(&it));
     }
@@ -3077,6 +3077,7 @@ void RulesOperators_3_and_optional_dependent_optional_pair_rel(void) {
         ecs_iter_t it = ecs_rule_iter(world, r);
         test_bool(true, ecs_rule_next(&it));
         test_uint(1, it.count);
+        test_uint(e1, it.entities[0]);
         test_uint(RelA, ecs_field_id(&it, 1));
         test_uint(ecs_pair(RelA, TgtA), ecs_field_id(&it, 2));
         test_uint(ecs_pair(RelA, TgtB), ecs_field_id(&it, 3));
@@ -3087,10 +3088,10 @@ void RulesOperators_3_and_optional_dependent_optional_pair_rel(void) {
         test_bool(true, ecs_field_is_set(&it, 2));
         test_bool(false, ecs_field_is_set(&it, 3));
         test_uint(RelA, ecs_iter_get_var(&it, x_var));
-        test_uint(e1, it.entities[0]);
 
         test_bool(true, ecs_rule_next(&it));
         test_uint(1, it.count);
+        test_uint(e2, it.entities[0]);
         test_uint(RelA, ecs_field_id(&it, 1));
         test_uint(ecs_pair(EcsWildcard, TgtA), ecs_field_id(&it, 2));
         test_uint(ecs_pair(EcsWildcard, TgtB), ecs_field_id(&it, 3));
@@ -3101,24 +3102,10 @@ void RulesOperators_3_and_optional_dependent_optional_pair_rel(void) {
         test_bool(false, ecs_field_is_set(&it, 2));
         test_bool(false, ecs_field_is_set(&it, 3));
         test_uint(EcsWildcard, ecs_iter_get_var(&it, x_var));
-        test_uint(e2, it.entities[0]);
 
         test_bool(true, ecs_rule_next(&it));
         test_uint(1, it.count);
-        test_uint(RelA, ecs_field_id(&it, 1));
-        test_uint(ecs_pair(RelA, TgtA), ecs_field_id(&it, 2));
-        test_uint(ecs_pair(RelA, TgtB), ecs_field_id(&it, 3));
-        test_uint(0, ecs_field_src(&it, 1));
-        test_uint(0, ecs_field_src(&it, 2));
-        test_uint(0, ecs_field_src(&it, 3));
-        test_bool(true, ecs_field_is_set(&it, 1));
-        test_bool(true, ecs_field_is_set(&it, 2));
-        test_bool(true, ecs_field_is_set(&it, 3));
-        test_uint(RelA, ecs_iter_get_var(&it, x_var));
         test_uint(e3, it.entities[0]);
-
-        test_bool(true, ecs_rule_next(&it));
-        test_uint(1, it.count);
         test_uint(RelA, ecs_field_id(&it, 1));
         test_uint(ecs_pair(RelA, TgtA), ecs_field_id(&it, 2));
         test_uint(ecs_pair(RelA, TgtB), ecs_field_id(&it, 3));
@@ -3129,10 +3116,24 @@ void RulesOperators_3_and_optional_dependent_optional_pair_rel(void) {
         test_bool(true, ecs_field_is_set(&it, 2));
         test_bool(true, ecs_field_is_set(&it, 3));
         test_uint(RelA, ecs_iter_get_var(&it, x_var));
-        test_uint(e4, it.entities[0]);
 
         test_bool(true, ecs_rule_next(&it));
         test_uint(1, it.count);
+        test_uint(e4, it.entities[0]);
+        test_uint(RelA, ecs_field_id(&it, 1));
+        test_uint(ecs_pair(RelA, TgtA), ecs_field_id(&it, 2));
+        test_uint(ecs_pair(RelA, TgtB), ecs_field_id(&it, 3));
+        test_uint(0, ecs_field_src(&it, 1));
+        test_uint(0, ecs_field_src(&it, 2));
+        test_uint(0, ecs_field_src(&it, 3));
+        test_bool(true, ecs_field_is_set(&it, 1));
+        test_bool(true, ecs_field_is_set(&it, 2));
+        test_bool(true, ecs_field_is_set(&it, 3));
+        test_uint(RelA, ecs_iter_get_var(&it, x_var));
+
+        test_bool(true, ecs_rule_next(&it));
+        test_uint(1, it.count);
+        test_uint(e4, it.entities[0]);
         test_uint(RelA, ecs_field_id(&it, 1));
         test_uint(ecs_pair(RelB, TgtA), ecs_field_id(&it, 2));
         test_uint(ecs_pair(RelB, TgtB), ecs_field_id(&it, 3));
@@ -3143,7 +3144,6 @@ void RulesOperators_3_and_optional_dependent_optional_pair_rel(void) {
         test_bool(true, ecs_field_is_set(&it, 2));
         test_bool(true, ecs_field_is_set(&it, 3));
         test_uint(RelB, ecs_iter_get_var(&it, x_var));
-        test_uint(e4, it.entities[0]);
 
         test_bool(false, ecs_rule_next(&it));
     }
@@ -3577,6 +3577,7 @@ void RulesOperators_3_and_optional_dependent_not_pair_src(void) {
         ecs_iter_t it = ecs_rule_iter(world, r);
         test_bool(true, ecs_rule_next(&it));
         test_uint(1, it.count);
+        test_uint(e1, it.entities[0]);
         test_uint(RelA, ecs_field_id(&it, 1));
         test_uint(ecs_pair(RelA, EcsWildcard), ecs_field_id(&it, 2));
         test_uint(Tag, ecs_field_id(&it, 3));
@@ -3587,7 +3588,6 @@ void RulesOperators_3_and_optional_dependent_not_pair_src(void) {
         test_bool(false, ecs_field_is_set(&it, 2));
         test_bool(false, ecs_field_is_set(&it, 3));
         test_uint(EcsWildcard, ecs_iter_get_var(&it, x_var));
-        test_uint(e1, it.entities[0]);
 
         test_bool(false, ecs_rule_next(&it));
     }
@@ -3598,6 +3598,7 @@ void RulesOperators_3_and_optional_dependent_not_pair_src(void) {
         ecs_iter_t it = ecs_rule_iter(world, r);
         test_bool(true, ecs_rule_next(&it));
         test_uint(1, it.count);
+        test_uint(e1, it.entities[0]);
         test_uint(RelA, ecs_field_id(&it, 1));
         test_uint(ecs_pair(RelA, EcsWildcard), ecs_field_id(&it, 2));
         test_uint(Tag, ecs_field_id(&it, 3));
@@ -3608,10 +3609,10 @@ void RulesOperators_3_and_optional_dependent_not_pair_src(void) {
         test_bool(false, ecs_field_is_set(&it, 2));
         test_bool(false, ecs_field_is_set(&it, 3));
         test_uint(EcsWildcard, ecs_iter_get_var(&it, x_var));
-        test_uint(e1, it.entities[0]);
 
         test_bool(true, ecs_rule_next(&it));
         test_uint(1, it.count);
+        test_uint(e2, it.entities[0]);
         test_uint(RelA, ecs_field_id(&it, 1));
         test_uint(ecs_pair(RelA, t1), ecs_field_id(&it, 2));
         test_uint(Tag, ecs_field_id(&it, 3));
@@ -3622,7 +3623,6 @@ void RulesOperators_3_and_optional_dependent_not_pair_src(void) {
         test_bool(true, ecs_field_is_set(&it, 2));
         test_bool(false, ecs_field_is_set(&it, 3));
         test_uint(t1, ecs_iter_get_var(&it, x_var));
-        test_uint(e2, it.entities[0]);
 
         test_bool(false, ecs_rule_next(&it));
     }
@@ -3633,6 +3633,7 @@ void RulesOperators_3_and_optional_dependent_not_pair_src(void) {
         ecs_iter_t it = ecs_rule_iter(world, r);
         test_bool(true, ecs_rule_next(&it));
         test_uint(1, it.count);
+        test_uint(e1, it.entities[0]);
         test_uint(RelA, ecs_field_id(&it, 1));
         test_uint(ecs_pair(RelA, EcsWildcard), ecs_field_id(&it, 2));
         test_uint(Tag, ecs_field_id(&it, 3));
@@ -3643,10 +3644,10 @@ void RulesOperators_3_and_optional_dependent_not_pair_src(void) {
         test_bool(false, ecs_field_is_set(&it, 2));
         test_bool(false, ecs_field_is_set(&it, 3));
         test_uint(EcsWildcard, ecs_iter_get_var(&it, x_var));
-        test_uint(e1, it.entities[0]);
 
         test_bool(true, ecs_rule_next(&it));
         test_uint(1, it.count);
+        test_uint(e2, it.entities[0]);
         test_uint(RelA, ecs_field_id(&it, 1));
         test_uint(ecs_pair(RelA, t1), ecs_field_id(&it, 2));
         test_uint(Tag, ecs_field_id(&it, 3));
@@ -3657,7 +3658,6 @@ void RulesOperators_3_and_optional_dependent_not_pair_src(void) {
         test_bool(true, ecs_field_is_set(&it, 2));
         test_bool(false, ecs_field_is_set(&it, 3));
         test_uint(t1, ecs_iter_get_var(&it, x_var));
-        test_uint(e2, it.entities[0]);
 
         test_bool(false, ecs_rule_next(&it));
     }
@@ -3668,6 +3668,8 @@ void RulesOperators_3_and_optional_dependent_not_pair_src(void) {
         ecs_iter_t it = ecs_rule_iter(world, r);
         test_bool(true, ecs_rule_next(&it));
         test_uint(2, it.count);
+        test_uint(e1, it.entities[0]);
+        test_uint(e3, it.entities[1]);
         test_uint(RelA, ecs_field_id(&it, 1));
         test_uint(ecs_pair(RelA, EcsWildcard), ecs_field_id(&it, 2));
         test_uint(Tag, ecs_field_id(&it, 3));
@@ -3678,11 +3680,10 @@ void RulesOperators_3_and_optional_dependent_not_pair_src(void) {
         test_bool(false, ecs_field_is_set(&it, 2));
         test_bool(false, ecs_field_is_set(&it, 3));
         test_uint(EcsWildcard, ecs_iter_get_var(&it, x_var));
-        test_uint(e1, it.entities[0]);
-        test_uint(e3, it.entities[1]);
 
         test_bool(true, ecs_rule_next(&it));
         test_uint(1, it.count);
+        test_uint(e2, it.entities[0]);
         test_uint(RelA, ecs_field_id(&it, 1));
         test_uint(ecs_pair(RelA, t1), ecs_field_id(&it, 2));
         test_uint(Tag, ecs_field_id(&it, 3));
@@ -3693,7 +3694,6 @@ void RulesOperators_3_and_optional_dependent_not_pair_src(void) {
         test_bool(true, ecs_field_is_set(&it, 2));
         test_bool(false, ecs_field_is_set(&it, 3));
         test_uint(t1, ecs_iter_get_var(&it, x_var));
-        test_uint(e2, it.entities[0]);
 
         test_bool(false, ecs_rule_next(&it));
     }
@@ -4555,35 +4555,35 @@ void RulesOperators_2_or_chains(void) {
         ecs_iter_t it = ecs_rule_iter(world, r);
         test_bool(true, ecs_rule_next(&it));
         test_uint(1, it.count);
-        test_uint(RelA, ecs_field_id(&it, 1));
-        test_uint(RelC, ecs_field_id(&it, 2));
-        test_uint(0, ecs_field_src(&it, 1));
-        test_bool(true, ecs_field_is_set(&it, 1));
         test_uint(e3, it.entities[0]);
+        test_uint(RelA, ecs_field_id(&it, 1));
+        test_uint(RelC, ecs_field_id(&it, 2));
+        test_uint(0, ecs_field_src(&it, 1));
+        test_bool(true, ecs_field_is_set(&it, 1));
 
         test_bool(true, ecs_rule_next(&it));
         test_uint(1, it.count);
+        test_uint(e4, it.entities[0]);
         test_uint(RelA, ecs_field_id(&it, 1));
         test_uint(RelD, ecs_field_id(&it, 2));
         test_uint(0, ecs_field_src(&it, 1));
         test_bool(true, ecs_field_is_set(&it, 1));
-        test_uint(e4, it.entities[0]);
 
         test_bool(true, ecs_rule_next(&it));
         test_uint(1, it.count);
+        test_uint(e5, it.entities[0]);
         test_uint(RelB, ecs_field_id(&it, 1));
         test_uint(RelC, ecs_field_id(&it, 2));
         test_uint(0, ecs_field_src(&it, 1));
         test_bool(true, ecs_field_is_set(&it, 1));
-        test_uint(e5, it.entities[0]);
 
         test_bool(true, ecs_rule_next(&it));
         test_uint(1, it.count);
+        test_uint(e6, it.entities[0]);
         test_uint(RelB, ecs_field_id(&it, 1));
         test_uint(RelD, ecs_field_id(&it, 2));
         test_uint(0, ecs_field_src(&it, 1));
         test_bool(true, ecs_field_is_set(&it, 1));
-        test_uint(e6, it.entities[0]);
 
         test_bool(false, ecs_rule_next(&it));
     }

--- a/test/addons/src/RulesScopes.c
+++ b/test/addons/src/RulesScopes.c
@@ -279,6 +279,7 @@ void RulesScopes_term_w_not_scope_2_terms_w_not_w_var(void) {
 
     ECS_TAG(world, Root);
     ECS_COMPONENT(world, Position);
+    ECS_TAG(world, Foo);
 
     ecs_entity_t parent_0 = ecs_new(world, Root);
     {
@@ -286,6 +287,9 @@ void RulesScopes_term_w_not_scope_2_terms_w_not_w_var(void) {
         ecs_set(world, child_1, Position, {10, 20});
         ecs_entity_t child_2 = ecs_new_w_pair(world, EcsChildOf, parent_0);
         ecs_set(world, child_2, Position, {10, 20});
+        ecs_entity_t child_3 = ecs_new_w_pair(world, EcsChildOf, parent_0);
+        ecs_set(world, child_3, Position, {10, 20});
+        ecs_add(world, child_3, Foo);
     }
 
     ecs_entity_t parent_1 = ecs_new(world, Root);
@@ -297,7 +301,8 @@ void RulesScopes_term_w_not_scope_2_terms_w_not_w_var(void) {
 
     ecs_entity_t parent_2 = ecs_new(world, Root);
     {
-        ecs_new_w_pair(world, EcsChildOf, parent_2);
+        ecs_entity_t child_1 = ecs_new_w_pair(world, EcsChildOf, parent_2);
+        ecs_add(world, child_1, Foo);
         ecs_new_w_pair(world, EcsChildOf, parent_2);
     }
 
@@ -310,10 +315,10 @@ void RulesScopes_term_w_not_scope_2_terms_w_not_w_var(void) {
         ecs_iter_t it = ecs_rule_iter(world, r);
         test_bool(true, ecs_rule_next(&it));
         test_uint(1, it.count);
+        test_uint(parent_0, it.entities[0]);
         test_uint(Root, ecs_field_id(&it, 1));
         test_uint(0, ecs_field_src(&it, 1));
         test_bool(true, ecs_field_is_set(&it, 1));
-        test_uint(parent_0, it.entities[0]);
         test_bool(false, ecs_rule_next(&it));
     }
 

--- a/test/addons/src/main.c
+++ b/test/addons/src/main.c
@@ -748,6 +748,15 @@ void RulesBasic_iter_empty_source_2_terms_mixed(void);
 void RulesBasic_iter_empty_source_2_terms_mixed_pair(void);
 void RulesBasic_iter_empty_source_2_terms_mixed_pair_wildcard(void);
 void RulesBasic_this_var_w_empty_entity(void);
+void RulesBasic_match_disabled(void);
+void RulesBasic_match_prefab(void);
+void RulesBasic_match_disabled_prefab(void);
+void RulesBasic_match_disabled_this_tgt(void);
+void RulesBasic_match_prefab_this_tgt(void);
+void RulesBasic_match_disabled_prefab_this_tgt(void);
+void RulesBasic_match_self_disabled(void);
+void RulesBasic_match_self_prefab(void);
+void RulesBasic_match_self_disabled_prefab(void);
 
 // Testsuite 'RulesVariables'
 void RulesVariables_1_ent_src_w_var(void);
@@ -4636,6 +4645,42 @@ bake_test_case RulesBasic_testcases[] = {
     {
         "this_var_w_empty_entity",
         RulesBasic_this_var_w_empty_entity
+    },
+    {
+        "match_disabled",
+        RulesBasic_match_disabled
+    },
+    {
+        "match_prefab",
+        RulesBasic_match_prefab
+    },
+    {
+        "match_disabled_prefab",
+        RulesBasic_match_disabled_prefab
+    },
+    {
+        "match_disabled_this_tgt",
+        RulesBasic_match_disabled_this_tgt
+    },
+    {
+        "match_prefab_this_tgt",
+        RulesBasic_match_prefab_this_tgt
+    },
+    {
+        "match_disabled_prefab_this_tgt",
+        RulesBasic_match_disabled_prefab_this_tgt
+    },
+    {
+        "match_self_disabled",
+        RulesBasic_match_self_disabled
+    },
+    {
+        "match_self_prefab",
+        RulesBasic_match_self_prefab
+    },
+    {
+        "match_self_disabled_prefab",
+        RulesBasic_match_self_disabled_prefab
     }
 };
 
@@ -8321,7 +8366,7 @@ static bake_test_suite suites[] = {
         "RulesBasic",
         NULL,
         NULL,
-        100,
+        109,
         RulesBasic_testcases
     },
     {


### PR DESCRIPTION
This PR: 
- Reimplements control flow instructions (aka query operators) for the rule engine
- Adds filtering on disabled/prefab entities