### PR TITLE
Use `fseek(file, 0, SEEK_SET)` instead of `rewind(file)`.

### DIFF
--- a/flecs.c
+++ b/flecs.c
@@ -14490,12 +14490,12 @@ char* flecs_load_from_file(
     }
 
     /* Determine file size */
-    fseek(file, 0 , SEEK_END);
+    fseek(file, 0, SEEK_END);
     bytes = (int32_t)ftell(file);
     if (bytes == -1) {
         goto error;
     }
-    rewind(file);
+    fseek(file, 0, SEEK_SET);
 
     /* Load contents in memory */
     content = ecs_os_malloc(bytes + 1);

--- a/src/misc.c
+++ b/src/misc.c
@@ -223,12 +223,12 @@ char* flecs_load_from_file(
     }
 
     /* Determine file size */
-    fseek(file, 0 , SEEK_END);
+    fseek(file, 0, SEEK_END);
     bytes = (int32_t)ftell(file);
     if (bytes == -1) {
         goto error;
     }
-    rewind(file);
+    fseek(file, 0, SEEK_SET);
 
     /* Load contents in memory */
     content = ecs_os_malloc(bytes + 1);


### PR DESCRIPTION
This removes a warning when using `clang-tidy` as `rewind()` can't report errors while `fseek()` can. (Not that we're checking for errors here anyway...)