### PR TITLE
CXX-20 MODULES - global module fragment support

### DIFF
--- a/include/flecs/addons/cpp/component.hpp
+++ b/include/flecs/addons/cpp/component.hpp
@@ -30,7 +30,7 @@ namespace _ {
 
 #if defined(__GNUC__) || defined(_WIN32)
 template <typename T>
-inline static const char* type_name() {
+inline const char* type_name() {
     static const size_t len = ECS_FUNC_TYPE_LEN(const char*, type_name, ECS_FUNC_NAME);
     static char result[len + 1] = {};
     static const size_t front_len = ECS_FUNC_NAME_FRONT(const char*, type_name);
@@ -43,7 +43,7 @@ inline static const char* type_name() {
 // Translate a typename into a language-agnostic identifier. This allows for
 // registration of components/modules across language boundaries.
 template <typename T>
-inline static const char* symbol_name() {
+inline const char* symbol_name() {
     static const size_t len = ECS_FUNC_TYPE_LEN(const char*, symbol_name, ECS_FUNC_NAME);
     static char result[len + 1] = {};
     return ecs_cpp_get_symbol_name(result, type_name<T>(), len);

--- a/include/flecs/addons/cpp/utils/signature.hpp
+++ b/include/flecs/addons/cpp/utils/signature.hpp
@@ -11,28 +11,28 @@ namespace flecs {
 namespace _ {
 
     template <typename T, if_t< is_const_p<T>::value > = 0>
-    static constexpr flecs::inout_kind_t type_to_inout() {
+    constexpr flecs::inout_kind_t type_to_inout() {
         return flecs::In;
     }
 
     template <typename T, if_t< is_reference<T>::value > = 0>
-    static constexpr flecs::inout_kind_t type_to_inout() {
+    constexpr flecs::inout_kind_t type_to_inout() {
         return flecs::Out;
     }
 
     template <typename T, if_not_t< 
         is_const_p<T>::value || is_reference<T>::value > = 0>
-    static constexpr flecs::inout_kind_t type_to_inout() {
+    constexpr flecs::inout_kind_t type_to_inout() {
         return flecs::InOutDefault;
     }
 
     template <typename T, if_t< is_pointer<T>::value > = 0>
-    static constexpr flecs::oper_kind_t type_to_oper() {
+    constexpr flecs::oper_kind_t type_to_oper() {
         return flecs::Optional;
     }
 
     template <typename T, if_not_t< is_pointer<T>::value > = 0>
-    static constexpr flecs::oper_kind_t type_to_oper() {
+    constexpr flecs::oper_kind_t type_to_oper() {
         return flecs::And;
     }
 


### PR DESCRIPTION
This PR is based on one sleepless night and a similar [PR for entt](https://github.com/skypjack/entt/pull/1047).

The problem is that we get compilation errors when using the methods (when include flecs.h in global module fragment):
```cpp
world.import<ModuleName>();
world.system<ComponentName>();
// And perhaps others that call some template functions, the corrections of which are given in this PR
```

The reason to be that certain function declarations that are implicitly required by the implementation aren't exported into the module interface since they are marked 'static' and have internal linkage.

And when compiling we get the following error (clang-18 ubuntu 24.04 package version 1:18.1.3-1):
```console
# This is an incomplete output for readability purposes.
/home/alexv/Desktop/flecs/include/flecs/private/../addons/cpp/mixins/term/../../utils/signature.hpp:44:25: error: no matching function for call to 'type_to_inout'
   44 |             , inout ({ (type_to_inout<Components>())... })
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~
```

This pull request solves this problem. I also advise to look at the original pull request for entt (link at the beginning of the description)