### PR TITLE
Add overloads for flecs::entity and depends_on to allow scoped enums with an underlying type of entity_t.  

### DIFF
--- a/include/flecs/addons/cpp/entity.hpp
+++ b/include/flecs/addons/cpp/entity.hpp
@@ -84,9 +84,10 @@ struct entity : entity_builder<entity>
      *
      * @param id The enum with an underlying type of flecs::entity_t value to convert.
      */
-    template <typename E, if_t<is_enum<E>::value && is_same<std::underlying_type_t<E>, entity_t>::value> = 0> 
+    template <typename E,
+              if_t<is_enum<E>::value && is_same<typename std::underlying_type<E>::type, entity_t>::value> = 0>
     entity(E id_enum)
-    : entity(std::underlying_type_t<E>(id_enum)) {}
+    : entity(std::underlying_type<E>(id_enum)) {}
 
     /** Get mutable component value.
      * This operation returns a mutable pointer to the component. If the entity

--- a/include/flecs/addons/cpp/entity.hpp
+++ b/include/flecs/addons/cpp/entity.hpp
@@ -79,6 +79,15 @@ struct entity : entity_builder<entity>
     explicit entity(entity_t id)
         : entity_builder( nullptr, id ) { }
 
+
+    /** Conversion from an enum with an underlying type of flecs::entity_t to flecs::entity.
+     *
+     * @param id The enum with an underlying type of flecs::entity_t value to convert.
+     */
+    template <typename E, if_t<is_enum<E>::value && is_same<std::underlying_type_t<E>, entity_t>::value> = 0> 
+    entity(E id_enum)
+    : entity(std::underlying_type_t<E>(id_enum)) {}
+
     /** Get mutable component value.
      * This operation returns a mutable pointer to the component. If the entity
      * did not yet have the component, it will be added. If a base entity had

--- a/include/flecs/addons/cpp/mixins/entity/builder.hpp
+++ b/include/flecs/addons/cpp/mixins/entity/builder.hpp
@@ -237,6 +237,17 @@ struct entity_builder : entity_view {
         return this->add(flecs::DependsOn, second);
     }
 
+
+    /** Shortcut for add(DependsOn, entity), enabled if using an enum with an underlying type of entity_t.
+     *
+     * @param second The second element of the pair.
+     */
+    template <typename E, if_t<is_enum<E>::value && is_same<std::underlying_type_t<E>, entity_t>::value> = 0>
+    Self& depends_on(E second) {
+        return this->depends_on(std::underlying_type_t<E>(second));
+    }
+    
+
     /** Shortcut for add(SlotOf, entity).
      *
      * @param second The second element of the pair.

--- a/include/flecs/addons/cpp/mixins/entity/builder.hpp
+++ b/include/flecs/addons/cpp/mixins/entity/builder.hpp
@@ -242,9 +242,9 @@ struct entity_builder : entity_view {
      *
      * @param second The second element of the pair.
      */
-    template <typename E, if_t<is_enum<E>::value && is_same<std::underlying_type_t<E>, entity_t>::value> = 0>
+    template <typename E, if_t<is_enum<E>::value && is_same<typename std::underlying_type<E>::type, entity_t>::value> = 0>
     Self& depends_on(E second) {
-        return this->depends_on(std::underlying_type_t<E>(second));
+        return this->depends_on(static_cast<std::underlying_type<E>::type>(second));
     }
     
 


### PR DESCRIPTION
I have some enums like:

```cpp
 enum class engine : flecs::entity_t
 {
     main_window = EcsFirstUserEntityId,
     input,
     renderer,
     scripting,
     MAX,
 };
```

which allows me to just add entity ids in sequence for hardcoded entities.  However, none of the flecs functions accept passing these enums as entity_t.  I have to cast to the underlying type in my code. 

So, I added some functions to accept enums like this so that I can just use these enums as I want.  

```cpp
//he::entities::pipeline is an enum with underlying type of flecs::entity_t
 world.entity(he::entities::pipeline::on_render_start).add(flecs::Phase).depends_on(he::entities::pipeline::on_window_start);
```

I only grabbed a few functions I'm currently using.  If this PR is accepted, I will probably add more as I go through.  
