### PR TITLE
Register builtin components in C++ API

### DIFF
--- a/flecs.c
+++ b/flecs.c
@@ -3209,6 +3209,10 @@ void flecs_bootstrap(
     flecs_bootstrap_builtin_t(world, table, EcsPoly);
     flecs_bootstrap_builtin_t(world, table, EcsTarget);
 
+    /* Patch up symbol of EcsIterable. The type is a typedef, which causes a
+     * symbol mismatch when registering the type with the C++ API. */
+    ecs_set_symbol(world, ecs_id(EcsIterable), "ecs_iterable_t");
+
     /* Initialize default entity id range */
     world->info.last_component_id = EcsFirstUserComponentId;
     flecs_entities_max_id(world) = EcsFirstUserEntityId;

--- a/flecs.h
+++ b/flecs.h
@@ -16030,6 +16030,7 @@ static const flecs::entity_t Toggle = ECS_TOGGLE;
 /* Builtin components */
 using Component = EcsComponent;
 using Identifier = EcsIdentifier;
+using Iterable = EcsIterable;
 using Poly = EcsPoly;
 using Target = EcsTarget;
 
@@ -18568,6 +18569,9 @@ using WorldStats = EcsWorldStats;
 
 /** Component that stores system/pipeline statistics */
 using PipelineStats = EcsPipelineStats;
+
+/** Component with world summary stats */
+using WorldSummary = EcsWorldSummary;
 
 struct monitor {
     monitor(flecs::world& world);
@@ -30751,6 +30755,7 @@ inline void init(flecs::world& world) {
     world.component<Enum>("flecs::meta::Enum");
     world.component<Bitmask>("flecs::meta::Bitmask");
     world.component<Member>("flecs::meta::Member");
+    world.component<MemberRanges>("flecs::meta::MemberRanges");
     world.component<Struct>("flecs::meta::Struct");
     world.component<Array>("flecs::meta::Array");
     world.component<Vector>("flecs::meta::Vector");
@@ -31090,6 +31095,9 @@ inline monitor::monitor(flecs::world& world) {
     /* Import C module  */
     FlecsMonitorImport(world);
 
+    world.component<WorldSummary>();
+    world.component<WorldStats>();
+    world.component<PipelineStats>();
 }
 
 }
@@ -31110,6 +31118,9 @@ inline metrics::metrics(flecs::world& world) {
 
     /* Import C module  */
     FlecsMetricsImport(world);
+
+    world.component<Value>();
+    world.component<Source>();
 
     world.entity<metrics::Instance>("::flecs::metrics::Instance");
     world.entity<metrics::Metric>("::flecs::metrics::Metric");
@@ -31453,8 +31464,13 @@ struct alert final : entity
 };
 
 inline alerts::alerts(flecs::world& world) {
+    world.import<metrics>();
+
     /* Import C module  */
     FlecsAlertsImport(world);
+
+    world.component<AlertsActive>();
+    world.component<Instance>();
 
     world.entity<alerts::Alert>("::flecs::alerts::Alert");
     world.entity<alerts::Info>("::flecs::alerts::Info");
@@ -31568,6 +31584,12 @@ namespace flecs
 {
 
 inline void world::init_builtin_components() {
+    this->component<Component>();
+    this->component<Identifier>();
+    this->component<Iterable>("flecs::core::Iterable");
+    this->component<Poly>();
+    this->component<Target>();
+
 #   ifdef FLECS_SYSTEM
     _::system_init(*this);
 #   endif

--- a/flecs.h
+++ b/flecs.h
@@ -30785,11 +30785,12 @@ inline void init(flecs::world& world) {
     }
 
     // Register opaque type support for C++ entity wrappers
-    world.component<flecs::entity_view>()
-        .opaque(flecs_entity_support<flecs::entity_view>);
-
-    world.component<flecs::entity>()
-        .opaque(flecs_entity_support<flecs::entity>);
+    world.entity("::flecs::cpp").add(flecs::Module).scope([&]{
+        world.component<flecs::entity_view>()
+            .opaque(flecs_entity_support<flecs::entity_view>);
+        world.component<flecs::entity>()
+            .opaque(flecs_entity_support<flecs::entity>);
+    });
 }
 
 } // namespace _

--- a/include/flecs/addons/cpp/c_types.hpp
+++ b/include/flecs/addons/cpp/c_types.hpp
@@ -62,6 +62,7 @@ static const flecs::entity_t Toggle = ECS_TOGGLE;
 /* Builtin components */
 using Component = EcsComponent;
 using Identifier = EcsIdentifier;
+using Iterable = EcsIterable;
 using Poly = EcsPoly;
 using Target = EcsTarget;
 

--- a/include/flecs/addons/cpp/impl/world.hpp
+++ b/include/flecs/addons/cpp/impl/world.hpp
@@ -9,6 +9,12 @@ namespace flecs
 {
 
 inline void world::init_builtin_components() {
+    this->component<Component>();
+    this->component<Identifier>();
+    this->component<Iterable>("flecs::core::Iterable");
+    this->component<Poly>();
+    this->component<Target>();
+
 #   ifdef FLECS_SYSTEM
     _::system_init(*this);
 #   endif

--- a/include/flecs/addons/cpp/mixins/alerts/impl.hpp
+++ b/include/flecs/addons/cpp/mixins/alerts/impl.hpp
@@ -31,8 +31,13 @@ struct alert final : entity
 };
 
 inline alerts::alerts(flecs::world& world) {
+    world.import<metrics>();
+
     /* Import C module  */
     FlecsAlertsImport(world);
+
+    world.component<AlertsActive>();
+    world.component<Instance>();
 
     world.entity<alerts::Alert>("::flecs::alerts::Alert");
     world.entity<alerts::Info>("::flecs::alerts::Info");

--- a/include/flecs/addons/cpp/mixins/meta/impl.hpp
+++ b/include/flecs/addons/cpp/mixins/meta/impl.hpp
@@ -83,11 +83,12 @@ inline void init(flecs::world& world) {
     }
 
     // Register opaque type support for C++ entity wrappers
-    world.component<flecs::entity_view>()
-        .opaque(flecs_entity_support<flecs::entity_view>);
-
-    world.component<flecs::entity>()
-        .opaque(flecs_entity_support<flecs::entity>);
+    world.entity("::flecs::cpp").add(flecs::Module).scope([&]{
+        world.component<flecs::entity_view>()
+            .opaque(flecs_entity_support<flecs::entity_view>);
+        world.component<flecs::entity>()
+            .opaque(flecs_entity_support<flecs::entity>);
+    });
 }
 
 } // namespace _

--- a/include/flecs/addons/cpp/mixins/meta/impl.hpp
+++ b/include/flecs/addons/cpp/mixins/meta/impl.hpp
@@ -53,6 +53,7 @@ inline void init(flecs::world& world) {
     world.component<Enum>("flecs::meta::Enum");
     world.component<Bitmask>("flecs::meta::Bitmask");
     world.component<Member>("flecs::meta::Member");
+    world.component<MemberRanges>("flecs::meta::MemberRanges");
     world.component<Struct>("flecs::meta::Struct");
     world.component<Array>("flecs::meta::Array");
     world.component<Vector>("flecs::meta::Vector");

--- a/include/flecs/addons/cpp/mixins/metrics/impl.hpp
+++ b/include/flecs/addons/cpp/mixins/metrics/impl.hpp
@@ -13,6 +13,9 @@ inline metrics::metrics(flecs::world& world) {
     /* Import C module  */
     FlecsMetricsImport(world);
 
+    world.component<Value>();
+    world.component<Source>();
+
     world.entity<metrics::Instance>("::flecs::metrics::Instance");
     world.entity<metrics::Metric>("::flecs::metrics::Metric");
     world.entity<metrics::Counter>("::flecs::metrics::Metric::Counter");

--- a/include/flecs/addons/cpp/mixins/monitor/decl.hpp
+++ b/include/flecs/addons/cpp/mixins/monitor/decl.hpp
@@ -21,6 +21,9 @@ using WorldStats = EcsWorldStats;
 /** Component that stores system/pipeline statistics */
 using PipelineStats = EcsPipelineStats;
 
+/** Component with world summary stats */
+using WorldSummary = EcsWorldSummary;
+
 struct monitor {
     monitor(flecs::world& world);
 };

--- a/include/flecs/addons/cpp/mixins/monitor/impl.hpp
+++ b/include/flecs/addons/cpp/mixins/monitor/impl.hpp
@@ -11,6 +11,9 @@ inline monitor::monitor(flecs::world& world) {
     /* Import C module  */
     FlecsMonitorImport(world);
 
+    world.component<WorldSummary>();
+    world.component<WorldStats>();
+    world.component<PipelineStats>();
 }
 
 }

--- a/src/bootstrap.c
+++ b/src/bootstrap.c
@@ -753,6 +753,10 @@ void flecs_bootstrap(
     flecs_bootstrap_builtin_t(world, table, EcsPoly);
     flecs_bootstrap_builtin_t(world, table, EcsTarget);
 
+    /* Patch up symbol of EcsIterable. The type is a typedef, which causes a
+     * symbol mismatch when registering the type with the C++ API. */
+    ecs_set_symbol(world, ecs_id(EcsIterable), "ecs_iterable_t");
+
     /* Initialize default entity id range */
     world->info.last_component_id = EcsFirstUserComponentId;
     flecs_entities_max_id(world) = EcsFirstUserEntityId;

--- a/test/custom_builds/cpp/no_auto_registration/src/main.cpp
+++ b/test/custom_builds/cpp/no_auto_registration/src/main.cpp
@@ -5,7 +5,210 @@ int main(int, char *[]) {
     flecs::world world;
 
     world.import<flecs::units>();
+    world.import<flecs::alerts>();
     world.import<flecs::monitor>();
+
+    // check if builtin components are registered
+
+    // core
+    world.id<flecs::Component>();
+    world.id<flecs::Identifier>();
+    world.id<flecs::Iterable>();
+    world.id<flecs::Poly>();
+    world.id<flecs::Target>();
+
+    // alerts
+    world.id<flecs::alerts::AlertsActive>();
+    world.id<flecs::alerts::Instance>();
+    world.id<flecs::alerts::Alert>();
+    world.id<flecs::alerts::Info>();
+    world.id<flecs::alerts::Warning>();
+    world.id<flecs::alerts::Error>();
+
+    // metrics
+    world.id<flecs::metrics::Value>();
+    world.id<flecs::metrics::Source>();
+    world.id<flecs::metrics::Instance>();
+    world.id<flecs::metrics::Metric>();
+    world.id<flecs::metrics::Counter>();
+    world.id<flecs::metrics::CounterIncrement>();
+    world.id<flecs::metrics::CounterId>();
+    world.id<flecs::metrics::Gauge>();
+
+    // doc
+    world.id<flecs::doc::Description>();
+
+    // monitor
+    world.id<flecs::WorldSummary>();
+    world.id<flecs::WorldStats>();
+    world.id<flecs::PipelineStats>();
+
+    // meta
+    world.id<flecs::bool_t>();
+    world.id<flecs::char_t>();
+    world.id<flecs::u8_t>();
+    world.id<flecs::u16_t>();
+    world.id<flecs::u32_t>();
+    world.id<flecs::u64_t>();
+    world.id<flecs::uptr_t>();
+    world.id<flecs::i8_t>();
+    world.id<flecs::i16_t>();
+    world.id<flecs::i32_t>();
+    world.id<flecs::i64_t>();
+    world.id<flecs::iptr_t>();
+    world.id<flecs::f32_t>();
+    world.id<flecs::f64_t>();
+
+    world.id<flecs::member_t>();
+    world.id<flecs::enum_constant_t>();
+    world.id<flecs::bitmask_constant_t>();
+
+    world.id<flecs::MetaType>();
+    world.id<flecs::MetaTypeSerialized>();
+    world.id<flecs::Primitive>();
+    world.id<flecs::Enum>();
+    world.id<flecs::Bitmask>();
+    world.id<flecs::Member>();
+    world.id<flecs::MemberRanges>();
+    world.id<flecs::Struct>();
+    world.id<flecs::Array>();
+    world.id<flecs::Vector>();
+    world.id<flecs::Unit>();
+
+    // rest
+    world.id<flecs::Rest>();
+
+    // timer
+    world.id<flecs::Timer>();
+    world.id<flecs::RateFilter>();
+
+    // units
+    world.id<flecs::units::Yocto>();
+    world.id<flecs::units::Zepto>();
+    world.id<flecs::units::Atto>();
+    world.id<flecs::units::Femto>();
+    world.id<flecs::units::Pico>();
+    world.id<flecs::units::Nano>();
+    world.id<flecs::units::Micro>();
+    world.id<flecs::units::Milli>();
+    world.id<flecs::units::Centi>();
+    world.id<flecs::units::Deci>();
+    world.id<flecs::units::Deca>();
+    world.id<flecs::units::Hecto>();
+    world.id<flecs::units::Kilo>();
+    world.id<flecs::units::Mega>();
+    world.id<flecs::units::Giga>();
+    world.id<flecs::units::Tera>();
+    world.id<flecs::units::Peta>();
+    world.id<flecs::units::Exa>();
+    world.id<flecs::units::Zetta>();
+    world.id<flecs::units::Yotta>();
+    world.id<flecs::units::Kibi>();
+    world.id<flecs::units::Mebi>();
+    world.id<flecs::units::Gibi>();
+    world.id<flecs::units::Tebi>();
+    world.id<flecs::units::Pebi>();
+    world.id<flecs::units::Exbi>();
+    world.id<flecs::units::Zebi>();
+    world.id<flecs::units::Yobi>();
+
+    world.id<flecs::units::Duration>();
+    world.id<flecs::units::Time>();
+    world.id<flecs::units::Mass>();
+    world.id<flecs::units::ElectricCurrent>();
+    world.id<flecs::units::LuminousIntensity>();
+    world.id<flecs::units::Force>();
+    world.id<flecs::units::Amount>();
+    world.id<flecs::units::Length>();
+    world.id<flecs::units::Pressure>();
+    world.id<flecs::units::Speed>();
+    world.id<flecs::units::Temperature>();
+    world.id<flecs::units::Data>();
+    world.id<flecs::units::DataRate>();
+    world.id<flecs::units::Angle>();
+    world.id<flecs::units::Frequency>();
+    world.id<flecs::units::Uri>();
+
+    world.id<flecs::units::duration::PicoSeconds>();
+    world.id<flecs::units::duration::NanoSeconds>();
+    world.id<flecs::units::duration::MicroSeconds>();
+    world.id<flecs::units::duration::MilliSeconds>();
+    world.id<flecs::units::duration::Seconds>();
+    world.id<flecs::units::duration::Minutes>();
+    world.id<flecs::units::duration::Hours>();
+    world.id<flecs::units::duration::Days>();
+
+    world.id<flecs::units::angle::Radians>();
+    world.id<flecs::units::angle::Degrees>();
+
+    world.id<flecs::units::time::Date>();
+
+    world.id<flecs::units::mass::Grams>();
+    world.id<flecs::units::mass::KiloGrams>();
+
+    world.id<flecs::units::electric_current::Ampere>();
+
+    world.id<flecs::units::amount::Mole>();
+
+    world.id<flecs::units::luminous_intensity::Candela>();
+
+    world.id<flecs::units::force::Newton>();
+
+    world.id<flecs::units::length::Meters>();
+    world.id<flecs::units::length::PicoMeters>();
+    world.id<flecs::units::length::NanoMeters>();
+    world.id<flecs::units::length::MicroMeters>();
+    world.id<flecs::units::length::MilliMeters>();
+    world.id<flecs::units::length::CentiMeters>();
+    world.id<flecs::units::length::KiloMeters>();
+    world.id<flecs::units::length::Miles>();
+    world.id<flecs::units::length::Pixels>();
+
+    world.id<flecs::units::pressure::Pascal>();
+    world.id<flecs::units::pressure::Bar>();
+
+    world.id<flecs::units::speed::MetersPerSecond>();
+    world.id<flecs::units::speed::KiloMetersPerSecond>();
+    world.id<flecs::units::speed::KiloMetersPerHour>();
+    world.id<flecs::units::speed::MilesPerHour>();
+
+    world.id<flecs::units::temperature::Kelvin>();
+    world.id<flecs::units::temperature::Celsius>();
+    world.id<flecs::units::temperature::Fahrenheit>();
+
+    world.id<flecs::units::data::Bits>();
+    world.id<flecs::units::data::KiloBits>();
+    world.id<flecs::units::data::MegaBits>();
+    world.id<flecs::units::data::GigaBits>();
+    world.id<flecs::units::data::Bytes>();
+    world.id<flecs::units::data::KiloBytes>();
+    world.id<flecs::units::data::MegaBytes>();
+    world.id<flecs::units::data::GigaBytes>();
+    world.id<flecs::units::data::KibiBytes>();
+    world.id<flecs::units::data::MebiBytes>();
+    world.id<flecs::units::data::GibiBytes>();
+
+    world.id<flecs::units::datarate::BitsPerSecond>();
+    world.id<flecs::units::datarate::KiloBitsPerSecond>();
+    world.id<flecs::units::datarate::MegaBitsPerSecond>();
+    world.id<flecs::units::datarate::GigaBitsPerSecond>();
+    world.id<flecs::units::datarate::BytesPerSecond>();
+    world.id<flecs::units::datarate::KiloBytesPerSecond>();
+    world.id<flecs::units::datarate::MegaBytesPerSecond>();
+    world.id<flecs::units::datarate::GigaBytesPerSecond>();
+
+    world.id<flecs::units::frequency::Hertz>();
+    world.id<flecs::units::frequency::KiloHertz>();
+    world.id<flecs::units::frequency::MegaHertz>();
+    world.id<flecs::units::frequency::GigaHertz>();
+
+    world.id<flecs::units::uri::Hyperlink>();
+    world.id<flecs::units::uri::Image>();
+    world.id<flecs::units::uri::File>();
+
+    world.id<flecs::units::Percentage>();
+    world.id<flecs::units::Bel>();
+    world.id<flecs::units::DeciBel>();
 
     return 0;
 }


### PR DESCRIPTION
This PR ensures that flecs components are registered when their module is imported. This prevents relying on automatic component registration, and makes builtin components play nice with the `FLECS_CPP_NO_AUTO_REGISTRATION` macro.