### PR TITLE
ci: Remove macOS-11 builds, add macOS-13.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -565,11 +565,9 @@ jobs:
       fail-fast: false
       matrix:
         os: 
-          - { version: macOS-11, xcode: '11.7' }
-          - { version: macOS-11, xcode: '12.4' }
-          - { version: macOS-11, xcode: '13.0' }
           - { version: macOS-12, xcode: '13.1' }
           - { version: macOS-12, xcode: '14.0' }
+          - { version: macOS-13, xcode: '14.3.1' }
           - { version: macOS-14, xcode: '15.2' }
 
     env:


### PR DESCRIPTION
The macOS 11 build runners are being deprecated and are intended to be removed by the middle of 2024:

https://github.com/actions/runner-images/issues/9255

Additionally, macOS-12 is to be deprecated in Q3 and removed in Q4, so prepare for that now by adding a macOS-13 build.