### PR TITLE
[v4] Fixes return with a value in void function 

### DIFF
--- a/flecs.h
+++ b/flecs.h
@@ -25483,7 +25483,7 @@ private:
         ecs_assert(iter->count > 0, ECS_INVALID_OPERATION,
             "no entities returned, use each() without flecs::entity argument");
 
-        return func(flecs::entity(iter->world, iter->entities[i]),
+        func(flecs::entity(iter->world, iter->entities[i]),
             (ColumnType< remove_reference_t<Components> >(comps, i)
                 .get_row())...);
     }

--- a/include/flecs/addons/cpp/delegate.hpp
+++ b/include/flecs/addons/cpp/delegate.hpp
@@ -254,7 +254,7 @@ private:
         ecs_assert(iter->count > 0, ECS_INVALID_OPERATION,
             "no entities returned, use each() without flecs::entity argument");
 
-        return func(flecs::entity(iter->world, iter->entities[i]),
+        func(flecs::entity(iter->world, iter->entities[i]),
             (ColumnType< remove_reference_t<Components> >(comps, i)
                 .get_row())...);
     }


### PR DESCRIPTION
When compiling against v4, I was getting the following error:
`include/flecs/flecs.h:25486:20: error: return-statement with a value, in function returning ‘void’ [-fpermissive]`
```c++
25486 |         return func(flecs::entity(iter->world, iter->entities[i]),
      |                ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
25487 |             (ColumnType< remove_reference_t<Components> >(comps, i)
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
25488 |                 .get_row())...);
```