### PR TITLE
Add support for generic callables to delegates

### DIFF
--- a/flecs.h
+++ b/flecs.h
@@ -25735,7 +25735,7 @@ private:
         if_t<sizeof...(Components) == sizeof...(Args)> = 0,
         decltype(bool(std::declval<const Fn&>()(
             std::declval<flecs::entity>(),
-            std::declval<ColumnType< remove_reference_t<Components> > >().get_row()...)), 0) = 0>
+            std::declval<ColumnType< remove_reference_t<Components> > >().get_row()...))) = true>
     static flecs::entity invoke_callback(
         ecs_iter_t *iter, const Func& func, size_t, Terms&, Args... comps) 
     {
@@ -25772,7 +25772,7 @@ private:
         decltype(bool(std::declval<const Fn&>()(
             std::declval<flecs::iter&>(),
             std::declval<size_t&>(),
-            std::declval<ColumnType< remove_reference_t<Components> > >().get_row()...)), 0) = 0>
+            std::declval<ColumnType< remove_reference_t<Components> > >().get_row()...))) = true>
     static flecs::entity invoke_callback(
         ecs_iter_t *iter, const Func& func, size_t, Terms&, Args... comps) 
     {
@@ -25808,7 +25808,7 @@ private:
         typename Fn = Func,
         if_t<sizeof...(Components) == sizeof...(Args)> = 0,
         decltype(bool(std::declval<const Fn&>()(
-            std::declval<ColumnType< remove_reference_t<Components> > >().get_row()...)), 0) = 0>
+            std::declval<ColumnType< remove_reference_t<Components> > >().get_row()...))) = true>
     static flecs::entity invoke_callback(
         ecs_iter_t *iter, const Func& func, size_t, Terms&, Args... comps) 
     {

--- a/flecs.h
+++ b/flecs.h
@@ -25376,6 +25376,8 @@ const char* from_json(const char *json) {
 
 #pragma once
 
+#include <utility> // std::declval
+
 namespace flecs
 {
 
@@ -25542,9 +25544,6 @@ struct each_ref_column : public each_column<T> {
 
 template <typename Func, typename ... Components>
 struct each_delegate : public delegate {
-    static_assert(arity<Func>::value > 0, 
-        "each() must have at least one argument");
-
     using Terms = typename term_ptrs<Components ...>::array;
 
     template < if_not_t< is_same< decay_t<Func>, decay_t<Func>& >::value > = 0>
@@ -25618,7 +25617,11 @@ struct each_delegate : public delegate {
 private:
     // func(flecs::entity, Components...)
     template <template<typename X, typename = int> class ColumnType, 
-        typename... Args, if_t<sizeof...(Args) + 1 == arity<Func>::value> = 0>
+        typename... Args,
+        typename Fn = Func,
+        decltype(std::declval<const Fn&>()(
+            std::declval<flecs::entity>(),
+            std::declval<ColumnType< remove_reference_t<Components> > >().get_row()...), 0) = 0>
     static void invoke_callback(
         ecs_iter_t *iter, const Func& func, size_t i, Args... comps) 
     {
@@ -25632,7 +25635,12 @@ private:
 
     // func(flecs::iter&, size_t row, Components...)
     template <template<typename X, typename = int> class ColumnType, 
-        typename... Args, if_t<sizeof...(Args) + 2 == arity<Func>::value> = 0>
+        typename... Args,
+        typename Fn = Func,
+        decltype(std::declval<const Fn&>()(
+            std::declval<flecs::iter&>(),
+            size_t{},
+            std::declval<ColumnType< remove_reference_t<Components> > >().get_row()...), 0) = 0>
     static void invoke_callback(
         ecs_iter_t *iter, const Func& func, size_t i, Args... comps) 
     {
@@ -25643,7 +25651,10 @@ private:
 
     // func(Components...)
     template <template<typename X, typename = int> class ColumnType, 
-        typename... Args, if_t<sizeof...(Args) == arity<Func>::value> = 0>
+        typename... Args,
+        typename Fn = Func,
+        decltype(std::declval<const Fn&>()(
+            std::declval<ColumnType< remove_reference_t<Components> > >().get_row()...), 0) = 0>
     static void invoke_callback(
         ecs_iter_t*, const Func& func, size_t i, Args... comps) 
     {

--- a/flecs.h
+++ b/flecs.h
@@ -25896,15 +25896,18 @@ struct entity_observer_delegate : delegate {
     static void run(ecs_iter_t *iter) {
         invoke<Func>(iter);
     }
+
 private:
-    template <typename F, if_t<arity<F>::value == 1> = 0>
+    template <typename F,
+        decltype(std::declval<const F&>()(std::declval<flecs::entity>()), 0) = 0>
     static void invoke(ecs_iter_t *iter) {
         auto self = static_cast<const entity_observer_delegate*>(iter->callback_ctx);
         ecs_assert(self != nullptr, ECS_INTERNAL_ERROR, NULL);
         self->func_(flecs::entity(iter->world, ecs_field_src(iter, 0)));
     }
 
-    template <typename F, if_t<arity<F>::value == 0> = 0>
+    template <typename F,
+        decltype(std::declval<const F&>()(), 0) = 0>
     static void invoke(ecs_iter_t *iter) {
         auto self = static_cast<const entity_observer_delegate*>(iter->callback_ctx);
         ecs_assert(self != nullptr, ECS_INTERNAL_ERROR, NULL);

--- a/flecs.h
+++ b/flecs.h
@@ -25639,7 +25639,7 @@ private:
         typename Fn = Func,
         decltype(std::declval<const Fn&>()(
             std::declval<flecs::iter&>(),
-            size_t{},
+            std::declval<size_t&>(),
             std::declval<ColumnType< remove_reference_t<Components> > >().get_row()...), 0) = 0>
     static void invoke_callback(
         ecs_iter_t *iter, const Func& func, size_t i, Args... comps) 
@@ -25733,9 +25733,9 @@ private:
         typename... Args,
         typename Fn = Func,
         if_t<sizeof...(Components) == sizeof...(Args)> = 0,
-        decltype(std::declval<const Fn&>()(
+        decltype(bool(std::declval<const Fn&>()(
             std::declval<flecs::entity>(),
-            std::declval<ColumnType< remove_reference_t<Components> > >().get_row()...), 0) = 0>
+            std::declval<ColumnType< remove_reference_t<Components> > >().get_row()...)), 0) = 0>
     static flecs::entity invoke_callback(
         ecs_iter_t *iter, const Func& func, size_t, Terms&, Args... comps) 
     {
@@ -25769,10 +25769,10 @@ private:
         typename... Args,
         typename Fn = Func,
         if_t<sizeof...(Components) == sizeof...(Args)> = 0,
-        decltype(std::declval<const Fn&>()(
+        decltype(bool(std::declval<const Fn&>()(
             std::declval<flecs::iter&>(),
-            size_t{},
-            std::declval<ColumnType< remove_reference_t<Components> > >().get_row()...), 0) = 0>
+            std::declval<size_t&>(),
+            std::declval<ColumnType< remove_reference_t<Components> > >().get_row()...)), 0) = 0>
     static flecs::entity invoke_callback(
         ecs_iter_t *iter, const Func& func, size_t, Terms&, Args... comps) 
     {
@@ -25807,8 +25807,8 @@ private:
         typename... Args,
         typename Fn = Func,
         if_t<sizeof...(Components) == sizeof...(Args)> = 0,
-        decltype(std::declval<const Fn&>()(
-            std::declval<ColumnType< remove_reference_t<Components> > >().get_row()...), 0) = 0>
+        decltype(bool(std::declval<const Fn&>()(
+            std::declval<ColumnType< remove_reference_t<Components> > >().get_row()...)), 0) = 0>
     static flecs::entity invoke_callback(
         ecs_iter_t *iter, const Func& func, size_t, Terms&, Args... comps) 
     {

--- a/flecs.h
+++ b/flecs.h
@@ -25925,7 +25925,9 @@ struct entity_payload_observer_delegate : delegate {
     }
 
 private:
-    template <typename F, if_t<arity<F>::value == 1> = 0>
+    template <typename F,
+        decltype(std::declval<const F&>()(
+            std::declval<Event&>()), 0) = 0>
     static void invoke(ecs_iter_t *iter) {
         auto self = static_cast<const entity_payload_observer_delegate*>(
             iter->callback_ctx);
@@ -25937,7 +25939,10 @@ private:
         self->func_(*data);
     }
 
-    template <typename F, if_t<arity<F>::value == 2> = 0>
+    template <typename F,
+        decltype(std::declval<const F&>()(
+            std::declval<flecs::entity>(),
+            std::declval<Event&>()), 0) = 0>
     static void invoke(ecs_iter_t *iter) {
         auto self = static_cast<const entity_payload_observer_delegate*>(
             iter->callback_ctx);

--- a/include/flecs/addons/cpp/delegate.hpp
+++ b/include/flecs/addons/cpp/delegate.hpp
@@ -525,15 +525,18 @@ struct entity_observer_delegate : delegate {
     static void run(ecs_iter_t *iter) {
         invoke<Func>(iter);
     }
+
 private:
-    template <typename F, if_t<arity<F>::value == 1> = 0>
+    template <typename F,
+        decltype(std::declval<const F&>()(std::declval<flecs::entity>()), 0) = 0>
     static void invoke(ecs_iter_t *iter) {
         auto self = static_cast<const entity_observer_delegate*>(iter->callback_ctx);
         ecs_assert(self != nullptr, ECS_INTERNAL_ERROR, NULL);
         self->func_(flecs::entity(iter->world, ecs_field_src(iter, 0)));
     }
 
-    template <typename F, if_t<arity<F>::value == 0> = 0>
+    template <typename F,
+        decltype(std::declval<const F&>()(), 0) = 0>
     static void invoke(ecs_iter_t *iter) {
         auto self = static_cast<const entity_observer_delegate*>(iter->callback_ctx);
         ecs_assert(self != nullptr, ECS_INTERNAL_ERROR, NULL);

--- a/include/flecs/addons/cpp/delegate.hpp
+++ b/include/flecs/addons/cpp/delegate.hpp
@@ -364,7 +364,7 @@ private:
         if_t<sizeof...(Components) == sizeof...(Args)> = 0,
         decltype(bool(std::declval<const Fn&>()(
             std::declval<flecs::entity>(),
-            std::declval<ColumnType< remove_reference_t<Components> > >().get_row()...)), 0) = 0>
+            std::declval<ColumnType< remove_reference_t<Components> > >().get_row()...))) = true>
     static flecs::entity invoke_callback(
         ecs_iter_t *iter, const Func& func, size_t, Terms&, Args... comps) 
     {
@@ -401,7 +401,7 @@ private:
         decltype(bool(std::declval<const Fn&>()(
             std::declval<flecs::iter&>(),
             std::declval<size_t&>(),
-            std::declval<ColumnType< remove_reference_t<Components> > >().get_row()...)), 0) = 0>
+            std::declval<ColumnType< remove_reference_t<Components> > >().get_row()...))) = true>
     static flecs::entity invoke_callback(
         ecs_iter_t *iter, const Func& func, size_t, Terms&, Args... comps) 
     {
@@ -437,7 +437,7 @@ private:
         typename Fn = Func,
         if_t<sizeof...(Components) == sizeof...(Args)> = 0,
         decltype(bool(std::declval<const Fn&>()(
-            std::declval<ColumnType< remove_reference_t<Components> > >().get_row()...)), 0) = 0>
+            std::declval<ColumnType< remove_reference_t<Components> > >().get_row()...))) = true>
     static flecs::entity invoke_callback(
         ecs_iter_t *iter, const Func& func, size_t, Terms&, Args... comps) 
     {

--- a/include/flecs/addons/cpp/delegate.hpp
+++ b/include/flecs/addons/cpp/delegate.hpp
@@ -268,7 +268,7 @@ private:
         typename Fn = Func,
         decltype(std::declval<const Fn&>()(
             std::declval<flecs::iter&>(),
-            size_t{},
+            std::declval<size_t&>(),
             std::declval<ColumnType< remove_reference_t<Components> > >().get_row()...), 0) = 0>
     static void invoke_callback(
         ecs_iter_t *iter, const Func& func, size_t i, Args... comps) 
@@ -362,9 +362,9 @@ private:
         typename... Args,
         typename Fn = Func,
         if_t<sizeof...(Components) == sizeof...(Args)> = 0,
-        decltype(std::declval<const Fn&>()(
+        decltype(bool(std::declval<const Fn&>()(
             std::declval<flecs::entity>(),
-            std::declval<ColumnType< remove_reference_t<Components> > >().get_row()...), 0) = 0>
+            std::declval<ColumnType< remove_reference_t<Components> > >().get_row()...)), 0) = 0>
     static flecs::entity invoke_callback(
         ecs_iter_t *iter, const Func& func, size_t, Terms&, Args... comps) 
     {
@@ -398,10 +398,10 @@ private:
         typename... Args,
         typename Fn = Func,
         if_t<sizeof...(Components) == sizeof...(Args)> = 0,
-        decltype(std::declval<const Fn&>()(
+        decltype(bool(std::declval<const Fn&>()(
             std::declval<flecs::iter&>(),
-            size_t{},
-            std::declval<ColumnType< remove_reference_t<Components> > >().get_row()...), 0) = 0>
+            std::declval<size_t&>(),
+            std::declval<ColumnType< remove_reference_t<Components> > >().get_row()...)), 0) = 0>
     static flecs::entity invoke_callback(
         ecs_iter_t *iter, const Func& func, size_t, Terms&, Args... comps) 
     {
@@ -436,8 +436,8 @@ private:
         typename... Args,
         typename Fn = Func,
         if_t<sizeof...(Components) == sizeof...(Args)> = 0,
-        decltype(std::declval<const Fn&>()(
-            std::declval<ColumnType< remove_reference_t<Components> > >().get_row()...), 0) = 0>
+        decltype(bool(std::declval<const Fn&>()(
+            std::declval<ColumnType< remove_reference_t<Components> > >().get_row()...)), 0) = 0>
     static flecs::entity invoke_callback(
         ecs_iter_t *iter, const Func& func, size_t, Terms&, Args... comps) 
     {

--- a/include/flecs/addons/cpp/delegate.hpp
+++ b/include/flecs/addons/cpp/delegate.hpp
@@ -554,7 +554,9 @@ struct entity_payload_observer_delegate : delegate {
     }
 
 private:
-    template <typename F, if_t<arity<F>::value == 1> = 0>
+    template <typename F,
+        decltype(std::declval<const F&>()(
+            std::declval<Event&>()), 0) = 0>
     static void invoke(ecs_iter_t *iter) {
         auto self = static_cast<const entity_payload_observer_delegate*>(
             iter->callback_ctx);
@@ -566,7 +568,10 @@ private:
         self->func_(*data);
     }
 
-    template <typename F, if_t<arity<F>::value == 2> = 0>
+    template <typename F,
+        decltype(std::declval<const F&>()(
+            std::declval<flecs::entity>(),
+            std::declval<Event&>()), 0) = 0>
     static void invoke(ecs_iter_t *iter) {
         auto self = static_cast<const entity_payload_observer_delegate*>(
             iter->callback_ctx);

--- a/include/flecs/addons/cpp/delegate.hpp
+++ b/include/flecs/addons/cpp/delegate.hpp
@@ -328,19 +328,6 @@ public:
 
 template <typename Func, typename ... Components>
 struct find_delegate : public delegate {
-    // If the number of arguments in the function signature is one more than the
-    // number of components in the query, an extra entity arg is required.
-    static constexpr bool PassEntity = 
-        (sizeof...(Components) + 1) == (arity<Func>::value);
-
-    // If the number of arguments in the function is two more than the number of
-    // components in the query, extra iter + index arguments are required.
-    static constexpr bool PassIter = 
-        (sizeof...(Components) + 2) == (arity<Func>::value);
-
-    static_assert(arity<Func>::value > 0, 
-        "each() must have at least one argument");
-
     using Terms = typename term_ptrs<Components ...>::array;
 
     template < if_not_t< is_same< decay_t<Func>, decay_t<Func>& >::value > = 0>
@@ -371,9 +358,13 @@ struct find_delegate : public delegate {
 private:
     // Number of function arguments is one more than number of components, pass
     // entity as argument.
-    template <template<typename X, typename = int> class ColumnType, 
-        typename... Args, if_t< 
-            sizeof...(Components) == sizeof...(Args) && PassEntity> = 0>
+    template <template<typename X, typename = int> class ColumnType,
+        typename... Args,
+        typename Fn = Func,
+        if_t<sizeof...(Components) == sizeof...(Args)> = 0,
+        decltype(std::declval<const Fn&>()(
+            std::declval<flecs::entity>(),
+            std::declval<ColumnType< remove_reference_t<Components> > >().get_row()...), 0) = 0>
     static flecs::entity invoke_callback(
         ecs_iter_t *iter, const Func& func, size_t, Terms&, Args... comps) 
     {
@@ -403,9 +394,14 @@ private:
 
     // Number of function arguments is two more than number of components, pass
     // iter + index as argument.
-    template <template<typename X, typename = int> class ColumnType, 
-        typename... Args, int Enabled = PassIter, if_t< 
-            sizeof...(Components) == sizeof...(Args) && Enabled> = 0>
+    template <template<typename X, typename = int> class ColumnType,
+        typename... Args,
+        typename Fn = Func,
+        if_t<sizeof...(Components) == sizeof...(Args)> = 0,
+        decltype(std::declval<const Fn&>()(
+            std::declval<flecs::iter&>(),
+            size_t{},
+            std::declval<ColumnType< remove_reference_t<Components> > >().get_row()...), 0) = 0>
     static flecs::entity invoke_callback(
         ecs_iter_t *iter, const Func& func, size_t, Terms&, Args... comps) 
     {
@@ -436,9 +432,12 @@ private:
     }
 
     // Number of function arguments is equal to number of components, no entity
-    template <template<typename X, typename = int> class ColumnType, 
-        typename... Args, if_t< 
-            sizeof...(Components) == sizeof...(Args) && !PassEntity && !PassIter> = 0>
+    template <template<typename X, typename = int> class ColumnType,
+        typename... Args,
+        typename Fn = Func,
+        if_t<sizeof...(Components) == sizeof...(Args)> = 0,
+        decltype(std::declval<const Fn&>()(
+            std::declval<ColumnType< remove_reference_t<Components> > >().get_row()...), 0) = 0>
     static flecs::entity invoke_callback(
         ecs_iter_t *iter, const Func& func, size_t, Terms&, Args... comps) 
     {

--- a/test/cpp/src/Event.cpp
+++ b/test/cpp/src/Event.cpp
@@ -532,32 +532,6 @@ void Event_entity_emit_event_w_payload(void) {
     test_int(count, 1);
 }
 
-// Generic lambdas are a C++14 feature.
-
-struct GenericLambdaObserveEntity {
-    template <typename E, typename P>
-    void operator()(E&&, P&&) const {
-        static_assert(flecs::is_same<E, flecs::entity>(), "");
-        static_assert(flecs::is_same<P, Position&>(), "");
-    }
-};
-
-struct GenericLambdaObservePayload {
-    template <typename P>
-    void operator()(P&&) const {
-        static_assert(flecs::is_same<P, Position&>(), "");
-    }
-};
-
-void Event_entity_emit_event_w_payload_generic(void) {
-    flecs::world ecs;
-
-    flecs::entity e = ecs.entity();
-
-    e.observe<Position>(GenericLambdaObserveEntity{});
-    e.observe<Position>(GenericLambdaObservePayload{});
-}
-
 void Event_entity_emit_event_id_no_src(void) {
     flecs::world ecs;
 
@@ -655,6 +629,40 @@ void Event_entity_emit_event_w_payload_derived_event_type_no_src(void) {
     e.emit<Position>({10, 20});
 
     test_int(count, 1);
+}
+
+// Generic lambdas are a C++14 feature.
+
+struct GenericLambdaObserveEntityPayload {
+    template <typename E, typename P>
+    void operator()(E&&, P&&) const {
+        static_assert(flecs::is_same<E, flecs::entity>(), "");
+        static_assert(flecs::is_same<P, Position&>(), "");
+    }
+};
+
+struct GenericLambdaObservePayload {
+    template <typename P>
+    void operator()(P&&) const {
+        static_assert(flecs::is_same<P, Position&>(), "");
+    }
+};
+
+struct GenericLambdaObserveEntity {
+    template <typename E>
+    void operator()(E&&) const {
+        static_assert(flecs::is_same<E, flecs::entity>(), "");
+    }
+};
+
+void Event_entity_observe_generic(void) {
+    flecs::world ecs;
+
+    flecs::entity e = ecs.entity();
+
+    e.observe<Position>(GenericLambdaObserveEntityPayload{});
+    e.observe<Position>(GenericLambdaObservePayload{});
+    e.observe<Evt>(GenericLambdaObserveEntity{});
 }
 
 void Event_enqueue_event(void) {

--- a/test/cpp/src/Event.cpp
+++ b/test/cpp/src/Event.cpp
@@ -532,6 +532,32 @@ void Event_entity_emit_event_w_payload(void) {
     test_int(count, 1);
 }
 
+// Generic lambdas are a C++14 feature.
+
+struct GenericLambdaObserveEntity {
+    template <typename E, typename P>
+    void operator()(E&&, P&&) const {
+        static_assert(flecs::is_same<E, flecs::entity>(), "");
+        static_assert(flecs::is_same<P, Position&>(), "");
+    }
+};
+
+struct GenericLambdaObservePayload {
+    template <typename P>
+    void operator()(P&&) const {
+        static_assert(flecs::is_same<P, Position&>(), "");
+    }
+};
+
+void Event_entity_emit_event_w_payload_generic(void) {
+    flecs::world ecs;
+
+    flecs::entity e = ecs.entity();
+
+    e.observe<Position>(GenericLambdaObserveEntity{});
+    e.observe<Position>(GenericLambdaObservePayload{});
+}
+
 void Event_entity_emit_event_id_no_src(void) {
     flecs::world ecs;
 

--- a/test/cpp/src/Query.cpp
+++ b/test/cpp/src/Query.cpp
@@ -523,6 +523,51 @@ void Query_find_w_entity(void) {
     test_assert(r == e2);
 }
 
+// Generic lambdas are a C++14 feature.
+
+struct GenericLambdaFindEntity {
+    template <typename E, typename P, typename V, typename M>
+    bool operator()(E&&, P&&, V&&, M&&) const {
+        static_assert(flecs::is_same<E, flecs::entity>::value, "");
+        static_assert(flecs::is_same<P, Position&>::value, "");
+        static_assert(flecs::is_same<V, const Velocity&>::value, "");
+        static_assert(flecs::is_same<M, Mass*>::value, "");
+        return true;
+    }
+};
+
+struct GenericLambdaFindIter {
+    template <typename T, typename I, typename P, typename V, typename M>
+    bool operator()(T&&, I&&, P&&, V&&, M&&) const {
+        static_assert(flecs::is_same<T, flecs::iter&>::value, "");
+        static_assert(flecs::is_same<I, size_t&>::value, "");
+        static_assert(flecs::is_same<P, Position&>::value, "");
+        static_assert(flecs::is_same<V, const Velocity&>::value, "");
+        static_assert(flecs::is_same<M, Mass*>::value, "");
+        return true;
+    }
+};
+
+struct GenericLambdaFindComps {
+    template <typename P, typename V, typename M>
+    bool operator()(P&&, V&&, M&&) const {
+        static_assert(flecs::is_same<P, Position&>::value, "");
+        static_assert(flecs::is_same<V, const Velocity&>::value, "");
+        static_assert(flecs::is_same<M, Mass*>::value, "");
+        return true;
+    }
+};
+
+void Query_find_generic(void) {
+    flecs::world world;
+
+    auto q = world.query<Position, const Velocity, Mass*>();
+
+    q.find(GenericLambdaFindEntity{});
+    q.find(GenericLambdaFindIter{});
+    q.find(GenericLambdaFindComps{});
+}
+
 void Query_optional_pair_term(void) {
     flecs::world ecs;
 
@@ -858,6 +903,48 @@ void Query_each_optional(void) {
     p = e4.get<Position>();
     test_int(p->x, 71);
     test_int(p->y, 81);  
+}
+
+// Generic lambdas are a C++14 feature.
+
+struct GenericLambdaEachEntity {
+    template <typename E, typename P, typename V, typename M>
+    void operator()(E&&, P&&, V&&, M&&) const {
+        static_assert(flecs::is_same<E, flecs::entity>::value, "");
+        static_assert(flecs::is_same<P, Position&>::value, "");
+        static_assert(flecs::is_same<V, const Velocity&>::value, "");
+        static_assert(flecs::is_same<M, Mass*>::value, "");
+    }
+};
+
+struct GenericLambdaEachIter {
+    template <typename T, typename I, typename P, typename V, typename M>
+    void operator()(T&&, I&&, P&&, V&&, M&&) const {
+        static_assert(flecs::is_same<T, flecs::iter&>::value, "");
+        static_assert(flecs::is_same<I, size_t&>::value, "");
+        static_assert(flecs::is_same<P, Position&>::value, "");
+        static_assert(flecs::is_same<V, const Velocity&>::value, "");
+        static_assert(flecs::is_same<M, Mass*>::value, "");
+    }
+};
+
+struct GenericLambdaEachComps {
+    template <typename P, typename V, typename M>
+    void operator()(P&&, V&&, M&&) const {
+        static_assert(flecs::is_same<P, Position&>::value, "");
+        static_assert(flecs::is_same<V, const Velocity&>::value, "");
+        static_assert(flecs::is_same<M, Mass*>::value, "");
+    }
+};
+
+void Query_each_generic(void) {
+    flecs::world world;
+
+    auto q = world.query<Position, const Velocity, Mass*>();
+
+    q.each(GenericLambdaEachEntity{});
+    q.each(GenericLambdaEachIter{});
+    q.each(GenericLambdaEachComps{});
 }
 
 void Query_signature(void) {

--- a/test/cpp/src/main.cpp
+++ b/test/cpp/src/main.cpp
@@ -511,6 +511,7 @@ void Event_emit_custom_for_any(void);
 void Event_entity_emit_event_id(void);
 void Event_entity_emit_event_type(void);
 void Event_entity_emit_event_w_payload(void);
+void Event_entity_emit_event_w_payload_generic(void);
 void Event_entity_emit_event_id_no_src(void);
 void Event_entity_emit_event_type_no_src(void);
 void Event_entity_emit_event_w_payload_no_src(void);
@@ -551,6 +552,7 @@ void Query_each(void);
 void Query_each_const(void);
 void Query_each_shared(void);
 void Query_each_optional(void);
+void Query_each_generic(void);
 void Query_signature(void);
 void Query_signature_const(void);
 void Query_signature_shared(void);
@@ -631,6 +633,7 @@ void Query_iter_get_pair_w_id(void);
 void Query_find(void);
 void Query_find_not_found(void);
 void Query_find_w_entity(void);
+void Query_find_generic(void);
 void Query_optional_pair_term(void);
 void Query_query_from_entity(void);
 void Query_query_from_entity_name(void);
@@ -3293,6 +3296,10 @@ bake_test_case Event_testcases[] = {
         Event_entity_emit_event_w_payload
     },
     {
+        "entity_emit_event_w_payload_generic",
+        Event_entity_emit_event_w_payload_generic
+    },
+    {
         "entity_emit_event_id_no_src",
         Event_entity_emit_event_id_no_src
     },
@@ -3441,6 +3448,10 @@ bake_test_case Query_testcases[] = {
     {
         "each_optional",
         Query_each_optional
+    },
+    {
+        "each_generic",
+        Query_each_generic
     },
     {
         "signature",
@@ -3761,6 +3772,10 @@ bake_test_case Query_testcases[] = {
     {
         "find_w_entity",
         Query_find_w_entity
+    },
+    {
+        "find_generic",
+        Query_find_generic
     },
     {
         "optional_pair_term",

--- a/test/cpp/src/main.cpp
+++ b/test/cpp/src/main.cpp
@@ -511,12 +511,12 @@ void Event_emit_custom_for_any(void);
 void Event_entity_emit_event_id(void);
 void Event_entity_emit_event_type(void);
 void Event_entity_emit_event_w_payload(void);
-void Event_entity_emit_event_w_payload_generic(void);
 void Event_entity_emit_event_id_no_src(void);
 void Event_entity_emit_event_type_no_src(void);
 void Event_entity_emit_event_w_payload_no_src(void);
 void Event_entity_emit_event_w_payload_derived_event_type(void);
 void Event_entity_emit_event_w_payload_derived_event_type_no_src(void);
+void Event_entity_observe_generic(void);
 void Event_enqueue_event(void);
 void Event_enqueue_entity_event(void);
 void Event_enqueue_event_w_payload(void);
@@ -3296,10 +3296,6 @@ bake_test_case Event_testcases[] = {
         Event_entity_emit_event_w_payload
     },
     {
-        "entity_emit_event_w_payload_generic",
-        Event_entity_emit_event_w_payload_generic
-    },
-    {
         "entity_emit_event_id_no_src",
         Event_entity_emit_event_id_no_src
     },
@@ -3318,6 +3314,10 @@ bake_test_case Event_testcases[] = {
     {
         "entity_emit_event_w_payload_derived_event_type_no_src",
         Event_entity_emit_event_w_payload_derived_event_type_no_src
+    },
+    {
+        "entity_observe_generic",
+        Event_entity_observe_generic
     },
     {
         "enqueue_event",


### PR DESCRIPTION
Updates several places that call a user-provided callable to select overloads using SFINAE rather than determining function arity using the callable's type. This allows generic lambdas to be used in places where they previously weren't allowed.

Resolves #1233.