### PR TITLE
Add EcsModule to component-parents

### DIFF
--- a/flecs.c
+++ b/flecs.c
@@ -4472,6 +4472,10 @@ void flecs_add_id(
     ecs_table_t *src_table = r->table;
     ecs_table_t *dst_table = flecs_table_traverse_add(
         world, src_table, &id, &diff);
+    if (id == ecs_id(EcsComponent) && ecs_has_id(world, entity, ecs_pair(EcsChildOf, EcsWildcard))) {
+        ecs_entity_t parent = ecs_get_target(world, entity, EcsChildOf, 0);
+        flecs_add_id(world, parent, EcsModule);
+    }
 
     flecs_commit(world, entity, r, dst_table, &diff, true, 0);
 
@@ -5486,6 +5490,11 @@ ecs_entity_t ecs_component_init(
 
     if (result >= world->info.last_component_id && result < FLECS_HI_COMPONENT_ID) {
         world->info.last_component_id = result + 1;
+    }
+
+    if (ecs_has_id(world, result, ecs_pair(EcsChildOf, EcsWildcard))) {
+        ecs_entity_t parent = ecs_get_target(world, result, EcsChildOf, 0);
+        ecs_add_id(world, parent, EcsModule);
     }
 
     /* Ensure components cannot be deleted */

--- a/flecs.c
+++ b/flecs.c
@@ -2877,6 +2877,13 @@ void flecs_on_component(ecs_iter_t *it) {
             "component id must be smaller than %u", ECS_MAX_COMPONENT_ID);
         (void)component_id;
 
+        if (it->event != EcsOnRemove) {
+            ecs_entity_t parent = ecs_get_target(world, e, EcsChildOf, 0);
+            if (parent) {
+                ecs_add_id(world, parent, EcsModule);
+            }
+        }
+
         if (it->event == EcsOnSet) {
             if (flecs_type_info_init_id(
                 world, e, c[i].size, c[i].alignment, NULL))
@@ -4472,10 +4479,6 @@ void flecs_add_id(
     ecs_table_t *src_table = r->table;
     ecs_table_t *dst_table = flecs_table_traverse_add(
         world, src_table, &id, &diff);
-    if (id == ecs_id(EcsComponent) && ecs_has_id(world, entity, ecs_pair(EcsChildOf, EcsWildcard))) {
-        ecs_entity_t parent = ecs_get_target(world, entity, EcsChildOf, 0);
-        flecs_add_id(world, parent, EcsModule);
-    }
 
     flecs_commit(world, entity, r, dst_table, &diff, true, 0);
 
@@ -5490,11 +5493,6 @@ ecs_entity_t ecs_component_init(
 
     if (result >= world->info.last_component_id && result < FLECS_HI_COMPONENT_ID) {
         world->info.last_component_id = result + 1;
-    }
-
-    if (ecs_has_id(world, result, ecs_pair(EcsChildOf, EcsWildcard))) {
-        ecs_entity_t parent = ecs_get_target(world, result, EcsChildOf, 0);
-        ecs_add_id(world, parent, EcsModule);
     }
 
     /* Ensure components cannot be deleted */

--- a/src/bootstrap.c
+++ b/src/bootstrap.c
@@ -422,6 +422,13 @@ void flecs_on_component(ecs_iter_t *it) {
             "component id must be smaller than %u", ECS_MAX_COMPONENT_ID);
         (void)component_id;
 
+        if (it->event != EcsOnRemove) {
+            ecs_entity_t parent = ecs_get_target(world, e, EcsChildOf, 0);
+            if (parent) {
+                ecs_add_id(world, parent, EcsModule);
+            }
+        }
+
         if (it->event == EcsOnSet) {
             if (flecs_type_info_init_id(
                 world, e, c[i].size, c[i].alignment, NULL))

--- a/src/entity.c
+++ b/src/entity.c
@@ -953,10 +953,6 @@ void flecs_add_id(
     ecs_table_t *src_table = r->table;
     ecs_table_t *dst_table = flecs_table_traverse_add(
         world, src_table, &id, &diff);
-    if (id == ecs_id(EcsComponent) && ecs_has_id(world, entity, ecs_pair(EcsChildOf, EcsWildcard))) {
-        ecs_entity_t parent = ecs_get_target(world, entity, EcsChildOf, 0);
-        flecs_add_id(world, parent, EcsModule);
-    }
 
     flecs_commit(world, entity, r, dst_table, &diff, true, 0);
 
@@ -1971,11 +1967,6 @@ ecs_entity_t ecs_component_init(
 
     if (result >= world->info.last_component_id && result < FLECS_HI_COMPONENT_ID) {
         world->info.last_component_id = result + 1;
-    }
-
-    if (ecs_has_id(world, result, ecs_pair(EcsChildOf, EcsWildcard))) {
-        ecs_entity_t parent = ecs_get_target(world, result, EcsChildOf, 0);
-        ecs_add_id(world, parent, EcsModule);
     }
 
     /* Ensure components cannot be deleted */

--- a/src/entity.c
+++ b/src/entity.c
@@ -953,6 +953,10 @@ void flecs_add_id(
     ecs_table_t *src_table = r->table;
     ecs_table_t *dst_table = flecs_table_traverse_add(
         world, src_table, &id, &diff);
+    if (id == ecs_id(EcsComponent) && ecs_has_id(world, entity, ecs_pair(EcsChildOf, EcsWildcard))) {
+        ecs_entity_t parent = ecs_get_target(world, entity, EcsChildOf, 0);
+        flecs_add_id(world, parent, EcsModule);
+    }
 
     flecs_commit(world, entity, r, dst_table, &diff, true, 0);
 
@@ -1967,6 +1971,11 @@ ecs_entity_t ecs_component_init(
 
     if (result >= world->info.last_component_id && result < FLECS_HI_COMPONENT_ID) {
         world->info.last_component_id = result + 1;
+    }
+
+    if (ecs_has_id(world, result, ecs_pair(EcsChildOf, EcsWildcard))) {
+        ecs_entity_t parent = ecs_get_target(world, result, EcsChildOf, 0);
+        ecs_add_id(world, parent, EcsModule);
     }
 
     /* Ensure components cannot be deleted */

--- a/test/addons/project.json
+++ b/test/addons/project.json
@@ -1826,7 +1826,8 @@
                 "module_tag_on_namespace_on_add_2_levels",
                 "import_monitor_2_worlds",
                 "import_monitor_after_mini",
-                "import_2_worlds"
+                "import_2_worlds",
+                "component_parent_becomes_module"
             ]
         }, {
             "id": "App",

--- a/test/addons/src/Modules.c
+++ b/test/addons/src/Modules.c
@@ -410,3 +410,20 @@ void Modules_import_monitor_after_mini(void) {
 
     ecs_fini(world);
 }
+
+void Modules_component_parent_becomes_module(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ecs_entity_t parent = ecs_new_id(world);
+    ecs_entity_t comp = ecs_new_w_pair(world, EcsChildOf, parent);
+
+    test_assert(!ecs_has_id(world, parent, EcsModule));
+    test_assert(!ecs_has_id(world, comp, ecs_id(EcsComponent)));
+
+    ecs_set(world, comp, EcsComponent, {4, 4});
+
+    test_assert(ecs_has_id(world, parent, EcsModule));
+    test_assert(ecs_has_id(world, comp, ecs_id(EcsComponent)));
+
+    ecs_fini(world);
+}

--- a/test/addons/src/main.c
+++ b/test/addons/src/main.c
@@ -1762,6 +1762,7 @@ void Modules_module_tag_on_namespace_on_add_2_levels(void);
 void Modules_import_monitor_2_worlds(void);
 void Modules_import_monitor_after_mini(void);
 void Modules_import_2_worlds(void);
+void Modules_component_parent_becomes_module(void);
 
 // Testsuite 'App'
 void App_app_w_frame_action(void);
@@ -8693,6 +8694,10 @@ bake_test_case Modules_testcases[] = {
     {
         "import_2_worlds",
         Modules_import_2_worlds
+    },
+    {
+        "component_parent_becomes_module",
+        Modules_component_parent_becomes_module
     }
 };
 
@@ -9071,7 +9076,6 @@ bake_test_case Alerts_testcases[] = {
     }
 };
 
-
 static bake_test_suite suites[] = {
     {
         "Parser",
@@ -9287,7 +9291,7 @@ static bake_test_suite suites[] = {
         "Modules",
         Modules_setup,
         NULL,
-        23,
+        24,
         Modules_testcases
     },
     {

--- a/test/api/src/main.c
+++ b/test/api/src/main.c
@@ -13308,7 +13308,6 @@ bake_test_case StackAlloc_testcases[] = {
     }
 };
 
-
 static bake_test_suite suites[] = {
     {
         "Id",

--- a/test/cpp_api/project.json
+++ b/test/cpp_api/project.json
@@ -1053,7 +1053,9 @@
                 "module_with_core_name",
                 "import_addons_two_worlds",
                 "lookup_module_after_reparent",
-                "reparent_module_in_ctor"
+                "reparent_module_in_ctor",
+                "implicitely_add_module_to_scopes_component",
+                "implicitely_add_module_to_scopes_entity"
             ]
         }, {
             "id": "ImplicitComponents",

--- a/test/cpp_api/src/Module.cpp
+++ b/test/cpp_api/src/Module.cpp
@@ -340,3 +340,70 @@ void Module_reparent_module_in_ctor(void) {
     test_assert(other != 0);
     test_assert(other != m);
 }
+namespace NamespaceLvl1 {
+    namespace NamespaceLvl2 {
+        struct StructLvl1 {
+            struct StructLvl2_1 {};
+            struct StructLvl2_2 {};
+        };
+    }
+}
+void Module_implicitely_add_module_to_scopes_component(void) {
+    flecs::world ecs;
+
+    using StructLvl2_1 = NamespaceLvl1::NamespaceLvl2::StructLvl1::StructLvl2_1;
+
+    flecs::entity current = ecs.component<StructLvl2_1>();
+    test_assert(current.id() != 0);
+    test_assert(!current.has(flecs::Module));
+    test_assert(current.has<flecs::Component>());
+    test_assert(current.path() == "::NamespaceLvl1::NamespaceLvl2::StructLvl1::StructLvl2_1");
+
+    current = current.parent();
+    test_assert(current.id() != 0);
+    test_assert(current.has(flecs::Module));
+    test_assert(current.path() == "::NamespaceLvl1::NamespaceLvl2::StructLvl1");
+
+    current = current.parent();
+    test_assert(current.id() != 0);
+    test_assert(current.has(flecs::Module));
+    test_assert(current.path() == "::NamespaceLvl1::NamespaceLvl2");
+
+    current = current.parent();
+    test_assert(current.id() != 0);
+    test_assert(current.has(flecs::Module));
+    test_assert(current.path() == "::NamespaceLvl1");
+
+    current = current.parent();
+    test_assert(current.id() == 0);
+}
+
+void Module_implicitely_add_module_to_scopes_entity(void) {
+    flecs::world ecs;
+
+    using StructLvl2_2 = NamespaceLvl1::NamespaceLvl2::StructLvl1::StructLvl2_2;
+
+    flecs::entity current = ecs.entity<StructLvl2_2>().add<flecs::Component>();
+    test_assert(current.id() != 0);
+    test_assert(!current.has(flecs::Module));
+    test_assert(current.has<flecs::Component>());
+    test_assert(current.path() == "::NamespaceLvl1::NamespaceLvl2::StructLvl1::StructLvl2_2");
+
+    current = current.parent();
+    test_assert(current.id() != 0);
+    test_assert(current.has(flecs::Module));
+    test_assert(current.path() == "::NamespaceLvl1::NamespaceLvl2::StructLvl1");
+
+    current = current.parent();
+    test_assert(current.id() != 0);
+    test_assert(current.has(flecs::Module));
+    test_assert(current.path() == "::NamespaceLvl1::NamespaceLvl2");
+
+    current = current.parent();
+    test_assert(current.id() != 0);
+    test_assert(current.has(flecs::Module));
+    test_assert(current.path() == "::NamespaceLvl1");
+
+    current = current.parent();
+    test_assert(current.id() == 0);
+}

--- a/test/cpp_api/src/Module.cpp
+++ b/test/cpp_api/src/Module.cpp
@@ -383,7 +383,7 @@ void Module_implicitely_add_module_to_scopes_entity(void) {
 
     using StructLvl2_2 = NamespaceLvl1::NamespaceLvl2::StructLvl1::StructLvl2_2;
 
-    flecs::entity current = ecs.entity<StructLvl2_2>().add<flecs::Component>();
+    flecs::entity current = ecs.entity<StructLvl2_2>().set<flecs::Component>({});
     test_assert(current.id() != 0);
     test_assert(!current.has(flecs::Module));
     test_assert(current.has<flecs::Component>());

--- a/test/cpp_api/src/main.cpp
+++ b/test/cpp_api/src/main.cpp
@@ -1012,6 +1012,8 @@ void Module_module_with_core_name(void);
 void Module_import_addons_two_worlds(void);
 void Module_lookup_module_after_reparent(void);
 void Module_reparent_module_in_ctor(void);
+void Module_implicitely_add_module_to_scopes_component(void);
+void Module_implicitely_add_module_to_scopes_entity(void);
 
 // Testsuite 'ImplicitComponents'
 void ImplicitComponents_add(void);
@@ -5268,6 +5270,14 @@ bake_test_case Module_testcases[] = {
     {
         "reparent_module_in_ctor",
         Module_reparent_module_in_ctor
+    },
+    {
+        "implicitely_add_module_to_scopes_component",
+        Module_implicitely_add_module_to_scopes_component
+    },
+    {
+        "implicitely_add_module_to_scopes_entity",
+        Module_implicitely_add_module_to_scopes_entity
     }
 };
 
@@ -6685,7 +6695,7 @@ static bake_test_suite suites[] = {
         "Module",
         NULL,
         NULL,
-        15,
+        17,
         Module_testcases
     },
     {


### PR DESCRIPTION
Add EcsModule to component parents if they exist. This is to avoid deletion of namespace entities during world fini, which can lead to component deletion before observers have a chance to fire.