### PR TITLE
Mark overriden methods explicitly to avoid warnings in more strict bu…

### DIFF
--- a/include/flecs/addons/cpp/mixins/filter/builder_i.hpp
+++ b/include/flecs/addons/cpp/mixins/filter/builder_i.hpp
@@ -248,7 +248,7 @@ struct filter_builder_i : term_builder_i<Base> {
     }
 
 protected:
-    virtual flecs::world_t* world_v() = 0;
+    virtual flecs::world_t* world_v() override = 0;
     int32_t m_term_index;
     int32_t m_expr_count;
 

--- a/include/flecs/addons/cpp/mixins/observer/builder_i.hpp
+++ b/include/flecs/addons/cpp/mixins/observer/builder_i.hpp
@@ -62,7 +62,7 @@ struct observer_builder_i : filter_builder_i<Base, Components ...> {
     }
 
 protected:
-    virtual flecs::world_t* world_v() = 0;
+    virtual flecs::world_t* world_v() override = 0;
 
 private:
     operator Base&() {

--- a/include/flecs/addons/cpp/mixins/query/builder_i.hpp
+++ b/include/flecs/addons/cpp/mixins/query/builder_i.hpp
@@ -146,7 +146,7 @@ public:
     Base& observable(const query_base& parent);
     
 protected:
-    virtual flecs::world_t* world_v() = 0;
+    virtual flecs::world_t* world_v() override = 0;
 
 private:
     operator Base&() {

--- a/include/flecs/addons/cpp/mixins/system/builder_i.hpp
+++ b/include/flecs/addons/cpp/mixins/system/builder_i.hpp
@@ -149,7 +149,7 @@ public:
     }
 
 protected:
-    virtual flecs::world_t* world_v() = 0;
+    virtual flecs::world_t* world_v() override = 0;
 
 private:
     operator Base&() {

--- a/include/flecs/addons/cpp/mixins/term/builder_i.hpp
+++ b/include/flecs/addons/cpp/mixins/term/builder_i.hpp
@@ -412,7 +412,7 @@ struct term_builder_i : term_id_builder_i<Base> {
     ecs_term_t *m_term;
 
 protected:
-    virtual flecs::world_t* world_v() = 0;
+    virtual flecs::world_t* world_v() override = 0;
 
     void set_term(ecs_term_t *term) {
         m_term = term;

--- a/include/flecs/addons/cpp/utils/iterable.hpp
+++ b/include/flecs/addons/cpp/utils/iterable.hpp
@@ -234,7 +234,7 @@ struct iter_iterable final : iterable<Components...> {
     }
 
 protected:
-    ecs_iter_t get_iter(flecs::world_t *world) const {
+    ecs_iter_t get_iter(flecs::world_t *world) const override {
         if (world) {
             ecs_iter_t result = m_it;
             result.world = world;
@@ -243,11 +243,11 @@ protected:
         return m_it;
     }
 
-    ecs_iter_next_action_t next_action() const {
+    ecs_iter_next_action_t next_action() const override {
         return m_next;
     }
 
-    ecs_iter_next_action_t next_each_action() const {
+    ecs_iter_next_action_t next_each_action() const override {
         return m_next_each;
     }
 


### PR DESCRIPTION
This simple PR marks all overriden methods explicitly, which documents code and hints the developer that a particular method is overriding something that exists in a base class. It also avoids warnings in more strict builds.