### PR TITLE
Add term_index method to cpp iterator

### DIFF
--- a/flecs.h
+++ b/flecs.h
@@ -22165,6 +22165,12 @@ public:
         return ecs_field_column_index(m_iter, index);
     }
 
+    /** Obtain term that triggered an observer
+     */
+    int32_t term_index() const {
+        return m_iter->term_index + 1; // in iter_t, the term index is zero-based, so add 1.
+    }
+
     /** Convert current iterator result to string.
      */
     flecs::string str() const {

--- a/include/flecs/addons/cpp/iter.hpp
+++ b/include/flecs/addons/cpp/iter.hpp
@@ -220,6 +220,12 @@ public:
         return ecs_field_column_index(m_iter, index);
     }
 
+    /** Obtain term that triggered an observer
+     */
+    int32_t term_index() const {
+        return m_iter->term_index + 1; // in iter_t, the term index is zero-based, so add 1.
+    }
+
     /** Convert current iterator result to string.
      */
     flecs::string str() const {

--- a/test/cpp_api/project.json
+++ b/test/cpp_api/project.json
@@ -924,7 +924,8 @@
                 "on_add_with_pair_singleton",
                 "add_in_yield_existing",
                 "add_in_yield_existing_multi",
-                "name_from_root"
+                "name_from_root",
+                "term_index"
             ]
         }, {
             "id": "Filter",

--- a/test/cpp_api/src/Observer.cpp
+++ b/test/cpp_api/src/Observer.cpp
@@ -816,3 +816,23 @@ void Observer_name_from_root(void) {
     flecs::entity ns = ecs.entity("::ns");
     test_assert(ns == sys.parent());
 }
+
+void Observer_term_index(void) {
+    flecs::world ecs;
+
+    auto e1 = ecs.entity().add<Position>().add<Velocity>();
+
+    int32_t last_term = -1;
+
+    ecs.observer<const Position, const Velocity>()
+        .event(flecs::OnSet)
+        .each([&](flecs::iter& it, size_t row, const Position &p, const Velocity &v) {
+            last_term = it.term_index();
+        });
+
+    e1.set<Position>({ 10, 20 });
+    test_int(last_term, 1);
+
+    e1.set<Velocity>({ 30, 40 }); 
+    test_int(last_term, 2);
+}

--- a/test/cpp_api/src/main.cpp
+++ b/test/cpp_api/src/main.cpp
@@ -891,6 +891,7 @@ void Observer_on_add_with_pair_singleton(void);
 void Observer_add_in_yield_existing(void);
 void Observer_add_in_yield_existing_multi(void);
 void Observer_name_from_root(void);
+void Observer_term_index(void);
 
 // Testsuite 'Filter'
 void Filter_term_each_component(void);
@@ -4825,6 +4826,10 @@ bake_test_case Observer_testcases[] = {
     {
         "name_from_root",
         Observer_name_from_root
+    },
+    {
+        "term_index",
+        Observer_term_index
     }
 };
 
@@ -6763,7 +6768,7 @@ static bake_test_suite suites[] = {
         "Observer",
         NULL,
         NULL,
-        32,
+        33,
         Observer_testcases
     },
     {


### PR DESCRIPTION
As per [our discussion in Discord](https://discord.com/channels/633826290415435777/1032491261548044299/threads/1237529263733735524), here is a convenience method to access what term triggered an observer, along with a test.