### PR TITLE
use destructive move semantics when move & move_ctor is not set. 

### DIFF
--- a/flecs.c
+++ b/flecs.c
@@ -39070,6 +39070,8 @@ error:
 int64_t ecs_block_allocator_alloc_count = 0;
 int64_t ecs_block_allocator_free_count = 0;
 
+#ifndef FLECS_USE_OS_ALLOC
+
 static
 ecs_block_allocator_chunk_header_t* flecs_balloc_block(
     ecs_block_allocator_t *allocator)
@@ -39108,6 +39110,8 @@ ecs_block_allocator_chunk_header_t* flecs_balloc_block(
     chunk->next = NULL;
     return first_chunk;
 }
+
+#endif
 
 void flecs_ballocator_init(
     ecs_block_allocator_t *ba,
@@ -39249,6 +39253,7 @@ void* flecs_brealloc(
 {
     void *result;
 #ifdef FLECS_USE_OS_ALLOC
+    (void)src;
     result = ecs_os_realloc(memory, dst->data_size);
 #else
     if (dst == src) {

--- a/flecs.c
+++ b/flecs.c
@@ -45243,11 +45243,10 @@ void flecs_table_delete(
 
                 ecs_move_t move_dtor = ti->hooks.move_dtor;
                 
-                // if move_ctor is not set and ctor_move_dtor is set,
-                // use move_dtor as ctor_move_dtor. The reason we
-                // do this is to influence how the operation within the table
-                // is performed from different language bindings where the memory
-                // model may be different than C.
+                // If move_ctor is not set but ctor_move_dtor is set, assign move_dtor to ctor_move_dtor.
+                // This adjustment is crucial for compatibility across different language bindings where
+                // the standard memory model of C may not apply, potentially altering how operations
+                // within the table are handled.
                 if (!ti->hooks.move_ctor && ti->hooks.ctor_move_dtor) {
                   move_dtor = ti->hooks.ctor_move_dtor;
                 }

--- a/src/storage/table.c
+++ b/src/storage/table.c
@@ -1668,10 +1668,10 @@ void flecs_table_delete(
 
                 ecs_move_t move_dtor = ti->hooks.move_dtor;
                 
-                // If move_ctor is not set but ctor_move_dtor is set, assign move_dtor to ctor_move_dtor.
-                // This adjustment is crucial for compatibility across different language bindings where
-                // the standard memory model of C may not apply, potentially altering how operations
-                // within the table are handled.
+                // If neither move nor move_ctor are set, this indicates that non-destructive move 
+                // semantics are not supported for this type. In such cases, we set the move_dtor
+                // as ctor_move_dtor, which indicates a destructive move operation. 
+                // This adjustment ensures compatibility with different language bindings.
                 if (!ti->hooks.move_ctor && ti->hooks.ctor_move_dtor) {
                   move_dtor = ti->hooks.ctor_move_dtor;
                 }

--- a/src/storage/table.c
+++ b/src/storage/table.c
@@ -1667,6 +1667,16 @@ void flecs_table_delete(
                 }
 
                 ecs_move_t move_dtor = ti->hooks.move_dtor;
+                
+                // if move_ctor & move is not set and ctor_move_dtor & move_dtor is set,
+                // use move_dtor as ctor_move_dtor. The reason we
+                // do this is to influence how the operation within the table
+                // is performed from different language bindings where the memory
+                // model may be different than C.
+                if (!ti->hooks.move_ctor && ti->hooks.ctor_move_dtor) {
+                  move_dtor = ti->hooks.ctor_move_dtor;
+                }
+
                 if (move_dtor) {
                     move_dtor(dst, src, 1, ti);
                 } else {

--- a/src/storage/table.c
+++ b/src/storage/table.c
@@ -1668,11 +1668,10 @@ void flecs_table_delete(
 
                 ecs_move_t move_dtor = ti->hooks.move_dtor;
                 
-                // if move_ctor & move is not set and ctor_move_dtor & move_dtor is set,
-                // use move_dtor as ctor_move_dtor. The reason we
-                // do this is to influence how the operation within the table
-                // is performed from different language bindings where the memory
-                // model may be different than C.
+                // If move_ctor is not set but ctor_move_dtor is set, assign move_dtor to ctor_move_dtor.
+                // This adjustment is crucial for compatibility across different language bindings where
+                // the standard memory model of C may not apply, potentially altering how operations
+                // within the table are handled.
                 if (!ti->hooks.move_ctor && ti->hooks.ctor_move_dtor) {
                   move_dtor = ti->hooks.ctor_move_dtor;
                 }

--- a/test/addons/src/main.c
+++ b/test/addons/src/main.c
@@ -9141,7 +9141,6 @@ bake_test_case Alerts_testcases[] = {
     }
 };
 
-
 static bake_test_suite suites[] = {
     {
         "Parser",

--- a/test/api/project.json
+++ b/test/api/project.json
@@ -1069,7 +1069,8 @@
                 "on_set_hook_on_auto_override",
                 "batched_set_new_component_w_lifecycle",
                 "batched_ensure_new_component_w_lifecycle",
-                "on_nested_prefab_copy_test_invokes_copy_count"
+                "on_nested_prefab_copy_test_invokes_copy_count",
+                "no_move_no_move_ctor_with_move_dtor_with_ctor_move_dtor"
             ]
         }, {
             "id": "Sorting",

--- a/test/api/src/ComponentLifecycle.c
+++ b/test/api/src/ComponentLifecycle.c
@@ -3314,10 +3314,10 @@ void ComponentLifecycle_on_nested_prefab_copy_test_invokes_copy_count(void) {
     ecs_fini(world);
 }
 
-// tests if move_dtor does not get invoked when a component is moved within the table
-// when you don't set move and move_ctor, but do set move_dtor and ctor_move_dtor
-// instead of move_dtor, ctor_move_dtor should be invoked.
-// In total ctor_move_dtor should be invoked 2 times. 
+// Tests if neither move nor move_ctor are set but move_dtor and ctor_move_dtor are set, 
+// the move_dtor does not get invoked when a component is moved within the table.
+// Instead ctor_move_dtor should be invoked for a destructive move operation. 
+// Hence in total ctor_move_dtor should be invoked 2 times. 
 // Once for the initial move, and once for the move within the table.
 void ComponentLifecycle_no_move_no_move_ctor_with_move_dtor_with_ctor_move_dtor(void) {
     ecs_world_t *world = ecs_mini();

--- a/test/api/src/ComponentLifecycle.c
+++ b/test/api/src/ComponentLifecycle.c
@@ -27,6 +27,9 @@ typedef struct cl_ctx {
     xtor_ctx dtor;
     copy_ctx copy;
     copy_ctx move;
+    copy_ctx ctor_move_dtor;
+    copy_ctx move_dtor;
+
 } cl_ctx;
 
 static
@@ -90,6 +93,42 @@ void comp_move(
     data->move.size = info->size;
     data->move.count = count;
     data->move.invoked ++;
+
+    memcpy(dst_ptr, src_ptr, info->size * count);
+}
+
+static
+void comp_move_dtor(
+    void *dst_ptr,
+    void *src_ptr,
+    int32_t count,
+    const ecs_type_info_t *info)
+{
+    cl_ctx *data = info->hooks.ctx;
+    data->move_dtor.component = info->component;
+    data->move_dtor.size = info->size;
+    data->move_dtor.count += count;
+    data->move_dtor.invoked ++;
+
+    memcpy(dst_ptr, src_ptr, info->size * count);
+}
+
+static
+void comp_pos_ctor_move_dtor(void *dst_ptr, void *src_ptr,
+    int32_t count, const ecs_type_info_t *info)
+{
+    cl_ctx *data = info->hooks.ctx;
+    data->ctor_move_dtor.component = info->component;
+    data->ctor_move_dtor.size = info->size;
+    data->ctor_move_dtor.count += count;
+    data->ctor_move_dtor.invoked ++;
+
+    Position *p = src_ptr;
+    int i;
+    for (i = 0; i < count; i ++) {
+        p[i].x = 10;
+        p[i].y = 20;
+    }
 
     memcpy(dst_ptr, src_ptr, info->size * count);
 }
@@ -3273,4 +3312,45 @@ void ComponentLifecycle_on_nested_prefab_copy_test_invokes_copy_count(void) {
     test_int(ctx.copy.count, 9);
 
     ecs_fini(world);
+}
+
+// tests if move_dtor does not get invoked when a component is moved within the table
+// when you don't set move and move_ctor, but do set move_dtor and ctor_move_dtor
+// instead of move_dtor, ctor_move_dtor should be invoked.
+// In total ctor_move_dtor should be invoked 2 times. 
+// Once for the initial move, and once for the move within the table.
+void ComponentLifecycle_no_move_no_move_ctor_with_move_dtor_with_ctor_move_dtor(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_COMPONENT(world, Position);
+    ECS_COMPONENT(world, Velocity);
+
+    cl_ctx ctx = { { 0 } };
+
+    ecs_set_hooks(world, Position, {
+        .ctor = NULL,
+        .move = NULL,
+        .move_ctor = NULL,
+        .dtor = comp_dtor,
+        .ctor_move_dtor = comp_pos_ctor_move_dtor,
+        .move_dtor = comp_move_dtor,
+        .ctx = &ctx
+    });
+
+    ecs_entity_t e = ecs_new_id(world);
+    ecs_add(world, e, Position); 
+
+    ecs_entity_t e2 = ecs_new_id(world);
+    ecs_add(world, e2, Position);
+
+    ecs_entity_t e3 = ecs_new_id(world);
+    ecs_add(world, e3, Position);
+
+    ctx.ctor_move_dtor.invoked = 0;
+    ctx.move_dtor.invoked = 0;
+
+    ecs_add(world, e2, Velocity);
+
+    test_int(ctx.move_dtor.invoked, 0);
+    test_int(ctx.ctor_move_dtor.invoked, 2);
 }

--- a/test/api/src/ComponentLifecycle.c
+++ b/test/api/src/ComponentLifecycle.c
@@ -3353,4 +3353,6 @@ void ComponentLifecycle_no_move_no_move_ctor_with_move_dtor_with_ctor_move_dtor(
 
     test_int(ctx.move_dtor.invoked, 0);
     test_int(ctx.ctor_move_dtor.invoked, 2);
+
+    ecs_fini(world);
 }

--- a/test/api/src/main.c
+++ b/test/api/src/main.c
@@ -1017,6 +1017,7 @@ void ComponentLifecycle_on_set_hook_on_auto_override(void);
 void ComponentLifecycle_batched_set_new_component_w_lifecycle(void);
 void ComponentLifecycle_batched_ensure_new_component_w_lifecycle(void);
 void ComponentLifecycle_on_nested_prefab_copy_test_invokes_copy_count(void);
+void ComponentLifecycle_no_move_no_move_ctor_with_move_dtor_with_ctor_move_dtor(void);
 
 // Testsuite 'Sorting'
 void Sorting_sort_by_component(void);
@@ -6635,6 +6636,10 @@ bake_test_case ComponentLifecycle_testcases[] = {
     {
         "on_nested_prefab_copy_test_invokes_copy_count",
         ComponentLifecycle_on_nested_prefab_copy_test_invokes_copy_count
+    },
+    {
+        "no_move_no_move_ctor_with_move_dtor_with_ctor_move_dtor",
+        ComponentLifecycle_no_move_no_move_ctor_with_move_dtor_with_ctor_move_dtor
     }
 };
 
@@ -13581,7 +13586,7 @@ static bake_test_suite suites[] = {
         "ComponentLifecycle",
         ComponentLifecycle_setup,
         NULL,
-        90,
+        91,
         ComponentLifecycle_testcases
     },
     {

--- a/test/collections/src/main.c
+++ b/test/collections/src/main.c
@@ -451,7 +451,6 @@ bake_test_case Strbuf_testcases[] = {
     }
 };
 
-
 static bake_test_suite suites[] = {
     {
         "Map",

--- a/test/meta/src/main.c
+++ b/test/meta/src/main.c
@@ -5738,7 +5738,6 @@ bake_test_case Misc_testcases[] = {
     }
 };
 
-
 static bake_test_suite suites[] = {
     {
         "PrimitiveTypes",


### PR DESCRIPTION
If neither move nor move_ctor are set, this indicates that non-destructive move 
semantics are not supported for this type. In such cases, we set the move_dtor
as ctor_move_dtor, which indicates a destructive move operation. 
This adjustment ensures compatibility with different language bindings.