### PR TITLE
Handle missing metatype

### DIFF
--- a/flecs.c
+++ b/flecs.c
@@ -58042,7 +58042,9 @@ int flecs_meta_serialize_array_component(
         return -1; /* Should never happen, will trigger internal error */
     }
 
-    flecs_meta_serialize_type(world, ptr->type, 0, ops);
+    if (flecs_meta_serialize_type(world, ptr->type, 0, ops) != 0) {
+        return -1;
+    }
 
     ecs_meta_type_op_t *first = ecs_vec_first(ops);
     first->count = ptr->count;
@@ -58108,8 +58110,9 @@ int flecs_meta_serialize_struct(
         ecs_member_t *member = &members[i];
 
         cur = ecs_vec_count(ops);
-        flecs_meta_serialize_type(world, 
-            member->type, offset + member->offset, ops);
+        if (flecs_meta_serialize_type(world, member->type, offset + member->offset, ops) != 0) {
+            continue;
+        }
 
         op = flecs_meta_ops_get(ops, cur);
         if (!op->type) {

--- a/src/addons/meta/serialized.c
+++ b/src/addons/meta/serialized.c
@@ -128,7 +128,9 @@ int flecs_meta_serialize_array_component(
         return -1; /* Should never happen, will trigger internal error */
     }
 
-    flecs_meta_serialize_type(world, ptr->type, 0, ops);
+    if (flecs_meta_serialize_type(world, ptr->type, 0, ops) != 0) {
+        return -1;
+    }
 
     ecs_meta_type_op_t *first = ecs_vec_first(ops);
     first->count = ptr->count;
@@ -194,8 +196,9 @@ int flecs_meta_serialize_struct(
         ecs_member_t *member = &members[i];
 
         cur = ecs_vec_count(ops);
-        flecs_meta_serialize_type(world, 
-            member->type, offset + member->offset, ops);
+        if (flecs_meta_serialize_type(world, member->type, offset + member->offset, ops) != 0) {
+            continue;
+        }
 
         op = flecs_meta_ops_get(ops, cur);
         if (!op->type) {

--- a/test/meta/project.json
+++ b/test/meta/project.json
@@ -281,7 +281,8 @@
                 "ops_bitmask",
                 "ops_struct_w_bitmask",
                 "ops_enum",
-                "ops_struct_w_enum"
+                "ops_struct_w_enum",
+                "ops_missing_metatype"
             ]
         }, {
             "id": "Cursor",

--- a/test/meta/src/Serialized.c
+++ b/test/meta/src/Serialized.c
@@ -2140,3 +2140,33 @@ void Serialized_ops_struct_w_enum(void) {
 
     ecs_fini(world);
 }
+
+void Serialized_ops_missing_metatype(void) {
+    typedef struct {
+        ecs_u64_t a;
+    } X;
+    typedef struct {
+        X x;
+    } T;
+
+    ecs_world_t *world = ecs_init();
+
+    ECS_COMPONENT(world, X);
+
+    ecs_entity_t t = ecs_struct_init(world, &(ecs_struct_desc_t){
+        .entity = ecs_entity(world, {.name = "T"}),
+        .members = {
+            {"x", ecs_id(X)}
+        }
+    });
+    test_assert(t != 0);
+
+    const EcsMetaTypeSerialized *s = ecs_get(world, t, EcsMetaTypeSerialized);
+    test_assert(s != NULL);
+    test_int(ecs_vec_count(&s->ops), 2);
+    
+    test_op(&s->ops, 0, EcsOpPush, 1, 2, t);
+    test_op(&s->ops, 1, EcsOpPop, 1, 1, 0);
+
+    ecs_fini(world);
+}

--- a/test/meta/src/main.c
+++ b/test/meta/src/main.c
@@ -261,6 +261,7 @@ void Serialized_ops_bitmask(void);
 void Serialized_ops_struct_w_bitmask(void);
 void Serialized_ops_enum(void);
 void Serialized_ops_struct_w_enum(void);
+void Serialized_ops_missing_metatype(void);
 
 // Testsuite 'Cursor'
 void Cursor_set_bool(void);
@@ -2022,6 +2023,10 @@ bake_test_case Serialized_testcases[] = {
     {
         "ops_struct_w_enum",
         Serialized_ops_struct_w_enum
+    },
+    {
+        "ops_missing_metatype",
+        Serialized_ops_missing_metatype
     }
 };
 
@@ -5189,7 +5194,7 @@ static bake_test_suite suites[] = {
         "Serialized",
         NULL,
         NULL,
-        61,
+        62,
         Serialized_testcases
     },
     {


### PR DESCRIPTION
Fixes a crash if a meta member is added that doesn't have `EcsMetaType`.

Previously in `flecs_meta_serialize_struct` when `flecs_meta_serialize_type` was called it would log a message and `return -1` directly after which it would call `op = flecs_meta_ops_get(ops, cur);` which would access an index out of bounds of the ops array.