### PR TITLE
Pair constraints

### DIFF
--- a/docs/Relationships.md
+++ b/docs/Relationships.md
@@ -1775,6 +1775,179 @@ The last step will delete all remaining entities. At this point cleanup policies
 ## Relationship properties
 Relationship properties are tags that can be added to relationships to modify their behavior.
 
+## Trait property
+The trait property marks an entity as a trait, which is any tag that is added to another tag/component/relationship to modify its behavior. All properties in this section are marked as trait. It is not required to mark a property as a trait before adding it to another tag/component/relationship. The main reason for the trait property is to ease some of the constraints on relationships (see the Relationship property).
+
+```c
+ECS_TAG(world, Serializable);
+
+ecs_add_id(world, Serializable, EcsTrait);
+```
+
+</li>
+<li><b class="tab-title">C++</b>
+
+```cpp
+struct Serializable { };
+
+world.component<Serializable>().add(flecs::Trait);
+```
+
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+public struct Serializable { }
+
+world.Component<Serializable>().Entity.Add(Ecs.Trait);
+```
+
+</li>
+</ul>
+</div>
+
+## Relationship property
+The relationship property enforces that an entity can only be used as relationship. Consider the following example:
+
+```c
+ECS_TAG(world, Likes);
+ECS_TAG(world, Apples);
+
+ecs_add_id(world, Likes, EcsRelationship);
+
+ecs_entity_t e = ecs_new_id(world);
+ecs_add(world, Likes);              // Panic, 'Likes' is not used as relationship
+ecs_add_pair(world, Apples, Likes); // Panic, 'Likes' is not used as relationship
+ecs_add_pair(world, Likes, Apples); // OK
+```
+
+</li>
+<li><b class="tab-title">C++</b>
+
+```cpp
+struct Likes { };
+struct Apples { };
+
+world.component<Likes>().add(flecs::Relationship);
+
+flecs::entity e = world.entity()
+  .add<Likes>()          // Panic, 'Likes' is not used as relationship
+  .add<Apples, Likes>()  // Panic, 'Likes' is not used as relationship
+  .add<Likes, Apples>(); // OK
+```
+
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+public struct Likes { }
+public struct Apples { }
+
+world.Component<Likes>().Entity.Add(Ecs.Relationship);
+
+Entity e = ecs.Entity()
+    .Add<Likes>()          // Panic, 'Likes' is not used as relationship
+    .Add<Apples, Likes>()  // Panic, 'Likes' is not used as relationship
+    .add<Likes, Apples>(); // OK
+```
+
+</li>
+</ul>
+</div>
+
+Entities marked with `Relationship` may still be used as target if the relationship part of the pair has the `Trait` property. This ensures the relationship can still be used to configure the behavior of other entities. Consider the following code example:
+
+```c
+ECS_TAG(world, Likes);
+ECS_TAG(world, Loves);
+
+ecs_add_id(world, Likes, EcsRelationship);
+
+// Even though Likes is marked as relationship and used as target here, this 
+// won't panic as With is marked as trait.
+ecs_add_pair(world, Loves, EcsWith, Likes);
+```
+
+</li>
+<li><b class="tab-title">C++</b>
+
+```cpp
+struct Likes { };
+struct Loves { };
+
+world.component<Likes>().add(flecs::Relationship);
+
+// Even though Likes is marked as relationship and used as target here, this 
+// won't panic as With is marked as trait.
+world.component<Loves>().add(flecs::With, world.component<Likes>());
+```
+
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+public struct Likes { }
+public struct Loves { }
+
+world.Component<Likes>().Entity.Add(Ecs.Relationship);
+
+world.Component<Loves>().Entity.Add(Ecs.With, world.Component<Likes>().Entity);
+```
+
+</li>
+</ul>
+</div>
+
+## Target property
+The target property enforces that an entity can only be used as relationship target. Consider the following example:
+
+```c
+ECS_TAG(world, Likes);
+ECS_TAG(world, Apples);
+
+ecs_add_id(world, Apples, EcsTarget);
+
+ecs_entity_t e = ecs_new_id(world);
+ecs_add(world, Apples);             // Panic, 'Apples' is not used as target
+ecs_add_pair(world, Apples, Likes); // Panic, 'Apples' is not used as target
+ecs_add_pair(world, Likes, Apples); // OK
+```
+
+</li>
+<li><b class="tab-title">C++</b>
+
+```cpp
+struct Likes { };
+struct Apples { };
+
+world.component<Apples>().add(flecs::Target);
+
+flecs::entity e = world.entity()
+  .add<Apples>()         // Panic, 'Apples' is not used as target
+  .add<Apples, Likes>()  // Panic, 'Apples' is not used as target
+  .add<Likes, Apples>(); // OK
+```
+
+</li>
+<li><b class="tab-title">C#</b>
+
+```cs
+public struct Likes { }
+public struct Apples { }
+
+world.Component<Apples>().Entity.Add(Ecs.Target);
+
+Entity e = ecs.Entity()
+    .Add<Apples>()         // Panic, 'Apples' is not used as target
+    .Add<Apples, Likes>()  // Panic, 'Apples' is not used as target
+    .add<Likes, Apples>(); // OK
+```
+
+</li>
+</ul>
+</div>
+
+
 ### Tag property
 A relationship can be marked as a tag in which case it will never contain data. By default the data associated with a pair is determined by whether either the relationship or target are components. For some relationships however, even if the target is a component, no data should be added to the relationship. Consider the following example:
 

--- a/flecs.c
+++ b/flecs.c
@@ -22522,7 +22522,7 @@ const ecs_entity_t EcsDelete =                      FLECS_HI_COMPONENT_ID + 51;
 const ecs_entity_t EcsPanic =                       FLECS_HI_COMPONENT_ID + 52;
 
 /* Misc */
-const ecs_entity_t ecs_id(EcsFlattenTarget) =              FLECS_HI_COMPONENT_ID + 53;
+const ecs_entity_t ecs_id(EcsFlattenTarget) =       FLECS_HI_COMPONENT_ID + 53;
 const ecs_entity_t EcsFlatten =                     FLECS_HI_COMPONENT_ID + 54;
 const ecs_entity_t EcsDefaultChildComponent =       FLECS_HI_COMPONENT_ID + 55;
 
@@ -22530,8 +22530,8 @@ const ecs_entity_t EcsDefaultChildComponent =       FLECS_HI_COMPONENT_ID + 55;
 const ecs_entity_t EcsPredEq =                      FLECS_HI_COMPONENT_ID + 56;
 const ecs_entity_t EcsPredMatch =                   FLECS_HI_COMPONENT_ID + 57;
 const ecs_entity_t EcsPredLookup =                  FLECS_HI_COMPONENT_ID + 58;
-const ecs_entity_t EcsScopeOpen =                    FLECS_HI_COMPONENT_ID + 59;
-const ecs_entity_t EcsScopeClose =                   FLECS_HI_COMPONENT_ID + 60;
+const ecs_entity_t EcsScopeOpen =                   FLECS_HI_COMPONENT_ID + 59;
+const ecs_entity_t EcsScopeClose =                  FLECS_HI_COMPONENT_ID + 60;
 
 /* Systems */
 const ecs_entity_t EcsMonitor =                     FLECS_HI_COMPONENT_ID + 61;
@@ -39098,11 +39098,8 @@ error:
 int64_t ecs_block_allocator_alloc_count = 0;
 int64_t ecs_block_allocator_free_count = 0;
 
-<<<<<<< HEAD
 #ifndef FLECS_USE_OS_ALLOC
 
-=======
->>>>>>> 6f39be5b5 (Add Relationship/Target/Trait traits)
 static
 ecs_block_allocator_chunk_header_t* flecs_balloc_block(
     ecs_block_allocator_t *allocator)
@@ -39141,11 +39138,8 @@ ecs_block_allocator_chunk_header_t* flecs_balloc_block(
     chunk->next = NULL;
     return first_chunk;
 }
-<<<<<<< HEAD
 
 #endif
-=======
->>>>>>> 6f39be5b5 (Add Relationship/Target/Trait traits)
 
 void flecs_ballocator_init(
     ecs_block_allocator_t *ba,
@@ -39289,6 +39283,7 @@ void* flecs_brealloc(
 {
     void *result;
 #ifdef FLECS_USE_OS_ALLOC
+    (void)src;
     result = ecs_os_realloc(memory, dst->data_size);
 #else
     if (dst == src) {

--- a/flecs.c
+++ b/flecs.c
@@ -2200,7 +2200,12 @@ void flecs_bootstrap(
     ecs_add_id(world, name, EcsFinal);\
     ecs_add_pair(world, name, EcsChildOf, ecs_get_scope(world));\
     ecs_set_name(world, name, (const char*)&#name[ecs_os_strlen(world->info.name_prefix)]);\
-    ecs_set_symbol(world, name, #name)
+    ecs_set_symbol(world, name, #name);
+
+#define flecs_bootstrap_trait(world, name)\
+    flecs_bootstrap_tag(world, name)\
+    ecs_add_id(world, name, EcsTrait)
+
 
 /* Bootstrap functions for other parts in the code */
 void flecs_bootstrap_hierarchy(ecs_world_t *world);
@@ -2716,8 +2721,14 @@ void flecs_register_id_flag_for_relation(
         bool changed = false;
 
         if (event == EcsOnAdd) {
-            ecs_id_record_t *idr = flecs_id_record_ensure(world, e);
-            changed |= flecs_set_id_flag(idr, flag);
+            ecs_id_record_t *idr;
+            if (!ecs_has_id(world, e, EcsPairRelationship) &&
+                !ecs_has_id(world, e, EcsPairTarget)) 
+            {
+                idr = flecs_id_record_ensure(world, e);
+                changed |= flecs_set_id_flag(idr, flag);
+            }
+
             idr = flecs_id_record_ensure(world, ecs_pair(e, EcsWildcard));
             do {
                 changed |= flecs_set_id_flag(idr, flag);
@@ -3256,7 +3267,7 @@ void flecs_bootstrap(
     /* Make EcsOnAdd, EcsOnSet events iterable to enable .yield_existing */
     ecs_set(world, EcsOnAdd, EcsIterable, { .init = flecs_on_event_iterable_init });
     ecs_set(world, EcsOnSet, EcsIterable, { .init = flecs_on_event_iterable_init });
-    
+
     /* Register observer for tag property before adding EcsTag */
     ecs_observer(world, {
         .entity = ecs_entity(world, {.add = { ecs_childof(EcsFlecsInternals)}}),
@@ -3312,25 +3323,26 @@ void flecs_bootstrap(
     flecs_bootstrap_entity(world, EcsFlag, "Flag", EcsFlecsCore);
 
     /* Component/relationship properties */
-    flecs_bootstrap_tag(world, EcsTransitive);
-    flecs_bootstrap_tag(world, EcsReflexive);
-    flecs_bootstrap_tag(world, EcsSymmetric);
-    flecs_bootstrap_tag(world, EcsFinal);
-    flecs_bootstrap_tag(world, EcsDontInherit);
-    flecs_bootstrap_tag(world, EcsAlwaysOverride);
-    flecs_bootstrap_tag(world, EcsTag);
-    flecs_bootstrap_tag(world, EcsUnion);
-    flecs_bootstrap_tag(world, EcsExclusive);
-    flecs_bootstrap_tag(world, EcsAcyclic);
-    flecs_bootstrap_tag(world, EcsTraversable);
-    flecs_bootstrap_tag(world, EcsWith);
-    flecs_bootstrap_tag(world, EcsOneOf);
-    flecs_bootstrap_tag(world, EcsTrait);
-    flecs_bootstrap_tag(world, EcsPairRelationship);
-    flecs_bootstrap_tag(world, EcsPairTarget);
+    flecs_bootstrap_trait(world, EcsTransitive);
+    flecs_bootstrap_trait(world, EcsReflexive);
+    flecs_bootstrap_trait(world, EcsSymmetric);
+    flecs_bootstrap_trait(world, EcsFinal);
+    flecs_bootstrap_trait(world, EcsDontInherit);
+    flecs_bootstrap_trait(world, EcsAlwaysOverride);
+    flecs_bootstrap_trait(world, EcsTag);
+    flecs_bootstrap_trait(world, EcsUnion);
+    flecs_bootstrap_trait(world, EcsExclusive);
+    flecs_bootstrap_trait(world, EcsAcyclic);
+    flecs_bootstrap_trait(world, EcsTraversable);
+    flecs_bootstrap_trait(world, EcsWith);
+    flecs_bootstrap_trait(world, EcsOneOf);
+    flecs_bootstrap_trait(world, EcsTrait);
+    flecs_bootstrap_trait(world, EcsPairRelationship);
+    flecs_bootstrap_trait(world, EcsPairTarget);
+    flecs_bootstrap_trait(world, EcsOnDelete);
+    flecs_bootstrap_trait(world, EcsOnDeleteTarget);
+    ecs_add_id(world, ecs_id(EcsTarget), EcsTrait);
 
-    flecs_bootstrap_tag(world, EcsOnDelete);
-    flecs_bootstrap_tag(world, EcsOnDeleteTarget);
     flecs_bootstrap_tag(world, EcsRemove);
     flecs_bootstrap_tag(world, EcsDelete);
     flecs_bootstrap_tag(world, EcsPanic);
@@ -3377,6 +3389,15 @@ void flecs_bootstrap(
     ecs_add_id(world, EcsOnDelete, EcsExclusive);
     ecs_add_id(world, EcsOnDeleteTarget, EcsExclusive);
     ecs_add_id(world, EcsDefaultChildComponent, EcsExclusive);
+
+    /* Relationships */
+    ecs_add_id(world, EcsChildOf, EcsPairRelationship);
+    ecs_add_id(world, EcsIsA, EcsPairRelationship);
+    ecs_add_id(world, EcsSlotOf, EcsPairRelationship);
+    ecs_add_id(world, EcsDependsOn, EcsPairRelationship);
+    ecs_add_id(world, EcsWith, EcsPairRelationship);
+    ecs_add_id(world, EcsOnDelete, EcsPairRelationship);
+    ecs_add_id(world, EcsOnDeleteTarget, EcsPairRelationship);
 
     /* Sync properties of ChildOf and Identifier with bootstrapped flags */
     ecs_add_pair(world, EcsChildOf, EcsOnDeleteTarget, EcsDelete);

--- a/flecs.h
+++ b/flecs.h
@@ -16172,7 +16172,7 @@ using Component = EcsComponent;
 using Identifier = EcsIdentifier;
 using Iterable = EcsIterable;
 using Poly = EcsPoly;
-using Target = EcsFlattenTarget;
+using FlattenTarget = EcsFlattenTarget;
 
 /* Builtin tags */
 static const flecs::entity_t Query = EcsQuery;
@@ -32172,7 +32172,7 @@ inline void world::init_builtin_components() {
     this->component<Identifier>();
     this->component<Iterable>("flecs::core::Iterable");
     this->component<Poly>();
-    this->component<Target>();
+    this->component<FlattenTarget>();
 
 #   ifdef FLECS_SYSTEM
     _::system_init(*this);

--- a/flecs.h
+++ b/flecs.h
@@ -4100,10 +4100,10 @@ typedef struct EcsPoly {
 } EcsPoly;
 
 /** Target data for flattened relationships. */
-typedef struct EcsTarget {
+typedef struct EcsFlattenTarget {
     int32_t count;
     ecs_record_t *target;
-} EcsTarget;
+} EcsFlattenTarget;
 
 /** Component for iterable entities */
 typedef ecs_iterable_t EcsIterable;
@@ -4298,7 +4298,7 @@ FLECS_API extern const ecs_entity_t EcsTrait;
  *   e.add(R) panics
  *   e.add(X, R) panics, unless X has the "Trait" trait
  */
-FLECS_API extern const ecs_entity_t EcsPairRelationship;
+FLECS_API extern const ecs_entity_t EcsRelationship;
 
 /** Ensure that an entity is always used in pair as target.
  *
@@ -4306,7 +4306,7 @@ FLECS_API extern const ecs_entity_t EcsPairRelationship;
  *   e.add(T) panics
  *   e.add(T, X) panics
  */
-FLECS_API extern const ecs_entity_t EcsPairTarget;
+FLECS_API extern const ecs_entity_t EcsTarget;
 
 /** Tag to indicate that relationship is stored as union. Union relationships
  * enable changing the target of a union without switching tables. Union
@@ -4395,7 +4395,7 @@ FLECS_API extern const ecs_entity_t EcsDelete;
 FLECS_API extern const ecs_entity_t EcsPanic;
 
 /** Component that stores data for flattened relationships */
-FLECS_API extern const ecs_entity_t ecs_id(EcsTarget);
+FLECS_API extern const ecs_entity_t ecs_id(EcsFlattenTarget);
 
 /** Tag added to root entity to indicate its subtree should be flattened. Used
  * together with assemblies. */
@@ -16172,7 +16172,7 @@ using Component = EcsComponent;
 using Identifier = EcsIdentifier;
 using Iterable = EcsIterable;
 using Poly = EcsPoly;
-using Target = EcsTarget;
+using Target = EcsFlattenTarget;
 
 /* Builtin tags */
 static const flecs::entity_t Query = EcsQuery;
@@ -16230,8 +16230,8 @@ static const flecs::entity_t Symmetric = EcsSymmetric;
 static const flecs::entity_t With = EcsWith;
 static const flecs::entity_t OneOf = EcsOneOf;
 static const flecs::entity_t Trait = EcsTrait;
-static const flecs::entity_t PairRelationship = EcsPairRelationship;
-static const flecs::entity_t PairTarget = EcsPairTarget;
+static const flecs::entity_t Relationship = EcsRelationship;
+static const flecs::entity_t Target = EcsTarget;
 
 /* Builtin relationships */
 static const flecs::entity_t IsA = EcsIsA;

--- a/flecs.h
+++ b/flecs.h
@@ -363,9 +363,6 @@ extern "C" {
 #define EcsIdWith                      (1u << 10)
 #define EcsIdUnion                     (1u << 11)
 #define EcsIdAlwaysOverride            (1u << 12)
-#define EcsIdTrait                     (1u << 13)
-#define EcsIdPairRelationship          (1u << 14)
-#define EcsIdPairTarget                (1u << 15)
 
 #define EcsIdHasOnAdd                  (1u << 16) /* Same values as table flags */
 #define EcsIdHasOnRemove               (1u << 17) 
@@ -16232,6 +16229,9 @@ static const flecs::entity_t Traversable = EcsTraversable;
 static const flecs::entity_t Symmetric = EcsSymmetric;
 static const flecs::entity_t With = EcsWith;
 static const flecs::entity_t OneOf = EcsOneOf;
+static const flecs::entity_t Trait = EcsTrait;
+static const flecs::entity_t PairRelationship = EcsPairRelationship;
+static const flecs::entity_t PairTarget = EcsPairTarget;
 
 /* Builtin relationships */
 static const flecs::entity_t IsA = EcsIsA;

--- a/flecs.h
+++ b/flecs.h
@@ -363,6 +363,9 @@ extern "C" {
 #define EcsIdWith                      (1u << 10)
 #define EcsIdUnion                     (1u << 11)
 #define EcsIdAlwaysOverride            (1u << 12)
+#define EcsIdTrait                     (1u << 13)
+#define EcsIdPairRelationship          (1u << 14)
+#define EcsIdPairTarget                (1u << 15)
 
 #define EcsIdHasOnAdd                  (1u << 16) /* Same values as table flags */
 #define EcsIdHasOnRemove               (1u << 17) 
@@ -4286,6 +4289,27 @@ FLECS_API extern const ecs_entity_t EcsOneOf;
 /** Can be added to relationship to indicate that it should never hold data,
  * even when it or the relationship target is a component. */
 FLECS_API extern const ecs_entity_t EcsTag;
+
+/** Can be added to components to indicate it is a trait. Traits are components
+ * and/or tags that are added to other components to modify their behavior.
+ */
+FLECS_API extern const ecs_entity_t EcsTrait;
+
+/** Ensure that an entity is always used in pair as relationship.
+ *
+ * Behavior:
+ *   e.add(R) panics
+ *   e.add(X, R) panics, unless X has the "Trait" trait
+ */
+FLECS_API extern const ecs_entity_t EcsPairRelationship;
+
+/** Ensure that an entity is always used in pair as target.
+ *
+ * Behavior:
+ *   e.add(T) panics
+ *   e.add(T, X) panics
+ */
+FLECS_API extern const ecs_entity_t EcsPairTarget;
 
 /** Tag to indicate that relationship is stored as union. Union relationships
  * enable changing the target of a union without switching tables. Union

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -1324,10 +1324,10 @@ typedef struct EcsPoly {
 } EcsPoly;
 
 /** Target data for flattened relationships. */
-typedef struct EcsTarget {
+typedef struct EcsFlattenTarget {
     int32_t count;
     ecs_record_t *target;
-} EcsTarget;
+} EcsFlattenTarget;
 
 /** Component for iterable entities */
 typedef ecs_iterable_t EcsIterable;
@@ -1501,7 +1501,7 @@ FLECS_API extern const ecs_entity_t EcsTrait;
  *   e.add(R) panics
  *   e.add(X, R) panics, unless X has the "Trait" trait
  */
-FLECS_API extern const ecs_entity_t EcsPairRelationship;
+FLECS_API extern const ecs_entity_t EcsRelationship;
 
 /** Ensure that an entity is always used in pair as target.
  *
@@ -1509,7 +1509,7 @@ FLECS_API extern const ecs_entity_t EcsPairRelationship;
  *   e.add(T) panics
  *   e.add(T, X) panics
  */
-FLECS_API extern const ecs_entity_t EcsPairTarget;
+FLECS_API extern const ecs_entity_t EcsTarget;
 
 /** Tag to indicate that relationship is stored as union. Union relationships
  * enable changing the target of a union without switching tables. Union
@@ -1598,7 +1598,7 @@ FLECS_API extern const ecs_entity_t EcsDelete;
 FLECS_API extern const ecs_entity_t EcsPanic;
 
 /** Component that stores data for flattened relationships */
-FLECS_API extern const ecs_entity_t ecs_id(EcsTarget);
+FLECS_API extern const ecs_entity_t ecs_id(EcsFlattenTarget);
 
 /** Tag added to root entity to indicate its subtree should be flattened. Used
  * together with assemblies. */

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -1490,6 +1490,27 @@ FLECS_API extern const ecs_entity_t EcsOneOf;
  * even when it or the relationship target is a component. */
 FLECS_API extern const ecs_entity_t EcsTag;
 
+/** Can be added to components to indicate it is a trait. Traits are components
+ * and/or tags that are added to other components to modify their behavior.
+ */
+FLECS_API extern const ecs_entity_t EcsTrait;
+
+/** Ensure that an entity is always used in pair as relationship.
+ *
+ * Behavior:
+ *   e.add(R) panics
+ *   e.add(X, R) panics, unless X has the "Trait" trait
+ */
+FLECS_API extern const ecs_entity_t EcsPairRelationship;
+
+/** Ensure that an entity is always used in pair as target.
+ *
+ * Behavior:
+ *   e.add(T) panics
+ *   e.add(T, X) panics
+ */
+FLECS_API extern const ecs_entity_t EcsPairTarget;
+
 /** Tag to indicate that relationship is stored as union. Union relationships
  * enable changing the target of a union without switching tables. Union
  * relationships are also marked as exclusive. */

--- a/include/flecs/addons/cpp/c_types.hpp
+++ b/include/flecs/addons/cpp/c_types.hpp
@@ -64,7 +64,7 @@ using Component = EcsComponent;
 using Identifier = EcsIdentifier;
 using Iterable = EcsIterable;
 using Poly = EcsPoly;
-using Target = EcsTarget;
+using Target = EcsFlattenTarget;
 
 /* Builtin tags */
 static const flecs::entity_t Query = EcsQuery;
@@ -122,8 +122,8 @@ static const flecs::entity_t Symmetric = EcsSymmetric;
 static const flecs::entity_t With = EcsWith;
 static const flecs::entity_t OneOf = EcsOneOf;
 static const flecs::entity_t Trait = EcsTrait;
-static const flecs::entity_t PairRelationship = EcsPairRelationship;
-static const flecs::entity_t PairTarget = EcsPairTarget;
+static const flecs::entity_t Relationship = EcsRelationship;
+static const flecs::entity_t Target = EcsTarget;
 
 /* Builtin relationships */
 static const flecs::entity_t IsA = EcsIsA;

--- a/include/flecs/addons/cpp/c_types.hpp
+++ b/include/flecs/addons/cpp/c_types.hpp
@@ -64,7 +64,7 @@ using Component = EcsComponent;
 using Identifier = EcsIdentifier;
 using Iterable = EcsIterable;
 using Poly = EcsPoly;
-using Target = EcsFlattenTarget;
+using FlattenTarget = EcsFlattenTarget;
 
 /* Builtin tags */
 static const flecs::entity_t Query = EcsQuery;

--- a/include/flecs/addons/cpp/c_types.hpp
+++ b/include/flecs/addons/cpp/c_types.hpp
@@ -121,6 +121,9 @@ static const flecs::entity_t Traversable = EcsTraversable;
 static const flecs::entity_t Symmetric = EcsSymmetric;
 static const flecs::entity_t With = EcsWith;
 static const flecs::entity_t OneOf = EcsOneOf;
+static const flecs::entity_t Trait = EcsTrait;
+static const flecs::entity_t PairRelationship = EcsPairRelationship;
+static const flecs::entity_t PairTarget = EcsPairTarget;
 
 /* Builtin relationships */
 static const flecs::entity_t IsA = EcsIsA;

--- a/include/flecs/addons/cpp/impl/world.hpp
+++ b/include/flecs/addons/cpp/impl/world.hpp
@@ -13,7 +13,7 @@ inline void world::init_builtin_components() {
     this->component<Identifier>();
     this->component<Iterable>("flecs::core::Iterable");
     this->component<Poly>();
-    this->component<Target>();
+    this->component<FlattenTarget>();
 
 #   ifdef FLECS_SYSTEM
     _::system_init(*this);

--- a/include/flecs/private/api_flags.h
+++ b/include/flecs/private/api_flags.h
@@ -68,9 +68,6 @@ extern "C" {
 #define EcsIdWith                      (1u << 10)
 #define EcsIdUnion                     (1u << 11)
 #define EcsIdAlwaysOverride            (1u << 12)
-#define EcsIdTrait                     (1u << 13)
-#define EcsIdPairRelationship          (1u << 14)
-#define EcsIdPairTarget                (1u << 15)
 
 #define EcsIdHasOnAdd                  (1u << 16) /* Same values as table flags */
 #define EcsIdHasOnRemove               (1u << 17) 

--- a/include/flecs/private/api_flags.h
+++ b/include/flecs/private/api_flags.h
@@ -68,6 +68,9 @@ extern "C" {
 #define EcsIdWith                      (1u << 10)
 #define EcsIdUnion                     (1u << 11)
 #define EcsIdAlwaysOverride            (1u << 12)
+#define EcsIdTrait                     (1u << 13)
+#define EcsIdPairRelationship          (1u << 14)
+#define EcsIdPairTarget                (1u << 15)
 
 #define EcsIdHasOnAdd                  (1u << 16) /* Same values as table flags */
 #define EcsIdHasOnRemove               (1u << 17) 

--- a/src/addons/doc.c
+++ b/src/addons/doc.c
@@ -165,7 +165,7 @@ void flecs_doc_import_core_definitions(
     ecs_doc_set_brief(world, ecs_id(EcsIterable), "Internal component to make (query) entities iterable");
     ecs_doc_set_brief(world, ecs_id(EcsPoly), "Internal component that stores pointer to poly objects");
     
-    ecs_doc_set_brief(world, ecs_id(EcsTarget), "Internal component that stores information for flattened trees");
+    ecs_doc_set_brief(world, ecs_id(EcsFlattenTarget), "Internal component that stores information for flattened trees");
     ecs_doc_set_brief(world, EcsFlatten, "Tag that when added to assembly automatically flattens tree");
 
     ecs_doc_set_brief(world, ecs_id(EcsIdentifier), "Component used for entity names");

--- a/src/bootstrap.c
+++ b/src/bootstrap.c
@@ -232,8 +232,14 @@ void flecs_register_id_flag_for_relation(
         bool changed = false;
 
         if (event == EcsOnAdd) {
-            ecs_id_record_t *idr = flecs_id_record_ensure(world, e);
-            changed |= flecs_set_id_flag(idr, flag);
+            ecs_id_record_t *idr;
+            if (!ecs_has_id(world, e, EcsPairRelationship) &&
+                !ecs_has_id(world, e, EcsPairTarget)) 
+            {
+                idr = flecs_id_record_ensure(world, e);
+                changed |= flecs_set_id_flag(idr, flag);
+            }
+
             idr = flecs_id_record_ensure(world, ecs_pair(e, EcsWildcard));
             do {
                 changed |= flecs_set_id_flag(idr, flag);
@@ -772,7 +778,7 @@ void flecs_bootstrap(
     /* Make EcsOnAdd, EcsOnSet events iterable to enable .yield_existing */
     ecs_set(world, EcsOnAdd, EcsIterable, { .init = flecs_on_event_iterable_init });
     ecs_set(world, EcsOnSet, EcsIterable, { .init = flecs_on_event_iterable_init });
-    
+
     /* Register observer for tag property before adding EcsTag */
     ecs_observer(world, {
         .entity = ecs_entity(world, {.add = { ecs_childof(EcsFlecsInternals)}}),
@@ -828,25 +834,26 @@ void flecs_bootstrap(
     flecs_bootstrap_entity(world, EcsFlag, "Flag", EcsFlecsCore);
 
     /* Component/relationship properties */
-    flecs_bootstrap_tag(world, EcsTransitive);
-    flecs_bootstrap_tag(world, EcsReflexive);
-    flecs_bootstrap_tag(world, EcsSymmetric);
-    flecs_bootstrap_tag(world, EcsFinal);
-    flecs_bootstrap_tag(world, EcsDontInherit);
-    flecs_bootstrap_tag(world, EcsAlwaysOverride);
-    flecs_bootstrap_tag(world, EcsTag);
-    flecs_bootstrap_tag(world, EcsUnion);
-    flecs_bootstrap_tag(world, EcsExclusive);
-    flecs_bootstrap_tag(world, EcsAcyclic);
-    flecs_bootstrap_tag(world, EcsTraversable);
-    flecs_bootstrap_tag(world, EcsWith);
-    flecs_bootstrap_tag(world, EcsOneOf);
-    flecs_bootstrap_tag(world, EcsTrait);
-    flecs_bootstrap_tag(world, EcsPairRelationship);
-    flecs_bootstrap_tag(world, EcsPairTarget);
+    flecs_bootstrap_trait(world, EcsTransitive);
+    flecs_bootstrap_trait(world, EcsReflexive);
+    flecs_bootstrap_trait(world, EcsSymmetric);
+    flecs_bootstrap_trait(world, EcsFinal);
+    flecs_bootstrap_trait(world, EcsDontInherit);
+    flecs_bootstrap_trait(world, EcsAlwaysOverride);
+    flecs_bootstrap_trait(world, EcsTag);
+    flecs_bootstrap_trait(world, EcsUnion);
+    flecs_bootstrap_trait(world, EcsExclusive);
+    flecs_bootstrap_trait(world, EcsAcyclic);
+    flecs_bootstrap_trait(world, EcsTraversable);
+    flecs_bootstrap_trait(world, EcsWith);
+    flecs_bootstrap_trait(world, EcsOneOf);
+    flecs_bootstrap_trait(world, EcsTrait);
+    flecs_bootstrap_trait(world, EcsPairRelationship);
+    flecs_bootstrap_trait(world, EcsPairTarget);
+    flecs_bootstrap_trait(world, EcsOnDelete);
+    flecs_bootstrap_trait(world, EcsOnDeleteTarget);
+    ecs_add_id(world, ecs_id(EcsTarget), EcsTrait);
 
-    flecs_bootstrap_tag(world, EcsOnDelete);
-    flecs_bootstrap_tag(world, EcsOnDeleteTarget);
     flecs_bootstrap_tag(world, EcsRemove);
     flecs_bootstrap_tag(world, EcsDelete);
     flecs_bootstrap_tag(world, EcsPanic);
@@ -893,6 +900,15 @@ void flecs_bootstrap(
     ecs_add_id(world, EcsOnDelete, EcsExclusive);
     ecs_add_id(world, EcsOnDeleteTarget, EcsExclusive);
     ecs_add_id(world, EcsDefaultChildComponent, EcsExclusive);
+
+    /* Relationships */
+    ecs_add_id(world, EcsChildOf, EcsPairRelationship);
+    ecs_add_id(world, EcsIsA, EcsPairRelationship);
+    ecs_add_id(world, EcsSlotOf, EcsPairRelationship);
+    ecs_add_id(world, EcsDependsOn, EcsPairRelationship);
+    ecs_add_id(world, EcsWith, EcsPairRelationship);
+    ecs_add_id(world, EcsOnDelete, EcsPairRelationship);
+    ecs_add_id(world, EcsOnDeleteTarget, EcsPairRelationship);
 
     /* Sync properties of ChildOf and Identifier with bootstrapped flags */
     ecs_add_pair(world, EcsChildOf, EcsOnDeleteTarget, EcsDelete);

--- a/src/bootstrap.c
+++ b/src/bootstrap.c
@@ -841,6 +841,9 @@ void flecs_bootstrap(
     flecs_bootstrap_tag(world, EcsTraversable);
     flecs_bootstrap_tag(world, EcsWith);
     flecs_bootstrap_tag(world, EcsOneOf);
+    flecs_bootstrap_tag(world, EcsTrait);
+    flecs_bootstrap_tag(world, EcsPairRelationship);
+    flecs_bootstrap_tag(world, EcsPairTarget);
 
     flecs_bootstrap_tag(world, EcsOnDelete);
     flecs_bootstrap_tag(world, EcsOnDeleteTarget);

--- a/src/bootstrap.c
+++ b/src/bootstrap.c
@@ -233,8 +233,8 @@ void flecs_register_id_flag_for_relation(
 
         if (event == EcsOnAdd) {
             ecs_id_record_t *idr;
-            if (!ecs_has_id(world, e, EcsPairRelationship) &&
-                !ecs_has_id(world, e, EcsPairTarget)) 
+            if (!ecs_has_id(world, e, EcsRelationship) &&
+                !ecs_has_id(world, e, EcsTarget)) 
             {
                 idr = flecs_id_record_ensure(world, e);
                 changed |= flecs_set_id_flag(idr, flag);
@@ -747,7 +747,7 @@ void flecs_bootstrap(
     });
 
     flecs_type_info_init(world, EcsIterable, { 0 });
-    flecs_type_info_init(world, EcsTarget, { 0 });
+    flecs_type_info_init(world, EcsFlattenTarget, { 0 });
 
     /* Create and cache often used id records on world */
     flecs_init_id_records(world);
@@ -763,7 +763,7 @@ void flecs_bootstrap(
     flecs_bootstrap_builtin_t(world, table, EcsComponent);
     flecs_bootstrap_builtin_t(world, table, EcsIterable);
     flecs_bootstrap_builtin_t(world, table, EcsPoly);
-    flecs_bootstrap_builtin_t(world, table, EcsTarget);
+    flecs_bootstrap_builtin_t(world, table, EcsFlattenTarget);
 
     /* Patch up symbol of EcsIterable. The type is a typedef, which causes a
      * symbol mismatch when registering the type with the C++ API. */
@@ -848,11 +848,11 @@ void flecs_bootstrap(
     flecs_bootstrap_trait(world, EcsWith);
     flecs_bootstrap_trait(world, EcsOneOf);
     flecs_bootstrap_trait(world, EcsTrait);
-    flecs_bootstrap_trait(world, EcsPairRelationship);
-    flecs_bootstrap_trait(world, EcsPairTarget);
+    flecs_bootstrap_trait(world, EcsRelationship);
+    flecs_bootstrap_trait(world, EcsTarget);
     flecs_bootstrap_trait(world, EcsOnDelete);
     flecs_bootstrap_trait(world, EcsOnDeleteTarget);
-    ecs_add_id(world, ecs_id(EcsTarget), EcsTrait);
+    ecs_add_id(world, ecs_id(EcsFlattenTarget), EcsTrait);
 
     flecs_bootstrap_tag(world, EcsRemove);
     flecs_bootstrap_tag(world, EcsDelete);
@@ -902,13 +902,14 @@ void flecs_bootstrap(
     ecs_add_id(world, EcsDefaultChildComponent, EcsExclusive);
 
     /* Relationships */
-    ecs_add_id(world, EcsChildOf, EcsPairRelationship);
-    ecs_add_id(world, EcsIsA, EcsPairRelationship);
-    ecs_add_id(world, EcsSlotOf, EcsPairRelationship);
-    ecs_add_id(world, EcsDependsOn, EcsPairRelationship);
-    ecs_add_id(world, EcsWith, EcsPairRelationship);
-    ecs_add_id(world, EcsOnDelete, EcsPairRelationship);
-    ecs_add_id(world, EcsOnDeleteTarget, EcsPairRelationship);
+    ecs_add_id(world, EcsChildOf, EcsRelationship);
+    ecs_add_id(world, EcsIsA, EcsRelationship);
+    ecs_add_id(world, EcsSlotOf, EcsRelationship);
+    ecs_add_id(world, EcsDependsOn, EcsRelationship);
+    ecs_add_id(world, EcsWith, EcsRelationship);
+    ecs_add_id(world, EcsOnDelete, EcsRelationship);
+    ecs_add_id(world, EcsOnDeleteTarget, EcsRelationship);
+    ecs_add_id(world, ecs_id(EcsIdentifier), EcsRelationship);
 
     /* Sync properties of ChildOf and Identifier with bootstrapped flags */
     ecs_add_pair(world, EcsChildOf, EcsOnDeleteTarget, EcsDelete);

--- a/src/entity.c
+++ b/src/entity.c
@@ -3513,8 +3513,8 @@ ecs_entity_t ecs_get_target(
             return 0;
         }
     } else if (table->flags & EcsTableHasTarget) {
-        EcsTarget *tf = ecs_table_get_id(world, table, 
-            ecs_pair_t(EcsTarget, rel), ECS_RECORD_TO_ROW(r->row));
+        EcsFlattenTarget *tf = ecs_table_get_id(world, table, 
+            ecs_pair_t(EcsFlattenTarget, rel), ECS_RECORD_TO_ROW(r->row));
         if (tf) {
             return ecs_record_get_entity(tf->target);
         }
@@ -3687,7 +3687,7 @@ void flecs_flatten(
 
     ecs_entity_t depth_id = flecs_id_for_depth(world, depth);
     ecs_id_t root_pair = ecs_pair(EcsChildOf, root);
-    ecs_id_t tgt_pair = ecs_pair_t(EcsTarget, EcsChildOf);
+    ecs_id_t tgt_pair = ecs_pair_t(EcsFlattenTarget, EcsChildOf);
     ecs_id_t depth_pair = ecs_pair(EcsFlatten, depth_id);
     ecs_id_t name_pair = ecs_pair_t(EcsIdentifier, EcsName);
 
@@ -3751,7 +3751,7 @@ void flecs_flatten(
                 &td.added, 0);
             flecs_table_diff_builder_fini(world, &diff);
 
-            EcsTarget *fh = ecs_table_get_id(world, dst, tgt_pair, 0);
+            EcsFlattenTarget *fh = ecs_table_get_id(world, dst, tgt_pair, 0);
             ecs_assert(fh != NULL, ECS_INTERNAL_ERROR, NULL);
             ecs_assert(count != 0, ECS_INTERNAL_ERROR, NULL);
             int32_t remain = count;

--- a/src/entity_filter.c
+++ b/src/entity_filter.c
@@ -325,7 +325,7 @@ done:
 static
 int32_t flecs_get_flattened_target(
     ecs_world_t *world,
-    EcsTarget *cur,
+    EcsFlattenTarget *cur,
     ecs_entity_t rel,
     ecs_id_t id,
     ecs_entity_t *src_out,
@@ -354,8 +354,8 @@ int32_t flecs_get_flattened_target(
     if (table->flags & EcsTableHasTarget) {
         int32_t col = table->column_map[table->_->ft_offset];
         ecs_assert(col != -1, ECS_INTERNAL_ERROR, NULL);
-        EcsTarget *next = table->data.columns[col].data.array;
-        next = ECS_ELEM_T(next, EcsTarget, ECS_RECORD_TO_ROW(r->row));
+        EcsFlattenTarget *next = table->data.columns[col].data.array;
+        next = ECS_ELEM_T(next, EcsFlattenTarget, ECS_RECORD_TO_ROW(r->row));
         return flecs_get_flattened_target(
             world, next, rel, id, src_out, tr_out);
     }
@@ -455,7 +455,7 @@ void flecs_entity_filter_init(
     /* Look for flattened fields */
     if (table->flags & EcsTableHasTarget) {
         const ecs_table_record_t *tr = flecs_table_record_get(world, table, 
-            ecs_pair_t(EcsTarget, EcsWildcard));
+            ecs_pair_t(EcsFlattenTarget, EcsWildcard));
         ecs_assert(tr != NULL, ECS_INTERNAL_ERROR, NULL);
         int32_t column = tr->index;
         ecs_assert(column != -1, ECS_INTERNAL_ERROR, NULL);
@@ -562,7 +562,7 @@ int flecs_entity_filter_next(
             bool first_for_table = it->prev != table;
             ecs_iter_t *iter = it->it;
             ecs_world_t *world = iter->real_world;
-            EcsTarget *ft = table->data.columns[flat_tree_column].data.array;
+            EcsFlattenTarget *ft = table->data.columns[flat_tree_column].data.array;
             int32_t ft_offset;
             int32_t ft_count;
 
@@ -578,7 +578,7 @@ int flecs_entity_filter_next(
             ecs_assert(ft_offset < ecs_table_count(table), 
                 ECS_INTERNAL_ERROR, NULL);
 
-            EcsTarget *cur = &ft[ft_offset];
+            EcsFlattenTarget *cur = &ft[ft_offset];
             ft_count = cur->count;
             bool is_last = (ft_offset + ft_count) >= range_end;
 

--- a/src/private_api.h
+++ b/src/private_api.h
@@ -37,7 +37,12 @@ void flecs_bootstrap(
     ecs_add_id(world, name, EcsFinal);\
     ecs_add_pair(world, name, EcsChildOf, ecs_get_scope(world));\
     ecs_set_name(world, name, (const char*)&#name[ecs_os_strlen(world->info.name_prefix)]);\
-    ecs_set_symbol(world, name, #name)
+    ecs_set_symbol(world, name, #name);
+
+#define flecs_bootstrap_trait(world, name)\
+    flecs_bootstrap_tag(world, name)\
+    ecs_add_id(world, name, EcsTrait)
+
 
 /* Bootstrap functions for other parts in the code */
 void flecs_bootstrap_hierarchy(ecs_world_t *world);

--- a/src/search.c
+++ b/src/search.c
@@ -369,7 +369,7 @@ int32_t flecs_relation_depth(
     int32_t depth_offset = 0;
     if (table->flags & EcsTableHasTarget) {
         if (ecs_table_get_type_index(world, table, 
-            ecs_pair_t(EcsTarget, r)) != -1)
+            ecs_pair_t(EcsFlattenTarget, r)) != -1)
         {
             ecs_id_t id;
             int32_t col = ecs_search(world, table, 

--- a/src/storage/id_index.c
+++ b/src/storage/id_index.c
@@ -168,7 +168,38 @@ ecs_id_record_t* flecs_id_record_new(
         if (tgt) {
             tgt = flecs_entities_get_alive(world, tgt);
             ecs_assert(tgt != 0, ECS_INTERNAL_ERROR, NULL);
+
+            /* Can't use relationship as target */
+            if (ecs_has_id(world, tgt, EcsPairRelationship)) {
+                if (!ecs_id_is_wildcard(rel) && 
+                    !ecs_has_id(world, rel, EcsTrait)) 
+                {
+                    char *idstr = ecs_id_str(world, id);
+                    char *tgtstr = ecs_id_str(world, tgt);
+                    ecs_err("constraint violated: relationship '%s' cannot be used"
+                        " as target in pair '%s'", tgtstr, idstr);
+                    ecs_os_free(tgtstr);
+                    ecs_os_free(idstr);
+                    #ifndef FLECS_SOFT_ASSERT
+                    ecs_abort(ECS_CONSTRAINT_VIOLATED, NULL);
+                    #endif
+                }
+            }
         }
+
+        if (ecs_has_id(world, rel, EcsPairTarget)) {
+            char *idstr = ecs_id_str(world, id);
+            char *relstr = ecs_id_str(world, rel);
+            ecs_err("constraint violated: "
+                "%s: target '%s' cannot be used as relationship",
+                    idstr, relstr);
+            ecs_os_free(relstr);
+            ecs_os_free(idstr);
+            #ifndef FLECS_SOFT_ASSERT
+            ecs_abort(ECS_CONSTRAINT_VIOLATED, NULL);
+            #endif
+        }
+
         if (tgt && !ecs_id_is_wildcard(tgt)) {
             /* Check if target of relationship satisfies OneOf property */
             ecs_entity_t oneof = flecs_get_oneof(world, rel);
@@ -229,6 +260,38 @@ ecs_id_record_t* flecs_id_record_new(
     } else {
         rel = id & ECS_COMPONENT_MASK;
         ecs_assert(rel != 0, ECS_INTERNAL_ERROR, NULL);
+
+        /* Can't use relationship outside of a pair */
+#ifdef FLECS_DEBUG
+        rel = flecs_entities_get_alive(world, rel);
+        if (ecs_has_id(world, rel, EcsPairRelationship) ||
+            ecs_has_id(world, rel, EcsPairTarget)) 
+        {
+            char *idstr = ecs_id_str(world, id);
+            char *relstr = ecs_id_str(world, rel);
+            ecs_err("constraint violated: "
+                "%s: relationship '%s' cannot be used as component",
+                    idstr, relstr);
+            ecs_os_free(relstr);
+            ecs_os_free(idstr);
+            #ifndef FLECS_SOFT_ASSERT
+            ecs_abort(ECS_CONSTRAINT_VIOLATED, NULL);
+            #endif
+        }
+
+        if (ecs_has_id(world, rel, EcsPairTarget)) {
+            char *idstr = ecs_id_str(world, id);
+            char *relstr = ecs_id_str(world, rel);
+            ecs_err("constraint violated: "
+                "%s: target '%s' cannot be used as component",
+                    idstr, relstr);
+            ecs_os_free(relstr);
+            ecs_os_free(idstr);
+            #ifndef FLECS_SOFT_ASSERT
+            ecs_abort(ECS_CONSTRAINT_VIOLATED, NULL);
+            #endif
+        }
+#endif
     }
 
     /* Initialize type info if id is not a tag */

--- a/src/storage/id_index.c
+++ b/src/storage/id_index.c
@@ -170,7 +170,7 @@ ecs_id_record_t* flecs_id_record_new(
             ecs_assert(tgt != 0, ECS_INTERNAL_ERROR, NULL);
 
             /* Can't use relationship as target */
-            if (ecs_has_id(world, tgt, EcsPairRelationship)) {
+            if (ecs_has_id(world, tgt, EcsRelationship)) {
                 if (!ecs_id_is_wildcard(rel) && 
                     !ecs_has_id(world, rel, EcsTrait)) 
                 {
@@ -187,7 +187,7 @@ ecs_id_record_t* flecs_id_record_new(
             }
         }
 
-        if (ecs_has_id(world, rel, EcsPairTarget)) {
+        if (ecs_has_id(world, rel, EcsTarget)) {
             char *idstr = ecs_id_str(world, id);
             char *relstr = ecs_id_str(world, rel);
             ecs_err("constraint violated: "
@@ -264,8 +264,8 @@ ecs_id_record_t* flecs_id_record_new(
         /* Can't use relationship outside of a pair */
 #ifdef FLECS_DEBUG
         rel = flecs_entities_get_alive(world, rel);
-        if (ecs_has_id(world, rel, EcsPairRelationship) ||
-            ecs_has_id(world, rel, EcsPairTarget)) 
+        if (ecs_has_id(world, rel, EcsRelationship) ||
+            ecs_has_id(world, rel, EcsTarget)) 
         {
             char *idstr = ecs_id_str(world, id);
             char *relstr = ecs_id_str(world, rel);
@@ -279,7 +279,7 @@ ecs_id_record_t* flecs_id_record_new(
             #endif
         }
 
-        if (ecs_has_id(world, rel, EcsPairTarget)) {
+        if (ecs_has_id(world, rel, EcsTarget)) {
             char *idstr = ecs_id_str(world, id);
             char *relstr = ecs_id_str(world, rel);
             ecs_err("constraint violated: "

--- a/src/storage/table.c
+++ b/src/storage/table.c
@@ -266,7 +266,7 @@ void flecs_table_init_flags(
                         meta->sw_offset = flecs_ito(int16_t, i);
                     }
                     meta->sw_count ++;
-                } else if (r == ecs_id(EcsTarget)) {
+                } else if (r == ecs_id(EcsFlattenTarget)) {
                     ecs_table__t *meta = table->_;
                     table->flags |= EcsTableHasTarget;
                     meta->ft_offset = flecs_ito(int16_t, i);

--- a/src/world.c
+++ b/src/world.c
@@ -53,27 +53,30 @@ const ecs_entity_t EcsAcyclic =                     FLECS_HI_COMPONENT_ID + 23;
 const ecs_entity_t EcsTraversable =                 FLECS_HI_COMPONENT_ID + 24;
 const ecs_entity_t EcsWith =                        FLECS_HI_COMPONENT_ID + 25;
 const ecs_entity_t EcsOneOf =                       FLECS_HI_COMPONENT_ID + 26;
+const ecs_entity_t EcsTrait =                       FLECS_HI_COMPONENT_ID + 27;
+const ecs_entity_t EcsPairRelationship =            FLECS_HI_COMPONENT_ID + 28;
+const ecs_entity_t EcsPairTarget =                  FLECS_HI_COMPONENT_ID + 29;
 
 /* Builtin relationships */
-const ecs_entity_t EcsChildOf =                     FLECS_HI_COMPONENT_ID + 27;
-const ecs_entity_t EcsIsA =                         FLECS_HI_COMPONENT_ID + 28;
-const ecs_entity_t EcsDependsOn =                   FLECS_HI_COMPONENT_ID + 29;
+const ecs_entity_t EcsChildOf =                     FLECS_HI_COMPONENT_ID + 30;
+const ecs_entity_t EcsIsA =                         FLECS_HI_COMPONENT_ID + 31;
+const ecs_entity_t EcsDependsOn =                   FLECS_HI_COMPONENT_ID + 32;
 
 /* Identifier tags */
-const ecs_entity_t EcsName =                        FLECS_HI_COMPONENT_ID + 30;
-const ecs_entity_t EcsSymbol =                      FLECS_HI_COMPONENT_ID + 31;
-const ecs_entity_t EcsAlias =                       FLECS_HI_COMPONENT_ID + 32;
+const ecs_entity_t EcsName =                        FLECS_HI_COMPONENT_ID + 33;
+const ecs_entity_t EcsSymbol =                      FLECS_HI_COMPONENT_ID + 34;
+const ecs_entity_t EcsAlias =                       FLECS_HI_COMPONENT_ID + 35;
 
 /* Events */
-const ecs_entity_t EcsOnAdd =                       FLECS_HI_COMPONENT_ID + 33;
-const ecs_entity_t EcsOnRemove =                    FLECS_HI_COMPONENT_ID + 34;
-const ecs_entity_t EcsOnSet =                       FLECS_HI_COMPONENT_ID + 35;
-const ecs_entity_t EcsUnSet =                       FLECS_HI_COMPONENT_ID + 36;
-const ecs_entity_t EcsOnDelete =                    FLECS_HI_COMPONENT_ID + 37;
-const ecs_entity_t EcsOnTableCreate =               FLECS_HI_COMPONENT_ID + 38;
-const ecs_entity_t EcsOnTableDelete =               FLECS_HI_COMPONENT_ID + 39;
-const ecs_entity_t EcsOnTableEmpty =                FLECS_HI_COMPONENT_ID + 40;
-const ecs_entity_t EcsOnTableFill =                 FLECS_HI_COMPONENT_ID + 41;
+const ecs_entity_t EcsOnAdd =                       FLECS_HI_COMPONENT_ID + 36;
+const ecs_entity_t EcsOnRemove =                    FLECS_HI_COMPONENT_ID + 37;
+const ecs_entity_t EcsOnSet =                       FLECS_HI_COMPONENT_ID + 38;
+const ecs_entity_t EcsUnSet =                       FLECS_HI_COMPONENT_ID + 39;
+const ecs_entity_t EcsOnDelete =                    FLECS_HI_COMPONENT_ID + 40;
+const ecs_entity_t EcsOnTableCreate =               FLECS_HI_COMPONENT_ID + 41;
+const ecs_entity_t EcsOnTableDelete =               FLECS_HI_COMPONENT_ID + 42;
+const ecs_entity_t EcsOnTableEmpty =                FLECS_HI_COMPONENT_ID + 43;
+const ecs_entity_t EcsOnTableFill =                 FLECS_HI_COMPONENT_ID + 44;
 const ecs_entity_t EcsOnDeleteTarget =              FLECS_HI_COMPONENT_ID + 46;
 
 /* Timers */

--- a/src/world.c
+++ b/src/world.c
@@ -54,8 +54,8 @@ const ecs_entity_t EcsTraversable =                 FLECS_HI_COMPONENT_ID + 24;
 const ecs_entity_t EcsWith =                        FLECS_HI_COMPONENT_ID + 25;
 const ecs_entity_t EcsOneOf =                       FLECS_HI_COMPONENT_ID + 26;
 const ecs_entity_t EcsTrait =                       FLECS_HI_COMPONENT_ID + 27;
-const ecs_entity_t EcsPairRelationship =            FLECS_HI_COMPONENT_ID + 28;
-const ecs_entity_t EcsPairTarget =                  FLECS_HI_COMPONENT_ID + 29;
+const ecs_entity_t EcsRelationship =            FLECS_HI_COMPONENT_ID + 28;
+const ecs_entity_t EcsTarget =                  FLECS_HI_COMPONENT_ID + 29;
 
 /* Builtin relationships */
 const ecs_entity_t EcsChildOf =                     FLECS_HI_COMPONENT_ID + 30;
@@ -90,7 +90,7 @@ const ecs_entity_t EcsDelete =                      FLECS_HI_COMPONENT_ID + 51;
 const ecs_entity_t EcsPanic =                       FLECS_HI_COMPONENT_ID + 52;
 
 /* Misc */
-const ecs_entity_t ecs_id(EcsTarget) =              FLECS_HI_COMPONENT_ID + 53;
+const ecs_entity_t ecs_id(EcsFlattenTarget) =              FLECS_HI_COMPONENT_ID + 53;
 const ecs_entity_t EcsFlatten =                     FLECS_HI_COMPONENT_ID + 54;
 const ecs_entity_t EcsDefaultChildComponent =       FLECS_HI_COMPONENT_ID + 55;
 

--- a/src/world.c
+++ b/src/world.c
@@ -90,7 +90,7 @@ const ecs_entity_t EcsDelete =                      FLECS_HI_COMPONENT_ID + 51;
 const ecs_entity_t EcsPanic =                       FLECS_HI_COMPONENT_ID + 52;
 
 /* Misc */
-const ecs_entity_t ecs_id(EcsFlattenTarget) =              FLECS_HI_COMPONENT_ID + 53;
+const ecs_entity_t ecs_id(EcsFlattenTarget) =       FLECS_HI_COMPONENT_ID + 53;
 const ecs_entity_t EcsFlatten =                     FLECS_HI_COMPONENT_ID + 54;
 const ecs_entity_t EcsDefaultChildComponent =       FLECS_HI_COMPONENT_ID + 55;
 
@@ -98,8 +98,8 @@ const ecs_entity_t EcsDefaultChildComponent =       FLECS_HI_COMPONENT_ID + 55;
 const ecs_entity_t EcsPredEq =                      FLECS_HI_COMPONENT_ID + 56;
 const ecs_entity_t EcsPredMatch =                   FLECS_HI_COMPONENT_ID + 57;
 const ecs_entity_t EcsPredLookup =                  FLECS_HI_COMPONENT_ID + 58;
-const ecs_entity_t EcsScopeOpen =                    FLECS_HI_COMPONENT_ID + 59;
-const ecs_entity_t EcsScopeClose =                   FLECS_HI_COMPONENT_ID + 60;
+const ecs_entity_t EcsScopeOpen =                   FLECS_HI_COMPONENT_ID + 59;
+const ecs_entity_t EcsScopeClose =                  FLECS_HI_COMPONENT_ID + 60;
 
 /* Systems */
 const ecs_entity_t EcsMonitor =                     FLECS_HI_COMPONENT_ID + 61;

--- a/test/api/project.json
+++ b/test/api/project.json
@@ -1909,7 +1909,14 @@
                 "oneof_other_constraint_violated",
                 "oneof_other_rel_parent_constraint_violated",
                 "set_w_recycled_rel",
-                "set_w_recycled_tgt"
+                "set_w_recycled_tgt",
+                "force_relationship_on_component",
+                "force_relationship_on_target",
+                "force_relationship_on_target_trait",
+                "force_relationship_on_relationship",
+                "force_target_on_component",
+                "force_target_on_relationship",
+                "force_target_on_target"
             ]
         }, {
            "id": "Trigger",

--- a/test/api/src/Pairs.c
+++ b/test/api/src/Pairs.c
@@ -3045,7 +3045,7 @@ void Pairs_force_relationship_on_component(void) {
 
     ecs_world_t *world = ecs_init();
 
-    ECS_ENTITY(world, Rel, PairRelationship);
+    ECS_ENTITY(world, Rel, Relationship);
 
     test_expect_abort();
     ecs_new(world, Rel);
@@ -3057,7 +3057,7 @@ void Pairs_force_relationship_on_target(void) {
     ecs_world_t *world = ecs_init();
 
     ECS_TAG(world, RelA);
-    ECS_ENTITY(world, Rel, PairRelationship);
+    ECS_ENTITY(world, Rel, Relationship);
 
     test_expect_abort();
     ecs_new_w_pair(world, RelA, Rel);
@@ -3067,7 +3067,7 @@ void Pairs_force_relationship_on_target_trait(void) {
     ecs_world_t *world = ecs_init();
 
     ECS_ENTITY(world, Trait, Trait);
-    ECS_ENTITY(world, Rel, PairRelationship);
+    ECS_ENTITY(world, Rel, Relationship);
 
     ecs_entity_t e = ecs_new_w_pair(world, Trait, Rel);
     test_assert(ecs_has_pair(world, e, Trait, Rel));
@@ -3078,7 +3078,7 @@ void Pairs_force_relationship_on_target_trait(void) {
 void Pairs_force_relationship_on_relationship(void) {
     ecs_world_t *world = ecs_init();
 
-    ECS_ENTITY(world, Rel, PairRelationship);
+    ECS_ENTITY(world, Rel, Relationship);
     ECS_TAG(world, Tgt);
 
     ecs_entity_t e = ecs_new_w_pair(world, Rel, Tgt);
@@ -3092,7 +3092,7 @@ void Pairs_force_target_on_component(void) {
 
     ecs_world_t *world = ecs_init();
 
-    ECS_ENTITY(world, Tgt, PairTarget);
+    ECS_ENTITY(world, Tgt, Target);
 
     test_expect_abort();
     ecs_new(world, Tgt);
@@ -3104,7 +3104,7 @@ void Pairs_force_target_on_relationship(void) {
     ecs_world_t *world = ecs_init();
 
     ECS_TAG(world, RelA);
-    ECS_ENTITY(world, Tgt, PairTarget);
+    ECS_ENTITY(world, Tgt, Target);
 
     test_expect_abort();
     ecs_new_w_pair(world, Tgt, RelA);
@@ -3114,7 +3114,7 @@ void Pairs_force_target_on_target(void) {
     ecs_world_t *world = ecs_init();
 
     ECS_TAG(world, RelA);
-    ECS_ENTITY(world, Tgt, PairTarget);
+    ECS_ENTITY(world, Tgt, Target);
 
     ecs_entity_t e = ecs_new_w_pair(world, RelA, Tgt);
     test_assert(ecs_has_pair(world, e, RelA, Tgt));

--- a/test/api/src/Pairs.c
+++ b/test/api/src/Pairs.c
@@ -3039,3 +3039,85 @@ void Pairs_set_w_recycled_tgt(void) {
 
     ecs_fini(world);
 }
+
+void Pairs_force_relationship_on_component(void) {
+    install_test_abort();
+
+    ecs_world_t *world = ecs_init();
+
+    ECS_ENTITY(world, Rel, PairRelationship);
+
+    test_expect_abort();
+    ecs_new(world, Rel);
+}
+
+void Pairs_force_relationship_on_target(void) {
+    install_test_abort();
+
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, RelA);
+    ECS_ENTITY(world, Rel, PairRelationship);
+
+    test_expect_abort();
+    ecs_new_w_pair(world, RelA, Rel);
+}
+
+void Pairs_force_relationship_on_target_trait(void) {
+    ecs_world_t *world = ecs_init();
+
+    ECS_ENTITY(world, Trait, Trait);
+    ECS_ENTITY(world, Rel, PairRelationship);
+
+    ecs_entity_t e = ecs_new_w_pair(world, Trait, Rel);
+    test_assert(ecs_has_pair(world, e, Trait, Rel));
+
+    ecs_fini(world);
+}
+
+void Pairs_force_relationship_on_relationship(void) {
+    ecs_world_t *world = ecs_init();
+
+    ECS_ENTITY(world, Rel, PairRelationship);
+    ECS_TAG(world, Tgt);
+
+    ecs_entity_t e = ecs_new_w_pair(world, Rel, Tgt);
+    test_assert(ecs_has_pair(world, e, Rel, Tgt));
+
+    ecs_fini(world);
+}
+
+void Pairs_force_target_on_component(void) {
+    install_test_abort();
+
+    ecs_world_t *world = ecs_init();
+
+    ECS_ENTITY(world, Tgt, PairTarget);
+
+    test_expect_abort();
+    ecs_new(world, Tgt);
+}
+
+void Pairs_force_target_on_relationship(void) {
+    install_test_abort();
+
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, RelA);
+    ECS_ENTITY(world, Tgt, PairTarget);
+
+    test_expect_abort();
+    ecs_new_w_pair(world, Tgt, RelA);
+}
+
+void Pairs_force_target_on_target(void) {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, RelA);
+    ECS_ENTITY(world, Tgt, PairTarget);
+
+    ecs_entity_t e = ecs_new_w_pair(world, RelA, Tgt);
+    test_assert(ecs_has_pair(world, e, RelA, Tgt));
+
+    ecs_fini(world);
+}

--- a/test/api/src/main.c
+++ b/test/api/src/main.c
@@ -1843,6 +1843,13 @@ void Pairs_oneof_other_constraint_violated(void);
 void Pairs_oneof_other_rel_parent_constraint_violated(void);
 void Pairs_set_w_recycled_rel(void);
 void Pairs_set_w_recycled_tgt(void);
+void Pairs_force_relationship_on_component(void);
+void Pairs_force_relationship_on_target(void);
+void Pairs_force_relationship_on_target_trait(void);
+void Pairs_force_relationship_on_relationship(void);
+void Pairs_force_target_on_component(void);
+void Pairs_force_target_on_relationship(void);
+void Pairs_force_target_on_target(void);
 
 // Testsuite 'Trigger'
 void Trigger_on_add_trigger_before_table(void);
@@ -9904,6 +9911,34 @@ bake_test_case Pairs_testcases[] = {
     {
         "set_w_recycled_tgt",
         Pairs_set_w_recycled_tgt
+    },
+    {
+        "force_relationship_on_component",
+        Pairs_force_relationship_on_component
+    },
+    {
+        "force_relationship_on_target",
+        Pairs_force_relationship_on_target
+    },
+    {
+        "force_relationship_on_target_trait",
+        Pairs_force_relationship_on_target_trait
+    },
+    {
+        "force_relationship_on_relationship",
+        Pairs_force_relationship_on_relationship
+    },
+    {
+        "force_target_on_component",
+        Pairs_force_target_on_component
+    },
+    {
+        "force_target_on_relationship",
+        Pairs_force_target_on_relationship
+    },
+    {
+        "force_target_on_target",
+        Pairs_force_target_on_target
     }
 };
 
@@ -13631,7 +13666,7 @@ static bake_test_suite suites[] = {
         "Pairs",
         NULL,
         NULL,
-        117,
+        124,
         Pairs_testcases
     },
     {

--- a/test/cpp_api/src/World.cpp
+++ b/test/cpp_api/src/World.cpp
@@ -92,7 +92,7 @@ void World_builtin_components(void) {
     test_assert(ecs.component<flecs::Component>() == ecs_id(EcsComponent));
     test_assert(ecs.component<flecs::Identifier>() == ecs_id(EcsIdentifier));
     test_assert(ecs.component<flecs::Poly>() == ecs_id(EcsPoly));
-    test_assert(ecs.component<flecs::Target>() == ecs_id(EcsFlattenTarget));
+    test_assert(ecs.component<flecs::FlattenTarget>() == ecs_id(EcsFlattenTarget));
     test_assert(ecs.component<flecs::RateFilter>() == ecs_id(EcsRateFilter));
     test_assert(ecs.component<flecs::TickSource>() == ecs_id(EcsTickSource));
     test_assert(flecs::Name == EcsName);

--- a/test/cpp_api/src/World.cpp
+++ b/test/cpp_api/src/World.cpp
@@ -92,7 +92,7 @@ void World_builtin_components(void) {
     test_assert(ecs.component<flecs::Component>() == ecs_id(EcsComponent));
     test_assert(ecs.component<flecs::Identifier>() == ecs_id(EcsIdentifier));
     test_assert(ecs.component<flecs::Poly>() == ecs_id(EcsPoly));
-    test_assert(ecs.component<flecs::Target>() == ecs_id(EcsTarget));
+    test_assert(ecs.component<flecs::Target>() == ecs_id(EcsFlattenTarget));
     test_assert(ecs.component<flecs::RateFilter>() == ecs_id(EcsRateFilter));
     test_assert(ecs.component<flecs::TickSource>() == ecs_id(EcsTickSource));
     test_assert(flecs::Name == EcsName);

--- a/test/cpp_api/src/main.cpp
+++ b/test/cpp_api/src/main.cpp
@@ -6644,6 +6644,7 @@ bake_test_case Doc_testcases[] = {
     }
 };
 
+
 static bake_test_suite suites[] = {
     {
         "PrettyFunction",

--- a/test/custom_builds/cpp/no_auto_registration/src/main.cpp
+++ b/test/custom_builds/cpp/no_auto_registration/src/main.cpp
@@ -15,7 +15,7 @@ int main(int, char *[]) {
     world.id<flecs::Identifier>();
     world.id<flecs::Iterable>();
     world.id<flecs::Poly>();
-    world.id<flecs::Target>();
+    world.id<flecs::FlattenTarget>();
 
     // alerts
     world.id<flecs::alerts::AlertsActive>();


### PR DESCRIPTION
This PR adds three new traits:
- A `Relationship` trait, which enforces that an entity can only be used as a relationship
- A `Target` trait, which enforces that an entity can only be used as a relationship target
- A `Trait` trait, which marks a property/trait as a trait