### PR TITLE
Add pair overload to get_ref

### DIFF
--- a/include/flecs/addons/cpp/entity.hpp
+++ b/include/flecs/addons/cpp/entity.hpp
@@ -225,13 +225,30 @@ struct entity : entity_builder<entity>
      * @tparam T component for which to get a reference.
      * @return The reference.
      */
-    template <typename T>
+    template <typename T, if_t< is_actual<T>::value > = 0>
     ref<T> get_ref() const {
         return ref<T>(m_world, m_id, _::cpp_type<T>::id(m_world));
     }
 
+    /** Get reference to component.
+     * Overload for when T is not the same as the actual type, which happens
+     * when using pair types.
+     * A reference allows for quick and safe access to a component value, and is
+     * a faster alternative to repeatedly calling 'get' for the same component.
+     *
+     * @tparam T component for which to get a reference.
+     * @return The reference.
+     */
+    template <typename T, typename A = actual_type_t<T>, if_t< flecs::is_pair<T>::value > = 0>
+    ref<A> get_ref() const {
+        return ref<A>(m_world, m_id,
+                      ecs_pair(_::cpp_type<T::first>::id(m_world),
+                               _::cpp_type<T::second>::id(m_world)));
+    }
+
+
     template <typename First, typename Second, typename P = flecs::pair<First, Second>,
-        typename A = actual_type_t<P>>
+    typename A = actual_type_t<P>>
     ref<A> get_ref() const {
         return ref<A>(m_world, m_id,
             ecs_pair(_::cpp_type<First>::id(m_world),

--- a/include/flecs/addons/cpp/entity.hpp
+++ b/include/flecs/addons/cpp/entity.hpp
@@ -242,13 +242,13 @@ struct entity : entity_builder<entity>
     template <typename T, typename A = actual_type_t<T>, if_t< flecs::is_pair<T>::value > = 0>
     ref<A> get_ref() const {
         return ref<A>(m_world, m_id,
-                      ecs_pair(_::cpp_type<T::first>::id(m_world),
-                               _::cpp_type<T::second>::id(m_world)));
+                      ecs_pair(_::cpp_type<typename T::first>::id(m_world),
+                               _::cpp_type<typename T::second>::id(m_world)));
     }
 
 
     template <typename First, typename Second, typename P = flecs::pair<First, Second>,
-    typename A = actual_type_t<P>>
+        typename A = actual_type_t<P>>
     ref<A> get_ref() const {
         return ref<A>(m_world, m_id,
             ecs_pair(_::cpp_type<First>::id(m_world),

--- a/test/cpp_api/src/Refs.cpp
+++ b/test/cpp_api/src/Refs.cpp
@@ -94,6 +94,30 @@ void Refs_pair_ref(void) {
     test_int((e.get<Position, Tag>()->x), 11);
 }
 
+using PositionTag = flecs::pair<Position, Tag>;
+
+void Refs_pair_ref_w_pair_type(void) {
+    flecs::world world;
+
+    auto e = world.entity().set<PositionTag>({10, 20});
+    auto ref = e.get_ref<PositionTag>();
+    ref->x++;
+
+    test_int((e.get<PositionTag>()->x), 11);
+}
+
+using TagPosition = flecs::pair<Tag, Position>;
+
+void Refs_pair_ref_w_pair_type_second(void) {
+    flecs::world world;
+
+    auto e = world.entity().set<TagPosition>({10, 20});
+    auto ref = e.get_ref<TagPosition>();
+    ref->x++;
+
+    test_int((e.get<TagPosition>()->x), 11);
+}
+
 void Refs_pair_ref_w_entity(void) {
     flecs::world world;
 


### PR DESCRIPTION
First time creating a pull request, I'm sorry in advance if I did something the wrong way !

This pull request adds a pair overload to `get_ref` to support pair types, so that a ref to the actual type is returned rather than a ref to the pair.

Here is a repro : 

```cpp
struct A {};
struct B {int value {0};};
using AB = flecs::pair<A, B>;
using SharedAB = flecs::pair<A, flecs::ref<B>>;

int main(int argc, char **argv)
{
    flecs::world world;
    auto a = world.entity("a");
    auto b = world.entity("b");
    a.add<AB>();
    b.set<SharedAB>({a.get_ref<AB>()});// This doesn't work. 
                                       // Returns flecs::ref<flecs::pair<A, flecs::ref<B>>>
    b.set<SharedAB>({a.get_ref<A, B>()}); // A workaround
                                          // Returns flecs::ref<B>
}
```

Changes were made to the normal `get_ref` to dissambiguate with the newly added overload.