### PR TITLE
Fix relationship example by specifying inout.

### DIFF
--- a/examples/cpp/relationships/union/src/main.cpp
+++ b/examples/cpp/relationships/union/src/main.cpp
@@ -35,10 +35,12 @@ int main(int argc, char *argv[]) {
     ecs.component<Direction>().add(flecs::Union);
 
     // Create a query that subscribes for all entities that have a Direction
-    // and that are walking
+    // and that are walking.
+    // with<T>() requests no data by default, so we must specify what we want. 
+    // in() requests Read-Only
     flecs::query<> q = ecs.query_builder()
-        .with(Walking)
-        .with<Direction>(flecs::Wildcard)
+        .with(Walking).in()
+        .with<Direction>(flecs::Wildcard).in()
         .build();
 
     // Create a few entities with various state combinations
@@ -61,8 +63,8 @@ int main(int argc, char *argv[]) {
     q.iter([&](const flecs::iter& it) {
         // Get the column with direction states. This is stored as an array
         // with identifiers to the individual states
-        auto movement = it.field<flecs::entity_t>(1);
-        auto direction = it.field<flecs::entity_t>(2);
+        auto movement = it.field<const flecs::entity_t>(1);
+        auto direction = it.field<const flecs::entity_t>(2);
 
         for (auto i : it) {
             // Movement will always be Walking, Direction can be any state


### PR DESCRIPTION
Fixes an example that is currently broken due to a change where .with<T> requests no data by default.

Another fix could have been to use .term<T> instead, but it's useful to see .with<T> and access modifiers in action.