### PR TITLE
Add alignment support to vec

### DIFF
--- a/flecs.h
+++ b/flecs.h
@@ -959,6 +959,7 @@ typedef struct ecs_vec_t {
     int32_t size;
 #ifdef FLECS_SANITIZE
     ecs_size_t elem_size;
+    ecs_size_t elem_alignment;
 #endif
 } ecs_vec_t;
 
@@ -967,18 +968,20 @@ ecs_vec_t* ecs_vec_init(
     struct ecs_allocator_t *allocator,
     ecs_vec_t *vec,
     ecs_size_t size,
+    ecs_size_t alignment,
     int32_t elem_count);
 
 #define ecs_vec_init_t(allocator, vec, T, elem_count) \
-    ecs_vec_init(allocator, vec, ECS_SIZEOF(T), elem_count)
+    ecs_vec_init(allocator, vec, ECS_SIZEOF(T), ECS_ALIGNOF(T), elem_count)
 
 FLECS_API
 void ecs_vec_init_if(
     ecs_vec_t *vec,
-    ecs_size_t size);
+    ecs_size_t size,
+    ecs_size_t alignment);
 
 #define ecs_vec_init_if_t(vec, T) \
-    ecs_vec_init_if(vec, ECS_SIZEOF(T))
+    ecs_vec_init_if(vec, ECS_SIZEOF(T), ECS_ALIGNOF(T))
 
 FLECS_API
 void ecs_vec_fini(
@@ -993,10 +996,11 @@ FLECS_API
 ecs_vec_t* ecs_vec_reset(
     struct ecs_allocator_t *allocator,
     ecs_vec_t *vec,
-    ecs_size_t size);
+    ecs_size_t size,
+    ecs_size_t alignment);
 
 #define ecs_vec_reset_t(allocator, vec, T) \
-    ecs_vec_reset(allocator, vec, ECS_SIZEOF(T))
+    ecs_vec_reset(allocator, vec, ECS_SIZEOF(T), ECS_ALIGNOF(T))
 
 FLECS_API
 void ecs_vec_clear(
@@ -1006,10 +1010,11 @@ FLECS_API
 void* ecs_vec_append(
     struct ecs_allocator_t *allocator,
     ecs_vec_t *vec,
-    ecs_size_t size);
+    ecs_size_t size,
+    ecs_size_t alignment);
 
 #define ecs_vec_append_t(allocator, vec, T) \
-    ECS_CAST(T*, ecs_vec_append(allocator, vec, ECS_SIZEOF(T)))
+    ECS_CAST(T*, ecs_vec_append(allocator, vec, ECS_SIZEOF(T), ECS_ALIGNOF(T)))
 
 FLECS_API
 void ecs_vec_remove(
@@ -1028,79 +1033,87 @@ FLECS_API
 ecs_vec_t ecs_vec_copy(
     struct ecs_allocator_t *allocator,
     const ecs_vec_t *vec,
-    ecs_size_t size);
+    ecs_size_t size,
+    ecs_size_t alignment);
 
 #define ecs_vec_copy_t(allocator, vec, T) \
-    ecs_vec_copy(allocator, vec, ECS_SIZEOF(T))
+    ecs_vec_copy(allocator, vec, ECS_SIZEOF(T), ECS_ALIGNOF(T))
 
 FLECS_API
 void ecs_vec_reclaim(
     struct ecs_allocator_t *allocator,
     ecs_vec_t *vec,
-    ecs_size_t size);
+    ecs_size_t size,
+    ecs_size_t alignment);
 
 #define ecs_vec_reclaim_t(allocator, vec, T) \
-    ecs_vec_reclaim(allocator, vec, ECS_SIZEOF(T))
+    ecs_vec_reclaim(allocator, vec, ECS_SIZEOF(T), ECS_ALIGNOF(T))
 
 FLECS_API
 void ecs_vec_set_size(
     struct ecs_allocator_t *allocator,
     ecs_vec_t *vec,
     ecs_size_t size,
+    ecs_size_t alignment,
     int32_t elem_count);
 
 #define ecs_vec_set_size_t(allocator, vec, T, elem_count) \
-    ecs_vec_set_size(allocator, vec, ECS_SIZEOF(T), elem_count)
+    ecs_vec_set_size(allocator, vec, ECS_SIZEOF(T), ECS_ALIGNOF(T), elem_count)
 
 FLECS_API
 void ecs_vec_set_min_size(
     struct ecs_allocator_t *allocator,
     ecs_vec_t *vec,
     ecs_size_t size,
+    ecs_size_t alignment,
     int32_t elem_count);
 
 #define ecs_vec_set_min_size_t(allocator, vec, T, elem_count) \
-    ecs_vec_set_min_size(allocator, vec, ECS_SIZEOF(T), elem_count)
+    ecs_vec_set_min_size(allocator, vec, ECS_SIZEOF(T), ECS_ALIGNOF(T), elem_count)
 
 FLECS_API
 void ecs_vec_set_min_count(
     struct ecs_allocator_t *allocator,
     ecs_vec_t *vec,
     ecs_size_t size,
+    ecs_size_t alignment,
     int32_t elem_count);
 
 #define ecs_vec_set_min_count_t(allocator, vec, T, elem_count) \
-    ecs_vec_set_min_count(allocator, vec, ECS_SIZEOF(T), elem_count)
+    ecs_vec_set_min_count(allocator, vec, ECS_SIZEOF(T), ECS_ALIGNOF(T), elem_count)
 
 FLECS_API
 void ecs_vec_set_min_count_zeromem(
     struct ecs_allocator_t *allocator,
     ecs_vec_t *vec,
     ecs_size_t size,
+    ecs_size_t alignment,
     int32_t elem_count);
 
 #define ecs_vec_set_min_count_zeromem_t(allocator, vec, T, elem_count) \
-    ecs_vec_set_min_count_zeromem(allocator, vec, ECS_SIZEOF(T), elem_count)
+    ecs_vec_set_min_count_zeromem(allocator, vec, ECS_SIZEOF(T), ECS_ALIGNOF(T), elem_count)
 
 FLECS_API
 void ecs_vec_set_count(
     struct ecs_allocator_t *allocator,
     ecs_vec_t *vec,
     ecs_size_t size,
+    ecs_size_t alignment,
     int32_t elem_count);
 
 #define ecs_vec_set_count_t(allocator, vec, T, elem_count) \
-    ecs_vec_set_count(allocator, vec, ECS_SIZEOF(T), elem_count)
+    ecs_vec_set_count(allocator, vec, ECS_SIZEOF(T), ECS_ALIGNOF(T), elem_count)
 
 FLECS_API
 void* ecs_vec_grow(
     struct ecs_allocator_t *allocator,
     ecs_vec_t *vec,
     ecs_size_t size,
+    ecs_size_t alignment,
     int32_t elem_count);
 
 #define ecs_vec_grow_t(allocator, vec, T, elem_count) \
-    ecs_vec_grow(allocator, vec, ECS_SIZEOF(T), elem_count)
+    ecs_vec_grow(allocator, vec, ECS_SIZEOF(T), ECS_ALIGNOF(T), elem_count)
 
 FLECS_API
 int32_t ecs_vec_count(
@@ -1138,7 +1151,7 @@ void* ecs_vec_last(
 }
 #endif
 
-#endif 
+#endif
 
 /**
  * @file sparse.h
@@ -3563,7 +3576,9 @@ typedef struct {
     ecs_hash_value_action_t hash;
     ecs_compare_action_t compare;
     ecs_size_t key_size;
+    ecs_size_t key_alignment;
     ecs_size_t value_size;
+    ecs_size_t value_alignment;
     ecs_block_allocator_t *hashmap_allocator;
     ecs_block_allocator_t bucket_allocator;
     ecs_map_t impl;
@@ -3585,13 +3600,15 @@ FLECS_DBG_API
 void flecs_hashmap_init_(
     ecs_hashmap_t *hm,
     ecs_size_t key_size,
+    ecs_size_t key_alignment,
     ecs_size_t value_size,
+    ecs_size_t value_alignment,
     ecs_hash_value_action_t hash,
     ecs_compare_action_t compare,
     ecs_allocator_t *allocator);
 
 #define flecs_hashmap_init(hm, K, V, hash, compare, allocator)\
-    flecs_hashmap_init_(hm, ECS_SIZEOF(K), ECS_SIZEOF(V), hash, compare, allocator)
+    flecs_hashmap_init_(hm, ECS_SIZEOF(K), ECS_ALIGNOF(K), ECS_SIZEOF(V), ECS_ALIGNOF(V), hash, compare, allocator)
 
 FLECS_DBG_API
 void flecs_hashmap_fini(
@@ -3612,10 +3629,11 @@ flecs_hashmap_result_t flecs_hashmap_ensure_(
     ecs_hashmap_t *map,
     ecs_size_t key_size,
     const void *key,
-    ecs_size_t value_size);
+    ecs_size_t value_size,
+    ecs_size_t value_alignment);
 
 #define flecs_hashmap_ensure(map, key, V)\
-    flecs_hashmap_ensure_(map, ECS_SIZEOF(*key), key, ECS_SIZEOF(V))
+    flecs_hashmap_ensure_(map, ECS_SIZEOF(*key), key, ECS_SIZEOF(V), ECS_ALIGNOF(V))
 
 FLECS_DBG_API
 void flecs_hashmap_set_(

--- a/flecs.h
+++ b/flecs.h
@@ -957,6 +957,7 @@ typedef struct ecs_vec_t {
     void *array;
     int32_t count;
     int32_t size;
+    void *mem;
 #ifdef FLECS_SANITIZE
     ecs_size_t elem_size;
     ecs_size_t elem_alignment;
@@ -987,10 +988,11 @@ FLECS_API
 void ecs_vec_fini(
     struct ecs_allocator_t *allocator,
     ecs_vec_t *vec,
-    ecs_size_t size);
+    ecs_size_t size,
+    ecs_size_t alignment);
 
 #define ecs_vec_fini_t(allocator, vec, T) \
-    ecs_vec_fini(allocator, vec, ECS_SIZEOF(T))
+    ecs_vec_fini(allocator, vec, ECS_SIZEOF(T), ECS_ALIGNOF(T))
 
 FLECS_API
 ecs_vec_t* ecs_vec_reset(
@@ -3536,6 +3538,12 @@ void flecs_dump_backtrace(
 #define ECS_OFFSET(o, offset) (void*)(((uintptr_t)(o)) + ((uintptr_t)(offset)))
 #endif
 #define ECS_OFFSET_T(o, T) ECS_OFFSET(o, ECS_SIZEOF(T))
+
+#ifdef __cplusplus
+#define ECS_ALIGN_PTR(ptr, alignment) reinterpret_cast<void*>((reinterpret_cast<uintptr_t>(ptr) + reinterpret_cast<uintptr_t>((alignment) - 1)) & ~reinterpret_cast<uintptr_t>((alignment) - 1))
+#else
+#define ECS_ALIGN_PTR(ptr, alignment) (void*)(((uintptr_t)(ptr) + (uintptr_t)((alignment) - 1)) & ~(uintptr_t)((alignment) - 1))
+#endif
 
 #define ECS_ELEM(ptr, size, index) ECS_OFFSET(ptr, (size) * (index))
 #define ECS_ELEM_T(o, T, index) ECS_ELEM(o, ECS_SIZEOF(T), index)

--- a/include/flecs/private/api_support.h
+++ b/include/flecs/private/api_support.h
@@ -82,6 +82,12 @@ void flecs_dump_backtrace(
 #endif
 #define ECS_OFFSET_T(o, T) ECS_OFFSET(o, ECS_SIZEOF(T))
 
+#ifdef __cplusplus
+#define ECS_ALIGN_PTR(ptr, alignment) reinterpret_cast<void*>((reinterpret_cast<uintptr_t>(ptr) + reinterpret_cast<uintptr_t>((alignment) - 1)) & ~reinterpret_cast<uintptr_t>((alignment) - 1))
+#else
+#define ECS_ALIGN_PTR(ptr, alignment) (void*)(((uintptr_t)(ptr) + (uintptr_t)((alignment) - 1)) & ~(uintptr_t)((alignment) - 1))
+#endif
+
 #define ECS_ELEM(ptr, size, index) ECS_OFFSET(ptr, (size) * (index))
 #define ECS_ELEM_T(o, T, index) ECS_ELEM(o, ECS_SIZEOF(T), index)
 

--- a/include/flecs/private/hashmap.h
+++ b/include/flecs/private/hashmap.h
@@ -21,7 +21,9 @@ typedef struct {
     ecs_hash_value_action_t hash;
     ecs_compare_action_t compare;
     ecs_size_t key_size;
+    ecs_size_t key_alignment;
     ecs_size_t value_size;
+    ecs_size_t value_alignment;
     ecs_block_allocator_t *hashmap_allocator;
     ecs_block_allocator_t bucket_allocator;
     ecs_map_t impl;
@@ -43,13 +45,15 @@ FLECS_DBG_API
 void flecs_hashmap_init_(
     ecs_hashmap_t *hm,
     ecs_size_t key_size,
+    ecs_size_t key_alignment,
     ecs_size_t value_size,
+    ecs_size_t value_alignment,
     ecs_hash_value_action_t hash,
     ecs_compare_action_t compare,
     ecs_allocator_t *allocator);
 
 #define flecs_hashmap_init(hm, K, V, hash, compare, allocator)\
-    flecs_hashmap_init_(hm, ECS_SIZEOF(K), ECS_SIZEOF(V), hash, compare, allocator)
+    flecs_hashmap_init_(hm, ECS_SIZEOF(K), ECS_ALIGNOF(K), ECS_SIZEOF(V), ECS_ALIGNOF(V), hash, compare, allocator)
 
 FLECS_DBG_API
 void flecs_hashmap_fini(
@@ -70,10 +74,11 @@ flecs_hashmap_result_t flecs_hashmap_ensure_(
     ecs_hashmap_t *map,
     ecs_size_t key_size,
     const void *key,
-    ecs_size_t value_size);
+    ecs_size_t value_size,
+    ecs_size_t value_alignment);
 
 #define flecs_hashmap_ensure(map, key, V)\
-    flecs_hashmap_ensure_(map, ECS_SIZEOF(*key), key, ECS_SIZEOF(V))
+    flecs_hashmap_ensure_(map, ECS_SIZEOF(*key), key, ECS_SIZEOF(V), ECS_ALIGNOF(V))
 
 FLECS_DBG_API
 void flecs_hashmap_set_(

--- a/include/flecs/private/vec.h
+++ b/include/flecs/private/vec.h
@@ -17,6 +17,7 @@ typedef struct ecs_vec_t {
     void *array;
     int32_t count;
     int32_t size;
+    void *mem;
 #ifdef FLECS_SANITIZE
     ecs_size_t elem_size;
     ecs_size_t elem_alignment;
@@ -47,10 +48,11 @@ FLECS_API
 void ecs_vec_fini(
     struct ecs_allocator_t *allocator,
     ecs_vec_t *vec,
-    ecs_size_t size);
+    ecs_size_t size,
+    ecs_size_t alignment);
 
 #define ecs_vec_fini_t(allocator, vec, T) \
-    ecs_vec_fini(allocator, vec, ECS_SIZEOF(T))
+    ecs_vec_fini(allocator, vec, ECS_SIZEOF(T), ECS_ALIGNOF(T))
 
 FLECS_API
 ecs_vec_t* ecs_vec_reset(

--- a/include/flecs/private/vec.h
+++ b/include/flecs/private/vec.h
@@ -19,6 +19,7 @@ typedef struct ecs_vec_t {
     int32_t size;
 #ifdef FLECS_SANITIZE
     ecs_size_t elem_size;
+    ecs_size_t elem_alignment;
 #endif
 } ecs_vec_t;
 
@@ -27,18 +28,20 @@ ecs_vec_t* ecs_vec_init(
     struct ecs_allocator_t *allocator,
     ecs_vec_t *vec,
     ecs_size_t size,
+    ecs_size_t alignment,
     int32_t elem_count);
 
 #define ecs_vec_init_t(allocator, vec, T, elem_count) \
-    ecs_vec_init(allocator, vec, ECS_SIZEOF(T), elem_count)
+    ecs_vec_init(allocator, vec, ECS_SIZEOF(T), ECS_ALIGNOF(T), elem_count)
 
 FLECS_API
 void ecs_vec_init_if(
     ecs_vec_t *vec,
-    ecs_size_t size);
+    ecs_size_t size,
+    ecs_size_t alignment);
 
 #define ecs_vec_init_if_t(vec, T) \
-    ecs_vec_init_if(vec, ECS_SIZEOF(T))
+    ecs_vec_init_if(vec, ECS_SIZEOF(T), ECS_ALIGNOF(T))
 
 FLECS_API
 void ecs_vec_fini(
@@ -53,10 +56,11 @@ FLECS_API
 ecs_vec_t* ecs_vec_reset(
     struct ecs_allocator_t *allocator,
     ecs_vec_t *vec,
-    ecs_size_t size);
+    ecs_size_t size,
+    ecs_size_t alignment);
 
 #define ecs_vec_reset_t(allocator, vec, T) \
-    ecs_vec_reset(allocator, vec, ECS_SIZEOF(T))
+    ecs_vec_reset(allocator, vec, ECS_SIZEOF(T), ECS_ALIGNOF(T))
 
 FLECS_API
 void ecs_vec_clear(
@@ -66,10 +70,11 @@ FLECS_API
 void* ecs_vec_append(
     struct ecs_allocator_t *allocator,
     ecs_vec_t *vec,
-    ecs_size_t size);
+    ecs_size_t size,
+    ecs_size_t alignment);
 
 #define ecs_vec_append_t(allocator, vec, T) \
-    ECS_CAST(T*, ecs_vec_append(allocator, vec, ECS_SIZEOF(T)))
+    ECS_CAST(T*, ecs_vec_append(allocator, vec, ECS_SIZEOF(T), ECS_ALIGNOF(T)))
 
 FLECS_API
 void ecs_vec_remove(
@@ -88,79 +93,87 @@ FLECS_API
 ecs_vec_t ecs_vec_copy(
     struct ecs_allocator_t *allocator,
     const ecs_vec_t *vec,
-    ecs_size_t size);
+    ecs_size_t size,
+    ecs_size_t alignment);
 
 #define ecs_vec_copy_t(allocator, vec, T) \
-    ecs_vec_copy(allocator, vec, ECS_SIZEOF(T))
+    ecs_vec_copy(allocator, vec, ECS_SIZEOF(T), ECS_ALIGNOF(T))
 
 FLECS_API
 void ecs_vec_reclaim(
     struct ecs_allocator_t *allocator,
     ecs_vec_t *vec,
-    ecs_size_t size);
+    ecs_size_t size,
+    ecs_size_t alignment);
 
 #define ecs_vec_reclaim_t(allocator, vec, T) \
-    ecs_vec_reclaim(allocator, vec, ECS_SIZEOF(T))
+    ecs_vec_reclaim(allocator, vec, ECS_SIZEOF(T), ECS_ALIGNOF(T))
 
 FLECS_API
 void ecs_vec_set_size(
     struct ecs_allocator_t *allocator,
     ecs_vec_t *vec,
     ecs_size_t size,
+    ecs_size_t alignment,
     int32_t elem_count);
 
 #define ecs_vec_set_size_t(allocator, vec, T, elem_count) \
-    ecs_vec_set_size(allocator, vec, ECS_SIZEOF(T), elem_count)
+    ecs_vec_set_size(allocator, vec, ECS_SIZEOF(T), ECS_ALIGNOF(T), elem_count)
 
 FLECS_API
 void ecs_vec_set_min_size(
     struct ecs_allocator_t *allocator,
     ecs_vec_t *vec,
     ecs_size_t size,
+    ecs_size_t alignment,
     int32_t elem_count);
 
 #define ecs_vec_set_min_size_t(allocator, vec, T, elem_count) \
-    ecs_vec_set_min_size(allocator, vec, ECS_SIZEOF(T), elem_count)
+    ecs_vec_set_min_size(allocator, vec, ECS_SIZEOF(T), ECS_ALIGNOF(T), elem_count)
 
 FLECS_API
 void ecs_vec_set_min_count(
     struct ecs_allocator_t *allocator,
     ecs_vec_t *vec,
     ecs_size_t size,
+    ecs_size_t alignment,
     int32_t elem_count);
 
 #define ecs_vec_set_min_count_t(allocator, vec, T, elem_count) \
-    ecs_vec_set_min_count(allocator, vec, ECS_SIZEOF(T), elem_count)
+    ecs_vec_set_min_count(allocator, vec, ECS_SIZEOF(T), ECS_ALIGNOF(T), elem_count)
 
 FLECS_API
 void ecs_vec_set_min_count_zeromem(
     struct ecs_allocator_t *allocator,
     ecs_vec_t *vec,
     ecs_size_t size,
+    ecs_size_t alignment,
     int32_t elem_count);
 
 #define ecs_vec_set_min_count_zeromem_t(allocator, vec, T, elem_count) \
-    ecs_vec_set_min_count_zeromem(allocator, vec, ECS_SIZEOF(T), elem_count)
+    ecs_vec_set_min_count_zeromem(allocator, vec, ECS_SIZEOF(T), ECS_ALIGNOF(T), elem_count)
 
 FLECS_API
 void ecs_vec_set_count(
     struct ecs_allocator_t *allocator,
     ecs_vec_t *vec,
     ecs_size_t size,
+    ecs_size_t alignment,
     int32_t elem_count);
 
 #define ecs_vec_set_count_t(allocator, vec, T, elem_count) \
-    ecs_vec_set_count(allocator, vec, ECS_SIZEOF(T), elem_count)
+    ecs_vec_set_count(allocator, vec, ECS_SIZEOF(T), ECS_ALIGNOF(T), elem_count)
 
 FLECS_API
 void* ecs_vec_grow(
     struct ecs_allocator_t *allocator,
     ecs_vec_t *vec,
     ecs_size_t size,
+    ecs_size_t alignment,
     int32_t elem_count);
 
 #define ecs_vec_grow_t(allocator, vec, T, elem_count) \
-    ecs_vec_grow(allocator, vec, ECS_SIZEOF(T), elem_count)
+    ecs_vec_grow(allocator, vec, ECS_SIZEOF(T), ECS_ALIGNOF(T), elem_count)
 
 FLECS_API
 int32_t ecs_vec_count(
@@ -198,4 +211,4 @@ void* ecs_vec_last(
 }
 #endif
 
-#endif 
+#endif

--- a/src/datastructures/hashmap.c
+++ b/src/datastructures/hashmap.c
@@ -55,8 +55,8 @@ void flecs_hashmap_fini(
 
     while (ecs_map_next(&it)) {
         ecs_hm_bucket_t *bucket = ecs_map_ptr(&it);
-        ecs_vec_fini(a, &bucket->keys, map->key_size);
-        ecs_vec_fini(a, &bucket->values, map->value_size);
+        ecs_vec_fini(a, &bucket->keys, map->key_size, map->key_alignment);
+        ecs_vec_fini(a, &bucket->values, map->value_size, map->value_alignment);
 #ifdef FLECS_SANITIZE        
         flecs_bfree(&map->bucket_allocator, bucket);
 #endif
@@ -190,8 +190,8 @@ void flecs_hm_bucket_remove(
 
     if (!ecs_vec_count(&bucket->keys)) {
         ecs_allocator_t *a = map->impl.allocator;
-        ecs_vec_fini(a, &bucket->keys, map->key_size);
-        ecs_vec_fini(a, &bucket->values, map->value_size);
+        ecs_vec_fini(a, &bucket->keys, map->key_size, map->key_alignment);
+        ecs_vec_fini(a, &bucket->values, map->value_size, map->value_alignment);
         ecs_hm_bucket_t *b = ecs_map_remove_ptr(&map->impl, hash);
         ecs_assert(bucket == b, ECS_INTERNAL_ERROR, NULL); (void)b;
         flecs_bfree(&map->bucket_allocator, bucket);

--- a/src/datastructures/name_index.c
+++ b/src/datastructures/name_index.c
@@ -34,8 +34,8 @@ void flecs_name_index_init(
     ecs_hashmap_t *hm,
     ecs_allocator_t *allocator) 
 {
-    flecs_hashmap_init_(hm, 
-        ECS_SIZEOF(ecs_hashed_string_t), ECS_SIZEOF(uint64_t), 
+    flecs_hashmap_init(hm, 
+        ecs_hashed_string_t, uint64_t, 
         flecs_name_index_hash, 
         flecs_name_index_compare,
         allocator);

--- a/src/stage.c
+++ b/src/stage.c
@@ -652,8 +652,8 @@ void flecs_stage_fini(
     ecs_allocator_t *a = &stage->allocator;
     
     ecs_vec_fini_t(a, &stage->post_frame_actions, ecs_action_elem_t);
-    ecs_vec_fini(NULL, &stage->variables, 0);
-    ecs_vec_fini(NULL, &stage->operations, 0);
+    ecs_vec_fini(NULL, &stage->variables, 0, 0);
+    ecs_vec_fini(NULL, &stage->operations, 0, 0);
 
     int32_t i;
     for (i = 0; i < ECS_MAX_DEFER_STACK; i ++) {

--- a/src/storage/table.c
+++ b/src/storage/table.c
@@ -890,7 +890,7 @@ void flecs_table_fini_data(
             ecs_assert(columns[c].data.count == data->entities.count,
                 ECS_INTERNAL_ERROR, NULL);
             ecs_vec_fini(&world->allocator,
-                &columns[c].data, columns[c].size);
+                &columns[c].data, columns[c].size, columns[c].alignment);
         }
         flecs_wfree_n(world, ecs_column_t, column_count, columns);
         data->columns = NULL;
@@ -1343,7 +1343,7 @@ void flecs_table_grow_column(
         }
 
         /* Free old vector */
-        ecs_vec_fini(&world->allocator, &column->data, size);
+        ecs_vec_fini(&world->allocator, &column->data, size, alignment);
 
         column->data = dst;
     } else {
@@ -2043,7 +2043,7 @@ void flecs_table_merge_vec(
     int32_t dst_count = dst->count;
 
     if (!dst_count) {
-        ecs_vec_fini(&world->allocator, dst, size);
+        ecs_vec_fini(&world->allocator, dst, size, alignment);
         *dst = *src;
         src->array = NULL;
         src->count = 0;
@@ -2062,7 +2062,7 @@ void flecs_table_merge_vec(
         void *src_ptr = src->array;
         ecs_os_memcpy(dst_ptr, src_ptr, size * src_count);
 
-        ecs_vec_fini(&world->allocator, src, size);
+        ecs_vec_fini(&world->allocator, src, size, alignment);
     }
 }
 
@@ -2075,10 +2075,11 @@ void flecs_table_merge_column(
     int32_t column_size)
 {
     ecs_size_t size = dst->size;
+    ecs_size_t alignment = dst->alignment;
     int32_t dst_count = dst->data.count;
 
     if (!dst_count) {
-        ecs_vec_fini(&world->allocator, &dst->data, size);
+        ecs_vec_fini(&world->allocator, &dst->data, size, alignment);
         *dst = *src;
         src->data.array = NULL;
         src->data.count = 0;
@@ -2103,7 +2104,7 @@ void flecs_table_merge_column(
             ecs_os_memcpy(dst_ptr, src_ptr, size * src_count);
         }
 
-        ecs_vec_fini(&world->allocator, &src->data, size);
+        ecs_vec_fini(&world->allocator, &src->data, size, alignment);
     }
 }
 
@@ -2159,7 +2160,7 @@ void flecs_table_merge_data(
         } else if (dst_id > src_id) {
             /* Old column does not occur in new table, destruct */
             flecs_table_invoke_dtor(src_column, 0, src_count);
-            ecs_vec_fini(a, &src_column->data, src_column->size);
+            ecs_vec_fini(a, &src_column->data, src_column->size, src_column->alignment);
             i_old ++;
         }
     }
@@ -2182,7 +2183,7 @@ void flecs_table_merge_data(
     for (; i_old < src_column_count; i_old ++) {
         ecs_column_t *column = &src_columns[i_old];
         flecs_table_invoke_dtor(column, 0, src_count);
-        ecs_vec_fini(a, &column->data, column->size);
+        ecs_vec_fini(a, &column->data, column->size, column->alignment);
     }
 
     /* Mark entity column as dirty */

--- a/src/storage/table.h
+++ b/src/storage/table.h
@@ -38,7 +38,7 @@ typedef struct ecs_table__t {
     int32_t traversable_count;       /* Traversable relationship targets in table */
     uint16_t generation;             /* Used for table cleanup */
     int16_t record_count;            /* Table record count including wildcards */
-    
+
     struct ecs_table_record_t *records; /* Array with table records */
     ecs_hashmap_t *name_index;       /* Cached pointer to name index */
 
@@ -57,6 +57,7 @@ typedef struct ecs_column_t {
     ecs_id_t id;                     /* Component id */
     ecs_type_info_t *ti;             /* Component type info */
     ecs_size_t size;                 /* Component size */
+    ecs_size_t alignment;            /* Component alignment */
 } ecs_column_t;
 
 /** Table data */
@@ -77,7 +78,7 @@ struct ecs_table_t {
 
     ecs_data_t data;                 /* Component storage */
     ecs_graph_node_t node;           /* Graph node */
-    
+
     int32_t *dirty_state;            /* Keep track of changes in columns */
     int32_t *column_map;             /* Map type index <-> column
                                       *  - 0..count(T):        type index -> column
@@ -111,7 +112,7 @@ ecs_table_t* flecs_table_find_or_create(
 /* Initialize columns for data */
 void flecs_table_init_data(
     ecs_world_t *world,
-    ecs_table_t *table); 
+    ecs_table_t *table);
 
 /* Clear all entities from a table. */
 void flecs_table_clear_entities(
@@ -132,7 +133,7 @@ void flecs_table_clear_entities_silent(
 void flecs_table_clear_data(
     ecs_world_t *world,
     ecs_table_t *table,
-    ecs_data_t *data);    
+    ecs_data_t *data);
 
 /* Return number of entities in data */
 int32_t flecs_table_data_count(
@@ -206,13 +207,13 @@ void flecs_table_remove_actions(
 /* Free table */
 void flecs_table_free(
     ecs_world_t *world,
-    ecs_table_t *table); 
+    ecs_table_t *table);
 
 /* Free table */
 void flecs_table_free_type(
     ecs_world_t *world,
-    ecs_table_t *table);     
-    
+    ecs_table_t *table);
+
 /* Replace data */
 void flecs_table_replace_data(
     ecs_world_t *world,


### PR DESCRIPTION
Fixes: https://github.com/SanderMertens/flecs/issues/478

# Changes
This change adds memory alignment support to vec which in turn fixes alignment support for components stored in tables.

Changes to vec.
1. Added `ecs_size_t alignment` argument alongside `ecs_size_t size` argument in vec API.
1. `ecs_vec_t` stores both `void* array` and `void* mem`.
  `array` is the same as before, it is the pointer to the data. `mem` is the original pointer that was allocated, this is used so we have the correct address to be able to realloc or free the memory.
1. Vec allocates a buffer of `size * elem_count + alignment` this is the `void* mem` pointer and then shifts the pointer in order to have the correct alignment for `void* array`.
1. When reallocating the vector a `memmove` may be necessary in order to correct for a different alignment of the new pointer.

This increases the memory usage of both the vec struct and the allocated arrays.

Since hashmap uses vec internally it also now has alignment support.