### PR TITLE
Fix an assert when moving a component without a ctor to an existing table

### DIFF
--- a/flecs.c
+++ b/flecs.c
@@ -45661,14 +45661,14 @@ void flecs_table_merge_column(
     } else {
         int32_t src_count = src->data.count;
 
-        flecs_table_grow_column(world, dst, src_count, column_size, true);
+        flecs_table_grow_column(world, dst, src_count, column_size, false);
         void *dst_ptr = ECS_ELEM(dst->data.array, size, dst_count);
         void *src_ptr = src->data.array;
 
         /* Move values into column */
         ecs_type_info_t *ti = dst->ti;
         ecs_assert(ti != NULL, ECS_INTERNAL_ERROR, NULL);
-        ecs_move_t move = ti->hooks.move_dtor;
+        ecs_move_t move = ti->hooks.ctor_move_dtor;
         if (move) {
             move(dst_ptr, src_ptr, src_count, ti);
         } else {

--- a/src/storage/table.c
+++ b/src/storage/table.c
@@ -2086,14 +2086,14 @@ void flecs_table_merge_column(
     } else {
         int32_t src_count = src->data.count;
 
-        flecs_table_grow_column(world, dst, src_count, column_size, true);
+        flecs_table_grow_column(world, dst, src_count, column_size, false);
         void *dst_ptr = ECS_ELEM(dst->data.array, size, dst_count);
         void *src_ptr = src->data.array;
 
         /* Move values into column */
         ecs_type_info_t *ti = dst->ti;
         ecs_assert(ti != NULL, ECS_INTERNAL_ERROR, NULL);
-        ecs_move_t move = ti->hooks.move_dtor;
+        ecs_move_t move = ti->hooks.ctor_move_dtor;
         if (move) {
             move(dst_ptr, src_ptr, src_count, ti);
         } else {

--- a/test/cpp_api/project.json
+++ b/test/cpp_api/project.json
@@ -1031,6 +1031,7 @@
                 "set_override_pair_w_entity_no_copy",
                 "dtor_after_defer_set",
                 "dtor_with_relation",
+                "dtor_relation_target",
                 "register_parent_after_child_w_hooks",
                 "register_parent_after_child_w_hooks_implicit"
             ]

--- a/test/cpp_api/src/ComponentLifecycle.cpp
+++ b/test/cpp_api/src/ComponentLifecycle.cpp
@@ -1780,10 +1780,10 @@ void ComponentLifecycle_dtor_with_relation(void) {
         test_int(Pod::move_ctor_invoked, 1);
     }
 
-    test_int(Pod::ctor_invoked, 5);
+    test_int(Pod::ctor_invoked, 4);
     test_int(Pod::dtor_invoked, 6);
-    test_int(Pod::move_invoked, 4);
-    test_int(Pod::move_ctor_invoked, 1);
+    test_int(Pod::move_invoked, 3);
+    test_int(Pod::move_ctor_invoked, 2);
 }
 
 void ComponentLifecycle_register_parent_after_child_w_hooks(void) {
@@ -1817,4 +1817,40 @@ void ComponentLifecycle_register_parent_after_child_w_hooks_implicit(void) {
     test_int(Pod::move_ctor_invoked, 0);
     test_int(Pod::copy_invoked, 0);
     test_int(Pod::copy_ctor_invoked, 0);
+}
+
+void ComponentLifecycle_dtor_relation_target(void) {
+    {
+        flecs::world ecs;
+
+        auto e = ecs.entity();
+        auto e2 = ecs.entity().emplace<CountNoDefaultCtor>(5).add<Tag>(e);
+        auto e3 = ecs.entity().emplace<CountNoDefaultCtor>(5);
+
+        test_int(CountNoDefaultCtor::ctor_invoked, 2);
+        test_int(CountNoDefaultCtor::dtor_invoked, 1);
+        test_int(CountNoDefaultCtor::move_invoked, 0);
+        test_int(CountNoDefaultCtor::move_ctor_invoked, 1);
+
+        const CountNoDefaultCtor *ptr = e2.get<CountNoDefaultCtor>();
+        test_assert(ptr != NULL);
+        test_int(ptr->value, 5);
+
+        test_int(CountNoDefaultCtor::ctor_invoked, 2);
+        test_int(CountNoDefaultCtor::dtor_invoked, 1);
+        test_int(CountNoDefaultCtor::move_invoked, 0);
+        test_int(CountNoDefaultCtor::move_ctor_invoked, 1);
+
+        e.destruct();
+
+        test_int(CountNoDefaultCtor::ctor_invoked, 2);
+        test_int(CountNoDefaultCtor::dtor_invoked, 2);
+        test_int(CountNoDefaultCtor::move_invoked, 0);
+        test_int(CountNoDefaultCtor::move_ctor_invoked, 2);
+    }
+
+    test_int(CountNoDefaultCtor::ctor_invoked, 2);
+    test_int(CountNoDefaultCtor::dtor_invoked, 4);
+    test_int(CountNoDefaultCtor::move_invoked, 0);
+    test_int(CountNoDefaultCtor::move_ctor_invoked, 2);
 }

--- a/test/cpp_api/src/main.cpp
+++ b/test/cpp_api/src/main.cpp
@@ -993,6 +993,7 @@ void ComponentLifecycle_set_override_pair_no_copy(void);
 void ComponentLifecycle_set_override_pair_w_entity_no_copy(void);
 void ComponentLifecycle_dtor_after_defer_set(void);
 void ComponentLifecycle_dtor_with_relation(void);
+void ComponentLifecycle_dtor_relation_target(void);
 void ComponentLifecycle_register_parent_after_child_w_hooks(void);
 void ComponentLifecycle_register_parent_after_child_w_hooks_implicit(void);
 
@@ -5221,6 +5222,10 @@ bake_test_case ComponentLifecycle_testcases[] = {
         ComponentLifecycle_dtor_with_relation
     },
     {
+        "dtor_relation_target",
+        ComponentLifecycle_dtor_relation_target
+    },
+    {
         "register_parent_after_child_w_hooks",
         ComponentLifecycle_register_parent_after_child_w_hooks
     },
@@ -6639,7 +6644,6 @@ bake_test_case Doc_testcases[] = {
     }
 };
 
-
 static bake_test_suite suites[] = {
     {
         "PrettyFunction",
@@ -6757,7 +6761,7 @@ static bake_test_suite suites[] = {
         "ComponentLifecycle",
         NULL,
         NULL,
-        75,
+        76,
         ComponentLifecycle_testcases
     },
     {


### PR DESCRIPTION
This changes the code in `flecs_table_merge_column` to not have `flecs_table_grow_column` default construct components in the new rows added to the column and instead handle it via `ctor_move_dtor` instead. This allows components that cannot be default constructed to be moved into existing tables.