### PR TITLE
Ensure Windows version macro is minimum required to include inet_pton

### DIFF
--- a/flecs.c
+++ b/flecs.c
@@ -26590,6 +26590,10 @@ const ecs_member_t* ecs_cpp_last_member(
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
+#if !defined(_WIN32_WINNT) | _WIN32_WINNT <= 0x502
+    #define WINVER 0x600
+    #define _WIN32_WINNT WINVER
+#endif
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #include <windows.h>

--- a/flecs.c
+++ b/flecs.c
@@ -26590,7 +26590,7 @@ const ecs_member_t* ecs_cpp_last_member(
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
-#if !defined(_WIN32_WINNT) | _WIN32_WINNT <= 0x502
+#if !defined(_WIN32_WINNT) || _WIN32_WINNT <= 0x502
     #define WINVER 0x600
     #define _WIN32_WINNT WINVER
 #endif


### PR DESCRIPTION
This should fix a _very obscure_ issue I was running into when cross-compiling from WSL using `x86_64-w64-mingw32-gcc-posix`, where WINVER was not defined and _WIN32_WINNT was 0x502 (Windows Server 2003) which was not a recent enough version to use `inet_pton` which caused some issues with #include's.

Solution based on this article from Microsoft which details how to manually set these values: https://learn.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt?view=msvc-170
