### PR TITLE
Changed enum constants to keep contiguous array and modifies index/search strategy

### DIFF
--- a/flecs.h
+++ b/flecs.h
@@ -16726,34 +16726,56 @@ struct enum_reflection {
         return static_cast<underlying_type_t<E>>(Value != from_int<0>());
     }
 
-    template <E Low, E High, typename... Args>
-    static constexpr underlying_type_t<E> each_enum_range(underlying_type_t<E> last_value, Args... args) {
+    template <E Low, E High, typename Args>
+    static constexpr underlying_type_t<E> each_enum_range(underlying_type_t<E> last_value, Args args) {
         return to_int<High>() - to_int<Low>() <= 1
             ? to_int<High>() == to_int<Low>()
-                ? Fn<E>::template fn<Low>(last_value, args...)
-                : Fn<E>::template fn<High>(Fn<E>::template fn<Low>(last_value, args...), args...)
+                ? Fn<E>::template fn<Low>(last_value, args)
+                : Fn<E>::template fn<High>(Fn<E>::template fn<Low>(last_value, args), args)
             : each_enum_range<from_int<(to_int<Low>()+to_int<High>()) / 2 + 1>(), High>(
-                    each_enum_range<Low, from_int<(to_int<Low>()+to_int<High>()) / 2>()>(last_value, args...),
-                    args...
+                    each_enum_range<Low, from_int<(to_int<Low>()+to_int<High>()) / 2>()>(last_value, args),
+                    args
               );
     }
 
-    template <E Low, E High, typename... Args>
-    static constexpr underlying_type_t<E> each_mask_range(underlying_type_t<E> last_value, Args... args) {
+    template <E Low, E High, typename Args>
+    static constexpr underlying_type_t<E> each_mask_range(underlying_type_t<E> last_value, Args args) {
         return (to_int<Low>() & to_int<High>()) || to_int<High>() == to_int<Low>()
             ? last_value
             : Fn<E>::template fn<High>(
-                each_mask_range<Low, from_int<((to_int<High>() >> 1) & ~high_bit)>()>(last_value, args...),
-                args...
+                each_mask_range<Low, from_int<((to_int<High>() >> 1) & ~high_bit)>()>(last_value, args),
+                args
               );
     }
 
-    template <E Value = FLECS_ENUM_MAX(E), typename... Args>
-    static constexpr underlying_type_t<E> each_enum(Args... args) {
-        return each_mask_range<Value, from_int<high_bit>()>(each_enum_range<from_int<0>(), Value>(0, args...), args...);
+    template <E Value = FLECS_ENUM_MAX(E), typename Args>
+    static constexpr underlying_type_t<E> each_enum(Args args) {
+        return each_mask_range<Value, from_int<high_bit>()>(each_enum_range<from_int<0>(), Value>(0, args), args);
     }
 
-    static const underlying_type_t<E> high_bit = static_cast<underlying_type_t<E>>(1) << (sizeof(underlying_type_t<E>) * 8 - 2);
+    template <E Low, E High>
+    static constexpr underlying_type_t<E> each_enum_range(underlying_type_t<E> last_value) {
+        return to_int<High>() - to_int<Low>() <= 1
+            ? to_int<High>() == to_int<Low>()
+                ? Fn<E>::template fn<Low>(last_value)
+                : Fn<E>::template fn<High>(Fn<E>::template fn<Low>(last_value))
+            : each_enum_range<from_int<(to_int<Low>()+to_int<High>()) / 2 + 1>(), High>(
+                    each_enum_range<Low, from_int<(to_int<Low>()+to_int<High>()) / 2>()>(last_value));
+    }
+
+    template <E Low, E High>
+    static constexpr underlying_type_t<E> each_mask_range(underlying_type_t<E> last_value) {
+        return (to_int<Low>() & to_int<High>()) || to_int<High>() == to_int<Low>()
+            ? last_value
+            : Fn<E>::template fn<High>(each_mask_range<Low, from_int<((to_int<High>() >> 1) & ~high_bit)>()>(last_value));
+    }
+
+    template <E Value = FLECS_ENUM_MAX(E)>
+    static constexpr underlying_type_t<E> each_enum() {
+        return each_mask_range<Value, from_int<high_bit>()>(each_enum_range<from_int<0>(), Value>(0));
+    }
+
+    static const underlying_type_t<E> high_bit = static_cast<underlying_type_t<E>>(1) << (sizeof(underlying_type_t<E>) * 8 - 1);
 };
 
 /** Enumeration type data */
@@ -16816,17 +16838,21 @@ struct enum_type {
         ecs_log_push();
         ecs_cpp_enum_init(world, id);
         data.id = id;
-        EnumReflectionInit::template each_enum< enum_last<E>::value >(world);
+        EnumReflectionInit::template each_enum< enum_last<E>::value >(enum_reflection_input{world});
         ecs_log_pop();
     }
 
+    struct enum_reflection_input {
+        flecs::world_t *world;
+    };
+
     template <E Value, flecs::if_not_t< enum_constant_is_valid<E, Value>() > = 0>
-    static underlying_type_t<E> fn(underlying_type_t<E> last_value, flecs::world_t*) {
+    static underlying_type_t<E> fn(underlying_type_t<E> last_value, enum_reflection_input) {
         return last_value;
     }
 
     template <E Value, flecs::if_t< enum_constant_is_valid<E, Value>() > = 0>
-    static underlying_type_t<E> fn(underlying_type_t<E> last_value, flecs::world_t *world) {
+    static underlying_type_t<E> fn(underlying_type_t<E> last_value, enum_reflection_input input) {
         auto v = EnumReflectionInit::template to_int<Value>();
         const char *name = enum_constant_to_name<E, Value>();
         ++data.max;
@@ -16843,7 +16869,7 @@ struct enum_type {
             " low negative. Consider using unsigned integers as underlying type.");
         data.constants[data.max].offset = v - last_value;
         data.constants[data.max].id = ecs_cpp_enum_constant_register(
-            world, data.id, 0, name, static_cast<int32_t>(v));
+            input.world, data.id, 0, name, static_cast<int32_t>(v));
         return v;
     }
 };

--- a/flecs.h
+++ b/flecs.h
@@ -16649,7 +16649,7 @@ constexpr size_t enum_type_len() {
 /** Test if value is valid for enumeration.
  * This function leverages that when a valid value is provided, 
  * __PRETTY_FUNCTION__ contains the enumeration name, whereas if a value is
- * invalid, the string contains a number. */
+ * invalid, the string contains a number or a negative (-) symbol. */
 #if defined(ECS_TARGET_CLANG)
 #if ECS_CLANG_VERSION < 13
 template <typename E, E C>
@@ -16708,8 +16708,17 @@ struct enum_constant_data {
     T offset;
 };
 
-/** Compile time generated enum data */
-template <typename E, template<typename> class Fn>
+/**
+ * @brief Provides utilities for enum reflection.
+ * 
+ * This struct provides static functions for enum reflection, including conversion
+ * between enum values and their underlying integral types, and iteration over enum
+ * values.
+ * 
+ * @tparam E The enum type.
+ * @tparam Handler The handler for enum reflection operations.
+ */
+template <typename E, template<typename> class Handler>
 struct enum_reflection {
     template <E Value>
     static constexpr underlying_type_t<E> to_int() {
@@ -16726,28 +16735,69 @@ struct enum_reflection {
         return static_cast<underlying_type_t<E>>(Value != from_int<0>());
     }
 
+    /**
+     * @brief Iterates over the range [Low, High] of enum values between Low and High.
+     *
+     * Recursively divide and conquers the search space to reduce the template-depth. Once
+     * recursive division is complete, calls Handle<E>::handle_constant in ascending order,
+     * passing the values computed up the chain.
+     * 
+     * @tparam Low The lower bound of the search range, inclusive.
+     * @tparam High The upper bound of the search range, inclusive.
+     * @tparam Args Additional arguments to be passed through to Handler<E>::handle_constant
+     * @param last_value The last value processed in the iteration.
+     * @param args Additional arguments to be passed through to Handler<E>::handle_constant
+     * @return constexpr underlying_type_t<E> The result of the iteration.
+     */
     template <E Low, E High, typename... Args>
     static constexpr underlying_type_t<E> each_enum_range(underlying_type_t<E> last_value, Args... args) {
         return to_int<High>() - to_int<Low>() <= 1
             ? to_int<High>() == to_int<Low>()
-                ? Fn<E>::template fn<Low>(last_value, args...)
-                : Fn<E>::template fn<High>(Fn<E>::template fn<Low>(last_value, args...), args...)
+                ? Handler<E>::template handle_constant<Low>(last_value, args...)
+                : Handler<E>::template handle_constant<High>(Handler<E>::template handle_constant<Low>(last_value, args...), args...)
             : each_enum_range<from_int<(to_int<Low>()+to_int<High>()) / 2 + 1>(), High>(
                     each_enum_range<Low, from_int<(to_int<Low>()+to_int<High>()) / 2>()>(last_value, args...),
                     args...
               );
     }
 
+    /**
+     * @brief Iterates over the mask range (Low, High] of enum values between Low and High.
+     *
+     * Recursively iterates the search space, looking for enums defined as multiple-of-2 
+     * bitmasks. Each iteration, shifts bit to the right until it hits Low, then calls
+     * Handler<E>::handle_constant for each bitmask in ascending order.
+     * 
+     * @tparam Low The lower bound of the search range, not inclusive
+     * @tparam High The upper bound of the search range, inclusive.
+     * @tparam Args Additional arguments to be passed through to Handler<E>::handle_constant
+     * @param last_value The last value processed in the iteration.
+     * @param Args Additional arguments to be passed through to Handler<E>::handle_constant
+     * @return constexpr underlying_type_t<E> The result of the iteration.
+     */
     template <E Low, E High, typename... Args>
     static constexpr underlying_type_t<E> each_mask_range(underlying_type_t<E> last_value, Args... args) {
-        return (to_int<Low>() & to_int<High>()) || to_int<High>() == to_int<Low>()
+        // If Low shares any bits with Current Flag, or if High is less than/equal to Low (and High isn't negative because max-flag signed)
+        return (to_int<Low>() & to_int<High>()) || (to_int<High>() <= to_int<Low>() && to_int<High>() != high_bit)
             ? last_value
-            : Fn<E>::template fn<High>(
+            : Handler<E>::template handle_constant<High>(
                 each_mask_range<Low, from_int<((to_int<High>() >> 1) & ~high_bit)>()>(last_value, args...),
                 args...
               );
     }
 
+    /**
+     * @brief Handles enum iteration for gathering reflection data.
+     *
+     * Iterates over all enum values up to a specified maximum value 
+     * (each_enum_range<0, Value>), then iterates the rest of the possible bitmasks
+     * (each_mask_range<Value, high_bit>).
+     * 
+     * @tparam Value The maximum enum value to iterate up to.
+     * @tparam Args Additional arguments to be passed through to Handler<E>::handle_constant
+     * @param Args Additional arguments to be passed through to Handler<E>::handle_constant
+     * @return constexpr underlying_type_t<E> The result of the iteration.
+     */
     template <E Value = FLECS_ENUM_MAX(E), typename... Args>
     static constexpr underlying_type_t<E> each_enum(Args... args) {
         return each_mask_range<Value, from_int<high_bit>()>(each_enum_range<from_int<0>(), Value>(0, args...), args...);
@@ -16760,27 +16810,31 @@ struct enum_reflection {
 template<typename E>
 struct enum_data_impl {
 private:
+    /**
+     * @brief Handler struct for generating compile-time count of enum constants.
+     */
     template<typename Enum>
     struct reflection_count {
         template <Enum Value, flecs::if_not_t< enum_constant_is_valid<Enum, Value>() > = 0>
-        static constexpr underlying_type_t<Enum> fn(underlying_type_t<E> last_value) {
+        static constexpr underlying_type_t<Enum> handle_constant(underlying_type_t<E> last_value) {
             return last_value;
         }
 
         template <Enum Value, flecs::if_t< enum_constant_is_valid<Enum, Value>() > = 0>
-        static constexpr underlying_type_t<Enum> fn(underlying_type_t<E> last_value) {
+        static constexpr underlying_type_t<Enum> handle_constant(underlying_type_t<E> last_value) {
             return 1 + last_value;
         }
     };
-    using EnumReflectionCount = enum_reflection<E, reflection_count>;
 public:
     flecs::entity_t id;
     int min;
     int max;
     bool has_contiguous;
+	// If enum constants start not-sparse, contiguous_until will be the index of the first sparse value, or end of the constants array
     underlying_type_t<E> contiguous_until;
+	// Compile-time generated count of enum constants.
+    static constexpr unsigned int constants_size = enum_reflection<E, reflection_count>::template each_enum< enum_last<E>::value >();
     // Constants array is sized to the number of found-constants, or 1 (to avoid 0-sized array)
-    static constexpr unsigned int constants_size = EnumReflectionCount::template each_enum< enum_last<E>::value >();
     enum_constant_data<underlying_type_t<E>> constants[constants_size? constants_size: 1];
 };
 
@@ -16788,22 +16842,35 @@ public:
 template <typename E>
 struct enum_type {
 private:
+    /**
+     * @brief Helper struct for filling enum_type's static `enum_data_impl<E>` member with reflection data.
+     *
+     * Because reflection occurs in-order, we can use current value/last value to determine continuity, and
+     * use that as a lookup heuristic later on.
+     * 
+     * @tparam Enum The enum type.
+     */
     template <typename Enum>
     struct reflection_init {
         template <Enum Value, flecs::if_not_t< enum_constant_is_valid<Enum, Value>() > = 0>
-        static underlying_type_t<Enum> fn(underlying_type_t<Enum> last_value, flecs::world_t*) {
+        static underlying_type_t<Enum> handle_constant(underlying_type_t<Enum> last_value, flecs::world_t*) {
+            // Search for constant failed. Pass last valid value through.
             return last_value;
         }
 
         template <Enum Value, flecs::if_t< enum_constant_is_valid<Enum, Value>() > = 0>
-        static underlying_type_t<Enum> fn(underlying_type_t<Enum> last_value, flecs::world_t *world) {
-            auto v = EnumReflectionInit::template to_int<Value>();
+        static underlying_type_t<Enum> handle_constant(underlying_type_t<Enum> last_value, flecs::world_t *world) {
+            // Constant is valid, so fill reflection data.
+            auto v = enum_reflection<E, reflection_init>::template to_int<Value>();
             const char *name = enum_constant_to_name<Enum, Value>();
-            ++enum_type<Enum>::data.max;
+            
+            ++enum_type<Enum>::data.max; // Increment cursor as we build constants array.
+
+            // If the enum was previously contiguous, and continues to be through the current value...
             if (enum_type<Enum>::data.has_contiguous && static_cast<underlying_type_t<Enum>>(enum_type<Enum>::data.max) == v && enum_type<Enum>::data.contiguous_until == v) {
-                // Still contiguous through current value
                 ++enum_type<Enum>::data.contiguous_until;
             }
+            // else, if the enum was never contiguous and hasn't been set as not contiguous...
             else if (!enum_type<Enum>::data.contiguous_until && enum_type<Enum>::data.has_contiguous) {
                 enum_type<Enum>::data.has_contiguous = false;
             }
@@ -16817,7 +16884,6 @@ private:
             return v;
         }
     };
-    using EnumReflectionInit = enum_reflection<E, reflection_init>;
 public:
 
     static enum_data_impl<E> data;
@@ -16839,6 +16905,7 @@ public:
 #if !FLECS_CPP_ENUM_REFLECTION_SUPPORT
         ecs_abort(ECS_UNSUPPORTED, "enum reflection requires gcc 7.5 or higher")
 #endif
+        // Initialize/reset reflection data values to default state.
         data.min = 0;
         data.max = -1;
         data.has_contiguous = true;
@@ -16847,7 +16914,9 @@ public:
         ecs_log_push();
         ecs_cpp_enum_init(world, id);
         data.id = id;
-        EnumReflectionInit::template each_enum< enum_last<E>::value >(world);
+
+        // Generate reflection data
+        enum_reflection<E, reflection_init>::template each_enum< enum_last<E>::value >(world);
         ecs_log_pop();
     }
 
@@ -16872,7 +16941,14 @@ struct enum_data {
     enum_data(flecs::world_t *world, _::enum_data_impl<E>& impl)
         : world_(world)
         , impl_(impl) { }
-
+    
+	/**
+     * @brief Checks if a given integral value is a valid enum value.
+     * 
+     * @param value The integral value.
+     * @return true If the value is a valid enum value.
+     * @return false If the value is not a valid enum value.
+     */
     bool is_valid(underlying_type_t<E> value) {
         int index = index_by_value(value);
         if (index < 0) {
@@ -16881,10 +16957,23 @@ struct enum_data {
         return impl_.constants[index].id != 0;
     }
 
+    /**
+     * @brief Checks if a given enum value is valid.
+     * 
+     * @param value The enum value.
+     * @return true If the value is valid.
+     * @return false If the value is not valid.
+     */
     bool is_valid(E value) {
         return is_valid(static_cast<underlying_type_t<E>>(value));
     }
 
+    /**
+     * @brief Finds the index into the constants array for a value, if one exists
+     * 
+     * @param value The enum value.
+     * @return int The index of the enum value.
+     */
     int index_by_value(underlying_type_t<E> value) const {
         if (!impl_.max) {
             return -1;
@@ -16903,6 +16992,12 @@ struct enum_data {
         return -1;
     }
 
+    /**
+     * @brief Finds the index into the constants array for an enum value, if one exists
+     * 
+     * @param value The enum value.
+     * @return int The index of the enum value.
+     */
     int index_by_value(E value) const {
         return index_by_value(static_cast<underlying_type_t<E>>(value));
     }
@@ -22612,6 +22707,9 @@ struct entity_view : public id {
     bool has(E value) const {
         auto r = _::cpp_type<E>::id(m_world);
         auto o = enum_type<E>(m_world).entity(value);
+        ecs_assert(o, ECS_INVALID_PARAMETER,
+            "Constant was not found in Enum reflection data."
+            " Did you mean to use has<E>() instead of has(E)?");
         return ecs_has_pair(m_world, m_id, r, o);
     }
 
@@ -23096,6 +23194,8 @@ struct entity_builder : entity_view {
         flecs::entity_t first = _::cpp_type<E>::id(this->m_world);
         const auto& et = enum_type<E>(this->m_world);
         flecs::entity_t second = et.entity(value);
+
+        ecs_assert(second, ECS_INVALID_PARAMETER, "Component was not found in reflection data.");
         return this->add(first, second);
     }
 
@@ -26361,6 +26461,8 @@ untyped_component& constant(const char *name, int32_t value) {
     ecs_set_id(m_world, eid, 
         ecs_pair(flecs::Constant, flecs::I32), sizeof(int32_t),
         &value);
+
+    ecs_add_pair(m_world, m_id, flecs::Constant, eid);
 
     return *this;
 }
@@ -31927,7 +32029,17 @@ inline flecs::entity enum_data<E>::entity(underlying_type_t<E> value) const {
     if (index >= 0) {
         return flecs::entity(world_, impl_.constants[index].id);
     }
-    return flecs::entity(world_, 0);
+#ifdef FLECS_META
+    // Reflection data lookup failed. Try value lookup amongst flecs::Constant relationships
+    flecs::entity enum_component = flecs::world(world_).component<E>();
+    int32_t i = 0;
+    while (auto constant = enum_component.target(flecs::Constant, i++)) {
+        if (constant.has<E>() && value == static_cast<underlying_type_t<E>>(*constant.get<E>())) {
+            return constant;
+        }
+    }
+#endif
+    return flecs::entity::null(world_);
 }
 
 template <typename E>

--- a/flecs.h
+++ b/flecs.h
@@ -16744,7 +16744,8 @@ struct enum_data_impl {
     int max;
     int contiguous_through;
     // Constants array is sized to the number of found-constants, or 1 (to avoid 0-sized array)
-    enum_constant_data constants[enum_reflection<E>::template num_enums< enum_last<E>::value >() || 1];
+    const static unsigned int constants_size = enum_reflection<E>::template num_enums< enum_last<E>::value >();
+    enum_constant_data constants[constants_size? constants_size: 1];
 };
 
 /** Class that scans an enum for constants, extracts names & creates entities */
@@ -31879,7 +31880,7 @@ inline flecs::entity enum_data<E>::entity(int value) const {
     if (index >= 0) {
         return flecs::entity(world_, impl_.constants[index].id);
     }
-    return flecs::entity::null(world_);
+    return flecs::entity(world_, 0);
 }
 
 template <typename E>

--- a/flecs.h
+++ b/flecs.h
@@ -16738,7 +16738,7 @@ struct enum_reflection {
 
     template <E Low, E High, typename... Args>
     static constexpr underlying_type_t<E> each_mask_range(underlying_type_t<E> last_value, Args... args) {
-        return (to_int<Low>() & to_int<High>()) || High == Low
+        return (to_int<Low>() & to_int<High>()) || to_int<High>() == to_int<Low>()
             ? last_value
             : Fn<E>::template fn<High>(
                 each_mask_range<Low, from_int<((to_int<High>() >> 1) & ~high_bit)>()>(last_value, args...),
@@ -16841,7 +16841,7 @@ struct enum_type {
             " low negative. Consider using unsigned integers as underlying type.");
         data.constants[data.max].offset = v - last_value;
         data.constants[data.max].id = ecs_cpp_enum_constant_register(
-            world, data.id, 0, name, v);
+            world, data.id, 0, name, static_cast<int32_t>(v));
         return v;
     }
 };
@@ -16884,10 +16884,10 @@ struct enum_data {
         }
         // Check if value is in contiguous lookup section
         if (impl_.has_contiguous && value < impl_.contiguous_until && value >= 0) {
-            return value;
+            return static_cast<int>(value);
         }
         underlying_type_t<E> accumulator = impl_.contiguous_until? impl_.contiguous_until - 1: 0;
-        for (int i = impl_.contiguous_until; i <= impl_.max; ++i) {
+        for (int i = static_cast<int>(impl_.contiguous_until); i <= impl_.max; ++i) {
             accumulator += impl_.constants[i].offset;
             if (accumulator == value) {
                 return i;

--- a/flecs.h
+++ b/flecs.h
@@ -16726,53 +16726,31 @@ struct enum_reflection {
         return static_cast<underlying_type_t<E>>(Value != from_int<0>());
     }
 
-    template <E Low, E High, typename Args>
-    static constexpr underlying_type_t<E> each_enum_range(underlying_type_t<E> last_value, Args args) {
+    template <E Low, E High, typename... Args>
+    static constexpr underlying_type_t<E> each_enum_range(underlying_type_t<E> last_value, Args... args) {
         return to_int<High>() - to_int<Low>() <= 1
             ? to_int<High>() == to_int<Low>()
-                ? Fn<E>::template fn<Low>(last_value, args)
-                : Fn<E>::template fn<High>(Fn<E>::template fn<Low>(last_value, args), args)
+                ? Fn<E>::template fn<Low>(last_value, args...)
+                : Fn<E>::template fn<High>(Fn<E>::template fn<Low>(last_value, args...), args...)
             : each_enum_range<from_int<(to_int<Low>()+to_int<High>()) / 2 + 1>(), High>(
-                    each_enum_range<Low, from_int<(to_int<Low>()+to_int<High>()) / 2>()>(last_value, args),
-                    args
+                    each_enum_range<Low, from_int<(to_int<Low>()+to_int<High>()) / 2>()>(last_value, args...),
+                    args...
               );
     }
 
-    template <E Low, E High, typename Args>
-    static constexpr underlying_type_t<E> each_mask_range(underlying_type_t<E> last_value, Args args) {
+    template <E Low, E High, typename... Args>
+    static constexpr underlying_type_t<E> each_mask_range(underlying_type_t<E> last_value, Args... args) {
         return (to_int<Low>() & to_int<High>()) || to_int<High>() == to_int<Low>()
             ? last_value
             : Fn<E>::template fn<High>(
-                each_mask_range<Low, from_int<((to_int<High>() >> 1) & ~high_bit)>()>(last_value, args),
-                args
+                each_mask_range<Low, from_int<((to_int<High>() >> 1) & ~high_bit)>()>(last_value, args...),
+                args...
               );
     }
 
-    template <E Value = FLECS_ENUM_MAX(E), typename Args>
-    static constexpr underlying_type_t<E> each_enum(Args args) {
-        return each_mask_range<Value, from_int<high_bit>()>(each_enum_range<from_int<0>(), Value>(0, args), args);
-    }
-
-    template <E Low, E High>
-    static constexpr underlying_type_t<E> each_enum_range(underlying_type_t<E> last_value) {
-        return to_int<High>() - to_int<Low>() <= 1
-            ? to_int<High>() == to_int<Low>()
-                ? Fn<E>::template fn<Low>(last_value)
-                : Fn<E>::template fn<High>(Fn<E>::template fn<Low>(last_value))
-            : each_enum_range<from_int<(to_int<Low>()+to_int<High>()) / 2 + 1>(), High>(
-                    each_enum_range<Low, from_int<(to_int<Low>()+to_int<High>()) / 2>()>(last_value));
-    }
-
-    template <E Low, E High>
-    static constexpr underlying_type_t<E> each_mask_range(underlying_type_t<E> last_value) {
-        return (to_int<Low>() & to_int<High>()) || to_int<High>() == to_int<Low>()
-            ? last_value
-            : Fn<E>::template fn<High>(each_mask_range<Low, from_int<((to_int<High>() >> 1) & ~high_bit)>()>(last_value));
-    }
-
-    template <E Value = FLECS_ENUM_MAX(E)>
-    static constexpr underlying_type_t<E> each_enum() {
-        return each_mask_range<Value, from_int<high_bit>()>(each_enum_range<from_int<0>(), Value>(0));
+    template <E Value = FLECS_ENUM_MAX(E), typename... Args>
+    static constexpr underlying_type_t<E> each_enum(Args... args) {
+        return each_mask_range<Value, from_int<high_bit>()>(each_enum_range<from_int<0>(), Value>(0, args...), args...);
     }
 
     static const underlying_type_t<E> high_bit = static_cast<underlying_type_t<E>>(1) << (sizeof(underlying_type_t<E>) * 8 - 1);
@@ -16809,7 +16787,38 @@ public:
 /** Class that scans an enum for constants, extracts names & creates entities */
 template <typename E>
 struct enum_type {
-    using EnumReflectionInit = enum_reflection<E, enum_type>;
+private:
+    template <typename Enum>
+    struct reflection_init {
+        template <Enum Value, flecs::if_not_t< enum_constant_is_valid<Enum, Value>() > = 0>
+        static underlying_type_t<Enum> fn(underlying_type_t<Enum> last_value, flecs::world_t*) {
+            return last_value;
+        }
+
+        template <Enum Value, flecs::if_t< enum_constant_is_valid<Enum, Value>() > = 0>
+        static underlying_type_t<Enum> fn(underlying_type_t<Enum> last_value, flecs::world_t *world) {
+            auto v = EnumReflectionInit::template to_int<Value>();
+            const char *name = enum_constant_to_name<Enum, Value>();
+            ++enum_type<Enum>::data.max;
+            if (enum_type<Enum>::data.has_contiguous && static_cast<underlying_type_t<Enum>>(enum_type<Enum>::data.max) == v && enum_type<Enum>::data.contiguous_until == v) {
+                // Still contiguous through current value
+                ++enum_type<Enum>::data.contiguous_until;
+            }
+            else if (!enum_type<Enum>::data.contiguous_until && enum_type<Enum>::data.has_contiguous) {
+                enum_type<Enum>::data.has_contiguous = false;
+            }
+
+            ecs_assert(!(last_value > 0 && v < std::numeric_limits<underlying_type_t<Enum>>::min() + last_value), ECS_UNSUPPORTED,
+                "Signed integer enums causes integer overflow when recording offset from high positive to"
+                " low negative. Consider using unsigned integers as underlying type.");
+            enum_type<Enum>::data.constants[enum_type<Enum>::data.max].offset = v - last_value;
+            enum_type<Enum>::data.constants[enum_type<Enum>::data.max].id = ecs_cpp_enum_constant_register(
+                world, enum_type<Enum>::data.id, 0, name, static_cast<int32_t>(v));
+            return v;
+        }
+    };
+    using EnumReflectionInit = enum_reflection<E, reflection_init>;
+public:
 
     static enum_data_impl<E> data;
 
@@ -16838,40 +16847,10 @@ struct enum_type {
         ecs_log_push();
         ecs_cpp_enum_init(world, id);
         data.id = id;
-        EnumReflectionInit::template each_enum< enum_last<E>::value >(enum_reflection_input{world});
+        EnumReflectionInit::template each_enum< enum_last<E>::value >(world);
         ecs_log_pop();
     }
 
-    struct enum_reflection_input {
-        flecs::world_t *world;
-    };
-
-    template <E Value, flecs::if_not_t< enum_constant_is_valid<E, Value>() > = 0>
-    static underlying_type_t<E> fn(underlying_type_t<E> last_value, enum_reflection_input) {
-        return last_value;
-    }
-
-    template <E Value, flecs::if_t< enum_constant_is_valid<E, Value>() > = 0>
-    static underlying_type_t<E> fn(underlying_type_t<E> last_value, enum_reflection_input input) {
-        auto v = EnumReflectionInit::template to_int<Value>();
-        const char *name = enum_constant_to_name<E, Value>();
-        ++data.max;
-        if (data.has_contiguous && static_cast<underlying_type_t<E>>(data.max) == v && data.contiguous_until == v) {
-            // Still contiguous through current value
-            ++data.contiguous_until;
-        }
-        else if (!data.contiguous_until && data.has_contiguous) {
-            data.has_contiguous = false;
-        }
-
-        ecs_assert(!(last_value > 0 && v < std::numeric_limits<underlying_type_t<E>>::min() + last_value), ECS_UNSUPPORTED,
-            "Signed integer enums causes integer overflow when recording offset from high positive to"
-            " low negative. Consider using unsigned integers as underlying type.");
-        data.constants[data.max].offset = v - last_value;
-        data.constants[data.max].id = ecs_cpp_enum_constant_register(
-            input.world, data.id, 0, name, static_cast<int32_t>(v));
-        return v;
-    }
 };
 
 template <typename E>

--- a/flecs.h
+++ b/flecs.h
@@ -16772,7 +16772,7 @@ struct enum_reflection {
      * @tparam High The upper bound of the search range, inclusive.
      * @tparam Args Additional arguments to be passed through to Handler<E>::handle_constant
      * @param last_value The last value processed in the iteration.
-     * @param Args Additional arguments to be passed through to Handler<E>::handle_constant
+     * @param args Additional arguments to be passed through to Handler<E>::handle_constant
      * @return constexpr underlying_type_t<E> The result of the iteration.
      */
     template <E Low, E High, typename... Args>
@@ -16795,7 +16795,7 @@ struct enum_reflection {
      * 
      * @tparam Value The maximum enum value to iterate up to.
      * @tparam Args Additional arguments to be passed through to Handler<E>::handle_constant
-     * @param Args Additional arguments to be passed through to Handler<E>::handle_constant
+     * @param args Additional arguments to be passed through to Handler<E>::handle_constant
      * @return constexpr underlying_type_t<E> The result of the iteration.
      */
     template <E Value = FLECS_ENUM_MAX(E), typename... Args>
@@ -26462,8 +26462,6 @@ untyped_component& constant(const char *name, int32_t value) {
         ecs_pair(flecs::Constant, flecs::I32), sizeof(int32_t),
         &value);
 
-    ecs_add_pair(m_world, m_id, flecs::Constant, eid);
-
     return *this;
 }
 
@@ -32031,15 +32029,19 @@ inline flecs::entity enum_data<E>::entity(underlying_type_t<E> value) const {
     }
 #ifdef FLECS_META
     // Reflection data lookup failed. Try value lookup amongst flecs::Constant relationships
-    flecs::entity enum_component = flecs::world(world_).component<E>();
-    int32_t i = 0;
-    while (auto constant = enum_component.target(flecs::Constant, i++)) {
-        if (constant.has<E>() && value == static_cast<underlying_type_t<E>>(*constant.get<E>())) {
-            return constant;
-        }
-    }
-#endif
+    flecs::world world = flecs::world(world_);
+    return world.filter_builder()
+        .with(flecs::ChildOf, world.id<E>())
+        .with(flecs::Constant, world.id<int32_t>())
+        .build()
+        .find([value](flecs::entity constant) {
+            const int32_t *constant_value = constant.get_second<int32_t>(flecs::Constant);
+            ecs_assert(constant_value, ECS_INTERNAL_ERROR, NULL);
+            return value == static_cast<underlying_type_t<E>>(*constant_value);
+        });
+#else
     return flecs::entity::null(world_);
+#endif
 }
 
 template <typename E>

--- a/flecs.h
+++ b/flecs.h
@@ -16726,31 +16726,31 @@ struct enum_reflection {
         return static_cast<underlying_type_t<E>>(Value != from_int<0>());
     }
 
-    template <E Low, E High, typename... Args>
-    static constexpr underlying_type_t<E> each_enum_range(underlying_type_t<E> last_value, Args... args) {
+    template <E Low, E High, typename Args = void*>
+    static constexpr underlying_type_t<E> each_enum_range(underlying_type_t<E> last_value, Args args = nullptr) {
         return to_int<High>() - to_int<Low>() <= 1
             ? to_int<High>() == to_int<Low>()
-                ? Fn<E>::template fn<Low>(last_value, args...)
-                : Fn<E>::template fn<High>(Fn<E>::template fn<Low>(last_value, args...), args...)
+                ? Fn<E>::template fn<Low>(last_value, args)
+                : Fn<E>::template fn<High>(Fn<E>::template fn<Low>(last_value, args), args)
             : each_enum_range<from_int<(to_int<Low>()+to_int<High>()) / 2 + 1>(), High>(
-                    each_enum_range<Low, from_int<(to_int<Low>()+to_int<High>()) / 2>()>(last_value, args...),
-                    args...
+                    each_enum_range<Low, from_int<(to_int<Low>()+to_int<High>()) / 2>()>(last_value, args),
+                    args
               );
     }
 
-    template <E Low, E High, typename... Args>
-    static constexpr underlying_type_t<E> each_mask_range(underlying_type_t<E> last_value, Args... args) {
+    template <E Low, E High, typename Args = void*>
+    static constexpr underlying_type_t<E> each_mask_range(underlying_type_t<E> last_value, Args args = nullptr) {
         return (to_int<Low>() & to_int<High>()) || to_int<High>() == to_int<Low>()
             ? last_value
             : Fn<E>::template fn<High>(
-                each_mask_range<Low, from_int<((to_int<High>() >> 1) & ~high_bit)>()>(last_value, args...),
-                args...
+                each_mask_range<Low, from_int<((to_int<High>() >> 1) & ~high_bit)>()>(last_value, args),
+                args
               );
     }
 
-    template <E Value = FLECS_ENUM_MAX(E), typename... Args>
-    static constexpr underlying_type_t<E> each_enum(Args... args) {
-        return each_mask_range<Value, from_int<high_bit>()>(each_enum_range<from_int<0>(), Value>(0, args...), args...);
+    template <E Value = FLECS_ENUM_MAX(E), typename Args = void*>
+    static constexpr underlying_type_t<E> each_enum(Args args = nullptr) {
+        return each_mask_range<Value, from_int<high_bit>()>(each_enum_range<from_int<0>(), Value>(0, args), args);
     }
 
     static const underlying_type_t<E> high_bit = static_cast<underlying_type_t<E>>(1) << (sizeof(underlying_type_t<E>) * 8 - 1);
@@ -16763,12 +16763,12 @@ private:
     template<typename Enum>
     struct reflection_count {
         template <Enum Value, flecs::if_not_t< enum_constant_is_valid<Enum, Value>() > = 0>
-        static constexpr underlying_type_t<Enum> fn(underlying_type_t<E> last_value) {
+        static constexpr underlying_type_t<Enum> fn(underlying_type_t<E> last_value, void*) {
             return last_value;
         }
 
         template <Enum Value, flecs::if_t< enum_constant_is_valid<Enum, Value>() > = 0>
-        static constexpr underlying_type_t<Enum> fn(underlying_type_t<E> last_value) {
+        static constexpr underlying_type_t<Enum> fn(underlying_type_t<E> last_value, void*) {
             return 1 + last_value;
         }
     };
@@ -16816,17 +16816,21 @@ struct enum_type {
         ecs_log_push();
         ecs_cpp_enum_init(world, id);
         data.id = id;
-        EnumReflectionInit::template each_enum< enum_last<E>::value >(world);
+        EnumReflectionInit::template each_enum< enum_last<E>::value >(enum_reflection_input{world});
         ecs_log_pop();
     }
 
+    struct enum_reflection_input {
+        flecs::world_t *world;
+    };
+
     template <E Value, flecs::if_not_t< enum_constant_is_valid<E, Value>() > = 0>
-    static underlying_type_t<E> fn(underlying_type_t<E> last_value, flecs::world_t*) {
+    static underlying_type_t<E> fn(underlying_type_t<E> last_value, enum_reflection_input) {
         return last_value;
     }
 
     template <E Value, flecs::if_t< enum_constant_is_valid<E, Value>() > = 0>
-    static underlying_type_t<E> fn(underlying_type_t<E> last_value, flecs::world_t *world) {
+    static underlying_type_t<E> fn(underlying_type_t<E> last_value, enum_reflection_input input) {
         auto v = EnumReflectionInit::template to_int<Value>();
         const char *name = enum_constant_to_name<E, Value>();
         ++data.max;
@@ -16843,7 +16847,7 @@ struct enum_type {
             " low negative. Consider using unsigned integers as underlying type.");
         data.constants[data.max].offset = v - last_value;
         data.constants[data.max].id = ecs_cpp_enum_constant_register(
-            world, data.id, 0, name, static_cast<int32_t>(v));
+            input.world, data.id, 0, name, static_cast<int32_t>(v));
         return v;
     }
 };

--- a/flecs.h
+++ b/flecs.h
@@ -16743,7 +16743,8 @@ struct enum_data_impl {
     int min;
     int max;
     int contiguous_through;
-    enum_constant_data constants[enum_reflection<E>::template num_enums< enum_last<E>::value >()];
+    // Constants array is sized to the number of found-constants, or 1 (to avoid 0-sized array)
+    enum_constant_data constants[enum_reflection<E>::template num_enums< enum_last<E>::value >() || 1];
 };
 
 /** Class that scans an enum for constants, extracts names & creates entities */
@@ -31878,7 +31879,7 @@ inline flecs::entity enum_data<E>::entity(int value) const {
     if (index >= 0) {
         return flecs::entity(world_, impl_.constants[index].id);
     }
-    return flecs::entity(world_, 0);
+    return flecs::entity::null(world_);
 }
 
 template <typename E>

--- a/flecs.h
+++ b/flecs.h
@@ -16654,11 +16654,13 @@ constexpr size_t enum_type_len() {
 #if ECS_CLANG_VERSION < 13
 template <typename E, E C>
 constexpr bool enum_constant_is_valid() {
-    return !(
+    return !((
         (ECS_FUNC_NAME[ECS_FUNC_NAME_FRONT(bool, enum_constant_is_valid) +
             enum_type_len<E>() + 6 /* ', C = ' */] >= '0') &&
         (ECS_FUNC_NAME[ECS_FUNC_NAME_FRONT(bool, enum_constant_is_valid) +
-            enum_type_len<E>() + 6 /* ', C = ' */] <= '9'));
+            enum_type_len<E>() + 6 /* ', C = ' */] <= '9')) ||
+        (ECS_FUNC_NAME[ECS_FUNC_NAME_FRONT(bool, enum_constant_is_valid) +
+            enum_type_len<E>() + 6 /* ', C = ' */] == '-'));
 }
 #else
 template <typename E, E C>

--- a/include/flecs/addons/cpp/entity_view.hpp
+++ b/include/flecs/addons/cpp/entity_view.hpp
@@ -549,6 +549,9 @@ struct entity_view : public id {
     bool has(E value) const {
         auto r = _::cpp_type<E>::id(m_world);
         auto o = enum_type<E>(m_world).entity(value);
+        ecs_assert(o, ECS_INVALID_PARAMETER,
+            "Constant was not found in Enum reflection data."
+            " Did you mean to use has<E>() instead of has(E)?");
         return ecs_has_pair(m_world, m_id, r, o);
     }
 

--- a/include/flecs/addons/cpp/impl/world.hpp
+++ b/include/flecs/addons/cpp/impl/world.hpp
@@ -259,18 +259,11 @@ inline flecs::entity enum_data<E>::entity() const {
 
 template <typename E>
 inline flecs::entity enum_data<E>::entity(int value) const {
-    if (value <= impl_.contiguous_through) {
-        return flecs::entity(world_, impl_.constants[value].id);
+    int index = index_by_value(value);
+    if (index >= 0) {
+        return flecs::entity(world_, impl_.constants[index].id);
     }
-    // Skip to last contiguous enum entry
-    int accumulator = impl_.contiguous_through; 
-    for (int i = impl_.contiguous_through + 1; i <= impl_.max; ++i) {
-        accumulator += impl_.constants[i].offset;
-        if (accumulator == value) {
-            return flecs::entity(world_, impl_.constants[i].id);
-        }
-    }
-    ecs_abort(ECS_INTERNAL_ERROR, "Enum value %s not found", value);
+    return flecs::entity(world_, 0);
 }
 
 template <typename E>

--- a/include/flecs/addons/cpp/impl/world.hpp
+++ b/include/flecs/addons/cpp/impl/world.hpp
@@ -258,7 +258,7 @@ inline flecs::entity enum_data<E>::entity() const {
 }
 
 template <typename E>
-inline flecs::entity enum_data<E>::entity(int value) const {
+inline flecs::entity enum_data<E>::entity(underlying_type_t<E> value) const {
     int index = index_by_value(value);
     if (index >= 0) {
         return flecs::entity(world_, impl_.constants[index].id);
@@ -268,7 +268,7 @@ inline flecs::entity enum_data<E>::entity(int value) const {
 
 template <typename E>
 inline flecs::entity enum_data<E>::entity(E value) const {
-    return entity(static_cast<int>(value));
+    return entity(static_cast<underlying_type_t<E>>(value));
 }
 
 /** Use provided scope for operations ran on returned world.

--- a/include/flecs/addons/cpp/impl/world.hpp
+++ b/include/flecs/addons/cpp/impl/world.hpp
@@ -263,7 +263,17 @@ inline flecs::entity enum_data<E>::entity(underlying_type_t<E> value) const {
     if (index >= 0) {
         return flecs::entity(world_, impl_.constants[index].id);
     }
-    return flecs::entity(world_, 0);
+#ifdef FLECS_META
+    // Reflection data lookup failed. Try value lookup amongst flecs::Constant relationships
+    flecs::entity enum_component = flecs::world(world_).component<E>();
+    int32_t i = 0;
+    while (auto constant = enum_component.target(flecs::Constant, i++)) {
+        if (constant.has<E>() && value == static_cast<underlying_type_t<E>>(*constant.get<E>())) {
+            return constant;
+        }
+    }
+#endif
+    return flecs::entity::null(world_);
 }
 
 template <typename E>

--- a/include/flecs/addons/cpp/mixins/entity/builder.hpp
+++ b/include/flecs/addons/cpp/mixins/entity/builder.hpp
@@ -43,6 +43,8 @@ struct entity_builder : entity_view {
         flecs::entity_t first = _::cpp_type<E>::id(this->m_world);
         const auto& et = enum_type<E>(this->m_world);
         flecs::entity_t second = et.entity(value);
+
+        ecs_assert(second, ECS_INVALID_PARAMETER, "Component was not found in reflection data.");
         return this->add(first, second);
     }
 

--- a/include/flecs/addons/cpp/mixins/meta/untyped_component.inl
+++ b/include/flecs/addons/cpp/mixins/meta/untyped_component.inl
@@ -96,8 +96,6 @@ untyped_component& constant(const char *name, int32_t value) {
         ecs_pair(flecs::Constant, flecs::I32), sizeof(int32_t),
         &value);
 
-    ecs_add_pair(m_world, m_id, flecs::Constant, eid);
-
     return *this;
 }
 

--- a/include/flecs/addons/cpp/mixins/meta/untyped_component.inl
+++ b/include/flecs/addons/cpp/mixins/meta/untyped_component.inl
@@ -96,6 +96,8 @@ untyped_component& constant(const char *name, int32_t value) {
         ecs_pair(flecs::Constant, flecs::I32), sizeof(int32_t),
         &value);
 
+    ecs_add_pair(m_world, m_id, flecs::Constant, eid);
+
     return *this;
 }
 

--- a/include/flecs/addons/cpp/utils/enum.hpp
+++ b/include/flecs/addons/cpp/utils/enum.hpp
@@ -205,7 +205,8 @@ struct enum_data_impl {
     int min;
     int max;
     int contiguous_through;
-    enum_constant_data constants[enum_reflection<E>::template num_enums< enum_last<E>::value >()];
+    // Constants array is sized to the number of found-constants, or 1 (to avoid 0-sized array)
+    enum_constant_data constants[enum_reflection<E>::template num_enums< enum_last<E>::value >() || 1];
 };
 
 /** Class that scans an enum for constants, extracts names & creates entities */

--- a/include/flecs/addons/cpp/utils/enum.hpp
+++ b/include/flecs/addons/cpp/utils/enum.hpp
@@ -185,34 +185,34 @@ struct enum_reflection {
         return static_cast<underlying_type_t<E>>(Value != from_int<0>());
     }
 
-    template <E Low, E High, typename Args = void*>
-    static constexpr underlying_type_t<E> each_enum_range(underlying_type_t<E> last_value, Args args = nullptr) {
+    template <E Low, E High, typename... Args>
+    static constexpr underlying_type_t<E> each_enum_range(underlying_type_t<E> last_value, Args... args) {
         return to_int<High>() - to_int<Low>() <= 1
             ? to_int<High>() == to_int<Low>()
-                ? Fn<E>::template fn<Low>(last_value, args)
-                : Fn<E>::template fn<High>(Fn<E>::template fn<Low>(last_value, args), args)
+                ? Fn<E>::template fn<Low>(last_value, args...)
+                : Fn<E>::template fn<High>(Fn<E>::template fn<Low>(last_value, args...), args...)
             : each_enum_range<from_int<(to_int<Low>()+to_int<High>()) / 2 + 1>(), High>(
-                    each_enum_range<Low, from_int<(to_int<Low>()+to_int<High>()) / 2>()>(last_value, args),
-                    args
+                    each_enum_range<Low, from_int<(to_int<Low>()+to_int<High>()) / 2>()>(last_value, args...),
+                    args...
               );
     }
 
-    template <E Low, E High, typename Args = void*>
-    static constexpr underlying_type_t<E> each_mask_range(underlying_type_t<E> last_value, Args args = nullptr) {
+    template <E Low, E High, typename... Args>
+    static constexpr underlying_type_t<E> each_mask_range(underlying_type_t<E> last_value, Args... args) {
         return (to_int<Low>() & to_int<High>()) || to_int<High>() == to_int<Low>()
             ? last_value
             : Fn<E>::template fn<High>(
-                each_mask_range<Low, from_int<((to_int<High>() >> 1) & ~high_bit)>()>(last_value, args),
-                args
+                each_mask_range<Low, from_int<((to_int<High>() >> 1) & ~high_bit)>()>(last_value, args...),
+                args...
               );
     }
 
-    template <E Value = FLECS_ENUM_MAX(E), typename Args = void*>
-    static constexpr underlying_type_t<E> each_enum(Args args = nullptr) {
-        return each_mask_range<Value, from_int<high_bit>()>(each_enum_range<from_int<0>(), Value>(0, args), args);
+    template <E Value = FLECS_ENUM_MAX(E), typename... Args>
+    static constexpr underlying_type_t<E> each_enum(Args... args) {
+        return each_mask_range<Value, from_int<high_bit>()>(each_enum_range<from_int<0>(), Value>(0, args...), args...);
     }
 
-    static const underlying_type_t<E> high_bit = static_cast<underlying_type_t<E>>(1) << (sizeof(underlying_type_t<E>) * 8 - 1);
+    static const underlying_type_t<E> high_bit = static_cast<underlying_type_t<E>>(1) << (sizeof(underlying_type_t<E>) * 8 - 2);
 };
 
 /** Enumeration type data */
@@ -222,12 +222,12 @@ private:
     template<typename Enum>
     struct reflection_count {
         template <Enum Value, flecs::if_not_t< enum_constant_is_valid<Enum, Value>() > = 0>
-        static constexpr underlying_type_t<Enum> fn(underlying_type_t<E> last_value, void*) {
+        static constexpr underlying_type_t<Enum> fn(underlying_type_t<E> last_value) {
             return last_value;
         }
 
         template <Enum Value, flecs::if_t< enum_constant_is_valid<Enum, Value>() > = 0>
-        static constexpr underlying_type_t<Enum> fn(underlying_type_t<E> last_value, void*) {
+        static constexpr underlying_type_t<Enum> fn(underlying_type_t<E> last_value) {
             return 1 + last_value;
         }
     };
@@ -275,21 +275,17 @@ struct enum_type {
         ecs_log_push();
         ecs_cpp_enum_init(world, id);
         data.id = id;
-        EnumReflectionInit::template each_enum< enum_last<E>::value >(enum_reflection_input{world});
+        EnumReflectionInit::template each_enum< enum_last<E>::value >(world);
         ecs_log_pop();
     }
 
-    struct enum_reflection_input {
-        flecs::world_t *world;
-    };
-
     template <E Value, flecs::if_not_t< enum_constant_is_valid<E, Value>() > = 0>
-    static underlying_type_t<E> fn(underlying_type_t<E> last_value, enum_reflection_input) {
+    static underlying_type_t<E> fn(underlying_type_t<E> last_value, flecs::world_t*) {
         return last_value;
     }
 
     template <E Value, flecs::if_t< enum_constant_is_valid<E, Value>() > = 0>
-    static underlying_type_t<E> fn(underlying_type_t<E> last_value, enum_reflection_input input) {
+    static underlying_type_t<E> fn(underlying_type_t<E> last_value, flecs::world_t *world) {
         auto v = EnumReflectionInit::template to_int<Value>();
         const char *name = enum_constant_to_name<E, Value>();
         ++data.max;
@@ -306,7 +302,7 @@ struct enum_type {
             " low negative. Consider using unsigned integers as underlying type.");
         data.constants[data.max].offset = v - last_value;
         data.constants[data.max].id = ecs_cpp_enum_constant_register(
-            input.world, data.id, 0, name, static_cast<int32_t>(v));
+            world, data.id, 0, name, static_cast<int32_t>(v));
         return v;
     }
 };

--- a/include/flecs/addons/cpp/utils/enum.hpp
+++ b/include/flecs/addons/cpp/utils/enum.hpp
@@ -113,11 +113,13 @@ constexpr size_t enum_type_len() {
 #if ECS_CLANG_VERSION < 13
 template <typename E, E C>
 constexpr bool enum_constant_is_valid() {
-    return !(
+    return !((
         (ECS_FUNC_NAME[ECS_FUNC_NAME_FRONT(bool, enum_constant_is_valid) +
             enum_type_len<E>() + 6 /* ', C = ' */] >= '0') &&
         (ECS_FUNC_NAME[ECS_FUNC_NAME_FRONT(bool, enum_constant_is_valid) +
-            enum_type_len<E>() + 6 /* ', C = ' */] <= '9'));
+            enum_type_len<E>() + 6 /* ', C = ' */] <= '9')) ||
+        (ECS_FUNC_NAME[ECS_FUNC_NAME_FRONT(bool, enum_constant_is_valid) +
+            enum_type_len<E>() + 6 /* ', C = ' */] == '-'));
 }
 #else
 template <typename E, E C>

--- a/include/flecs/addons/cpp/utils/enum.hpp
+++ b/include/flecs/addons/cpp/utils/enum.hpp
@@ -206,7 +206,7 @@ struct enum_data_impl {
     int max;
     int contiguous_through;
     // Constants array is sized to the number of found-constants, or 1 (to avoid 0-sized array)
-    const static int constants_size = enum_reflection<E>::template num_enums< enum_last<E>::value >();
+    const static unsigned int constants_size = enum_reflection<E>::template num_enums< enum_last<E>::value >();
     enum_constant_data constants[constants_size? constants_size: 1];
 };
 

--- a/include/flecs/addons/cpp/utils/enum.hpp
+++ b/include/flecs/addons/cpp/utils/enum.hpp
@@ -206,7 +206,8 @@ struct enum_data_impl {
     int max;
     int contiguous_through;
     // Constants array is sized to the number of found-constants, or 1 (to avoid 0-sized array)
-    enum_constant_data constants[enum_reflection<E>::template num_enums< enum_last<E>::value >() || 1];
+    const static int constants_size = enum_reflection<E>::template num_enums< enum_last<E>::value >();
+    enum_constant_data constants[constants_size? constants_size: 1];
 };
 
 /** Class that scans an enum for constants, extracts names & creates entities */

--- a/include/flecs/addons/cpp/utils/enum.hpp
+++ b/include/flecs/addons/cpp/utils/enum.hpp
@@ -197,7 +197,7 @@ struct enum_reflection {
 
     template <E Low, E High, typename... Args>
     static constexpr underlying_type_t<E> each_mask_range(underlying_type_t<E> last_value, Args... args) {
-        return (to_int<Low>() & to_int<High>()) || High == Low
+        return (to_int<Low>() & to_int<High>()) || to_int<High>() == to_int<Low>()
             ? last_value
             : Fn<E>::template fn<High>(
                 each_mask_range<Low, from_int<((to_int<High>() >> 1) & ~high_bit)>()>(last_value, args...),
@@ -300,7 +300,7 @@ struct enum_type {
             " low negative. Consider using unsigned integers as underlying type.");
         data.constants[data.max].offset = v - last_value;
         data.constants[data.max].id = ecs_cpp_enum_constant_register(
-            world, data.id, 0, name, v);
+            world, data.id, 0, name, static_cast<int32_t>(v));
         return v;
     }
 };
@@ -343,10 +343,10 @@ struct enum_data {
         }
         // Check if value is in contiguous lookup section
         if (impl_.has_contiguous && value < impl_.contiguous_until && value >= 0) {
-            return value;
+            return static_cast<int>(value);
         }
         underlying_type_t<E> accumulator = impl_.contiguous_until? impl_.contiguous_until - 1: 0;
-        for (int i = impl_.contiguous_until; i <= impl_.max; ++i) {
+        for (int i = static_cast<int>(impl_.contiguous_until); i <= impl_.max; ++i) {
             accumulator += impl_.constants[i].offset;
             if (accumulator == value) {
                 return i;

--- a/include/flecs/addons/cpp/utils/enum.hpp
+++ b/include/flecs/addons/cpp/utils/enum.hpp
@@ -7,6 +7,7 @@
  */
 
 #include <string.h>
+#include <limits>
 
 #define FLECS_ENUM_MAX(T) _::to_constant<T, 128>::value
 #define FLECS_ENUM_MAX_COUNT (FLECS_ENUM_MAX(int) + 1)
@@ -158,13 +159,14 @@ static const char* enum_constant_to_name() {
 }
 
 /** Enumeration constant data */
+template<typename T>
 struct enum_constant_data {
     flecs::entity_t id;
-    int offset;
+    T offset;
 };
 
 /** Compile time generated enum data */
-template <typename E>
+template <typename E, template<typename> class Fn>
 struct enum_reflection {
     template <E Value>
     static constexpr underlying_type_t<E> to_int() {
@@ -181,56 +183,69 @@ struct enum_reflection {
         return static_cast<underlying_type_t<E>>(Value != from_int<0>());
     }
 
-    template <E Value, flecs::if_not_t< enum_constant_is_valid<E, Value>() > = 0>
-    static constexpr underlying_type_t<E> count_if_valid() {
-        return 0;
-    }
-
-    template <E Value, flecs::if_t< enum_constant_is_valid<E, Value>() > = 0>
-    static constexpr underlying_type_t<E> count_if_valid() {
-        return 1;
-    }
-
-    template <E Low, E High>
-    static constexpr underlying_type_t<E> num_enums() {
+    template <E Low, E High, typename... Args>
+    static constexpr underlying_type_t<E> each_enum_range(underlying_type_t<E> last_value, Args... args) {
         return to_int<High>() - to_int<Low>() <= 1
             ? to_int<High>() == to_int<Low>()
-                ? count_if_valid<Low>()
-                : count_if_valid<Low>() + count_if_valid<High>()
-            : num_enums<Low, from_int<(to_int<Low>()+to_int<High>()) / 2>()>() + num_enums<from_int<(to_int<Low>()+to_int<High>()) / 2 + 1>(), High>();
+                ? Fn<E>::template fn<Low>(last_value, args...)
+                : Fn<E>::template fn<High>(Fn<E>::template fn<Low>(last_value, args...), args...)
+            : each_enum_range<from_int<(to_int<Low>()+to_int<High>()) / 2 + 1>(), High>(
+                    each_enum_range<Low, from_int<(to_int<Low>()+to_int<High>()) / 2>()>(last_value, args...),
+                    args...
+              );
     }
 
-    template <E Low, E High>
-    static constexpr underlying_type_t<E> num_masks() {
+    template <E Low, E High, typename... Args>
+    static constexpr underlying_type_t<E> each_mask_range(underlying_type_t<E> last_value, Args... args) {
         return (to_int<Low>() & to_int<High>()) || High == Low
-            ? 0
-            : count_if_valid<High>() + num_masks<Low, from_int<((to_int<High>() >> 1) & ~MSB)>()>();
+            ? last_value
+            : Fn<E>::template fn<High>(
+                each_mask_range<Low, from_int<((to_int<High>() >> 1) & ~high_bit)>()>(last_value, args...),
+                args...
+              );
     }
 
-    template <E Value = FLECS_ENUM_MAX(E)>
-    static constexpr underlying_type_t<E> num_enums() {
-        return num_enums<from_int<0>(), Value>() + num_masks<Value, from_int<MSB>()>();
+    template <E Value = FLECS_ENUM_MAX(E), typename... Args>
+    static constexpr underlying_type_t<E> each_enum(Args... args) {
+        return each_mask_range<Value, from_int<high_bit>()>(each_enum_range<from_int<0>(), Value>(0, args...), args...);
     }
 
-    static const underlying_type_t<E> MSB = (underlying_type_t<E>)1 << (sizeof(underlying_type_t<E>) * 8 - 1);
+    static const underlying_type_t<E> high_bit = static_cast<underlying_type_t<E>>(1) << (sizeof(underlying_type_t<E>) * 8 - 1);
 };
 
 /** Enumeration type data */
 template<typename E>
 struct enum_data_impl {
+private:
+    template<typename Enum>
+    struct reflection_count {
+        template <Enum Value, flecs::if_not_t< enum_constant_is_valid<Enum, Value>() > = 0>
+        static constexpr underlying_type_t<Enum> fn(underlying_type_t<E> last_value) {
+            return last_value;
+        }
+
+        template <Enum Value, flecs::if_t< enum_constant_is_valid<Enum, Value>() > = 0>
+        static constexpr underlying_type_t<Enum> fn(underlying_type_t<E> last_value) {
+            return 1 + last_value;
+        }
+    };
+    using EnumReflectionCount = enum_reflection<E, reflection_count>;
+public:
     flecs::entity_t id;
     int min;
     int max;
     bool has_contiguous;
     underlying_type_t<E> contiguous_until;
     // Constants array is sized to the number of found-constants, or 1 (to avoid 0-sized array)
-    static constexpr unsigned int constants_size = enum_reflection<E>::template num_enums< enum_last<E>::value >();
-    enum_constant_data constants[constants_size? constants_size: 1];
+    static constexpr unsigned int constants_size = EnumReflectionCount::template each_enum< enum_last<E>::value >();
+    enum_constant_data<underlying_type_t<E>> constants[constants_size? constants_size: 1];
 };
 
 /** Class that scans an enum for constants, extracts names & creates entities */
 template <typename E>
 struct enum_type {
+    using EnumReflectionInit = enum_reflection<E, enum_type>;
+
     static enum_data_impl<E> data;
 
     static enum_type<E>& get() {
@@ -258,43 +273,35 @@ struct enum_type {
         ecs_log_push();
         ecs_cpp_enum_init(world, id);
         data.id = id;
-        init< enum_last<E>::value >(world);
+        EnumReflectionInit::template each_enum< enum_last<E>::value >(world);
         ecs_log_pop();
     }
 
-private:
-
     template <E Value, flecs::if_not_t< enum_constant_is_valid<E, Value>() > = 0>
-    static underlying_type_t<E> init_constant(flecs::world_t*, underlying_type_t<E> last_value) {
+    static underlying_type_t<E> fn(underlying_type_t<E> last_value, flecs::world_t*) {
         return last_value;
     }
 
     template <E Value, flecs::if_t< enum_constant_is_valid<E, Value>() > = 0>
-    static underlying_type_t<E> init_constant(flecs::world_t *world, underlying_type_t<E> last_value) {
-        auto v = enum_reflection<E>::template to_int<Value>();
+    static underlying_type_t<E> fn(underlying_type_t<E> last_value, flecs::world_t *world) {
+        auto v = EnumReflectionInit::template to_int<Value>();
         const char *name = enum_constant_to_name<E, Value>();
         ++data.max;
         if (data.has_contiguous && static_cast<underlying_type_t<E>>(data.max) == v && data.contiguous_until == v) {
             // Still contiguous through current value
             ++data.contiguous_until;
         }
-        else if (data.has_contiguous) {
+        else if (!data.contiguous_until && data.has_contiguous) {
             data.has_contiguous = false;
         }
 
+        ecs_assert(!(last_value > 0 && v < std::numeric_limits<underlying_type_t<E>>::min() + last_value), ECS_UNSUPPORTED,
+            "Signed integer enums causes integer overflow when recording offset from high positive to"
+            " low negative. Consider using unsigned integers as underlying type.");
         data.constants[data.max].offset = v - last_value;
         data.constants[data.max].id = ecs_cpp_enum_constant_register(
             world, data.id, 0, name, v);
         return v;
-    }
-
-    template <E Value = FLECS_ENUM_MAX(E) >
-    static underlying_type_t<E> init(flecs::world_t *world) {
-        underlying_type_t<E> last_value = 0;
-        if (enum_reflection<E>::template is_not_0<Value>()) {
-            last_value = init<enum_reflection<E>::template from_int<enum_reflection<E>::template to_int<Value>() - enum_reflection<E>::template is_not_0<Value>()>()>(world);
-        }
-        return init_constant<Value>(world, last_value);
     }
 };
 
@@ -331,14 +338,14 @@ struct enum_data {
     }
 
     int index_by_value(underlying_type_t<E> value) const {
-        if (value < 0 || !impl_.max) {
+        if (!impl_.max) {
             return -1;
         }
         // Check if value is in contiguous lookup section
-        if (impl_.has_contiguous && value < impl_.contiguous_until) {
+        if (impl_.has_contiguous && value < impl_.contiguous_until && value >= 0) {
             return value;
         }
-        underlying_type_t<E> accumulator = impl_.contiguous_until;
+        underlying_type_t<E> accumulator = impl_.contiguous_until? impl_.contiguous_until - 1: 0;
         for (int i = impl_.contiguous_until; i <= impl_.max; ++i) {
             accumulator += impl_.constants[i].offset;
             if (accumulator == value) {

--- a/include/flecs/addons/cpp/utils/enum.hpp
+++ b/include/flecs/addons/cpp/utils/enum.hpp
@@ -185,31 +185,31 @@ struct enum_reflection {
         return static_cast<underlying_type_t<E>>(Value != from_int<0>());
     }
 
-    template <E Low, E High, typename... Args>
-    static constexpr underlying_type_t<E> each_enum_range(underlying_type_t<E> last_value, Args... args) {
+    template <E Low, E High, typename Args = void*>
+    static constexpr underlying_type_t<E> each_enum_range(underlying_type_t<E> last_value, Args args = nullptr) {
         return to_int<High>() - to_int<Low>() <= 1
             ? to_int<High>() == to_int<Low>()
-                ? Fn<E>::template fn<Low>(last_value, args...)
-                : Fn<E>::template fn<High>(Fn<E>::template fn<Low>(last_value, args...), args...)
+                ? Fn<E>::template fn<Low>(last_value, args)
+                : Fn<E>::template fn<High>(Fn<E>::template fn<Low>(last_value, args), args)
             : each_enum_range<from_int<(to_int<Low>()+to_int<High>()) / 2 + 1>(), High>(
-                    each_enum_range<Low, from_int<(to_int<Low>()+to_int<High>()) / 2>()>(last_value, args...),
-                    args...
+                    each_enum_range<Low, from_int<(to_int<Low>()+to_int<High>()) / 2>()>(last_value, args),
+                    args
               );
     }
 
-    template <E Low, E High, typename... Args>
-    static constexpr underlying_type_t<E> each_mask_range(underlying_type_t<E> last_value, Args... args) {
+    template <E Low, E High, typename Args = void*>
+    static constexpr underlying_type_t<E> each_mask_range(underlying_type_t<E> last_value, Args args = nullptr) {
         return (to_int<Low>() & to_int<High>()) || to_int<High>() == to_int<Low>()
             ? last_value
             : Fn<E>::template fn<High>(
-                each_mask_range<Low, from_int<((to_int<High>() >> 1) & ~high_bit)>()>(last_value, args...),
-                args...
+                each_mask_range<Low, from_int<((to_int<High>() >> 1) & ~high_bit)>()>(last_value, args),
+                args
               );
     }
 
-    template <E Value = FLECS_ENUM_MAX(E), typename... Args>
-    static constexpr underlying_type_t<E> each_enum(Args... args) {
-        return each_mask_range<Value, from_int<high_bit>()>(each_enum_range<from_int<0>(), Value>(0, args...), args...);
+    template <E Value = FLECS_ENUM_MAX(E), typename Args = void*>
+    static constexpr underlying_type_t<E> each_enum(Args args = nullptr) {
+        return each_mask_range<Value, from_int<high_bit>()>(each_enum_range<from_int<0>(), Value>(0, args), args);
     }
 
     static const underlying_type_t<E> high_bit = static_cast<underlying_type_t<E>>(1) << (sizeof(underlying_type_t<E>) * 8 - 1);
@@ -222,12 +222,12 @@ private:
     template<typename Enum>
     struct reflection_count {
         template <Enum Value, flecs::if_not_t< enum_constant_is_valid<Enum, Value>() > = 0>
-        static constexpr underlying_type_t<Enum> fn(underlying_type_t<E> last_value) {
+        static constexpr underlying_type_t<Enum> fn(underlying_type_t<E> last_value, void*) {
             return last_value;
         }
 
         template <Enum Value, flecs::if_t< enum_constant_is_valid<Enum, Value>() > = 0>
-        static constexpr underlying_type_t<Enum> fn(underlying_type_t<E> last_value) {
+        static constexpr underlying_type_t<Enum> fn(underlying_type_t<E> last_value, void*) {
             return 1 + last_value;
         }
     };
@@ -275,17 +275,21 @@ struct enum_type {
         ecs_log_push();
         ecs_cpp_enum_init(world, id);
         data.id = id;
-        EnumReflectionInit::template each_enum< enum_last<E>::value >(world);
+        EnumReflectionInit::template each_enum< enum_last<E>::value >(enum_reflection_input{world});
         ecs_log_pop();
     }
 
+    struct enum_reflection_input {
+        flecs::world_t *world;
+    };
+
     template <E Value, flecs::if_not_t< enum_constant_is_valid<E, Value>() > = 0>
-    static underlying_type_t<E> fn(underlying_type_t<E> last_value, flecs::world_t*) {
+    static underlying_type_t<E> fn(underlying_type_t<E> last_value, enum_reflection_input) {
         return last_value;
     }
 
     template <E Value, flecs::if_t< enum_constant_is_valid<E, Value>() > = 0>
-    static underlying_type_t<E> fn(underlying_type_t<E> last_value, flecs::world_t *world) {
+    static underlying_type_t<E> fn(underlying_type_t<E> last_value, enum_reflection_input input) {
         auto v = EnumReflectionInit::template to_int<Value>();
         const char *name = enum_constant_to_name<E, Value>();
         ++data.max;
@@ -302,7 +306,7 @@ struct enum_type {
             " low negative. Consider using unsigned integers as underlying type.");
         data.constants[data.max].offset = v - last_value;
         data.constants[data.max].id = ecs_cpp_enum_constant_register(
-            world, data.id, 0, name, static_cast<int32_t>(v));
+            input.world, data.id, 0, name, static_cast<int32_t>(v));
         return v;
     }
 };

--- a/include/flecs/addons/cpp/utils/utils.hpp
+++ b/include/flecs/addons/cpp/utils/utils.hpp
@@ -85,6 +85,9 @@ using remove_pointer_t = typename std::remove_pointer<T>::type;
 template <typename T>
 using remove_reference_t = typename std::remove_reference<T>::type;
 
+template <typename T>
+using underlying_type_t = typename std::underlying_type<T>::type;
+
 using std::is_base_of;
 using std::is_empty;
 using std::is_const;

--- a/test/cpp_api/project.json
+++ b/test/cpp_api/project.json
@@ -345,6 +345,8 @@
             "testcases": [
                 "standard_enum_reflection",
                 "sparse_enum_reflection",
+                "bitmask_enum_reflection",
+                "bitmask_enum_with_type_reflection",
                 "enum_class_reflection",
                 "prefixed_enum_reflection",
                 "constant_with_num_reflection",
@@ -366,7 +368,7 @@
                 "add_enum_constant_w_tag",
                 "remove_enum_constant_w_tag",
                 "set_enum_constant_w_tag",
-                "enum_w_incorrect_size",
+                "enum_w_different_size",
                 "add_union_enum",
                 "add_2_union_enums",
                 "add_2_union_enums_reverse",

--- a/test/cpp_api/project.json
+++ b/test/cpp_api/project.json
@@ -368,7 +368,7 @@
                 "add_enum_constant_w_tag",
                 "remove_enum_constant_w_tag",
                 "set_enum_constant_w_tag",
-                "enum_w_different_size",
+                "enum_w_incorrect_size",
                 "add_union_enum",
                 "add_2_union_enums",
                 "add_2_union_enums_reverse",

--- a/test/cpp_api/project.json
+++ b/test/cpp_api/project.json
@@ -347,6 +347,7 @@
                 "sparse_enum_reflection",
                 "bitmask_enum_reflection",
                 "bitmask_enum_with_type_reflection",
+                "enum_with_mixed_constants_and_bitmask",
                 "enum_class_reflection",
                 "prefixed_enum_reflection",
                 "constant_with_num_reflection",

--- a/test/cpp_api/src/Enum.cpp
+++ b/test/cpp_api/src/Enum.cpp
@@ -12,6 +12,83 @@ enum SparseEnum {
     Black = 1, White = 3, Grey = 5
 };
 
+enum BitMaskEnum {
+    ZERO = 0,
+    bit_LS_0,
+    bit_LS_1 = bit_LS_0 << 1,
+    bit_LS_2 = bit_LS_0<<2,
+    bit_LS_3 = bit_LS_0<<3,
+    bit_LS_4 = bit_LS_0<<4,
+    bit_LS_5 = bit_LS_0<<5,
+    bit_LS_6 = bit_LS_0<<6,
+    bit_LS_7 = bit_LS_0<<7,
+    bit_LS_8 = bit_LS_0<<8,
+    bit_LS_9 = bit_LS_0<<9,
+    bit_LS_10 = bit_LS_0<<10,
+    bit_LS_11 = bit_LS_0<<11,
+    bit_LS_12 = bit_LS_0<<12,
+    bit_LS_13 = bit_LS_0<<13,
+    bit_LS_14 = bit_LS_0<<14,
+    bit_LS_15 = bit_LS_0<<15,
+    bit_LS_16 = bit_LS_0<<16,
+    bit_LS_17 = bit_LS_0<<17,
+    bit_LS_18 = bit_LS_0<<18,
+    bit_LS_19 = bit_LS_0<<19,
+    bit_LS_20 = bit_LS_0<<20,
+    bit_LS_21 = bit_LS_0<<21,
+    bit_LS_22 = bit_LS_0<<22,
+    bit_LS_23 = bit_LS_0<<23,
+    bit_LS_24 = bit_LS_0<<24,
+    bit_LS_25 = bit_LS_0<<25,
+    bit_LS_26 = bit_LS_0<<26,
+    bit_LS_27 = bit_LS_0<<27,
+    bit_LS_28 = bit_LS_0<<28,
+    bit_LS_29 = bit_LS_0<<29,
+    bit_LS_30 = bit_LS_0<<30,
+    bit_LS_31 = bit_LS_0<<31,
+};
+
+enum class TypedBitMaskEnum : uint64_t {
+    ZERO = 0,
+    bit_LS_0,
+    bit_LS_1 = bit_LS_0 << 1,
+    bit_LS_2 = bit_LS_0<<2,
+    bit_LS_3 = bit_LS_0<<3,
+    bit_LS_4 = bit_LS_0<<4,
+    bit_LS_5 = bit_LS_0<<5,
+    bit_LS_6 = bit_LS_0<<6,
+    bit_LS_7 = bit_LS_0<<7,
+    bit_LS_8 = bit_LS_0<<8,
+    bit_LS_9 = bit_LS_0<<9,
+    bit_LS_10 = bit_LS_0<<10,
+    bit_LS_11 = bit_LS_0<<11,
+    bit_LS_12 = bit_LS_0<<12,
+    bit_LS_13 = bit_LS_0<<13,
+    bit_LS_14 = bit_LS_0<<14,
+    bit_LS_15 = bit_LS_0<<15,
+    bit_LS_16 = bit_LS_0<<16,
+    bit_LS_17 = bit_LS_0<<17,
+    bit_LS_18 = bit_LS_0<<18,
+    bit_LS_19 = bit_LS_0<<19,
+    bit_LS_20 = bit_LS_0<<20,
+    bit_LS_21 = bit_LS_0<<21,
+    bit_LS_22 = bit_LS_0<<22,
+    bit_LS_23 = bit_LS_0<<23,
+    bit_LS_24 = bit_LS_0<<24,
+    bit_LS_25 = bit_LS_0<<25,
+    bit_LS_26 = bit_LS_0<<26,
+    bit_LS_27 = bit_LS_0<<27,
+    bit_LS_28 = bit_LS_0<<28,
+    bit_LS_29 = bit_LS_0<<29,
+    bit_LS_30 = bit_LS_0<<30,
+    bit_LS_31 = bit_LS_0<<31,
+    bit_LS_32 = bit_LS_0<<32,
+    bit_LS_33 = bit_LS_0<<33,
+    bit_LS_34 = bit_LS_0<<34,
+    bit_LS_35 = bit_LS_0<<35,
+    bit_LS_36 = bit_LS_0<<36,
+};
+
 enum class EnumClass {
     Grass, Sand, Stone
 };
@@ -129,6 +206,102 @@ void Enum_sparse_enum_reflection(void) {
     test_bool(enum_type.is_valid(0), false);
     test_bool(enum_type.is_valid(2), false);
     test_bool(enum_type.is_valid(4), false);
+    test_bool(enum_type.is_valid(6), false);
+}
+
+void Enum_bitmask_enum_reflection(void) {
+    flecs::world ecs;
+
+    auto enum_type = flecs::enum_type<BitMaskEnum>(ecs);
+    test_int(enum_type.impl_.constants_size, 33);
+
+    auto e = enum_type.entity();
+    test_assert(e != 0);
+    test_assert(e == ecs.component<BitMaskEnum>());
+    test_str(e.path().c_str(), "::BitMaskEnum");
+    test_int(enum_type.first(), 0);
+    test_int(enum_type.last(), 32);
+
+    test_int(enum_type.index_by_value(ZERO), 0);
+    test_int(enum_type.index_by_value(bit_LS_0), 1);
+    test_int(enum_type.index_by_value(bit_LS_1), 2);
+    test_int(enum_type.index_by_value(2), 2);
+    test_int(enum_type.index_by_value(4), 3);
+    test_int(enum_type.index_by_value(bit_LS_31), 32);
+    test_int(enum_type.index_by_value(7), -1);
+
+    auto e_8 = enum_type.entity(8);
+    auto e_16 = enum_type.entity(bit_LS_5);
+    auto e_32 = enum_type.entity(0x20);
+
+    test_assert(e_8 != 0);
+    test_str(e_8.path().c_str(), "::BitMaskEnum::bit_LS_4");
+    test_bool(enum_type.is_valid(bit_LS_8), true);
+    test_assert(e_8.get<BitMaskEnum>() != nullptr);
+    test_assert(e_8.get<BitMaskEnum>()[0] == bit_LS_8);
+
+    test_assert(e_16 != 0);
+    test_str(e_16.path().c_str(), "::BitMaskEnum::bit_LS_5");
+    test_bool(enum_type.is_valid(bit_LS_5), true);
+    test_assert(e_16.get<BitMaskEnum>() != nullptr);
+    test_assert(e_16.get<BitMaskEnum>()[0] == bit_LS_5);
+
+    test_assert(e_32 != 0);
+    test_str(e_32.path().c_str(), "::BitMaskEnum::bit_LS_6");
+    test_bool(enum_type.is_valid(bit_LS_6), true);
+    test_assert(e_32.get<BitMaskEnum>() != nullptr);
+    test_assert(e_32.get<BitMaskEnum>()[0] == bit_LS_6);
+
+    test_bool(enum_type.is_valid(3), false);
+    test_bool(enum_type.is_valid(5), false);
+    test_bool(enum_type.is_valid(6), false);
+}
+
+void Enum_bitmask_enum_with_type_reflection(void) {
+    flecs::world ecs;
+
+    auto enum_type = flecs::enum_type<TypedBitMaskEnum>(ecs);
+    test_int(enum_type.impl_.constants_size, 36);
+
+    auto e = enum_type.entity();
+    test_assert(e != 0);
+    test_assert(e == ecs.component<TypedBitMaskEnum>());
+    test_str(e.path().c_str(), "::TypedBitMaskEnum");
+    test_int(enum_type.first(), 0);
+    test_int(enum_type.last(), 36);
+
+    test_int(enum_type.index_by_value(TypedBitMaskEnum::ZERO), 0);
+    test_int(enum_type.index_by_value(TypedBitMaskEnum::bit_LS_0), 1);
+    test_int(enum_type.index_by_value(TypedBitMaskEnum::bit_LS_1), 2);
+    test_int(enum_type.index_by_value(2), 2);
+    test_int(enum_type.index_by_value(4), 3);
+    test_int(enum_type.index_by_value(TypedBitMaskEnum::bit_LS_31), 32);
+    test_int(enum_type.index_by_value(7), -1);
+
+    auto e_8 = enum_type.entity(8);
+    auto e_16 = enum_type.entity(TypedBitMaskEnum::bit_LS_5);
+    auto e_32 = enum_type.entity(0x20);
+
+    test_assert(e_8 != 0);
+    test_str(e_8.path().c_str(), "::TypedBitMaskEnum::bit_LS_4");
+    test_bool(enum_type.is_valid(TypedBitMaskEnum::bit_LS_8), true);
+    test_assert(e_8.get<TypedBitMaskEnum>() != nullptr);
+    test_assert(e_8.get<TypedBitMaskEnum>()[0] == TypedBitMaskEnum::bit_LS_8);
+
+    test_assert(e_16 != 0);
+    test_str(e_16.path().c_str(), "::TypedBitMaskEnum::bit_LS_5");
+    test_bool(enum_type.is_valid(TypedBitMaskEnum::bit_LS_5), true);
+    test_assert(e_16.get<TypedBitMaskEnum>() != nullptr);
+    test_assert(e_16.get<TypedBitMaskEnum>()[0] == TypedBitMaskEnum::bit_LS_5);
+
+    test_assert(e_32 != 0);
+    test_str(e_32.path().c_str(), "::TypedBitMaskEnum::bit_LS_6");
+    test_bool(enum_type.is_valid(TypedBitMaskEnum::bit_LS_6), true);
+    test_assert(e_32.get<TypedBitMaskEnum>() != nullptr);
+    test_assert(e_32.get<TypedBitMaskEnum>()[0] == TypedBitMaskEnum::bit_LS_6);
+
+    test_bool(enum_type.is_valid(3), false);
+    test_bool(enum_type.is_valid(5), false);
     test_bool(enum_type.is_valid(6), false);
 }
 
@@ -965,4 +1138,8 @@ void Enum_enum_child_count(void) {
         .build();
 
     test_assert(f.count() == 3);
+}
+
+void Enum_enum_w_different_size(void) {
+    // Implement testcase
 }

--- a/test/cpp_api/src/Enum.cpp
+++ b/test/cpp_api/src/Enum.cpp
@@ -55,6 +55,11 @@ void Enum_standard_enum_reflection(void) {
     test_int(enum_type.first(), Red);
     test_int(enum_type.last(), Blue);
 
+    test_int(enum_type.index_by_value(Red), 0);
+    test_int(enum_type.index_by_value(Green), 1);
+    test_int(enum_type.index_by_value(Blue), 2);
+    test_int(enum_type.index_by_value(Blue+1), -1);
+
     auto e_red = enum_type.entity(Red);
     auto e_green = enum_type.entity(Green);
     auto e_blue = enum_type.entity(Blue);
@@ -89,8 +94,13 @@ void Enum_sparse_enum_reflection(void) {
     test_assert(e != 0);
     test_assert(e == ecs.component<SparseEnum>());
     test_str(e.path().c_str(), "::SparseEnum");
-    test_int(enum_type.first(), Black);
-    test_int(enum_type.last(), Grey);
+    test_int(enum_type.first(), 0);
+    test_int(enum_type.last(), 2);
+
+    test_int(enum_type.index_by_value(Black), 0);
+    test_int(enum_type.index_by_value(White), 1);
+    test_int(enum_type.index_by_value(Grey), 2);
+    test_int(enum_type.index_by_value(Grey+1), -1);
 
     auto e_black = enum_type.entity(Black);
     auto e_white = enum_type.entity(White);
@@ -132,6 +142,11 @@ void Enum_enum_class_reflection(void) {
     test_int(enum_type.first(), (int)EnumClass::Grass);
     test_int(enum_type.last(), (int)EnumClass::Stone);
 
+    test_int(enum_type.index_by_value(EnumClass::Grass), 0);
+    test_int(enum_type.index_by_value(EnumClass::Sand), 1);
+    test_int(enum_type.index_by_value(EnumClass::Stone), 2);
+    test_int(enum_type.index_by_value((int)EnumClass::Stone + 1), -1);
+
     auto e_grass = enum_type.entity(EnumClass::Grass);
     auto e_sand = enum_type.entity(EnumClass::Sand);
     auto e_stone = enum_type.entity(EnumClass::Stone);
@@ -169,6 +184,9 @@ void Enum_prefixed_enum_reflection(void) {
     test_int(enum_type.first(), PrefixEnum::PrefixEnumFoo);
     test_int(enum_type.last(), PrefixEnum::PrefixEnumBar);
 
+    test_int(enum_type.index_by_value(PrefixEnum::PrefixEnumFoo), 0);
+    test_int(enum_type.index_by_value(PrefixEnum::PrefixEnumBar), 1);
+
     auto e_foo = enum_type.entity(PrefixEnum::PrefixEnumFoo);
     auto e_bar = enum_type.entity(PrefixEnum::PrefixEnumBar);
 
@@ -180,7 +198,7 @@ void Enum_prefixed_enum_reflection(void) {
 
     test_assert(e_bar != 0);
     test_str(e_bar.path().c_str(), "::PrefixEnum::Bar");
-    test_bool(enum_type.is_valid(PrefixEnum::PrefixEnumFoo), true);
+    test_bool(enum_type.is_valid(PrefixEnum::PrefixEnumBar), true);
     test_assert(e_bar.get<PrefixEnum>() != nullptr);
     test_assert(e_bar.get<PrefixEnum>()[0] == PrefixEnum::PrefixEnumBar);
 
@@ -198,6 +216,10 @@ void Enum_constant_with_num_reflection(void) {
     test_str(e.path().c_str(), "::ConstantsWithNum");
     test_int(enum_type.first(), ConstantsWithNum::Num1);
     test_int(enum_type.last(), ConstantsWithNum::Num3);
+
+    test_int(enum_type.index_by_value(ConstantsWithNum::Num1), 0);
+    test_int(enum_type.index_by_value(ConstantsWithNum::Num2), 1);
+    test_int(enum_type.index_by_value(ConstantsWithNum::Num3), 2);
 
     auto num_1 = enum_type.entity(ConstantsWithNum::Num1);
     auto num_2 = enum_type.entity(ConstantsWithNum::Num2);

--- a/test/cpp_api/src/Enum.cpp
+++ b/test/cpp_api/src/Enum.cpp
@@ -49,7 +49,7 @@ enum class TypedBitMaskEnum : uint32_t {
     bit_LS_13 = bit_LS_0<<13,
     bit_LS_14 = bit_LS_0<<14,
     bit_LS_15 = bit_LS_0<<15,
-    bit_LS_31 = bit_LS_0<<31,
+    bit_LS_30 = bit_LS_0<<30,
 };
 
 enum class EnumClass {
@@ -251,7 +251,7 @@ void Enum_bitmask_enum_with_type_reflection(void) {
     auto e_16 = enum_type.entity(TypedBitMaskEnum::bit_LS_4);
     auto e_32 = enum_type.entity(0x20);
     auto e_ls_15 = enum_type.entity(TypedBitMaskEnum::bit_LS_15);
-    auto e_ls_31 = enum_type.entity(TypedBitMaskEnum::bit_LS_31);
+    auto e_ls_30 = enum_type.entity(TypedBitMaskEnum::bit_LS_30);
 
     test_assert(e_8 != 0);
     test_str(e_8.path().c_str(), "::TypedBitMaskEnum::bit_LS_3");
@@ -277,11 +277,11 @@ void Enum_bitmask_enum_with_type_reflection(void) {
     test_assert(e_ls_15.get<TypedBitMaskEnum>() != nullptr);
     test_assert(e_ls_15.get<TypedBitMaskEnum>()[0] == TypedBitMaskEnum::bit_LS_15);
 
-    test_assert(e_ls_31 != 0);
-    test_str(e_ls_31.path().c_str(), "::TypedBitMaskEnum::bit_LS_31");
-    test_bool(enum_type.is_valid(TypedBitMaskEnum::bit_LS_31), true);
-    test_assert(e_ls_31.get<TypedBitMaskEnum>() != nullptr);
-    test_assert(e_ls_31.get<TypedBitMaskEnum>()[0] == TypedBitMaskEnum::bit_LS_31);
+    test_assert(e_ls_30 != 0);
+    test_str(e_ls_30.path().c_str(), "::TypedBitMaskEnum::bit_LS_30");
+    test_bool(enum_type.is_valid(TypedBitMaskEnum::bit_LS_30), true);
+    test_assert(e_ls_30.get<TypedBitMaskEnum>() != nullptr);
+    test_assert(e_ls_30.get<TypedBitMaskEnum>()[0] == TypedBitMaskEnum::bit_LS_30);
 
     test_bool(enum_type.is_valid(3), false);
     test_bool(enum_type.is_valid(5), false);

--- a/test/cpp_api/src/Enum.cpp
+++ b/test/cpp_api/src/Enum.cpp
@@ -49,7 +49,7 @@ enum class TypedBitMaskEnum : uint32_t {
     bit_LS_13 = bit_LS_0<<13,
     bit_LS_14 = bit_LS_0<<14,
     bit_LS_15 = bit_LS_0<<15,
-    bit_LS_30 = bit_LS_0<<30,
+    bit_LS_31 = bit_LS_0<<31,
 };
 
 enum class EnumClass {
@@ -251,7 +251,7 @@ void Enum_bitmask_enum_with_type_reflection(void) {
     auto e_16 = enum_type.entity(TypedBitMaskEnum::bit_LS_4);
     auto e_32 = enum_type.entity(0x20);
     auto e_ls_15 = enum_type.entity(TypedBitMaskEnum::bit_LS_15);
-    auto e_ls_30 = enum_type.entity(TypedBitMaskEnum::bit_LS_30);
+    auto e_ls_31 = enum_type.entity(TypedBitMaskEnum::bit_LS_31);
 
     test_assert(e_8 != 0);
     test_str(e_8.path().c_str(), "::TypedBitMaskEnum::bit_LS_3");
@@ -277,11 +277,11 @@ void Enum_bitmask_enum_with_type_reflection(void) {
     test_assert(e_ls_15.get<TypedBitMaskEnum>() != nullptr);
     test_assert(e_ls_15.get<TypedBitMaskEnum>()[0] == TypedBitMaskEnum::bit_LS_15);
 
-    test_assert(e_ls_30 != 0);
-    test_str(e_ls_30.path().c_str(), "::TypedBitMaskEnum::bit_LS_30");
-    test_bool(enum_type.is_valid(TypedBitMaskEnum::bit_LS_30), true);
-    test_assert(e_ls_30.get<TypedBitMaskEnum>() != nullptr);
-    test_assert(e_ls_30.get<TypedBitMaskEnum>()[0] == TypedBitMaskEnum::bit_LS_30);
+    test_assert(e_ls_31 != 0);
+    test_str(e_ls_31.path().c_str(), "::TypedBitMaskEnum::bit_LS_31");
+    test_bool(enum_type.is_valid(TypedBitMaskEnum::bit_LS_31), true);
+    test_assert(e_ls_31.get<TypedBitMaskEnum>() != nullptr);
+    test_assert(e_ls_31.get<TypedBitMaskEnum>()[0] == TypedBitMaskEnum::bit_LS_31);
 
     test_bool(enum_type.is_valid(3), false);
     test_bool(enum_type.is_valid(5), false);

--- a/test/cpp_api/src/Enum.cpp
+++ b/test/cpp_api/src/Enum.cpp
@@ -47,6 +47,7 @@ void Enum_standard_enum_reflection(void) {
     flecs::world ecs;
 
     auto enum_type = flecs::enum_type<StandardEnum>(ecs);
+    test_int(enum_type.impl_.constants_size, 3);
 
     auto e = enum_type.entity();
     test_assert(e != 0);
@@ -89,6 +90,7 @@ void Enum_sparse_enum_reflection(void) {
     flecs::world ecs;
 
     auto enum_type = flecs::enum_type<SparseEnum>(ecs);
+    test_int(enum_type.impl_.constants_size, 3);
 
     auto e = enum_type.entity();
     test_assert(e != 0);
@@ -134,6 +136,7 @@ void Enum_enum_class_reflection(void) {
     flecs::world ecs;
 
     auto enum_type = flecs::enum_type<EnumClass>(ecs);
+    test_int(enum_type.impl_.constants_size, 3);
 
     auto e = enum_type.entity();
     test_assert(e != 0);
@@ -176,6 +179,7 @@ void Enum_prefixed_enum_reflection(void) {
     flecs::world ecs;
 
     auto enum_type = flecs::enum_type<PrefixEnum>(ecs);
+    test_int(enum_type.impl_.constants_size, 2);
 
     auto e = enum_type.entity();
     test_assert(e != 0);
@@ -209,6 +213,7 @@ void Enum_constant_with_num_reflection(void) {
     flecs::world ecs;
 
     auto enum_type = flecs::enum_type<ConstantsWithNum>(ecs);
+    test_int(enum_type.impl_.constants_size, 3);
 
     auto e = enum_type.entity();
     test_assert(e != 0);

--- a/test/cpp_api/src/Enum.cpp
+++ b/test/cpp_api/src/Enum.cpp
@@ -15,7 +15,7 @@ enum SparseEnum {
 enum BitMaskEnum {
     ZERO = 0,
     bit_LS_0,
-    bit_LS_1 = bit_LS_0 << 1,
+    bit_LS_1 = bit_LS_0<<1,
     bit_LS_2 = bit_LS_0<<2,
     bit_LS_3 = bit_LS_0<<3,
     bit_LS_4 = bit_LS_0<<4,
@@ -23,35 +23,18 @@ enum BitMaskEnum {
     bit_LS_6 = bit_LS_0<<6,
     bit_LS_7 = bit_LS_0<<7,
     bit_LS_8 = bit_LS_0<<8,
-    bit_LS_9 = bit_LS_0<<9,
-    bit_LS_10 = bit_LS_0<<10,
-    bit_LS_11 = bit_LS_0<<11,
-    bit_LS_12 = bit_LS_0<<12,
-    bit_LS_13 = bit_LS_0<<13,
     bit_LS_14 = bit_LS_0<<14,
     bit_LS_15 = bit_LS_0<<15,
-    bit_LS_16 = bit_LS_0<<16,
-    bit_LS_17 = bit_LS_0<<17,
-    bit_LS_18 = bit_LS_0<<18,
-    bit_LS_19 = bit_LS_0<<19,
-    bit_LS_20 = bit_LS_0<<20,
-    bit_LS_21 = bit_LS_0<<21,
-    bit_LS_22 = bit_LS_0<<22,
-    bit_LS_23 = bit_LS_0<<23,
-    bit_LS_24 = bit_LS_0<<24,
-    bit_LS_25 = bit_LS_0<<25,
-    bit_LS_26 = bit_LS_0<<26,
-    bit_LS_27 = bit_LS_0<<27,
     bit_LS_28 = bit_LS_0<<28,
     bit_LS_29 = bit_LS_0<<29,
     bit_LS_30 = bit_LS_0<<30,
-    bit_LS_31 = bit_LS_0<<31,
+    // bit_LS_31 = bit_LS_0<<31,
 };
 
-enum class TypedBitMaskEnum : uint64_t {
+enum class TypedBitMaskEnum : uint32_t {
     ZERO = 0,
     bit_LS_0,
-    bit_LS_1 = bit_LS_0 << 1,
+    bit_LS_1 = bit_LS_0<<1,
     bit_LS_2 = bit_LS_0<<2,
     bit_LS_3 = bit_LS_0<<3,
     bit_LS_4 = bit_LS_0<<4,
@@ -66,27 +49,7 @@ enum class TypedBitMaskEnum : uint64_t {
     bit_LS_13 = bit_LS_0<<13,
     bit_LS_14 = bit_LS_0<<14,
     bit_LS_15 = bit_LS_0<<15,
-    bit_LS_16 = bit_LS_0<<16,
-    bit_LS_17 = bit_LS_0<<17,
-    bit_LS_18 = bit_LS_0<<18,
-    bit_LS_19 = bit_LS_0<<19,
-    bit_LS_20 = bit_LS_0<<20,
-    bit_LS_21 = bit_LS_0<<21,
-    bit_LS_22 = bit_LS_0<<22,
-    bit_LS_23 = bit_LS_0<<23,
-    bit_LS_24 = bit_LS_0<<24,
-    bit_LS_25 = bit_LS_0<<25,
-    bit_LS_26 = bit_LS_0<<26,
-    bit_LS_27 = bit_LS_0<<27,
-    bit_LS_28 = bit_LS_0<<28,
-    bit_LS_29 = bit_LS_0<<29,
-    bit_LS_30 = bit_LS_0<<30,
     bit_LS_31 = bit_LS_0<<31,
-    bit_LS_32 = bit_LS_0<<32,
-    bit_LS_33 = bit_LS_0<<33,
-    bit_LS_34 = bit_LS_0<<34,
-    bit_LS_35 = bit_LS_0<<35,
-    bit_LS_36 = bit_LS_0<<36,
 };
 
 enum class EnumClass {
@@ -213,92 +176,112 @@ void Enum_bitmask_enum_reflection(void) {
     flecs::world ecs;
 
     auto enum_type = flecs::enum_type<BitMaskEnum>(ecs);
-    test_int(enum_type.impl_.constants_size, 33);
+    test_int(enum_type.impl_.constants_size, 15);
 
     auto e = enum_type.entity();
     test_assert(e != 0);
     test_assert(e == ecs.component<BitMaskEnum>());
     test_str(e.path().c_str(), "::BitMaskEnum");
     test_int(enum_type.first(), 0);
-    test_int(enum_type.last(), 32);
+    test_int(enum_type.last(), 14);
 
     test_int(enum_type.index_by_value(ZERO), 0);
     test_int(enum_type.index_by_value(bit_LS_0), 1);
     test_int(enum_type.index_by_value(bit_LS_1), 2);
     test_int(enum_type.index_by_value(2), 2);
     test_int(enum_type.index_by_value(4), 3);
-    test_int(enum_type.index_by_value(bit_LS_31), 32);
+    test_int(enum_type.index_by_value(bit_LS_30), 14);
     test_int(enum_type.index_by_value(7), -1);
 
     auto e_8 = enum_type.entity(8);
-    auto e_16 = enum_type.entity(bit_LS_5);
+    auto e_16 = enum_type.entity(bit_LS_4);
     auto e_32 = enum_type.entity(0x20);
+    auto e_ls_30 = enum_type.entity(bit_LS_30);
 
     test_assert(e_8 != 0);
-    test_str(e_8.path().c_str(), "::BitMaskEnum::bit_LS_4");
-    test_bool(enum_type.is_valid(bit_LS_8), true);
+    test_str(e_8.path().c_str(), "::BitMaskEnum::bit_LS_3");
+    test_bool(enum_type.is_valid(bit_LS_3), true);
     test_assert(e_8.get<BitMaskEnum>() != nullptr);
-    test_assert(e_8.get<BitMaskEnum>()[0] == bit_LS_8);
+    test_assert(e_8.get<BitMaskEnum>()[0] == bit_LS_3);
 
     test_assert(e_16 != 0);
-    test_str(e_16.path().c_str(), "::BitMaskEnum::bit_LS_5");
-    test_bool(enum_type.is_valid(bit_LS_5), true);
+    test_str(e_16.path().c_str(), "::BitMaskEnum::bit_LS_4");
+    test_bool(enum_type.is_valid(bit_LS_4), true);
     test_assert(e_16.get<BitMaskEnum>() != nullptr);
-    test_assert(e_16.get<BitMaskEnum>()[0] == bit_LS_5);
+    test_assert(e_16.get<BitMaskEnum>()[0] == bit_LS_4);
 
     test_assert(e_32 != 0);
-    test_str(e_32.path().c_str(), "::BitMaskEnum::bit_LS_6");
-    test_bool(enum_type.is_valid(bit_LS_6), true);
+    test_str(e_32.path().c_str(), "::BitMaskEnum::bit_LS_5");
+    test_bool(enum_type.is_valid(bit_LS_5), true);
     test_assert(e_32.get<BitMaskEnum>() != nullptr);
-    test_assert(e_32.get<BitMaskEnum>()[0] == bit_LS_6);
+    test_assert(e_32.get<BitMaskEnum>()[0] == bit_LS_5);
+
+    test_assert(e_ls_30 != 0);
+    test_str(e_ls_30.path().c_str(), "::BitMaskEnum::bit_LS_30");
+    test_bool(enum_type.is_valid(bit_LS_30), true);
+    test_assert(e_ls_30.get<BitMaskEnum>() != nullptr);
+    test_assert(e_ls_30.get<BitMaskEnum>()[0] == bit_LS_30);
 
     test_bool(enum_type.is_valid(3), false);
     test_bool(enum_type.is_valid(5), false);
-    test_bool(enum_type.is_valid(6), false);
+    test_bool(enum_type.is_valid((1 << 31) + 1), false);
 }
 
 void Enum_bitmask_enum_with_type_reflection(void) {
     flecs::world ecs;
 
     auto enum_type = flecs::enum_type<TypedBitMaskEnum>(ecs);
-    test_int(enum_type.impl_.constants_size, 36);
+    test_int(enum_type.impl_.constants_size, 18);
 
     auto e = enum_type.entity();
     test_assert(e != 0);
     test_assert(e == ecs.component<TypedBitMaskEnum>());
     test_str(e.path().c_str(), "::TypedBitMaskEnum");
     test_int(enum_type.first(), 0);
-    test_int(enum_type.last(), 36);
+    test_int(enum_type.last(), 17);
 
     test_int(enum_type.index_by_value(TypedBitMaskEnum::ZERO), 0);
     test_int(enum_type.index_by_value(TypedBitMaskEnum::bit_LS_0), 1);
     test_int(enum_type.index_by_value(TypedBitMaskEnum::bit_LS_1), 2);
     test_int(enum_type.index_by_value(2), 2);
     test_int(enum_type.index_by_value(4), 3);
-    test_int(enum_type.index_by_value(TypedBitMaskEnum::bit_LS_31), 32);
     test_int(enum_type.index_by_value(7), -1);
 
     auto e_8 = enum_type.entity(8);
-    auto e_16 = enum_type.entity(TypedBitMaskEnum::bit_LS_5);
+    auto e_16 = enum_type.entity(TypedBitMaskEnum::bit_LS_4);
     auto e_32 = enum_type.entity(0x20);
+    auto e_ls_15 = enum_type.entity(TypedBitMaskEnum::bit_LS_15);
+    auto e_ls_31 = enum_type.entity(TypedBitMaskEnum::bit_LS_31);
 
     test_assert(e_8 != 0);
-    test_str(e_8.path().c_str(), "::TypedBitMaskEnum::bit_LS_4");
-    test_bool(enum_type.is_valid(TypedBitMaskEnum::bit_LS_8), true);
+    test_str(e_8.path().c_str(), "::TypedBitMaskEnum::bit_LS_3");
+    test_bool(enum_type.is_valid(TypedBitMaskEnum::bit_LS_3), true);
     test_assert(e_8.get<TypedBitMaskEnum>() != nullptr);
-    test_assert(e_8.get<TypedBitMaskEnum>()[0] == TypedBitMaskEnum::bit_LS_8);
+    test_assert(e_8.get<TypedBitMaskEnum>()[0] == TypedBitMaskEnum::bit_LS_3);
 
     test_assert(e_16 != 0);
-    test_str(e_16.path().c_str(), "::TypedBitMaskEnum::bit_LS_5");
-    test_bool(enum_type.is_valid(TypedBitMaskEnum::bit_LS_5), true);
+    test_str(e_16.path().c_str(), "::TypedBitMaskEnum::bit_LS_4");
+    test_bool(enum_type.is_valid(TypedBitMaskEnum::bit_LS_4), true);
     test_assert(e_16.get<TypedBitMaskEnum>() != nullptr);
-    test_assert(e_16.get<TypedBitMaskEnum>()[0] == TypedBitMaskEnum::bit_LS_5);
+    test_assert(e_16.get<TypedBitMaskEnum>()[0] == TypedBitMaskEnum::bit_LS_4);
 
     test_assert(e_32 != 0);
-    test_str(e_32.path().c_str(), "::TypedBitMaskEnum::bit_LS_6");
-    test_bool(enum_type.is_valid(TypedBitMaskEnum::bit_LS_6), true);
+    test_str(e_32.path().c_str(), "::TypedBitMaskEnum::bit_LS_5");
+    test_bool(enum_type.is_valid(TypedBitMaskEnum::bit_LS_5), true);
     test_assert(e_32.get<TypedBitMaskEnum>() != nullptr);
-    test_assert(e_32.get<TypedBitMaskEnum>()[0] == TypedBitMaskEnum::bit_LS_6);
+    test_assert(e_32.get<TypedBitMaskEnum>()[0] == TypedBitMaskEnum::bit_LS_5);
+
+    test_assert(e_ls_15 != 0);
+    test_str(e_ls_15.path().c_str(), "::TypedBitMaskEnum::bit_LS_15");
+    test_bool(enum_type.is_valid(TypedBitMaskEnum::bit_LS_15), true);
+    test_assert(e_ls_15.get<TypedBitMaskEnum>() != nullptr);
+    test_assert(e_ls_15.get<TypedBitMaskEnum>()[0] == TypedBitMaskEnum::bit_LS_15);
+
+    test_assert(e_ls_31 != 0);
+    test_str(e_ls_31.path().c_str(), "::TypedBitMaskEnum::bit_LS_31");
+    test_bool(enum_type.is_valid(TypedBitMaskEnum::bit_LS_31), true);
+    test_assert(e_ls_31.get<TypedBitMaskEnum>() != nullptr);
+    test_assert(e_ls_31.get<TypedBitMaskEnum>()[0] == TypedBitMaskEnum::bit_LS_31);
 
     test_bool(enum_type.is_valid(3), false);
     test_bool(enum_type.is_valid(5), false);
@@ -1140,6 +1123,3 @@ void Enum_enum_child_count(void) {
     test_assert(f.count() == 3);
 }
 
-void Enum_enum_w_different_size(void) {
-    // Implement testcase
-}

--- a/test/cpp_api/src/Enum.cpp
+++ b/test/cpp_api/src/Enum.cpp
@@ -52,6 +52,18 @@ enum class TypedBitMaskEnum : uint32_t {
     bit_LS_31 = bit_LS_0<<31,
 };
 
+enum MixedConstantBitmaskEnum {
+    Vim,
+    Emacs,
+    Nano,
+    VsCode,
+    Editor = 1 << 7,
+    OperatingSystem = 1 << 8,
+    Terminal = 1 << 9,
+    GUI = 1 << 30,
+    BAD_BEEF = -0xBADBEEF
+};
+
 enum class EnumClass {
     Grass, Sand, Stone
 };
@@ -286,6 +298,37 @@ void Enum_bitmask_enum_with_type_reflection(void) {
     test_bool(enum_type.is_valid(3), false);
     test_bool(enum_type.is_valid(5), false);
     test_bool(enum_type.is_valid(6), false);
+}
+
+void Enum_enum_with_mixed_constants_and_bitmask(void) {
+    flecs::world ecs;
+    auto ec = ecs.component<MixedConstantBitmaskEnum>()
+        .constant("BAD_BEEF", BAD_BEEF);
+
+    auto bad_beef_e = ec.lookup("BAD_BEEF");
+    test_assert(bad_beef_e != 0);
+
+    flecs::entity vim = ecs.entity().add(Vim);
+    test_assert(vim.has(Vim));
+
+    flecs::entity vs_code = ecs.entity().add(MixedConstantBitmaskEnum::VsCode);
+    test_assert(vs_code.has(VsCode));
+
+    flecs::entity terminal = ecs.entity().add(MixedConstantBitmaskEnum::Terminal);
+    test_assert(terminal.has(Terminal));
+
+    flecs::entity gui = ecs.entity().add(MixedConstantBitmaskEnum::GUI);
+    test_assert(gui.has(GUI));
+
+    vim.add(Editor);
+    test_assert(vim.has(Editor));
+    test_assert(!vim.has(Vim));
+
+    flecs::entity bad_beef = ecs.entity().add(MixedConstantBitmaskEnum::BAD_BEEF);
+    test_assert(bad_beef.has(BAD_BEEF));
+    bad_beef.add(Nano);
+    test_assert(bad_beef.has(Nano));
+    test_assert(!bad_beef.has(BAD_BEEF));
 }
 
 void Enum_enum_class_reflection(void) {
@@ -988,6 +1031,7 @@ void Enum_component_registered_as_enum(void) {
     test_assert(e.has<flecs::Enum>());
 
     const flecs::MetaType *mt = e.get<flecs::MetaType>();
+
     test_assert(mt != nullptr);
     test_assert(mt->kind == flecs::meta::EnumType);
 
@@ -1122,4 +1166,3 @@ void Enum_enum_child_count(void) {
 
     test_assert(f.count() == 3);
 }
-

--- a/test/cpp_api/src/Misc.cpp
+++ b/test/cpp_api/src/Misc.cpp
@@ -386,9 +386,9 @@ void Misc_oneof_gauge_metric(void) {
             test_uint(s[1].entity, e2);
             test_uint(s[2].entity, e3);
 
-            test_str(ecs.to_json(m, &i[0]), "{\"blue\":0, \"green\":0, \"red\":1}");
-            test_str(ecs.to_json(m, &i[1]), "{\"blue\":0, \"green\":1, \"red\":0}");
-            test_str(ecs.to_json(m, &i[2]), "{\"blue\":1, \"green\":0, \"red\":0}");
+            test_str(ecs.to_json(m, &i[0]), "{\"red\":1, \"green\":0, \"blue\":0}");
+            test_str(ecs.to_json(m, &i[1]), "{\"red\":0, \"green\":1, \"blue\":0}");
+            test_str(ecs.to_json(m, &i[2]), "{\"red\":0, \"green\":0, \"blue\":1}");
 
             test_assert(it.entity(0).has<flecs::metrics::Instance>());
             test_assert(it.entity(1).has<flecs::metrics::Instance>());
@@ -409,9 +409,9 @@ void Misc_oneof_gauge_metric(void) {
             test_uint(s[1].entity, e2);
             test_uint(s[2].entity, e3);
 
-            test_str(ecs.to_json(m, &i[0]), "{\"blue\":0, \"green\":0, \"red\":1}");
-            test_str(ecs.to_json(m, &i[1]), "{\"blue\":0, \"green\":1, \"red\":0}");
-            test_str(ecs.to_json(m, &i[2]), "{\"blue\":1, \"green\":0, \"red\":0}");
+            test_str(ecs.to_json(m, &i[0]), "{\"red\":1, \"green\":0, \"blue\":0}");
+            test_str(ecs.to_json(m, &i[1]), "{\"red\":0, \"green\":1, \"blue\":0}");
+            test_str(ecs.to_json(m, &i[2]), "{\"red\":0, \"green\":0, \"blue\":1}");
 
             test_assert(it.entity(0).has<flecs::metrics::Instance>());
             test_assert(it.entity(1).has<flecs::metrics::Instance>());
@@ -503,9 +503,9 @@ void Misc_oneof_counter_metric(void) {
             test_uint(s[1].entity, e2);
             test_uint(s[2].entity, e3);
 
-            test_str(ecs.to_json(m, &i[0]), "{\"blue\":0, \"green\":0, \"red\":1}");
-            test_str(ecs.to_json(m, &i[1]), "{\"blue\":0, \"green\":1, \"red\":0}");
-            test_str(ecs.to_json(m, &i[2]), "{\"blue\":1, \"green\":0, \"red\":0}");
+            test_str(ecs.to_json(m, &i[0]), "{\"red\":1, \"green\":0, \"blue\":0}");
+            test_str(ecs.to_json(m, &i[1]), "{\"red\":0, \"green\":1, \"blue\":0}");
+            test_str(ecs.to_json(m, &i[2]), "{\"red\":0, \"green\":0, \"blue\":1}");
 
             test_assert(it.entity(0).has<flecs::metrics::Instance>());
             test_assert(it.entity(1).has<flecs::metrics::Instance>());
@@ -527,9 +527,9 @@ void Misc_oneof_counter_metric(void) {
             test_uint(s[1].entity, e2);
             test_uint(s[2].entity, e3);
 
-            test_str(ecs.to_json(m, &i[0]), "{\"blue\":0, \"green\":0, \"red\":2}");
-            test_str(ecs.to_json(m, &i[1]), "{\"blue\":0, \"green\":2, \"red\":0}");
-            test_str(ecs.to_json(m, &i[2]), "{\"blue\":2, \"green\":0, \"red\":0}");
+            test_str(ecs.to_json(m, &i[0]), "{\"red\":2, \"green\":0, \"blue\":0}");
+            test_str(ecs.to_json(m, &i[1]), "{\"red\":0, \"green\":2, \"blue\":0}");
+            test_str(ecs.to_json(m, &i[2]), "{\"red\":0, \"green\":0, \"blue\":2}");
 
             test_assert(it.entity(0).has<flecs::metrics::Instance>());
             test_assert(it.entity(1).has<flecs::metrics::Instance>());

--- a/test/cpp_api/src/main.cpp
+++ b/test/cpp_api/src/main.cpp
@@ -335,6 +335,7 @@ void Enum_standard_enum_reflection(void);
 void Enum_sparse_enum_reflection(void);
 void Enum_bitmask_enum_reflection(void);
 void Enum_bitmask_enum_with_type_reflection(void);
+void Enum_enum_with_mixed_constants_and_bitmask(void);
 void Enum_enum_class_reflection(void);
 void Enum_prefixed_enum_reflection(void);
 void Enum_constant_with_num_reflection(void);
@@ -2630,6 +2631,10 @@ bake_test_case Enum_testcases[] = {
     {
         "bitmask_enum_with_type_reflection",
         Enum_bitmask_enum_with_type_reflection
+    },
+    {
+        "enum_with_mixed_constants_and_bitmask",
+        Enum_enum_with_mixed_constants_and_bitmask
     },
     {
         "enum_class_reflection",
@@ -6555,7 +6560,7 @@ static bake_test_suite suites[] = {
         "Enum",
         NULL,
         NULL,
-        38,
+        39,
         Enum_testcases
     },
     {

--- a/test/cpp_api/src/main.cpp
+++ b/test/cpp_api/src/main.cpp
@@ -333,6 +333,8 @@ void Pairs_set_R_existing_value(void);
 // Testsuite 'Enum'
 void Enum_standard_enum_reflection(void);
 void Enum_sparse_enum_reflection(void);
+void Enum_bitmask_enum_reflection(void);
+void Enum_bitmask_enum_with_type_reflection(void);
 void Enum_enum_class_reflection(void);
 void Enum_prefixed_enum_reflection(void);
 void Enum_constant_with_num_reflection(void);
@@ -2620,6 +2622,14 @@ bake_test_case Enum_testcases[] = {
     {
         "sparse_enum_reflection",
         Enum_sparse_enum_reflection
+    },
+    {
+        "bitmask_enum_reflection",
+        Enum_bitmask_enum_reflection
+    },
+    {
+        "bitmask_enum_with_type_reflection",
+        Enum_bitmask_enum_with_type_reflection
     },
     {
         "enum_class_reflection",
@@ -6519,7 +6529,6 @@ bake_test_case Doc_testcases[] = {
     }
 };
 
-
 static bake_test_suite suites[] = {
     {
         "PrettyFunction",
@@ -6546,7 +6555,7 @@ static bake_test_suite suites[] = {
         "Enum",
         NULL,
         NULL,
-        36,
+        38,
         Enum_testcases
     },
     {


### PR DESCRIPTION
This modifies the storage of enum reflection data from a sparse array lookup table to a contiguous-array with both lookup table/linked list scanning strategies.

Changes enum constants array constant (default) size of 128 to a compile-time determined size based on number of enum constants found during reflection.

Modified enum reflection search mechanisms by:
- Finds 0->128 in ascending order.
- Generates 0->128 by recursively dividing range, reducing the template depth from n to ln(n).
- Additionally finds bitmasks from `1 << (sizeof(underlying_type) * 8 - 1)` until it reaches the value used by the previous search (128).

It maintains a `contiguous_until` index, which is used to track the last default enum value. This is used as a heuristic to shortcut iteration, and direct lookup in the case that the user's enum is using default enumeration values for part or all of the enumerators. If the enum is sparse or the value is beyond the contiguous section, `contiguous_until` index is skipped to and a search on reflection data occurs instead.