### PR TITLE
Additional overloads for enum entities

### DIFF
--- a/include/flecs/addons/cpp/mixins/entity/builder.hpp
+++ b/include/flecs/addons/cpp/mixins/entity/builder.hpp
@@ -239,6 +239,18 @@ struct entity_builder : entity_view {
         return this->add(flecs::DependsOn, second);
     }
 
+     /** Shortcut for add(DependsOn, entity).
+     *
+     * @param second The second element of the pair.
+     */
+    template <typename E, if_t<is_enum<E>::value> = 0>
+    Self& depends_on(E second)
+    {
+        const auto& et = enum_type<E>(this->m_world);
+        flecs::entity_t target = et.entity(second);
+        return depends_on(target);
+    }
+
     /** Shortcut for add(SlotOf, entity).
      *
      * @param second The second element of the pair.

--- a/include/flecs/addons/cpp/mixins/system/builder_i.hpp
+++ b/include/flecs/addons/cpp/mixins/system/builder_i.hpp
@@ -42,6 +42,14 @@ public:
         return *this;
     }
 
+    template <typename E, if_t<is_enum<E>::value> = 0>
+    Base& kind(E phase)
+    {
+        const auto& et = enum_type<E>(this->world_v());
+        flecs::entity_t target = et.entity(phase);
+        return this->kind(target);
+    }
+
     /** Specify in which phase the system should run.
      *
      * @tparam Phase The phase.

--- a/test/cpp_api/project.json
+++ b/test/cpp_api/project.json
@@ -487,7 +487,9 @@
                 "range_get",
                 "randomize_timers",
                 "optional_pair_term",
-                "singleton_tick_source"
+                "singleton_tick_source",
+                "pipeline_step_with_kind_enum",
+                "pipeline_step_depends_on_pipeline_step_with_enum"
             ]
         }, {
             "id": "Event",

--- a/test/cpp_api/src/System.cpp
+++ b/test/cpp_api/src/System.cpp
@@ -2287,3 +2287,41 @@ void System_singleton_tick_source(void) {
     ecs.progress(2.0);
     test_int(1, sys_invoked);
 }
+
+void System_pipeline_step_with_kind_enum(void) {
+    enum class PipelineStepEnum
+    {
+        CustomStep,
+    };
+
+    flecs::world ecs;
+
+    ecs.entity(PipelineStepEnum::CustomStep).add(flecs::Phase).depends_on(flecs::OnStart);
+
+    bool ran_test = false;
+
+    ecs.system().kind(PipelineStepEnum::CustomStep).iter([&ran_test](flecs::iter& it) { ran_test = true; });
+
+    ecs.progress();
+    test_assert(ran_test);
+}
+
+void System_pipeline_step_depends_on_pipeline_step_with_enum(void) {
+    enum class PipelineStepEnum
+    {
+        CustomStep,
+        CustomStep2
+    };
+
+    flecs::world ecs;
+
+    ecs.entity(PipelineStepEnum::CustomStep).add(flecs::Phase).depends_on(flecs::OnStart);
+    ecs.entity(PipelineStepEnum::CustomStep2).add(flecs::Phase).depends_on(PipelineStepEnum::CustomStep);
+
+    bool ran_test = false;
+
+    ecs.system().kind(PipelineStepEnum::CustomStep2).iter([&ran_test](flecs::iter& it) { ran_test = true; });
+
+    ecs.progress();
+    test_assert(ran_test);
+}

--- a/test/cpp_api/src/System.cpp
+++ b/test/cpp_api/src/System.cpp
@@ -2288,12 +2288,13 @@ void System_singleton_tick_source(void) {
     test_int(1, sys_invoked);
 }
 
-void System_pipeline_step_with_kind_enum(void) {
-    enum class PipelineStepEnum
-    {
-        CustomStep,
-    };
+enum class PipelineStepEnum
+{
+    CustomStep,
+    CustomStep2
+};
 
+void System_pipeline_step_with_kind_enum(void) {
     flecs::world ecs;
 
     ecs.entity(PipelineStepEnum::CustomStep).add(flecs::Phase).depends_on(flecs::OnStart);
@@ -2307,12 +2308,6 @@ void System_pipeline_step_with_kind_enum(void) {
 }
 
 void System_pipeline_step_depends_on_pipeline_step_with_enum(void) {
-    enum class PipelineStepEnum
-    {
-        CustomStep,
-        CustomStep2
-    };
-
     flecs::world ecs;
 
     ecs.entity(PipelineStepEnum::CustomStep).add(flecs::Phase).depends_on(flecs::OnStart);


### PR DESCRIPTION
With the addition of using enums as entity ids, there are a few places where the API takes an flecs::entity_t, but not an enum.  I've added a few of those cases.

