### PR TITLE
[v4] Added Enum specialization for event_builder_base::id(Enum::Value)

### DIFF
--- a/flecs.h
+++ b/flecs.h
@@ -17868,6 +17868,14 @@ struct event_builder_base {
         return id(ecs_pair(first, second));
     }
 
+
+    template <typename Enum, if_t<is_enum<Enum>::value> = 0>
+    Base& id(Enum value) {
+        const auto& et = enum_type<Enum>(this->m_world);
+        flecs::entity_t target = et.entity(value);
+        return id(et.entity(), target);
+    }
+
     /** Add (component) id to emit for */
     Base& id(flecs::id_t id) {
         ids_.array = ids_array_;

--- a/flecs.h
+++ b/flecs.h
@@ -17868,10 +17868,9 @@ struct event_builder_base {
         return id(ecs_pair(first, second));
     }
 
-
     template <typename Enum, if_t<is_enum<Enum>::value> = 0>
     Base& id(Enum value) {
-        const auto& et = enum_type<Enum>(this->m_world);
+        const auto& et = enum_type<Enum>(this->world_);
         flecs::entity_t target = et.entity(value);
         return id(et.entity(), target);
     }

--- a/include/flecs/addons/cpp/mixins/event/builder.hpp
+++ b/include/flecs/addons/cpp/mixins/event/builder.hpp
@@ -66,6 +66,14 @@ struct event_builder_base {
         return id(ecs_pair(first, second));
     }
 
+
+    template <typename Enum, if_t<is_enum<Enum>::value> = 0>
+    Base& id(Enum value) {
+        const auto& et = enum_type<Enum>(this->m_world);
+        flecs::entity_t target = et.entity(value);
+        return id(et.entity(), target);
+    }
+
     /** Add (component) id to emit for */
     Base& id(flecs::id_t id) {
         ids_.array = ids_array_;

--- a/include/flecs/addons/cpp/mixins/event/builder.hpp
+++ b/include/flecs/addons/cpp/mixins/event/builder.hpp
@@ -66,10 +66,9 @@ struct event_builder_base {
         return id(ecs_pair(first, second));
     }
 
-
     template <typename Enum, if_t<is_enum<Enum>::value> = 0>
     Base& id(Enum value) {
-        const auto& et = enum_type<Enum>(this->m_world);
+        const auto& et = enum_type<Enum>(this->world_);
         flecs::entity_t target = et.entity(value);
         return id(et.entity(), target);
     }

--- a/test/cpp/project.json
+++ b/test/cpp/project.json
@@ -536,7 +536,8 @@
                 "enqueue_event_w_payload",
                 "enqueue_entity_event_w_payload",
                 "enqueue_entity_from_readonly_world",
-                "enqueue_entity_w_payload_from_readonly_world"
+                "enqueue_entity_w_payload_from_readonly_world",
+                "enum_event"
             ]
         }, {
             "id": "Iterable",

--- a/test/cpp/src/main.cpp
+++ b/test/cpp/src/main.cpp
@@ -517,6 +517,7 @@ void Event_enqueue_event_w_payload(void);
 void Event_enqueue_entity_event_w_payload(void);
 void Event_enqueue_entity_from_readonly_world(void);
 void Event_enqueue_entity_w_payload_from_readonly_world(void);
+void Event_enum_event(void);
 
 // Testsuite 'Iterable'
 void Iterable_page_each(void);
@@ -3307,6 +3308,10 @@ bake_test_case Event_testcases[] = {
     {
         "enqueue_entity_w_payload_from_readonly_world",
         Event_enqueue_entity_w_payload_from_readonly_world
+    },
+    {
+        "enum_event",
+        Event_enum_event
     }
 };
 
@@ -6390,11 +6395,6 @@ bake_test_case Doc_testcases[] = {
     }
 };
 
-const char* QueryBuilder_cache_kind_param[] = {"default", "auto"};
-bake_test_param QueryBuilder_params[] = {
-    {"cache_kind", (char**)QueryBuilder_cache_kind_param, 2}
-};
-
 static bake_test_suite suites[] = {
     {
         "PrettyFunction",
@@ -6449,7 +6449,7 @@ static bake_test_suite suites[] = {
         "Event",
         NULL,
         NULL,
-        30,
+        31,
         Event_testcases
     },
     {
@@ -6471,9 +6471,7 @@ static bake_test_suite suites[] = {
         QueryBuilder_setup,
         NULL,
         164,
-        QueryBuilder_testcases,
-        1,
-        QueryBuilder_params
+        QueryBuilder_testcases
     },
     {
         "SystemBuilder",


### PR DESCRIPTION
Adds ability to create events with enum component ids via `event_builder_base::id(Enum::Value)` specialization, and adds companion test.

Replaces #1210 (master PR) for v4 branch