### PR TITLE
Fix warnings when `FLECS_USE_OS_ALLOC`.

### DIFF
--- a/flecs.c
+++ b/flecs.c
@@ -39070,6 +39070,7 @@ error:
 int64_t ecs_block_allocator_alloc_count = 0;
 int64_t ecs_block_allocator_free_count = 0;
 
+#ifndef FLECS_USE_OS_ALLOC
 static
 ecs_block_allocator_chunk_header_t* flecs_balloc_block(
     ecs_block_allocator_t *allocator)
@@ -39108,6 +39109,7 @@ ecs_block_allocator_chunk_header_t* flecs_balloc_block(
     chunk->next = NULL;
     return first_chunk;
 }
+#endif
 
 void flecs_ballocator_init(
     ecs_block_allocator_t *ba,
@@ -39249,6 +39251,7 @@ void* flecs_brealloc(
 {
     void *result;
 #ifdef FLECS_USE_OS_ALLOC
+    (void)src;
     result = ecs_os_realloc(memory, dst->data_size);
 #else
     if (dst == src) {


### PR DESCRIPTION
When using the OS allocator, `flecs_balloc_block()` is unused and can be removed. Also, the `src` parameter to `flecs_brealloc()` is not used.