### PR TITLE
Add C# code snippets to the docs

### DIFF
--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -162,6 +162,14 @@ flecs::world world;
 // Do the ECS stuff
 ```
 </li>
+<li><b class="tab-title">C#</b>
+
+```cs
+using World world = World.Create();
+
+// Do the ECS stuff
+```
+</li>
 </ul>
 </div>
 
@@ -189,6 +197,16 @@ e.destruct();
 e.is_alive(); // false!
 ```
 </li>
+<li><b class="tab-title">C#</b>
+
+```cs
+Entity e = world.Entity();
+e.IsAlive(); // true!
+
+e.Destruct();
+e.IsAlive(); // false!
+```
+</li>
 </ul>
 </div>
 
@@ -212,6 +230,14 @@ auto e = world.entity("Bob");
 std::cout << "Entity name: " << e.name() << std::endl;
 ```
 </li>
+<li><b class="tab-title">C#</b>
+
+```cs
+Entity e = world.Entity("Bob");
+
+Console.WriteLine($"Entity name: {e.Name()}");
+```
+</li>
 </ul>
 </div>
 
@@ -228,6 +254,12 @@ ecs_entity_t e = ecs_lookup(world, "Bob");
 
 ```cpp
 auto e = world.lookup("Bob");
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+Entity e = world.Lookup("Bob");
 ```
 </li>
 </ul>
@@ -287,6 +319,27 @@ const Position *p = e.get<Position>();
 e.remove<Position>();
 ```
 </li>
+<li><b class="tab-title">C#</b>
+
+```cs
+Entity e = world.Entity();
+
+// Add a component. This creates the component in the ECS storage, but does not
+// assign it with a value.
+e.Add<Velocity>();
+
+// Set the value for the Position & Velocity components. A component will be
+// added if the entity doesn't have it yet.
+e.Set<Position>(new(10, 20))
+ .Set<Velocity>(new(1, 2));
+
+// Get a component
+ref readonly Position p = ref e.Get<Position>();
+
+// Remove component
+e.Remove<Position>();
+```
+</li>
 </ul>
 </div>
 
@@ -317,6 +370,17 @@ std::cout << "Name: " << pos_e.name() << std::endl;  // outputs 'Name: Position'
 pos_e.add<Serializable>();
 ```
 </li>
+<li><b class="tab-title">C#</b>
+
+C# applications can use the `World.Entity()` function.
+```cs
+Entity posE = world.Entity<Position>();
+Console.WriteLine($"Name: {posE.Name()}"); // outputs 'Name: Position'
+
+// It's possible to add components like you would for any entity
+posE.Add<Serializable>();
+```
+</li>
 </ul>
 </div>
 
@@ -341,6 +405,15 @@ flecs::entity pos_e = world.entity<Position>();
 
 const EcsComponent *c = pos_e.get<flecs::Component>();
 std::cout << "Component size: " << c->size << std::endl;
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+Entity posE = world.Entity<Position>();
+
+ref readonly EcsComponent c = ref posE.Get<EcsComponent>();
+Console.WriteLine($"Component size: {c.size}");
 ```
 </li>
 </ul>
@@ -393,6 +466,31 @@ e.remove(Enemy);
 e.has(Enemy); // false!
 ```
 </li>
+<li><b class="tab-title">C#</b>
+
+```cs
+// Option 1: create Tag as empty struct
+public struct Enemy { }
+
+// Create entity, add Enemy tag
+Entity e = world.Entity().Add<Enemy>();
+e.Has<Enemy>(); // true!
+
+e.Remove<Enemy>();
+e.Has<Enemy>(); // false!
+
+
+// Option 2: create Tag as entity
+Entity Enemy = world.Entity();
+
+// Create entity, add Enemy tag
+Entity e = world.Entity().Add(Enemy);
+e.Has(Enemy); // true!
+
+e.Remove(Enemy);
+e.Has(Enemy); // false!
+```
+</li>
 </ul>
 </div>
 
@@ -440,6 +538,24 @@ Bob.remove<Likes>(Alice);
 Bob.has<Likes>(Alice); // false!
 ```
 </li>
+<li><b class="tab-title">C#</b>
+
+```cs
+// Create Likes relationship as empty type (tag)
+public struct Likes { }
+
+// Create a small graph with two entities that like each other
+Entity Bob = world.Entity();
+Entity Alice = world.Entity();
+
+Bob.Add<Likes>(Alice); // Bob likes Alice
+Alice.Add<Likes>(Bob); // Alice likes Bob
+Bob.Has<Likes>(Alice); // true!
+
+Bob.Remove<Likes>(Alice);
+Bob.Has<Likes>(Alice); // false!
+```
+</li>
 </ul>
 </div>
 
@@ -456,6 +572,12 @@ ecs_id_t id = ecs_pair(Likes, Bob);
 
 ```cpp
 flecs::id id = world.pair<Likes>(Bob);
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+Id id = world.Pair<Likes>(bob);
 ```
 </li>
 </ul>
@@ -480,6 +602,17 @@ flecs::id id = ...;
 if (id.is_pair()) {
     auto relationship = id.first();
     auto target = id.second();
+}
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+Id id = ...;
+if (id.IsPair())
+{
+    Entity relationship = id.First();
+    Entity target = id.Second();
 }
 ```
 </li>
@@ -514,6 +647,19 @@ bob.has(Eats, Pears);  // true!
 bob.has(Grows, Pears); // true!
 ```
 </li>
+<li><b class="tab-title">C#</b>
+
+```cs
+Entity Bob = ...;
+Bob.Add(Eats, Apples);
+Bob.Add(Eats, Pears);
+Bob.Add(Grows, Pears);
+
+Bob.Has(Eats, Apples); // true!
+Bob.Has(Eats, Pears);  // true!
+Bob.Has(Grows, Pears); // true!
+```
+</li>
 </ul>
 </div>
 
@@ -531,6 +677,13 @@ ecs_entity_t o = ecs_get_target(world, Alice, Likes, 0); // Returns Bob
 ```cpp
 flecs::entity alice = ...;
 auto o = alice.target<Likes>(); // Returns Bob
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+Entity Alice = ...;
+Entity o = Alice.Target<Likes>(); // Returns Bob
 ```
 </li>
 </ul>
@@ -562,6 +715,16 @@ auto child = world.entity().child_of(parent);
 
 // Deleting the parent also deletes its children
 parent.destruct();
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+Entity parent = world.Entity();
+Entity child = world.Entity().ChildOf(parent);
+
+// Deleting the parent also deletes its children
+parent.Destruct();
 ```
 </li>
 </ul>
@@ -600,6 +763,17 @@ std::cout << child.path() << std::endl; // output: 'parent::child'
 
 world.lookup("parent::child"); // returns child
 parent.lookup("child"); // returns child
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+Entity parent = world.Entity("parent");
+Entity child = world.Entity("child").ChildOf(parent);
+Console.WriteLine(child.Path()); // output: 'parent.child'
+
+world.Lookup("parent.child"); // returns child
+parent.Lookup("child"); // returns child
 ```
 </li>
 </ul>
@@ -643,6 +817,19 @@ q.each([](Position& p, Position& p_parent) {
 });
 ```
 </li>
+<li><b class="tab-title">C#</b>
+
+```cs
+Query q = world.QueryBuilder<Position, Position>()
+    .TermAt(2).Parent().Cascade()
+    .Build();
+
+q.Each((ref Position p, ref Position pParent) =>
+{
+    // Do the thing
+});
+```
+</li>
 </ul>
 </div>
 
@@ -671,6 +858,16 @@ auto e = world.entity().is_a(base);
 const Triangle *t = e.get<Triangle>(); // gets Triangle from base
 ```
 </li>
+<li><b class="tab-title">C#</b>
+
+```cs
+Entity base = world.Entity().Set<Triangle>(new Triangle(new(0, 0), new(1, 1), new(-1, -1)));
+
+// Create entity that shares components with base
+Entity e = world.Entity().IsA(base);
+ref readonly Triangle t = ref e.Get<Triangle>(); // gets Triangle from base
+```
+</li>
 </ul>
 </div>
 
@@ -689,6 +886,13 @@ ecs_add(world, e, Triangle);
 ```cpp
 // Add private instance of Triangle to e, copy value from base
 e.add<Triangle>();
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+// Add private instance of Triangle to e, copy value from base
+e.Add<Triangle>();
 ```
 </li>
 </ul>
@@ -726,6 +930,16 @@ auto e = ecs.entity()
 std::cout << e.type().str() << std::endl; // output: 'Position,Velocity'
 ```
 </li>
+<li><b class="tab-title">C#</b>
+
+```cs
+Entity e = ecs.Entity()
+    .Add<Position>()
+    .Add<Velocity>();
+
+Console.WriteLine(e.Type().Str()); // output: 'Position,Velocity'
+```
+</li>
 </ul>
 </div>
 
@@ -748,6 +962,18 @@ for (int i = 0; i < type->count; i++) {
 ```cpp
 e.each([&](flecs::id id) {
     if (id == world.id<Position>()) {
+        // Found Position component!
+    }
+});
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+e.Each((Id id) =>
+{
+    if (id == world.Id<Position>()) 
+    {
         // Found Position component!
     }
 });
@@ -780,6 +1006,16 @@ world.set<Gravity>({ 9.81 });
 const Gravity *g = world.get<Gravity>();
 ```
 </li>
+<li><b class="tab-title">C#</b>
+
+```cs
+// Set singleton component
+world.Set<Gravity>(new(9.81));
+
+// Get singleton component
+ref readonly Gravity g = ref world.Get<Gravity>();
+```
+</li>
 </ul>
 </div>
 
@@ -802,6 +1038,16 @@ flecs::entity grav_e = world.entity<Gravity>();
 grav_e.set<Gravity>({10, 20});
 
 const Gravity *g = grav_e.get<Gravity>();
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+Entity gravE = world.Entity<Gravity>();
+
+gravE.Set<Gravity>(new(10, 20));
+
+ref readonly Gravity g = ref gravE.Get<Gravity>();
 ```
 </li>
 </ul>
@@ -833,6 +1079,14 @@ ECS_SYSTEM(world, ApplyGravity, EcsOnUpdate, Velocity, Gravity($));
 world.query_builder<Velocity, Gravity>()
     .term_at(2).singleton()
     .build();
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+world.QueryBuilder<Velocity, Gravity>()
+    .TermAt(2).Singleton()
+    .Build();
 ```
 </li>
 </ul>
@@ -899,6 +1153,35 @@ f.iter([](flecs::iter& it, Position *p) {
 });
 ```
 </li>
+<li><b class="tab-title">C#</b>
+
+```cs
+// For simple queries the each function can be used
+world.Each((ref Position p, ref Velocity v) => // Entity argument is optional
+{
+    p.X += v.X;
+    p.Y += v.Y;
+});
+
+// More complex filters can first be created, then iterated
+using Filter f = world.FilterBuilder<Position>()
+    .Term(Ecs.ChildOf, parent)
+    .Build();
+
+// Option 1: Each() function that iterates each entity
+f.Each((Entity e, ref Position p) =>
+{
+    Console.WriteLine($"{e.Name()}: ({p.X}, {p.Y})")
+});
+
+// Option 2: Iter() function that iterates each archetype
+f.Iter((Iter it, Column<Position> p) =>
+{
+    foreach (int i in it)
+        Console.WriteLine($"{it.Entity(i).Name()}: ({p[i].X}, {p[i].Y})")
+});
+```
+</li>
 </ul>
 </div>
 
@@ -927,6 +1210,17 @@ auto f = world.filter_builder<>()
     .term(flecs::ChildOf, flecs::Wildcard)
     .term<Position>().oper(flecs::Not)
     .build();
+
+// Iteration code is the same
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+using Filter f = world.FilterBuilder()
+    .Term(Ecs.ChildOf, Ecs.Wildcard)
+    .Term<Position>().Oper(Ecs.Not)
+    .Build();
 
 // Iteration code is the same
 ```
@@ -964,6 +1258,17 @@ while (ecs_query_next(&it)) {
 auto q = world.query_builder<Position>()
     .term(flecs::ChildOf, flecs::Wildcard)
     .build();
+
+// Iteration is the same as filters
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+// Create a query with two terms
+Query q = world.QueryBuilder<Position>()
+    .Term(Ecs.ChildOf, Ecs.Wildcard)
+    .Build();
 
 // Iteration is the same as filters
 ```
@@ -1027,6 +1332,26 @@ auto move_sys = world.system<Position, Velocity>()
 move_sys.run();
 ```
 </li>
+<li><b class="tab-title">C#</b>
+
+```cs
+// Use Each() function that iterates each individual entity
+Routine moveSys = world.Routine<Position, Velocity>()
+    .Iter((Iter it, Column<Position> p, Column<Velocity> v) =>
+    {
+        foreach (int i in it) 
+        {
+            p[i].X += v[i].X * it.DeltaTime();
+            p[i].Y += v[i].Y * it.DeltaTime();
+        }
+    });
+
+    // Just like with filters & queries, systems have both the Iter() and
+    // Each() methods to iterate entities.
+
+moveSys.Run();
+```
+</li>
 </ul>
 </div>
 
@@ -1047,6 +1372,14 @@ ecs_delete(world, move_sys);
 std::cout << "System: " << move_sys.name() << std::endl;
 move_sys.add(flecs::OnUpdate);
 move_sys.destruct();
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+Console.WriteLine($"System: {moveSys.Name()}");
+moveSys.Entity.Add(Ecs.OnUpdate);
+moveSys.Entity.Destruct();
 ```
 </li>
 </ul>
@@ -1082,6 +1415,19 @@ flecs::PreStore
 flecs::OnStore
 ```
 </li>
+<li><b class="tab-title">C#</b>
+
+```cs
+Ecs.OnLoad
+Ecs.PostLoad
+Ecs.PreUpdate
+Ecs.OnUpdate
+Ecs.OnValidate
+Ecs.PostUpdate
+Ecs.PreStore
+Ecs.OnStore
+```
+</li>
 </ul>
 </div>
 
@@ -1108,6 +1454,16 @@ world.system<Transform, Mesh>("Render").kind(flecs::OnStore).each( ... );
 world.progress();
 ```
 </li>
+<li><b class="tab-title">C#</b>
+
+```cs
+world.Routine<Position, Velocity>("Move").Kind(Ecs.OnUpdate).Each( ... );
+world.Routine<Position, Transform>("Transform").Kind(Ecs.PostUpdate).Each( ... );
+world.Routine<Transform, Mesh>("Render").Kind(Ecs.OnStore).Each( ... );
+
+world.Progress();
+```
+</li>
 </ul>
 </div>
 
@@ -1126,6 +1482,13 @@ ecs_add_id(world, Move, EcsPostUpdate);
 ```cpp
 move_sys.add(flecs::OnUpdate);
 move_sys.remove(flecs::PostUpdate);
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+moveSys.Add(Ecs.OnUpdate);
+moveSys.Remove(Ecs.PostUpdate);
 ```
 </li>
 </ul>
@@ -1167,6 +1530,17 @@ auto e = ecs.entity();     // Doesn't invoke the observer
 e.set<Position>({10, 20}); // Doesn't invoke the observer
 e.set<Velocity>({1, 2});   // Invokes the observer
 e.set<Position>({20, 30}); // Invokes the observer
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+world.Observer<Position, Velocity>("OnSetPosition").Event(Ecs.OnSet).Each( ... );
+
+Entity e = ecs.Entity();      // Doesn't invoke the observer
+e.Set<Position>(new(10, 20)); // Doesn't invoke the observer
+e.Set<Velocity>(new(1, 2));   // Invokes the observer
+e.Set<Position>(new(20, 30)); // Invokes the observer
 ```
 </li>
 </ul>
@@ -1216,6 +1590,24 @@ struct my_module {
 
 // Import code
 world.import<my_module>();
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+public struct MyModule : IFlecsModule
+{
+    public void InitModule(ref World world)
+    {
+        world.Module<MyModule>();
+
+        // Define components, systems, triggers, ... as usual. They will be
+        // automatically created inside the scope of the module.
+    }
+};
+
+// Import code
+world.Import<MyModule>();
 ```
 </li>
 </ul>

--- a/docs/RestApi.md
+++ b/docs/RestApi.md
@@ -19,6 +19,13 @@ ecs_singleton_set(world, EcsRest, {0});
 world.set<flecs::Rest>({});
 ```
 </li>
+<li><b class="tab-title">C#</b>
+
+```cs
+// Start REST API with default parameters
+world.Set<EcsRest>(default);
+```
+</li>
 </ul>
 </div>
 
@@ -41,6 +48,15 @@ ecs_app_run(world, &(ecs_app_desc_t){
 world.app()
   .enable_rest()
   .run();
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+// Start application main loop, enable REST interface
+world.App()
+  .EnableRest()
+  .Run();
 ```
 </li>
 </ul>
@@ -67,6 +83,12 @@ ECS_IMPORT(world, FlecsMonitor);
 world.import<flecs::monitor>();
 ```
 </li>
+<li><b class="tab-title">C#</b>
+
+```cs
+world.Import<Ecs.Monitor>();
+```
+</li>
 </ul>
 </div>
 
@@ -91,6 +113,16 @@ world.app()
   .enable_rest()
   .enable_monitor()
   .run();
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+// Start application main loop, enable REST interface and monitoring
+world.App()
+  .EnableRest()
+  .EnableMonitor()
+  .Run();
 ```
 </li>
 </ul>
@@ -122,6 +154,12 @@ ecs_world_t *world = ecs_init_w_args(argc, argv);
 
 ```c++
 flecs::world world(argc, argc);
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+using World world = World.Create(args);
 ```
 </li>
 </ul>
@@ -160,6 +198,14 @@ In C++ a name can be provided to the query factory method:
 
 ```cpp
 auto q = world.query<Position, Velocity>("Move");
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+In C# a name can be provided to the query factory method:
+
+```cs
+Query q = world.Query<Position, Velocity>("Move");
 ```
 </li>
 </ul>

--- a/docs/Systems.md
+++ b/docs/Systems.md
@@ -52,6 +52,19 @@ flecs::system sys = world.system<Position, const Velocity>("Move")
     });
 ```
 </li>
+<li><b class="tab-title">C#</b>
+
+```cs
+// System declaration
+Routine sys = world.Routine<Position, Velocity>("Move")
+    .Each((ref Position p, ref Velocity v) =>
+    {
+        // Each is invoked for each entity
+        p.X += v.X;
+        p.Y += v.Y;
+    });
+```
+</li>
 </ul>
 </div>
 
@@ -69,6 +82,13 @@ ecs_run(world, ecs_id(Move), 0.0 /* delta_time */, NULL /* param */)
 ```cpp
 flecs::system sys = ...;
 sys.run();
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+Routine sys = ...;
+sys.Run();
 ```
 </li>
 </ul>
@@ -90,6 +110,13 @@ flecs::world world = ...;
 world.progress();
 ```
 </li>
+<li><b class="tab-title">C#</b>
+
+```cs
+using World world = World.Create();
+world.Progress();
+```
+</li>
 </ul>
 </div>
 
@@ -108,6 +135,14 @@ ECS_SYSTEM(world, Move, 0, Position, [in] Velocity);
 flecs::system sys = world.system<Position, const Velocity>("Move")
     .kind(0)
     .each([](Position& p, const Velocity &v) { /* ... */ });
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+Routine sys = world.Routine<Position, Velocity>("Move")
+    .Kind(0)
+    .Each((ref Position p, ref Velocity v) => { /* ... */ });
 ```
 </li>
 </ul>
@@ -183,6 +218,41 @@ The `iter` function can be invoked multiple times per frame, once for each match
 
 Note that there is no significant performance difference between `iter` and `each`, which can both be vectorized by the compiler. By default `each` can actually end up being faster, as it is instanced (see [query manual](Queries.md#each-c)).
 </li>
+<li><b class="tab-title">C#</b>
+
+```cs
+// Query iteration (Each)
+q.Each((ref Position p, ref Velocity v) => { /* ... */ });
+
+// System iteration (Each)
+world.Routine<Position, Velocity>("Move")
+    .Each((ref Position p, ref Velocity v) => { /* ... */ });
+```
+```cs
+// Query iteration (Iter)
+q.Iter((Iter it, Column<Position> p, Column<Velocity> v) =>
+{
+    foreach (int i in it) 
+    {
+        p[i].X += v[i].X;
+        p[i].Y += v[i].Y;
+    }
+});
+
+// System iteration (Iter)
+world.Routine<Position, Velocity>("Move")
+    .Iter((Iter it, Column<Position> p, Column<Velocity> v) =>
+    {
+        foreach (int i in it)
+        {
+            p[i].X += v[i].X;
+            p[i].Y += v[i].Y;
+        }
+    });
+```
+
+The `Iter` function can be invoked multiple times per frame, once for each matched table. The `Each` function is called once per matched entity.
+</li>
 </ul>
 </div>
 
@@ -208,7 +278,7 @@ for (int i = 0; i < it->count, i++) {
 
 ```cpp
 world.system<Position, const Velocity>("Move")
-    .iter([](flecs::iter& it, size_t, Position& p, const Velocity &v) {
+    .each([](flecs::iter& it, size_t, Position& p, const Velocity &v) {
         p.x += v.x * it.delta_time();
         p.y += v.y * it.delta_time();
     });
@@ -218,6 +288,27 @@ world.system<Position, const Velocity>("Move")
         for (auto i : it) {
             p[i].x += v[i].x * it.delta_time();
             p[i].y += v[i].y * it.delta_time();
+        }
+    });
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+world.Routine<Position, Velocity>("Move")
+    .Each((Iter it, int i, ref Position p, ref Velocity v) =>
+    {
+        p.X += v.X * it.DeltaTime();
+        p.Y += v.Y * it.DeltaTime();
+    });
+
+world.Routine<Position, Velocity>("Move")
+    .Iter((Iter it, Column<Position> p, Column<Velocity> v) =>
+    {
+        foreach (int i in it)
+        {
+            p[i].X += v[i].X * it.DeltaTime();
+            p[i].Y += v[i].Y * it.DeltaTime();
         }
     });
 ```
@@ -240,6 +331,12 @@ ecs_progress(world, delta_time);
 world.progress(delta_time);
 ```
 </li>
+<li><b class="tab-title">C#</b>
+
+```cs
+world.Progress(deltaTime);
+```
+</li>
 </ul>
 </div>
 
@@ -256,6 +353,12 @@ ecs_progress(world, 0);
 
 ```cpp
 world.progress();
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+world.Progress();
 ```
 </li>
 </ul>
@@ -298,6 +401,20 @@ world.system("PrintTime")
     .kind(flecs::OnUpdate)
     .iter([](flecs::iter& it) {
         printf("Time: %f\n", it.delta_time());
+    });
+
+// Runs PrintTime
+world.progress();
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+world.Routine("PrintTime")
+    .Kind(Ecs.OnUpdate)
+    .Iter((Iter it) =>
+    {
+        Console.WriteLine($"Time: {it.DeltaTime()}");
     });
 
 // Runs PrintTime
@@ -348,6 +465,18 @@ world.system<Game>("PrintTime")
     });
 ```
 </li>
+<li><b class="tab-title">C#</b>
+
+```cs
+world.Routine<Game>("PrintTime")
+    .TermAt(1).Singleton()
+    .Kind(Ecs.OnUpdate)
+    .Each((ref Game g) =>
+    {
+        Console.WriteLine($"Time: {g.Time}");
+    });
+```
+</li>
 </ul>
 </div>
 
@@ -382,6 +511,18 @@ world.system<Position, Velocity>("Move")
   .each([](Position& p, Velocity& v) {
     // ...
   });
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+// System is created with (DependsOn, OnUpdate)
+world.Routine<Position, Velocity>("Move")
+    .Kind(Ecs.OnUpdate)
+    .Each((ref Position p, ref Velocity v) =>
+    {
+        // ...
+    });
 ```
 </li>
 </ul>
@@ -425,6 +566,18 @@ Flecs has the following builtin phases, listed in topology order:
 - `flecs::PostUpdate`
 - `flecs::PreStore`
 - `flecs::OnStore`
+</li>
+<li><b class="tab-title">C#</b>
+
+- `Ecs.OnStart`
+- `Ecs.OnLoad`
+- `Ecs.PostLoad`
+- `Ecs.PreUpdate`
+- `Ecs.OnUpdate`
+- `Ecs.OnValidate`
+- `Ecs.PostUpdate`
+- `Ecs.PreStore`
+- `Ecs.OnStore`
 </li>
 </ul>
 </div>
@@ -481,6 +634,17 @@ world.pipeline()
 flecs.system.System, Phase(cascade(DependsOn)), !Disabled(up(DependsOn)), !Disabled(up(ChildOf))
 ```
 </li>
+<li><b class="tab-title">C#</b>
+
+```cs
+world.Pipeline()
+    .With(Ecs.System)
+    .With(Ecs.Phase).Cascade(Ecs.DependsOn)
+    .Without(Ecs.Disabled).Up(Ecs.DependsOn)
+    .Without(Ecs.Disabled).Up(Ecs.ChildOf)
+    .Build();
+```
+</li>
 </ul>
 </div>
 
@@ -532,6 +696,27 @@ auto move = world.system<Position, Velocity>("Move")
 world.progress();
 ```
 </li>
+<li><b class="tab-title">C#</b>
+
+```cs
+// Create custom pipeline
+Pipeline pipeline = world.Pipeline()
+    .With(Ecs.System)
+    .With(foo) // or .With<Foo>() if a type
+    .Build();
+
+// Configure the world to use the custom pipeline
+world.SetPipeline(pipeline);
+
+// Create system
+Routine move = world.Routine<Position, Velocity>("Move")
+    .Kind(foo) // or .Kind<Foo>() if a type
+    .Each(...);
+
+// Runs the pipeline & system
+world.Progress();
+```
+</li>
 </ul>
 </div>
 
@@ -553,6 +738,12 @@ ecs_add(world, Move, Foo);
 
 ```cpp
 move.add(Foo);
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+move.Entity.Add(foo);
 ```
 </li>
 </ul>
@@ -588,6 +779,15 @@ s.disable();
 s.enable();
 ```
 </li>
+<li><b class="tab-title">C#</b>
+
+```cs
+// Disable system in C#
+s.Entity.Disable();
+// Enable system in C#
+s.Entity.Enable();
+```
+</li>
 </ul>
 </div>
 
@@ -604,6 +804,12 @@ ecs_add_id(world, Move, EcsDisabled);
 
 ```cpp
 s.add(flecs::Disabled);
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+s.Entity.Add(Ecs.Disabled);
 ```
 </li>
 </ul>
@@ -684,6 +890,15 @@ world.system<Position>()
     .each( /* ... */);
 ```
 </li>
+<li><b class="tab-title">C#</b>
+
+```cs
+// In the C# API, use the write method to indicate commands could be inserted.
+world.Routine<Position>()
+    .Write<Transform>()
+    .Each( /* ... */);
+```
+</li>
 </ul>
 </div>
 
@@ -717,6 +932,15 @@ ecs_system(world, {
 world.system<Position>()
     .read<Transform>()
     .each( /* ... */);
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+// In the C# API, use the read method to indicate a component is read using .Get
+world.Routine<Position>()
+    .Read<Transform>()
+    .Each( /* ... */);
 ```
 </li>
 </ul>
@@ -762,6 +986,15 @@ ecs_system(ecs, {
         .iter([&](flecs::iter& it) { /* ... */ })
 ```
 </li>
+<li><b class="tab-title">C#</b>
+
+```cs
+ecs.Routine("AssignPlate")
+    .With<Plate>()
+    .NoReadonly() // disable readonly mode for this system
+    .Iter((Iter it) => { /* ... */ })
+```
+</li>
 </ul>
 </div>
 
@@ -796,6 +1029,22 @@ void AssignPlate(ecs_iter_t *it) {
 });
 ```
 </li>
+<li><b class="tab-title">C#</b>
+
+```cs
+.Iter((Iter it) =>
+{
+    foreach (int i in it)
+    {
+        // ECS operations ran here are visible after running the system
+        it.World().DeferSuspend();
+        // ECS operations ran here are immediately visible
+        it.World().DeferResume();
+        // ECS operations ran here are visible after running the system
+    }
+});
+```
+</li>
 </ul>
 </div>
 
@@ -815,6 +1064,12 @@ ecs_set_threads(world, 4); // Create 4 worker threads
 
 ```cpp
 world.set_threads(4);
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+world.SetThreads(4);
 ```
 </li>
 </ul>
@@ -846,6 +1101,14 @@ world.system<Position>()
   .each( /* ... */ );
 ```
 </li>
+<li><b class="tab-title">C#</b>
+
+```cs
+world.Routine<Position>()
+  .MultiThreaded()
+  .Each( /* ... */ );
+```
+</li>
 </ul>
 </div>
 
@@ -868,6 +1131,12 @@ ecs_set_task_threads(world, 4); // Create 4 worker task threads for the duration
 
 ```cpp
 world.set_task_threads(4);
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+world.SetTaskThreads(4);
 ```
 </li>
 </ul>
@@ -918,6 +1187,14 @@ world.system<Position, const Velocity>()
     .each(...);
 ```
 </li>
+<li><b class="tab-title">C#</b>
+
+```cs
+world.Routine<Position, Velocity>()
+    .Interval(1.0f) // Run at 1Hz
+    .Each(...);
+```
+</li>
 </ul>
 </div>
 
@@ -954,6 +1231,14 @@ ecs_system(world, {
 world.system<Position, const Velocity>()
     .rate(2) // Run every other frame
     .each(...);
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+world.Routine<Position, Velocity>()
+    .Rate(2) // Run every other frame
+    .Each(...);
 ```
 </li>
 </ul>
@@ -1008,6 +1293,18 @@ world.system<Position, const Velocity>()
     .each(...);
 ```
 </li>
+<li><b class="tab-title">C#</b>
+
+```cs
+// A rate filter can be created with .Rate(2)
+TimerEntity tickSource = world.Timer()
+    .Interval(1.0f);
+
+world.Routine<Position, Velocity>()
+    .TickSource(tickSource) // Set tick source for system
+    .Each(...);
+```
+</li>
 </ul>
 </div>
 
@@ -1032,6 +1329,16 @@ tick_source.stop();
 
 // Resume timer
 tick_source.start();
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+// Pause timer
+tickSource.Stop();
+
+// Resume timer
+tickSource.Start();
 ```
 </li>
 </ul>
@@ -1072,6 +1379,22 @@ flecs::entity each_minute = world.timer()
 // Tick each hour
 flecs::entity each_hour = world.timer()
     .rate(60, each_minute);
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+// Tick at 1Hz
+TimerEntity eachSecond = world.Timer()
+    .Interval(1.0f);
+
+// Tick each minute
+TimerEntity eachMinute = world.Timer()
+    .Rate(60, eachSecond);
+
+// Tick each hour
+TimerEntity eachHour = world.Timer()
+    .Rate(60, eachMinute);
 ```
 </li>
 </ul>
@@ -1135,6 +1458,27 @@ flecs::entity each_hour = world.system("EachHour")
     .tick_source(each_minute)
     .rate(60)
     .iter([](flecs::iter& it) { /* ... */ });
+```
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+// Tick at 1Hz
+Routine eachSecond = world.Routine("EachSecond")
+    .Interval(1.0f)
+    .Iter((Iter it) => { /* ... */ });
+
+// Tick each minute
+Routine eachMinute = world.Routine("EachMinute")
+    .TickSource(eachSecond)
+    .Rate(60)
+    .Iter((Iter it) => { /* ... */ });
+
+// Tick each hour
+Routine eachHour = world.Routine("EachHour")
+    .TickSource(eachMinute)
+    .Rate(60)
+    .Iter((Iter it) => { /* ... */ });
 ```
 </li>
 </ul>


### PR DESCRIPTION
Added C# code snippets to the docs using the new tabs feature introduced in this PR https://github.com/SanderMertens/flecs/pull/1138. I only provided snippets for the quickstart, rest api, and system manual since those are currently the only pages using tabs right now.

A live version can be viewed with these links:
- [Quick Start](https://beancheeseburrito.github.io/flecs/md_docs_2Quickstart.html)
- [System Manual](https://beancheeseburrito.github.io/flecs/md_docs_2Quickstart.html)
- [Rest Api](https://beancheeseburrito.github.io/flecs/md_docs_2Quickstart.html)