### PR TITLE
Update Quickstart observer to use 'events' instead of 'event'

### DIFF
--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -1508,7 +1508,7 @@ An example of an observer with two components:
 ```c
 ecs_observer(world, {
     .filter.terms = { { ecs_id(Position) }, { ecs_id(Velocity) }},
-    .event = EcsOnSet,
+    .events = { EcsOnSet },
     .callback = OnSetPosition
 });
 


### PR DESCRIPTION
The latest release of flecs uses an array for events in the description of observer