### PR TITLE
Reduce copies when duplicating tables with non-POD components for snapshots

### DIFF
--- a/flecs.c
+++ b/flecs.c
@@ -35124,7 +35124,7 @@ ecs_data_t* flecs_duplicate_data(
 
     ecs_data_t *result = ecs_os_calloc_t(ecs_data_t);
     int32_t i, column_count = table->column_count;
-    result->columns = flecs_wdup_n(world, ecs_column_t, column_count, 
+    result->columns = flecs_wdup_n(world, ecs_column_t, column_count,
         main_data->columns);
 
     /* Copy entities */
@@ -35137,19 +35137,18 @@ ecs_data_t* flecs_duplicate_data(
         ecs_type_info_t *ti = column->ti;
         ecs_assert(ti != NULL, ECS_INTERNAL_ERROR, NULL);
         int32_t size = ti->size;
-        ecs_copy_t copy = ti->hooks.copy;
+        ecs_copy_t copy = ti->hooks.copy_ctor;
         if (copy) {
-            ecs_vec_t dst = ecs_vec_copy(a, &column->data, size);
             int32_t count = ecs_vec_count(&column->data);
-            void *dst_ptr = ecs_vec_first(&dst);
             void *src_ptr = ecs_vec_first(&column->data);
 
-            ecs_xtor_t ctor = ti->hooks.ctor;
-            if (ctor) {
-                ctor(dst_ptr, count, ti);
-            }
+            ecs_vec_t dst = {0};
+            ecs_vec_init_if(&dst, size);
+            ecs_vec_set_count(a, &dst, size, count);
+            void *dst_ptr = ecs_vec_first(&dst);
 
             copy(dst_ptr, src_ptr, count, ti);
+
             column->data = dst;
         } else {
             column->data = ecs_vec_copy(a, &column->data, size);

--- a/flecs.h
+++ b/flecs.h
@@ -1034,6 +1034,15 @@ ecs_vec_t ecs_vec_copy(
     ecs_vec_copy(allocator, vec, ECS_SIZEOF(T))
 
 FLECS_API
+ecs_vec_t ecs_vec_copy_shrink(
+    struct ecs_allocator_t *allocator,
+    const ecs_vec_t *vec,
+    ecs_size_t size);
+
+#define ecs_vec_copy_shrink_t(allocator, vec, T) \
+    ecs_vec_copy_shrink(allocator, vec, ECS_SIZEOF(T))
+
+FLECS_API
 void ecs_vec_reclaim(
     struct ecs_allocator_t *allocator,
     ecs_vec_t *vec,
@@ -1138,7 +1147,7 @@ void* ecs_vec_last(
 }
 #endif
 
-#endif 
+#endif
 
 /**
  * @file sparse.h

--- a/include/flecs/private/vec.h
+++ b/include/flecs/private/vec.h
@@ -94,6 +94,15 @@ ecs_vec_t ecs_vec_copy(
     ecs_vec_copy(allocator, vec, ECS_SIZEOF(T))
 
 FLECS_API
+ecs_vec_t ecs_vec_copy_shrink(
+    struct ecs_allocator_t *allocator,
+    const ecs_vec_t *vec,
+    ecs_size_t size);
+
+#define ecs_vec_copy_shrink_t(allocator, vec, T) \
+    ecs_vec_copy_shrink(allocator, vec, ECS_SIZEOF(T))
+
+FLECS_API
 void ecs_vec_reclaim(
     struct ecs_allocator_t *allocator,
     ecs_vec_t *vec,
@@ -198,4 +207,4 @@ void* ecs_vec_last(
 }
 #endif
 
-#endif 
+#endif

--- a/src/addons/snapshot.c
+++ b/src/addons/snapshot.c
@@ -30,7 +30,8 @@ ecs_data_t* flecs_duplicate_data(
     ecs_table_t *table,
     ecs_data_t *main_data)
 {
-    if (!ecs_table_count(table)) {
+    int32_t count = ecs_table_count(table);
+    if (!count) {
         return NULL;
     }
 
@@ -41,7 +42,7 @@ ecs_data_t* flecs_duplicate_data(
 
     /* Copy entities */
     ecs_allocator_t *a = &world->allocator;
-    result->entities = ecs_vec_copy_t(a, &main_data->entities, ecs_entity_t);
+    result->entities = ecs_vec_copy_shrink_t(a, &main_data->entities, ecs_entity_t);
 
     /* Copy each column */
     for (i = 0; i < column_count; i ++) {
@@ -51,11 +52,10 @@ ecs_data_t* flecs_duplicate_data(
         int32_t size = ti->size;
         ecs_copy_t copy = ti->hooks.copy_ctor;
         if (copy) {
-            int32_t count = ecs_vec_count(&column->data);
             void *src_ptr = ecs_vec_first(&column->data);
 
-            ecs_vec_t dst = {0};
-            ecs_vec_init_if(&dst, size);
+            ecs_vec_t dst;
+            ecs_vec_init(a, &dst, size, count);
             ecs_vec_set_count(a, &dst, size, count);
             void *dst_ptr = ecs_vec_first(&dst);
 
@@ -63,7 +63,7 @@ ecs_data_t* flecs_duplicate_data(
 
             column->data = dst;
         } else {
-            column->data = ecs_vec_copy(a, &column->data, size);
+            column->data = ecs_vec_copy_shrink(a, &column->data, size);
         }
     }
 

--- a/src/addons/snapshot.c
+++ b/src/addons/snapshot.c
@@ -36,7 +36,7 @@ ecs_data_t* flecs_duplicate_data(
 
     ecs_data_t *result = ecs_os_calloc_t(ecs_data_t);
     int32_t i, column_count = table->column_count;
-    result->columns = flecs_wdup_n(world, ecs_column_t, column_count, 
+    result->columns = flecs_wdup_n(world, ecs_column_t, column_count,
         main_data->columns);
 
     /* Copy entities */
@@ -49,19 +49,18 @@ ecs_data_t* flecs_duplicate_data(
         ecs_type_info_t *ti = column->ti;
         ecs_assert(ti != NULL, ECS_INTERNAL_ERROR, NULL);
         int32_t size = ti->size;
-        ecs_copy_t copy = ti->hooks.copy;
+        ecs_copy_t copy = ti->hooks.copy_ctor;
         if (copy) {
-            ecs_vec_t dst = ecs_vec_copy(a, &column->data, size);
             int32_t count = ecs_vec_count(&column->data);
-            void *dst_ptr = ecs_vec_first(&dst);
             void *src_ptr = ecs_vec_first(&column->data);
 
-            ecs_xtor_t ctor = ti->hooks.ctor;
-            if (ctor) {
-                ctor(dst_ptr, count, ti);
-            }
+            ecs_vec_t dst = {0};
+            ecs_vec_init_if(&dst, size);
+            ecs_vec_set_count(a, &dst, size, count);
+            void *dst_ptr = ecs_vec_first(&dst);
 
             copy(dst_ptr, src_ptr, count, ti);
+
             column->data = dst;
         } else {
             column->data = ecs_vec_copy(a, &column->data, size);

--- a/src/datastructures/vec.c
+++ b/src/datastructures/vec.c
@@ -105,6 +105,31 @@ ecs_vec_t ecs_vec_copy(
     };
 }
 
+ecs_vec_t ecs_vec_copy_shrink(
+    ecs_allocator_t *allocator,
+    const ecs_vec_t *v,
+    ecs_size_t size)
+{
+    ecs_san_assert(size == v->elem_size, ECS_INVALID_PARAMETER, NULL);
+    int32_t count = v->count;
+    void *array = NULL;
+    if (count) {
+        if (allocator) {
+            array = flecs_dup(allocator, size * count, v->array);
+        } else {
+            array = ecs_os_memdup(v->array, size * count);
+        }
+    }
+    return (ecs_vec_t) {
+        .count = count,
+        .size = count,
+        .array = array
+#ifdef FLECS_SANITIZE
+        , .elem_size = size
+#endif
+    };
+}
+
 void ecs_vec_reclaim(
     ecs_allocator_t *allocator,
     ecs_vec_t *v,
@@ -187,7 +212,7 @@ void ecs_vec_set_min_count_zeromem(
     int32_t count = vec->count;
     if (count < elem_count) {
         ecs_vec_set_min_count(allocator, vec, size, elem_count);
-        ecs_os_memset(ECS_ELEM(vec->array, size, count), 0, 
+        ecs_os_memset(ECS_ELEM(vec->array, size, count), 0,
             size * (elem_count - count));
     }
 }
@@ -284,7 +309,7 @@ void* ecs_vec_last(
     const ecs_vec_t *v,
     ecs_size_t size)
 {
-    ecs_san_assert(!v->elem_size || size == v->elem_size, 
+    ecs_san_assert(!v->elem_size || size == v->elem_size,
         ECS_INVALID_PARAMETER, NULL);
     return ECS_ELEM(v->array, size, v->count - 1);
 }


### PR DESCRIPTION
I was browsing the code and noticed this case could be optimized.

1. Use `ecs_vec_init` then `ecs_vec_set_count` instead of `ecs_vec_copy`.
  Removes 1 copy.
2. Use `copy_ctor` instead of `ctor` then `copy`.
  Best case removes unnecessary initialization.
  Worse case no change.
  `ti->hooks.ctor` is always set if `ti->hooks.copy` is set, so we also remove a redundant branch.


Another thing I noticed is that the duplicated table could previously have empty space at the end since the vectors get size to the nearest power of 2, because snapshots don't get modified there isn't any need for this empty space so we could save some memory by only allocating vectors for the exact number of rows that is in the table.

This does mean that after restoring a snapshot adding an entity will cause table reallocation in order for it to grow. Perhaps it would be best if this was a flag that is passed when creating a snapshot so the user can chose the case they wish to optimize for?