### PR TITLE
Prevent worker threads from being preempted by other tasks on Mac and iOS

### DIFF
--- a/src/addons/os_api_impl/posix_impl.inl
+++ b/src/addons/os_api_impl/posix_impl.inl
@@ -27,9 +27,19 @@ ecs_os_thread_t posix_thread_new(
 {
     pthread_t *thread = ecs_os_malloc(sizeof(pthread_t));
 
-    if (pthread_create (thread, NULL, callback, arg) != 0) {
+    /* Opt out of Quality of Service and set a high priority 
+     * to prevent preemption by system services. */
+    pthread_attr_t attr;
+    pthread_attr_init (&attr);
+    pthread_attr_setschedpolicy(&attr, SCHED_RR);    
+    struct sched_param param = {.sched_priority = 45};
+    pthread_attr_setschedparam(&attr, &param);
+    
+    if (pthread_create(thread, &attr, callback, arg) != 0) {
         ecs_os_abort();
     }
+
+    pthread_attr_destroy(&attr);
 
     return (ecs_os_thread_t)(uintptr_t)thread;
 }


### PR DESCRIPTION
When doing some profiling on Mac and iOS to find the cause of stuttery frame rates, I found the threads being created for multithreaded systems were occasionally being preempted for a large chunk of time by both non-application tasks, and from non-render threads in the application itself.

I found this https://github.com/flutter/flutter/issues/65752 and added in the few lines of code found in this WWDC video:
https://developer.apple.com/videos/play/wwdc2018/612/?time=1111 

And now the ECS system threads are no longer pre-empted and the stutters gone!

I'm not sure if this helps on linux or if this needs more thinking about.

It's also kinda hard to prove as the problem relies on the OS deciding to prioritise other work over the flecs threads, but it's working great for me on Mac + iOS

