### PR TITLE
Fix issue where the use of a function pointer cast can trip -fsanitize=undefined on recent versions of clang

### DIFF
--- a/src/addons/rules/api.c
+++ b/src/addons/rules/api.c
@@ -103,6 +103,13 @@ void flecs_rule_fini(
     ecs_poly_free(rule, ecs_rule_t);
 }
 
+/* ecs_poly_dtor_t-compatible wrapper */
+static
+void flecs_rule_fini_poly(void *rule)
+{
+    flecs_rule_fini(rule);
+}
+
 void ecs_rule_fini(
     ecs_rule_t *rule)
 {
@@ -137,7 +144,7 @@ ecs_rule_t* ecs_rule_init(
     }
 
     ecs_entity_t entity = const_desc->entity;
-    result->dtor = (ecs_poly_dtor_t)flecs_rule_fini;
+    result->dtor = flecs_rule_fini_poly;
 
     if (entity) {
         EcsPoly *poly = ecs_poly_bind(world, entity, ecs_rule_t);

--- a/src/addons/system/system.c
+++ b/src/addons/system/system.c
@@ -229,6 +229,13 @@ void flecs_system_fini(ecs_system_t *sys) {
     ecs_poly_free(sys, ecs_system_t);
 }
 
+/* ecs_poly_dtor_t-compatible wrapper */
+static
+void flecs_system_fini_poly(void *sys)
+{
+    flecs_system_fini(sys);
+}
+
 static
 void flecs_system_init_timer(
     ecs_world_t *world,
@@ -281,7 +288,7 @@ ecs_entity_t ecs_system_init(
         
         poly->poly = system;
         system->world = world;
-        system->dtor = (ecs_poly_dtor_t)flecs_system_fini;
+        system->dtor = flecs_system_fini_poly;
         system->entity = entity;
 
         ecs_query_desc_t query_desc = desc->query;

--- a/src/filter.c
+++ b/src/filter.c
@@ -1484,6 +1484,13 @@ void flecs_filter_fini(
     }
 }
 
+/* ecs_poly_dtor_t-compatible wrapper */
+static
+void flecs_filter_fini_poly(void *filter)
+{
+    flecs_filter_fini(filter);
+}
+
 void ecs_filter_fini(
     ecs_filter_t *filter) 
 {
@@ -1672,7 +1679,7 @@ ecs_filter_t* ecs_filter_init(
 
     f->variable_names[0] = NULL;
     f->iterable.init = flecs_filter_iter_init;
-    f->dtor = (ecs_poly_dtor_t)flecs_filter_fini;
+    f->dtor = flecs_filter_fini_poly;
     f->entity = entity;
 
     if (entity && (f->flags & EcsFilterOwnsStorage)) {

--- a/src/observer.c
+++ b/src/observer.c
@@ -825,6 +825,13 @@ error:
     return -1;
 }
 
+/* ecs_poly_dtor_t-compatible wrapper */
+static
+void flecs_observer_fini_poly(void *observer)
+{
+    flecs_observer_fini(observer);
+}
+
 ecs_entity_t ecs_observer_init(
     ecs_world_t *world,
     const ecs_observer_desc_t *desc)
@@ -846,7 +853,7 @@ ecs_entity_t ecs_observer_init(
 
         ecs_observer_t *observer = ecs_poly_new(ecs_observer_t);
         ecs_assert(observer != NULL, ECS_INTERNAL_ERROR, NULL);
-        observer->dtor = (ecs_poly_dtor_t)flecs_observer_fini;
+        observer->dtor = flecs_observer_fini_poly;
 
         /* Make writeable copy of filter desc so that we can set name. This will
          * make debugging easier, as any error messages related to creating the

--- a/src/query.c
+++ b/src/query.c
@@ -2027,6 +2027,13 @@ void flecs_query_fini(
     ecs_poly_free(query, ecs_query_t);
 }
 
+/* ecs_poly_dtor_t-compatible wrapper */
+static
+void flecs_query_fini_poly(void *query)
+{
+    flecs_query_fini(query);
+}
+
 /* -- Public API -- */
 
 ecs_query_t* ecs_query_init(
@@ -2081,7 +2088,7 @@ ecs_query_t* ecs_query_init(
     }
 
     result->iterable.init = flecs_query_iter_init;
-    result->dtor = (ecs_poly_dtor_t)flecs_query_fini;
+    result->dtor = flecs_query_fini_poly;
     result->prev_match_count = -1;
 
     result->ctx = desc->ctx;


### PR DESCRIPTION
**Note:** The changes were made against v3.11.2, *not* master. Hopefully they'll be useful anyway.

---

The error in question: (plus others, for each case of a casted dtor function pointer)

```
<...>/flecs/src/bootstrap.c:142:8: runtime error: call to function flecs_observer_fini through pointer to incorrect function type 'void (*)(void *)'
<...>/flecs/src/observer.c:1017: note: flecs_observer_fini defined here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior <...>/flecs/src/bootstrap.c:142:8 
```
