### PR TITLE
[v4] Fix crash when copying world cpp object during fini

### DIFF
--- a/flecs.h
+++ b/flecs.h
@@ -20504,6 +20504,10 @@ struct world {
                 if (ecs_stage_get_id(world_) == -1) {
                     ecs_stage_free(world_);
                 } else {
+                    // before we call ecs_fini(), we increment the reference count back to 1
+                    // otherwise, copies of this object created during ecs_fini (e.g. a component on_remove hook)
+                    // would call again this destructor and ecs_fini().
+                    flecs_poly_claim(world_);
                     ecs_fini(world_);
                 }
             }

--- a/include/flecs/addons/cpp/world.hpp
+++ b/include/flecs/addons/cpp/world.hpp
@@ -190,6 +190,10 @@ struct world {
                 if (ecs_stage_get_id(world_) == -1) {
                     ecs_stage_free(world_);
                 } else {
+                    // before we call ecs_fini(), we increment the reference count back to 1
+                    // otherwise, copies of this object created during ecs_fini (e.g. a component on_remove hook)
+                    // would call again this destructor and ecs_fini().
+                    flecs_poly_claim(world_);
                     ecs_fini(world_);
                 }
             }

--- a/test/cpp/project.json
+++ b/test/cpp/project.json
@@ -1200,7 +1200,8 @@
                 "get_mut_T",
                 "get_mut_R_T",
                 "world_mini",
-                "copy_world"
+                "copy_world",
+                "fini_reentrancy"
             ]
         }, {
             "id": "Singleton",

--- a/test/cpp/src/main.cpp
+++ b/test/cpp/src/main.cpp
@@ -1156,6 +1156,7 @@ void World_get_mut_T(void);
 void World_get_mut_R_T(void);
 void World_world_mini(void);
 void World_copy_world(void);
+void World_fini_reentrancy(void);
 
 // Testsuite 'Singleton'
 void Singleton_set_get_singleton(void);
@@ -5826,6 +5827,10 @@ bake_test_case World_testcases[] = {
     {
         "copy_world",
         World_copy_world
+    },
+    {
+        "fini_reentrancy",
+        World_fini_reentrancy
     }
 };
 
@@ -6638,7 +6643,7 @@ static bake_test_suite suites[] = {
         "World",
         NULL,
         NULL,
-        114,
+        115,
         World_testcases
     },
     {


### PR DESCRIPTION
When inadvertently copying a `flecs::world` object during shutdown, e.g., as part of a component `on_remove` hook, `ecs_fini()` is re-entered causing an abort.

Reproduction: 

```cpp
  struct A {
    int a;
  };

  flecs::world ecs;

  // declare on remove hook for component A:
  ecs.component<A>().on_remove([](flecs::entity e, A &) {  //
    // This code runs on world destroy, since we did not remove this component manually
    // before the world was destroyed.
    
    // obtain the entity's world. This increments the hdr refcount when it already was zero
    flecs::world ecs_copy = e.world();

    // here ecs_copy object wrapping c world is destroyed, and `world::~world()` for this copied instance
    // will be called, causing a repeated call to `ecs_fini()`
    // therefore, world destroy will be called again wreaking havoc.
  });

  ecs.entity().add<A>();

  // world will be destroyed here. Program will crash when `ecs_copy` goes out of scope as part
  // of the on_remove hook handler.

```

This PR corrects this issue and adds a test to verify the above code works as expected.