### PR TITLE
docs: Fix observers grouping.

### DIFF
--- a/flecs.h
+++ b/flecs.h
@@ -7479,7 +7479,7 @@ void* ecs_query_get_binding_ctx(
 /** @} */
 
 /**
- * @defgroup observer Observers
+ * @defgroup observers Observers
  * Functions for working with events and observers.
  *
  * @{

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -4649,7 +4649,7 @@ void* ecs_query_get_binding_ctx(
 /** @} */
 
 /**
- * @defgroup observer Observers
+ * @defgroup observers Observers
  * Functions for working with events and observers.
  *
  * @{


### PR DESCRIPTION
Things were using adding themselves to the group `observers` but the group was created as `observer`. The other similar things all use plural names, so creating this as `observers` instead.