### PR TITLE
Support associating a timer or tick source with a type

### DIFF
--- a/flecs.h
+++ b/flecs.h
@@ -20948,6 +20948,10 @@ flecs::system_builder<Components...> system(Args &&... args) const;
  * \ingroup cpp_addons_timer
  */
 
+/** Find or register a singleton timer. */
+template <typename T>
+flecs::timer timer() const;
+
 /** Find or register a timer. */
 template <typename... Args>
 flecs::timer timer(Args &&... args) const;
@@ -29390,6 +29394,17 @@ public:
     /** Set tick source.
      * This operation sets a shared tick source for the system.
      *
+     * @tparam T The type associated with the singleton tick source to use for the system.
+     */
+    template<typename T>
+    Base& tick_source() {
+        m_desc->tick_source = _::cpp_type<T>::id(world_v());
+        return *this;
+    }
+
+    /** Set tick source.
+     * This operation sets a shared tick source for the system.
+     *
      * @param tick_source The tick source to use for the system.
      */
     Base& tick_source(flecs::entity_t tick_source) {
@@ -29608,6 +29623,12 @@ void start();
  * @see ecs_start_timer
  */
 void stop();
+
+/** Set external tick source.
+ * @see ecs_set_tick_source
+ */
+template<typename T>
+void set_tick_source();
 
 /** Set external tick source.
  * @see ecs_set_tick_source
@@ -29838,6 +29859,11 @@ struct timer final : entity {
     }
 };
 
+template <typename T>
+inline flecs::timer world::timer() const {
+    return flecs::timer(m_world, _::cpp_type<T>::id(m_world));
+}
+
 template <typename... Args>
 inline flecs::timer world::timer(Args &&... args) const {
     return flecs::timer(m_world, FLECS_FWD(args)...);
@@ -29873,6 +29899,11 @@ inline void system::start() {
 
 inline void system::stop() {
     ecs_stop_timer(m_world, m_id);
+}
+
+template<typename T>
+inline void system::set_tick_source() {
+    ecs_set_tick_source(m_world, m_id, _::cpp_type<T>::id(m_world));
 }
 
 inline void system::set_tick_source(flecs::entity e) {

--- a/include/flecs/addons/cpp/mixins/system/builder_i.hpp
+++ b/include/flecs/addons/cpp/mixins/system/builder_i.hpp
@@ -110,6 +110,17 @@ public:
     /** Set tick source.
      * This operation sets a shared tick source for the system.
      *
+     * @tparam T The type associated with the singleton tick source to use for the system.
+     */
+    template<typename T>
+    Base& tick_source() {
+        m_desc->tick_source = _::cpp_type<T>::id(world_v());
+        return *this;
+    }
+
+    /** Set tick source.
+     * This operation sets a shared tick source for the system.
+     *
      * @param tick_source The tick source to use for the system.
      */
     Base& tick_source(flecs::entity_t tick_source) {

--- a/include/flecs/addons/cpp/mixins/timer/impl.hpp
+++ b/include/flecs/addons/cpp/mixins/timer/impl.hpp
@@ -43,6 +43,11 @@ struct timer final : entity {
     }
 };
 
+template <typename T>
+inline flecs::timer world::timer() const {
+    return flecs::timer(m_world, _::cpp_type<T>::id(m_world));
+}
+
 template <typename... Args>
 inline flecs::timer world::timer(Args &&... args) const {
     return flecs::timer(m_world, FLECS_FWD(args)...);
@@ -78,6 +83,11 @@ inline void system::start() {
 
 inline void system::stop() {
     ecs_stop_timer(m_world, m_id);
+}
+
+template<typename T>
+inline void system::set_tick_source() {
+    ecs_set_tick_source(m_world, m_id, _::cpp_type<T>::id(m_world));
 }
 
 inline void system::set_tick_source(flecs::entity e) {

--- a/include/flecs/addons/cpp/mixins/timer/mixin.inl
+++ b/include/flecs/addons/cpp/mixins/timer/mixin.inl
@@ -8,6 +8,10 @@
  * \ingroup cpp_addons_timer
  */
 
+/** Find or register a singleton timer. */
+template <typename T>
+flecs::timer timer() const;
+
 /** Find or register a timer. */
 template <typename... Args>
 flecs::timer timer(Args &&... args) const;

--- a/include/flecs/addons/cpp/mixins/timer/system_mixin.inl
+++ b/include/flecs/addons/cpp/mixins/timer/system_mixin.inl
@@ -46,6 +46,12 @@ void stop();
 /** Set external tick source.
  * @see ecs_set_tick_source
  */
+template<typename T>
+void set_tick_source();
+
+/** Set external tick source.
+ * @see ecs_set_tick_source
+ */
 void set_tick_source(flecs::entity e);
 
 /** @} */

--- a/test/cpp_api/project.json
+++ b/test/cpp_api/project.json
@@ -483,7 +483,8 @@
                 "table_get",
                 "range_get",
                 "randomize_timers",
-                "optional_pair_term"
+                "optional_pair_term",
+                "singleton_tick_source"
             ]
         }, {
             "id": "Event",

--- a/test/cpp_api/src/System.cpp
+++ b/test/cpp_api/src/System.cpp
@@ -2264,3 +2264,26 @@ void System_optional_pair_term(void) {
     test_int(1, with_pair);
     test_int(1, without_pair);
 }
+
+void System_singleton_tick_source(void) {
+    flecs::world ecs;
+
+    ecs.timer<TagA>().timeout(1.5);
+
+    int32_t sys_invoked = 0;
+
+    ecs.system()
+        .tick_source<TagA>()
+        .iter([&](flecs::iter& it) {
+            sys_invoked ++;
+        });
+
+    ecs.progress(1.0);
+    test_int(0, sys_invoked);
+
+    ecs.progress(1.0);
+    test_int(1, sys_invoked);
+
+    ecs.progress(2.0);
+    test_int(1, sys_invoked);
+}

--- a/test/cpp_api/src/main.cpp
+++ b/test/cpp_api/src/main.cpp
@@ -466,6 +466,7 @@ void System_table_get(void);
 void System_range_get(void);
 void System_randomize_timers(void);
 void System_optional_pair_term(void);
+void System_singleton_tick_source(void);
 
 // Testsuite 'Event'
 void Event_evt_1_id_entity(void);
@@ -3134,6 +3135,10 @@ bake_test_case System_testcases[] = {
     {
         "optional_pair_term",
         System_optional_pair_term
+    },
+    {
+        "singleton_tick_source",
+        System_singleton_tick_source
     }
 };
 
@@ -6551,7 +6556,7 @@ static bake_test_suite suites[] = {
         "System",
         NULL,
         NULL,
-        68,
+        69,
         System_testcases
     },
     {


### PR DESCRIPTION
## Change Log
- Added `flecs::world::timer<T>()`
- Added `flecs::system_builder_i::tick_source<T>()`
- Added `flecs::system::set_tick_source<T>()`

## Details
This allows associating timers and tick sources with a type, effectively a singleton timer.