### PR TITLE
Json fixes

### DIFF
--- a/docs/FlecsRemoteApi.md
+++ b/docs/FlecsRemoteApi.md
@@ -465,6 +465,7 @@ GET entity/<path>
 | full_paths    | bool     | Serialize full tag/pair/component paths         |
 | inherited     | bool     | Serialize inherited components                  |
 | values        | bool     | Serialize component values                      |
+| builtin       | bool     | Serialize builtin components for parent & name  |
 | type_info     | bool     | Serialize type info for components              |
 | matches       | bool     | Serialize matched with queries                  |
 | alerts        | bool     | Serialize active alerts for entity & children   |
@@ -473,7 +474,7 @@ GET entity/<path>
 
 #### Examples
 
-In this example, `Mass` is a component with reflection data, `(Identifier, Name)` is a pair component without reflection data, and `(Description, Color)` is a pair component with reflection data.
+In this example, `Mass` is a component with reflection data, `Position` is a pair component without reflection data, and `(Description, Color)` is a pair component with reflection data.
 
 <div class="flecs-snippet-tabs">
 <ul>
@@ -526,22 +527,19 @@ auto json = e.to_json();
   "tags": [
     "Planet"
   ],
-  "pairs": {
-    "ChildOf": "Sun"
-  },
   "components": {
     "Mass": {
       "value": "5.9722e24"
     },
-    "(Identifier,Name)": null,
-    "(Description,Color)": {
+    "Position": null,
+    "(flecs.doc.Description,flecs.doc.Color)": {
       "value": "#6b93d6"
     }
   }
 }
 ```
 ---
-This example shows how `type_info` can be used to obtain the component schema's. If no schema is available a `null` placeholder is sent. The example also shows the `entity_id` option, which adds the `id` member.
+This example shows how `type_info` can be used to obtain the component schema's. If no schema is available a `null` placeholder is sent. Note how the member name used in the `type_info` object is the same as used in the `components` object. The example also shows the `entity_id` option, which adds the `id` member.
 
 <div class="flecs-snippet-tabs">
 <ul>
@@ -608,8 +606,8 @@ auto json = e.to_json(&desc);
         }
       ]
     },
-    "(Identifier,Name)": 0,
-    "(Description,Color)": {
+    "Position": 0,
+    "(flecs.doc.Description,flecs.doc.Color)": {
       "value": [
         "text"
       ]
@@ -618,85 +616,11 @@ auto json = e.to_json(&desc);
   "tags": [
     "Planet"
   ],
-  "pairs": {
-    "ChildOf": "Sun"
-  },
   "components": {
     "Mass": {
       "value": "5.9722e24"
     },
-    "(Identifier,Name)": null,
-    "(Description,Color)": {
-      "value": "#6b93d6"
-    }
-  }
-}
-```
----
-This example shows the effect of setting `full_paths`. This can be useful when tag, pair or component names are used in follow up requests, which often require full paths. It can also be used to disambiguate between names in different namespaces.
-
-<div class="flecs-snippet-tabs">
-<ul>
-<li><b class="tab-title">HTTP</b>
-
-```
-GET /entity/Sun/Earth?full_paths=true
-```
-
-</li>
-<li><b class="tab-title">JavaScript</b>
-
-```js
-const conn = flecs.connect("localhost");
-
-conn.entity("Sun.Earth", {full_paths: true}, (reply) => {
-  // ...
-});
-```
-
-</li>
-<li><b class="tab-title">C</b>
-
-```c
-ecs_entity_t e = ecs_lookup(world, "Sun.Earth");
-
-ecs_entity_to_json_desc_t desc = ECS_ENTITY_TO_JSON_INIT;
-desc.serialize_full_paths = true;
-char *json = ecs_entity_to_json(world, e, &desc);
-// ...
-ecs_os_free(json);
-```
-
-</li>
-<li><b class="tab-title">C++</b>
-
-```cpp
-flecs::entity e = world.lookup("Sun::Earth");
-
-ecs_entity_to_json_desc_t desc = ECS_ENTITY_TO_JSON_INIT;
-desc.serialize_full_paths = true;
-auto json = e.to_json(&desc);
-```
-
-</li>
-</ul>
-</div>
-
-```json
-{
-  "parent": "Sun",
-  "name": "Earth",
-  "tags": [
-    "planets.Planet"
-  ],
-  "pairs": {
-    "flecs.core.ChildOf": "Sun"
-  },
-  "components": {
-    "planets.Mass": {
-      "value": "5.9722e24"
-    },
-    "(flecs.core.Identifier,flecs.core.Name)": null,
+    "Position": null,
     "(flecs.doc.Description,flecs.doc.Color)": {
       "value": "#6b93d6"
     }
@@ -761,8 +685,7 @@ auto json = e.to_json(&desc);
     "Planet"
   ],
   "pairs": {
-    "ChildOf": "Sun",
-    "IsA": "HabitablePlanet"
+    "flecs.core.IsA": "HabitablePlanet"
   },
   "inherited": {
     "planets.HabitablePlanet": {
@@ -775,10 +698,6 @@ auto json = e.to_json(&desc);
   "components": {
     "Mass": {
       "value": "5.9722e24"
-    },
-    "(Identifier,Name)": null,
-    "(Description,Color)": {
-      "value": "#6b93d6"
     }
   }
 }
@@ -840,13 +759,8 @@ auto json = e.to_json(&desc);
   "tags": [
     "Planet"
   ],
-  "pairs": {
-    "ChildOf": "Sun"
-  },
   "components": {
     "Mass": null,
-    "(Identifier,Name)": null,
-    "(Description,Color)": null
   }
 }
 ```
@@ -1254,6 +1168,7 @@ GET /query/?expr=<query expression>
 | full_paths    | bool     | Serialize full tag/pair/component paths         |
 | inherited     | bool     | Serialize inherited components                  |
 | values        | bool     | Serialize component values                      |
+| builtin       | bool     | Serialize builtin components for parent & name  |
 | fields        | bool     | Serialize query fields                          |
 | table         | bool     | Serialize table (all components for match)      |
 | result        | bool     | Serialize results (disable for metadata-only request) |
@@ -1419,8 +1334,7 @@ auto json = q.iter().to_json(&desc);
         "FtlEnabled"
       ],
       "pairs": {
-        "ChildOf": "shipyard",
-        "IsA": "Freighter"
+        "flecs.core.IsA": "Freighter"
       },
       "components": {
         "Position": {
@@ -1430,8 +1344,7 @@ auto json = q.iter().to_json(&desc);
         "Velocity": {
           "x": 1,
           "y": 1
-        },
-        "(Identifier,Name)": null
+        }
       }
     },
     {
@@ -1441,7 +1354,6 @@ auto json = q.iter().to_json(&desc);
         "FtlEnabled"
       ],
       "pairs": {
-        "ChildOf": "shipyard",
         "IsA": "Freighter"
       },
       "components": {
@@ -1452,8 +1364,7 @@ auto json = q.iter().to_json(&desc);
         "Velocity": {
           "x": 3,
           "y": 4
-        },
-        "(Identifier,Name)": null
+        }
       }
     }
   ]

--- a/flecs.h
+++ b/flecs.h
@@ -13378,6 +13378,7 @@ typedef struct ecs_entity_to_json_desc_t {
     bool serialize_full_paths; /**< Serialize full paths for tags, components and pairs */
     bool serialize_inherited;  /**< Serialize base components */
     bool serialize_values;     /**< Serialize component values */
+    bool serialize_builtin;    /**< Serialize builtin data as components (e.g. "name", "parent") */
     bool serialize_type_info;  /**< Serialize type info (requires serialize_values) */
     bool serialize_alerts;     /**< Serialize active alerts for entity */
     ecs_entity_t serialize_refs; /**< Serialize references (incoming edges) for relationship */
@@ -13387,9 +13388,10 @@ typedef struct ecs_entity_to_json_desc_t {
 /** Utility used to initialize JSON entity serializer. */
 #define ECS_ENTITY_TO_JSON_INIT (ecs_entity_to_json_desc_t){\
     .serialize_doc = false, \
-    .serialize_full_paths = false, \
+    .serialize_full_paths = true, \
     .serialize_inherited = false, \
     .serialize_values = true, \
+    .serialize_builtin = false, \
     .serialize_type_info = false, \
     .serialize_alerts = false, \
     .serialize_refs = 0, \
@@ -13431,8 +13433,8 @@ int ecs_entity_to_json_buf(
 typedef struct ecs_iter_to_json_desc_t {
     bool serialize_entity_ids;      /**< Serialize entity ids */
     bool serialize_values;          /**< Serialize component values */
+    bool serialize_builtin;         /**< Serialize builtin data as components (e.g. "name", "parent") */
     bool serialize_doc;             /**< Serialize doc attributes */
-    bool serialize_var_labels;      /**< Serialize doc names of matched variables */
     bool serialize_full_paths;      /**< Serialize full paths for tags, components and pairs */
     bool serialize_fields;          /**< Serialize field data */
     bool serialize_inherited;       /**< Serialize inherited components */
@@ -13453,8 +13455,9 @@ typedef struct ecs_iter_to_json_desc_t {
 #define ECS_ITER_TO_JSON_INIT (ecs_iter_to_json_desc_t){\
     .serialize_entity_ids =      false, \
     .serialize_values =          true, \
+    .serialize_builtin =         false, \
     .serialize_doc =             false, \
-    .serialize_full_paths =      false, \
+    .serialize_full_paths =      true, \
     .serialize_fields =          true, \
     .serialize_inherited =       false, \
     .serialize_table =           false, \

--- a/include/flecs/addons/json.h
+++ b/include/flecs/addons/json.h
@@ -219,6 +219,7 @@ typedef struct ecs_entity_to_json_desc_t {
     bool serialize_full_paths; /**< Serialize full paths for tags, components and pairs */
     bool serialize_inherited;  /**< Serialize base components */
     bool serialize_values;     /**< Serialize component values */
+    bool serialize_builtin;    /**< Serialize builtin data as components (e.g. "name", "parent") */
     bool serialize_type_info;  /**< Serialize type info (requires serialize_values) */
     bool serialize_alerts;     /**< Serialize active alerts for entity */
     ecs_entity_t serialize_refs; /**< Serialize references (incoming edges) for relationship */
@@ -228,9 +229,10 @@ typedef struct ecs_entity_to_json_desc_t {
 /** Utility used to initialize JSON entity serializer. */
 #define ECS_ENTITY_TO_JSON_INIT (ecs_entity_to_json_desc_t){\
     .serialize_doc = false, \
-    .serialize_full_paths = false, \
+    .serialize_full_paths = true, \
     .serialize_inherited = false, \
     .serialize_values = true, \
+    .serialize_builtin = false, \
     .serialize_type_info = false, \
     .serialize_alerts = false, \
     .serialize_refs = 0, \
@@ -272,8 +274,8 @@ int ecs_entity_to_json_buf(
 typedef struct ecs_iter_to_json_desc_t {
     bool serialize_entity_ids;      /**< Serialize entity ids */
     bool serialize_values;          /**< Serialize component values */
+    bool serialize_builtin;         /**< Serialize builtin data as components (e.g. "name", "parent") */
     bool serialize_doc;             /**< Serialize doc attributes */
-    bool serialize_var_labels;      /**< Serialize doc names of matched variables */
     bool serialize_full_paths;      /**< Serialize full paths for tags, components and pairs */
     bool serialize_fields;          /**< Serialize field data */
     bool serialize_inherited;       /**< Serialize inherited components */
@@ -294,8 +296,9 @@ typedef struct ecs_iter_to_json_desc_t {
 #define ECS_ITER_TO_JSON_INIT (ecs_iter_to_json_desc_t){\
     .serialize_entity_ids =      false, \
     .serialize_values =          true, \
+    .serialize_builtin =         false, \
     .serialize_doc =             false, \
-    .serialize_full_paths =      false, \
+    .serialize_full_paths =      true, \
     .serialize_fields =          true, \
     .serialize_inherited =       false, \
     .serialize_table =           false, \

--- a/src/addons/json/deserialize.c
+++ b/src/addons/json/deserialize.c
@@ -91,6 +91,7 @@ ecs_entity_t flecs_json_lookup(
     if (parent) {
         ecs_set_scope(world, scope);
     }
+
     return result;
 }
 
@@ -162,6 +163,19 @@ ecs_entity_t flecs_json_ensure_entity(
 }
 
 static
+bool flecs_json_add_id_to_type(
+    ecs_id_t id)
+{
+    if (id == ecs_pair_t(EcsIdentifier, EcsName)) {
+        return false;
+    }
+    if (ECS_IS_PAIR(id) && ECS_PAIR_FIRST(id) == EcsChildOf) {
+        return false;
+    }
+    return true;
+}
+
+static
 const char* flecs_json_deser_tags(
     ecs_world_t *world,
     ecs_entity_t e,
@@ -193,7 +207,9 @@ const char* flecs_json_deser_tags(
         }
 
         ecs_entity_t tag = flecs_json_lookup(world, 0, str, desc);
-        ecs_vec_append_t(ctx->a, &ctx->table_type, ecs_id_t)[0] = tag;
+        if (flecs_json_add_id_to_type(tag)) {
+            ecs_vec_append_t(ctx->a, &ctx->table_type, ecs_id_t)[0] = tag;
+        }
 
         ecs_add_id(world, e, tag);
 
@@ -260,7 +276,9 @@ const char* flecs_json_deser_pairs(
                 ecs_entity_t tgt = flecs_json_lookup(world, 0, token, desc);
                 ecs_id_t id = ecs_pair(rel, tgt);
                 ecs_add_id(world, e, id);
-                ecs_vec_append_t(ctx->a, &ctx->table_type, ecs_id_t)[0] = id;
+                if (flecs_json_add_id_to_type(id)) {
+                    ecs_vec_append_t(ctx->a, &ctx->table_type, ecs_id_t)[0] = id;
+                }
             } else if (token_kind == JsonLargeString) {
                 ecs_strbuf_t large_token = ECS_STRBUF_INIT;
                 json = flecs_json_parse_large_string(json, &large_token);
@@ -273,7 +291,9 @@ const char* flecs_json_deser_pairs(
                 ecs_os_free(str);
                 ecs_id_t id = ecs_pair(rel, tgt);
                 ecs_add_id(world, e, id);
-                ecs_vec_append_t(ctx->a, &ctx->table_type, ecs_id_t)[0] = id;
+                if (flecs_json_add_id_to_type(id)) {
+                    ecs_vec_append_t(ctx->a, &ctx->table_type, ecs_id_t)[0] = id;
+                }
             } else if (token_kind == JsonArrayOpen) {
                 if (multiple_targets) {
                     ecs_parser_error(NULL, expr, json - expr, 
@@ -416,7 +436,10 @@ const char* flecs_json_deser_components(
             json = lah;
         }
 
-        ecs_vec_append_t(ctx->a, &ctx->table_type, ecs_id_t)[0] = id;
+        /* Don't add ids that have their own fields in serialized data. */
+        if (flecs_json_add_id_to_type(id)) {
+            ecs_vec_append_t(ctx->a, &ctx->table_type, ecs_id_t)[0] = id;
+        }
 
         json = flecs_json_parse(json, &token_kind, token);
         if (token_kind != JsonComma) {
@@ -480,11 +503,13 @@ const char* flecs_entity_from_json(
         }
 
         parent = flecs_json_lookup(world, 0, str, desc);
+
         if (e) {
             ecs_add_pair(world, e, EcsChildOf, parent);
-            ecs_vec_append_t(ctx->a, &ctx->table_type, ecs_id_t)[0] =
-                ecs_pair(EcsChildOf, parent);
         }
+
+        ecs_vec_append_t(ctx->a, &ctx->table_type, ecs_id_t)[0] =
+            ecs_pair(EcsChildOf, parent);
 
         if (str != token) ecs_os_free(str);
 
@@ -508,6 +533,9 @@ const char* flecs_entity_from_json(
             e = flecs_json_lookup(world, parent, str, desc);
         } else {
             ecs_set_name(world, e, str);
+        }
+
+        if (str[0] != '#') {
             ecs_vec_append_t(ctx->a, &ctx->table_type, ecs_id_t)[0] =
                 ecs_pair_t(EcsIdentifier, EcsName);
         }
@@ -635,9 +663,18 @@ const char* flecs_entity_from_json(
 
         ecs_table_t *dst_table = ecs_table_find(world, 
             ecs_vec_first(&ctx->table_type), ecs_vec_count(&ctx->table_type));
+        if (dst_table->type.count == 0) {
+            dst_table = NULL;
+        }
 
         /* Entity had existing components that weren't in the serialized data */
         if (table != dst_table) {
+            ecs_assert(ecs_get_target(world, e, EcsChildOf, 0) != EcsFlecsCore,
+                ECS_INVALID_OPERATION, "%s\n[%s] => \n[%s]",
+                    ecs_get_path(world, e),
+                    ecs_table_str(world, table),
+                    ecs_table_str(world, dst_table));
+
             if (!dst_table) {
                 ecs_clear(world, e);
             } else {

--- a/src/addons/json/json.c
+++ b/src/addons/json/json.c
@@ -368,7 +368,7 @@ const char* flecs_json_skip_object(
         ecs_assert(json != NULL, ECS_INTERNAL_ERROR, NULL);
     }
 
-    ecs_parser_error(desc->name, desc->expr, 0, 
+    ecs_parser_error(desc->name, json, 0, 
         "expected }, got end of string");
     return NULL;
 }
@@ -558,8 +558,10 @@ void flecs_json_label(
     if (lbl) {
         flecs_json_string_escape(buf, lbl);
     } else {
+        ecs_strbuf_appendch(buf, '"');
         ecs_strbuf_appendch(buf, '#');
         ecs_strbuf_appendint(buf, (uint32_t)e);
+        ecs_strbuf_appendch(buf, '"');
     }
 }
 

--- a/src/addons/json/json.h
+++ b/src/addons/json/json.h
@@ -290,6 +290,9 @@ int flecs_json_serialize_alerts(
     ecs_strbuf_t *buf,
     ecs_entity_t entity);
 
+bool flecs_json_is_builtin(
+    ecs_id_t id);
+
 #endif
 
 #endif /* FLECS_JSON_PRIVATE_H */

--- a/src/addons/json/serialize_entity.c
+++ b/src/addons/json/serialize_entity.c
@@ -57,11 +57,12 @@ int ecs_entity_to_json_buf(
         .serialize_table = true,
         .serialize_entity_ids =   desc ? desc->serialize_entity_id : false,
         .serialize_values =       desc ? desc->serialize_values : true,
+        .serialize_builtin =       desc ? desc->serialize_builtin : false,
         .serialize_doc =          desc ? desc->serialize_doc : false,
         .serialize_matches =      desc ? desc->serialize_matches : false,
         .serialize_refs =         desc ? desc->serialize_refs : 0,
         .serialize_alerts =       desc ? desc->serialize_alerts : false,
-        .serialize_full_paths =   desc ? desc->serialize_full_paths : false,
+        .serialize_full_paths =   desc ? desc->serialize_full_paths : true,
         .serialize_inherited =    desc ? desc->serialize_inherited : false,
         .serialize_type_info =    desc ? desc->serialize_type_info : false
     };

--- a/src/addons/json/serialize_iter_result.c
+++ b/src/addons/json/serialize_iter_result.c
@@ -46,7 +46,7 @@ bool flecs_json_serialize_vars(
 
         flecs_json_member(buf, var_name);
         flecs_json_path_or_label(buf, world, var, 
-            desc ? desc->serialize_full_paths : false);
+            desc ? desc->serialize_full_paths : true);
     }
 
     if (actual_count) {
@@ -306,7 +306,7 @@ bool flecs_json_serialize_get_value_ctx(
 
         ecs_strbuf_t idlbl = ECS_STRBUF_INIT;
         flecs_json_id_member(&idlbl, world, id, 
-            desc ? desc->serialize_full_paths : false);
+            desc ? desc->serialize_full_paths : true);
         ctx->id_label = ecs_strbuf_get(&idlbl);
 
         ecs_entity_t type = ecs_get_typeid(world, id);

--- a/src/addons/meta/definitions.c
+++ b/src/addons/meta/definitions.c
@@ -60,8 +60,11 @@ void flecs_meta_import_core_definitions(
 
     ecs_entity_t addon_vec = ecs_opaque(world, {
         .entity = ecs_component(world, { 
-            .type = {
+            .entity = ecs_entity(world, {
                 .name = "flecs.core.addon_vec_t",
+                .root_sep = ""
+            }),
+            .type = {
                 .size = ECS_SIZEOF(char**),
                 .alignment = ECS_ALIGNOF(char**)
             }

--- a/src/addons/rest.c
+++ b/src/addons/rest.c
@@ -170,6 +170,7 @@ void flecs_rest_parse_json_ser_entity_params(
     flecs_rest_bool_param(req, "full_paths", &desc->serialize_full_paths);
     flecs_rest_bool_param(req, "inherited", &desc->serialize_inherited);
     flecs_rest_bool_param(req, "values", &desc->serialize_values);
+    flecs_rest_bool_param(req, "builtin", &desc->serialize_builtin);
     flecs_rest_bool_param(req, "type_info", &desc->serialize_type_info);
     flecs_rest_bool_param(req, "matches", &desc->serialize_matches);
     flecs_rest_bool_param(req, "alerts", &desc->serialize_alerts);
@@ -190,6 +191,8 @@ void flecs_rest_parse_json_ser_iter_params(
     flecs_rest_bool_param(req, "doc", &desc->serialize_doc);
     flecs_rest_bool_param(req, "full_paths", &desc->serialize_full_paths);
     flecs_rest_bool_param(req, "inherited", &desc->serialize_inherited);
+    flecs_rest_bool_param(req, "values", &desc->serialize_values);
+    flecs_rest_bool_param(req, "builtin", &desc->serialize_builtin);
     flecs_rest_bool_param(req, "type_info", &desc->serialize_type_info);
     flecs_rest_bool_param(req, "field_info", &desc->serialize_field_info);
     flecs_rest_bool_param(req, "query_info", &desc->serialize_query_info);

--- a/src/entity_name.c
+++ b/src/entity_name.c
@@ -25,31 +25,39 @@ bool flecs_path_append(
     ecs_size_t name_len = 0;
 
     if (child && ecs_is_alive(world, child)) {
-        cur = ecs_get_target(world, child, EcsChildOf, 0);
-        if (cur) {
-            ecs_assert(cur != child, ECS_CYCLE_DETECTED, NULL);
-            if (cur != parent && (cur != EcsFlecsCore || prefix != NULL)) {
-                flecs_path_append(world, parent, cur, sep, prefix, buf);
-                if (!sep[1]) {
-                    ecs_strbuf_appendch(buf, sep[0]);
-                } else {
-                    ecs_strbuf_appendstr(buf, sep);
-                }
-            }
-        } else if (prefix && prefix[0]) {
-            if (!prefix[1]) {
-                ecs_strbuf_appendch(buf, prefix[0]);
-            } else {
-                ecs_strbuf_appendstr(buf, prefix);
-            }
+        ecs_record_t *r = flecs_entities_get(world, child);
+        bool hasName = false;
+        if (r && r->table) {
+            hasName = r->table->flags & EcsTableHasName;
         }
 
-        const EcsIdentifier *id = ecs_get_pair(
-            world, child, EcsIdentifier, EcsName);
-        if (id) {
-            name = id->value;
-            name_len = id->length;
-        }      
+        if (hasName) {
+            cur = ecs_get_target(world, child, EcsChildOf, 0);
+            if (cur) {
+                ecs_assert(cur != child, ECS_CYCLE_DETECTED, NULL);
+                if (cur != parent && (cur != EcsFlecsCore || prefix != NULL)) {
+                    flecs_path_append(world, parent, cur, sep, prefix, buf);
+                    if (!sep[1]) {
+                        ecs_strbuf_appendch(buf, sep[0]);
+                    } else {
+                        ecs_strbuf_appendstr(buf, sep);
+                    }
+                }
+            } else if (prefix && prefix[0]) {
+                if (!prefix[1]) {
+                    ecs_strbuf_appendch(buf, prefix[0]);
+                } else {
+                    ecs_strbuf_appendstr(buf, prefix);
+                }
+            }
+
+            const EcsIdentifier *id = ecs_get_pair(
+                world, child, EcsIdentifier, EcsName);
+            if (id) {
+                name = id->value;
+                name_len = id->length;
+            } 
+        }     
     }
 
     if (name) {
@@ -565,6 +573,9 @@ void flecs_add_path(
     if (parent) {
         ecs_add_pair(world, entity, EcsChildOf, parent);
     }
+
+    ecs_assert(name[0] != '#', ECS_INVALID_PARAMETER, 
+        "path should not contain identifier with #");
 
     ecs_set_name(world, entity, name);
 

--- a/test/addons/src/Rest.c
+++ b/test/addons/src/Rest.c
@@ -25,8 +25,7 @@ void Rest_get(void) {
     test_assert(reply_str != NULL);
     test_str(reply_str,
             "{\"parent\":\"flecs.core\", \"name\":\"World\", "
-                "\"pairs\":{\"ChildOf\":\"core\"}, "
-                "\"components\":{\"(Identifier,Name)\":null, \"(Identifier,Symbol)\":null, \"(Description,Brief)\":{\"value\":\"Entity associated with world\"}}}");
+                "\"components\":{\"(flecs.core.Identifier,flecs.core.Symbol)\":null, \"(flecs.doc.Description,flecs.doc.Brief)\":{\"value\":\"Entity associated with world\"}}}");
     ecs_os_free(reply_str);
 
     ecs_rest_server_fini(srv);
@@ -53,8 +52,7 @@ void Rest_get_cached(void) {
         test_assert(reply_str != NULL);
         test_str(reply_str,
             "{\"parent\":\"flecs.core\", \"name\":\"World\", "
-                "\"pairs\":{\"ChildOf\":\"core\"}, "
-                "\"components\":{\"(Identifier,Name)\":null, \"(Identifier,Symbol)\":null, \"(Description,Brief)\":{\"value\":\"Entity associated with world\"}}}");
+                "\"components\":{\"(flecs.core.Identifier,flecs.core.Symbol)\":null, \"(flecs.doc.Description,flecs.doc.Brief)\":{\"value\":\"Entity associated with world\"}}}");
         ecs_os_free(reply_str);
     }
 
@@ -68,8 +66,7 @@ void Rest_get_cached(void) {
         test_assert(reply_str != NULL);
         test_str(reply_str,
             "{\"parent\":\"flecs.core\", \"name\":\"World\", "
-                "\"pairs\":{\"ChildOf\":\"core\"}, "
-                "\"components\":{\"(Identifier,Name)\":null, \"(Identifier,Symbol)\":null, \"(Description,Brief)\":{\"value\":\"Entity associated with world\"}}}");
+                "\"components\":{\"(flecs.core.Identifier,flecs.core.Symbol)\":null, \"(flecs.doc.Description,flecs.doc.Brief)\":{\"value\":\"Entity associated with world\"}}}");
         ecs_os_free(reply_str);
     }
 

--- a/test/cpp/src/Enum.cpp
+++ b/test/cpp/src/Enum.cpp
@@ -1001,6 +1001,11 @@ void Enum_query_union_enum(void) {
         while (it.next()) {
             test_int(it.count(), 1);
             if (count == 0) {
+                test_int(it.entity(0), e2);
+                test_assert(it.id(0) == 
+                    ecs.pair<StandardEnum>(ecs.to_entity(StandardEnum::Green)));
+            }
+            if (count == 2) {
                 test_int(it.entity(0), e1);
                 test_assert(it.id(0) == 
                     ecs.pair<StandardEnum>(ecs.to_entity(StandardEnum::Red)));
@@ -1009,11 +1014,6 @@ void Enum_query_union_enum(void) {
                 test_int(it.entity(0), e3);
                 test_assert(it.id(0) == 
                     ecs.pair<StandardEnum>(ecs.to_entity(StandardEnum::Blue)));
-            }
-            if (count == 2) {
-                test_int(it.entity(0), e2);
-                test_assert(it.id(0) == 
-                    ecs.pair<StandardEnum>(ecs.to_entity(StandardEnum::Green)));
             }
             count ++;
         }

--- a/test/meta/project.json
+++ b/test/meta/project.json
@@ -464,6 +464,8 @@
                 "struct_w_nested_members_struct",
                 "struct_w_2_nested_members_struct",
                 "ser_deser_entity_named",
+                "ser_deser_entity_named_child",
+                "ser_deser_entity_namespaced_component",
                 "deser_entity_1_component_1_member",
                 "deser_entity_1_component_1_member_w_spaces",
                 "deser_entity_1_component_2_members",
@@ -656,7 +658,11 @@
                 "serialize_no_matches",
                 "serialize_id_recycled",
                 "serialize_union_target",
-                "serialize_union_target_recycled"
+                "serialize_union_target_recycled",
+                "serialize_anonymous_w_builtin",
+                "serialize_named_w_builtin",
+                "serialize_named_child_w_builtin",
+                "serialize_named_child_w_builtin_w_type_info"
             ]
         }, {
             "id": "SerializeIterToJson",
@@ -701,6 +707,7 @@
                 "serialize_ids_2_entities",
                 "serialize_anonymous",
                 "serialize_anonymous_ids",
+                "serialize_variable_anonymous_no_full_path",
                 "serialize_variable_anonymous",
                 "serialize_anonymous_tag",
                 "serialize_anonymous_component",

--- a/test/meta/src/SerializeEntityToJson.c
+++ b/test/meta/src/SerializeEntityToJson.c
@@ -25,7 +25,7 @@ void SerializeEntityToJson_serialize_w_name(void) {
 
     char *json = ecs_entity_to_json(world, e, NULL);
     test_assert(json != NULL);
-    test_json(json, "{\"name\":\"Foo\", \"components\":{\"(Identifier,Name)\":null}}");
+    test_json(json, "{\"name\":\"Foo\"}");
     ecs_os_free(json);
 
     ecs_fini(world);
@@ -41,7 +41,7 @@ void SerializeEntityToJson_serialize_w_name_1_tag(void) {
 
     char *json = ecs_entity_to_json(world, e, NULL);
     test_assert(json != NULL);
-    test_json(json, "{\"name\":\"Foo\", \"tags\":[\"Tag\"], \"components\":{\"(Identifier,Name)\":null}}");
+    test_json(json, "{\"name\":\"Foo\", \"tags\":[\"Tag\"]}");
     ecs_os_free(json);
 
     ecs_fini(world);
@@ -60,7 +60,7 @@ void SerializeEntityToJson_serialize_w_name_2_tags(void) {
     char *json = ecs_entity_to_json(world, e, NULL);
     test_assert(json != NULL);
     test_json(json, 
-        "{\"name\":\"Foo\", \"tags\":[\"TagA\", \"TagB\"], \"components\":{\"(Identifier,Name)\":null}}");
+        "{\"name\":\"Foo\", \"tags\":[\"TagA\", \"TagB\"]}");
     ecs_os_free(json);
 
     ecs_fini(world);
@@ -78,7 +78,7 @@ void SerializeEntityToJson_serialize_w_name_1_pair(void) {
     char *json = ecs_entity_to_json(world, e, NULL);
     test_assert(json != NULL);
     test_json(json, 
-        "{\"name\":\"Foo\", \"pairs\":{\"Rel\":\"Obj\"}, \"components\":{\"(Identifier,Name)\":null}}");
+        "{\"name\":\"Foo\", \"pairs\":{\"Rel\":\"Obj\"}}");
     ecs_os_free(json);
 
     ecs_fini(world);
@@ -102,7 +102,7 @@ void SerializeEntityToJson_serialize_w_base(void) {
     };
     char *json = ecs_entity_to_json(world, e, &desc);
     test_assert(json != NULL);
-    test_json(json, "{\"name\":\"Foo\", \"tags\":[\"TagB\"],\"pairs\":{\"IsA\":\"Base\"},\"inherited\":{\"Base\":{\"tags\":[\"TagA\"]}}, \"components\":{\"(Identifier,Name)\":null}}");
+    test_json(json, "{\"name\":\"Foo\", \"tags\":[\"TagB\"],\"pairs\":{\"IsA\":\"Base\"},\"inherited\":{\"Base\":{\"tags\":[\"TagA\"]}}}");
 
     ecs_os_free(json);
 
@@ -124,7 +124,7 @@ void SerializeEntityToJson_serialize_w_2_base(void) {
 
     char *json = ecs_entity_to_json(world, e, NULL);
     test_assert(json != NULL);
-    test_json(json, "{\"name\":\"Foo\", \"pairs\":{\"IsA\":[\"BaseA\", \"BaseB\"]}, \"components\":{\"(Identifier,Name)\":null}}");
+    test_json(json, "{\"name\":\"Foo\", \"pairs\":{\"flecs.core.IsA\":[\"BaseA\", \"BaseB\"]}}");
 
     ecs_os_free(json);
 
@@ -146,7 +146,7 @@ void SerializeEntityToJson_serialize_w_nested_base(void) {
 
     char *json = ecs_entity_to_json(world, e, NULL);
     test_assert(json != NULL);
-    test_json(json, "{\"name\":\"Foo\", \"pairs\":{\"IsA\":\"Base\"}, \"components\":{\"(Identifier,Name)\":null}}");
+    test_json(json, "{\"name\":\"Foo\", \"pairs\":{\"flecs.core.IsA\":\"Base\"}}");
 
     ecs_os_free(json);
 
@@ -172,7 +172,7 @@ void SerializeEntityToJson_serialize_w_1_component(void) {
 
     char *json = ecs_entity_to_json(world, e, &desc);
     test_assert(json != NULL);
-    test_json(json, "{\"name\":\"Foo\", \"components\":{\"Position\":{\"x\":10, \"y\":20}, \"(Identifier,Name)\":null}}");
+    test_json(json, "{\"name\":\"Foo\", \"components\":{\"Position\":{\"x\":10, \"y\":20}}}");
 
     ecs_os_free(json);
 
@@ -206,7 +206,7 @@ void SerializeEntityToJson_serialize_w_2_components(void) {
 
     char *json = ecs_entity_to_json(world, e, &desc);
     test_assert(json != NULL);
-    test_json(json, "{\"name\":\"Foo\", \"components\":{\"Position\":{\"x\":10, \"y\":20}, \"Mass\":{\"value\":1234}, \"(Identifier,Name)\":null}}");
+    test_json(json, "{\"name\":\"Foo\", \"components\":{\"Position\":{\"x\":10, \"y\":20}, \"Mass\":{\"value\":1234}}}");
 
     ecs_os_free(json);
 
@@ -224,7 +224,7 @@ void SerializeEntityToJson_serialize_w_primitive_component(void) {
 
     char *json = ecs_entity_to_json(world, e, &desc);
     test_assert(json != NULL);
-    test_json(json, "{\"name\":\"Foo\", \"components\":{\"i32\":10, \"(Identifier,Name)\":null}}");
+    test_json(json, "{\"name\":\"Foo\", \"components\":{\"flecs.meta.i32\":10}}");
 
     ecs_os_free(json);
 
@@ -255,7 +255,7 @@ void SerializeEntityToJson_serialize_w_enum_component(void) {
 
     char *json = ecs_entity_to_json(world, e, &desc);
     test_assert(json != NULL);
-    test_json(json, "{\"name\":\"Foo\", \"components\":{\"Color\":\"Blue\", \"(Identifier,Name)\":null}}");
+    test_json(json, "{\"name\":\"Foo\", \"components\":{\"Color\":\"Blue\"}}");
 
     ecs_os_free(json);
 
@@ -297,7 +297,7 @@ void SerializeEntityToJson_serialize_w_struct_and_enum_component(void) {
 
     char *json = ecs_entity_to_json(world, e, &desc);
     test_assert(json != NULL);
-    test_json(json, "{\"name\":\"Foo\", \"components\":{\"Position\":{\"x\":10, \"y\":20}, \"Color\":\"Blue\", \"(Identifier,Name)\":null}}");
+    test_json(json, "{\"name\":\"Foo\", \"components\":{\"Position\":{\"x\":10, \"y\":20}, \"Color\":\"Blue\"}}");
 
     ecs_os_free(json);
 
@@ -353,7 +353,7 @@ void SerializeEntityToJson_serialize_w_type_info(void) {
 
     char *json = ecs_entity_to_json(world, e, &desc);
     test_assert(json != NULL);
-    test_json(json, "{\"name\":\"Foo\", \"type_info\":{\"Position\":{\"x\":[\"int\"], \"y\":[\"int\"]}, \"(Identifier,Name)\":0}, \"components\":{\"Position\":{\"x\":10, \"y\":20}, \"(Identifier,Name)\":null}}");
+    test_json(json, "{\"name\":\"Foo\", \"type_info\":{\"Position\":{\"x\":[\"int\"], \"y\":[\"int\"]}}, \"components\":{\"Position\":{\"x\":10, \"y\":20}}}");
 
     ecs_os_free(json);
 
@@ -390,7 +390,7 @@ void SerializeEntityToJson_serialize_w_type_info_unit(void) {
 
     char *json = ecs_entity_to_json(world, e, &desc);
     test_assert(json != NULL);
-    test_json(json, "{\"name\":\"Foo\", \"type_info\":{\"T\":{\"value\":[\"int\", {\"unit\":\"celsius\", \"symbol\":\"°\"}]}, \"(Identifier,Name)\":0}, \"components\":{\"T\":{\"value\":24}, \"(Identifier,Name)\":null}}");
+    test_json(json, "{\"name\":\"Foo\", \"type_info\":{\"T\":{\"value\":[\"int\", {\"unit\":\"celsius\", \"symbol\":\"°\"}]}}, \"components\":{\"T\":{\"value\":24}}}");
 
     ecs_os_free(json);
 
@@ -433,7 +433,7 @@ void SerializeEntityToJson_serialize_w_type_info_unit_quantity(void) {
 
     char *json = ecs_entity_to_json(world, e, &desc);
     test_assert(json != NULL);
-    test_json(json, "{\"name\":\"Foo\", \"type_info\":{\"T\":{\"value\":[\"int\", {\"unit\":\"celsius\", \"symbol\":\"°\", \"quantity\":\"temperature\"}]}, \"(Identifier,Name)\":0}, \"components\":{\"T\":{\"value\":24}, \"(Identifier,Name)\":null}}");
+    test_json(json, "{\"name\":\"Foo\", \"type_info\":{\"T\":{\"value\":[\"int\", {\"unit\":\"celsius\", \"symbol\":\"°\", \"quantity\":\"temperature\"}]}}, \"components\":{\"T\":{\"value\":24}}}");
 
     ecs_os_free(json);
 
@@ -485,7 +485,7 @@ void SerializeEntityToJson_serialize_w_type_info_unit_over(void) {
     char *json = ecs_entity_to_json(world, e, &desc);
     test_assert(json != NULL);
     test_assert(json != NULL);
-    test_json(json, "{\"name\":\"Foo\", \"type_info\":{\"T\":{\"value\":[\"int\", {\"unit\":\"meters_per_second\", \"symbol\":\"m/s\"}]}, \"(Identifier,Name)\":0}, \"components\":{\"T\":{\"value\":24}, \"(Identifier,Name)\":null}}");
+    test_json(json, "{\"name\":\"Foo\", \"type_info\":{\"T\":{\"value\":[\"int\", {\"unit\":\"meters_per_second\", \"symbol\":\"m/s\"}]}}, \"components\":{\"T\":{\"value\":24}}}");
 
     ecs_os_free(json);
 
@@ -506,7 +506,7 @@ void SerializeEntityToJson_serialize_w_type_info_no_types(void) {
 
     char *json = ecs_entity_to_json(world, e, &desc);
     test_assert(json != NULL);
-    test_json(json, "{\"name\":\"Foo\", \"type_info\":{\"Position\":0, \"(Identifier,Name)\":0}, \"components\":{\"Position\":null, \"(Identifier,Name)\":null}}");
+    test_json(json, "{\"name\":\"Foo\", \"type_info\":{\"Position\":0}, \"components\":{\"Position\":null}}");
 
     ecs_os_free(json);
 
@@ -551,7 +551,7 @@ void SerializeEntityToJson_serialize_w_label(void) {
     char *json = ecs_entity_to_json(world, e, &desc);
 
     test_assert(json != NULL);
-    test_json(json, "{\"name\":\"Foo\", \"doc\":{\"label\":\"My name\"}, \"tags\":[\"Tag\"], \"components\":{\"(Identifier,Name)\":null, \"(Description,Name)\":{\"value\":\"My name\"}}}");
+    test_json(json, "{\"name\":\"Foo\", \"doc\":{\"label\":\"My name\"}, \"tags\":[\"Tag\"], \"components\":{\"(flecs.doc.Description,flecs.core.Name)\":{\"value\":\"My name\"}}}");
 
     ecs_os_free(json);
 
@@ -595,7 +595,7 @@ void SerializeEntityToJson_serialize_w_brief(void) {
     char *json = ecs_entity_to_json(world, e, &desc);
     test_assert(json != NULL);
 
-    test_json(json, "{\"name\":\"Foo\", \"doc\":{\"label\":\"Foo\", \"brief\":\"Brief description\"}, \"tags\":[\"Tag\"], \"components\":{\"(Identifier,Name)\":null, \"(Description,Brief)\":{\"value\":\"Brief description\"}}}");
+    test_json(json, "{\"name\":\"Foo\", \"doc\":{\"label\":\"Foo\", \"brief\":\"Brief description\"}, \"tags\":[\"Tag\"], \"components\":{\"(flecs.doc.Description,flecs.doc.Brief)\":{\"value\":\"Brief description\"}}}");
 
     ecs_os_free(json);
 
@@ -615,7 +615,7 @@ void SerializeEntityToJson_serialize_w_brief_no_brief(void) {
     char *json = ecs_entity_to_json(world, e, &desc);
     test_assert(json != NULL);
 
-    test_json(json, "{\"name\":\"Foo\", \"doc\":{\"label\":\"Foo\"}, \"tags\":[\"Tag\"], \"components\":{\"(Identifier,Name)\":null}}");
+    test_json(json, "{\"name\":\"Foo\", \"doc\":{\"label\":\"Foo\"}, \"tags\":[\"Tag\"]}");
 
     ecs_os_free(json);
 
@@ -636,7 +636,7 @@ void SerializeEntityToJson_serialize_w_link(void) {
     char *json = ecs_entity_to_json(world, e, &desc);
     test_assert(json != NULL);
 
-    test_json(json, "{\"name\":\"Foo\", \"doc\":{\"label\":\"Foo\", \"link\":\"Link\"}, \"tags\":[\"Tag\"], \"components\":{\"(Identifier,Name)\":null, \"(Description,Link)\":{\"value\":\"Link\"}}}");
+    test_json(json, "{\"name\":\"Foo\", \"doc\":{\"label\":\"Foo\", \"link\":\"Link\"}, \"tags\":[\"Tag\"], \"components\":{\"(flecs.doc.Description,flecs.doc.Link)\":{\"value\":\"Link\"}}}");
 
     ecs_os_free(json);
 
@@ -656,7 +656,7 @@ void SerializeEntityToJson_serialize_w_link_no_link(void) {
     char *json = ecs_entity_to_json(world, e, &desc);
     test_assert(json != NULL);
 
-    test_json(json, "{\"name\":\"Foo\", \"doc\":{\"label\":\"Foo\"}, \"tags\":[\"Tag\"], \"components\":{\"(Identifier,Name)\":null}}");
+    test_json(json, "{\"name\":\"Foo\", \"doc\":{\"label\":\"Foo\"}, \"tags\":[\"Tag\"]}");
 
     ecs_os_free(json);
 
@@ -677,7 +677,7 @@ void SerializeEntityToJson_serialize_color(void) {
     char *json = ecs_entity_to_json(world, e, &desc);
     test_assert(json != NULL);
 
-    test_json(json, "{\"name\":\"Foo\", \"doc\":{\"label\":\"Foo\", \"color\":\"#47B576\"}, \"tags\":[\"Tag\"], \"components\":{\"(Identifier,Name)\":null, \"(Description,Color)\":{\"value\":\"#47B576\"}}}");
+    test_json(json, "{\"name\":\"Foo\", \"doc\":{\"label\":\"Foo\", \"color\":\"#47B576\"}, \"tags\":[\"Tag\"], \"components\":{\"(flecs.doc.Description,flecs.doc.Color)\":{\"value\":\"#47B576\"}}}");
 
     ecs_os_free(json);
 
@@ -703,7 +703,7 @@ void SerializeEntityToJson_serialize_w_doc_w_quotes(void) {
     char *json = ecs_entity_to_json(world, e, &desc);
     test_assert(json != NULL);
 
-    test_json(json, "{\"parent\":\"Parent\", \"name\":\"Child\", \"doc\":{\"label\":\"Doc \\\"name\\\"\", \"brief\":\"Doc \\\"brief\\\"\", \"color\":\"Doc \\\"color\\\"\", \"link\":\"Doc \\\"link\\\"\"}, \"tags\":[\"Tag\"],\"pairs\":{\"ChildOf\":\"Parent\"}, \"components\":{\"(Identifier,Name)\":null, \"(Description,Name)\":{\"value\":\"Doc \\\"name\\\"\"}, \"(Description,Brief)\":{\"value\":\"Doc \\\"brief\\\"\"}, \"(Description,Link)\":{\"value\":\"Doc \\\"link\\\"\"}, \"(Description,Color)\":{\"value\":\"Doc \\\"color\\\"\"}}}");
+    test_json(json, "{\"parent\":\"Parent\", \"name\":\"Child\", \"doc\":{\"label\":\"Doc \\\"name\\\"\", \"brief\":\"Doc \\\"brief\\\"\", \"color\":\"Doc \\\"color\\\"\", \"link\":\"Doc \\\"link\\\"\"}, \"tags\":[\"Tag\"], \"components\":{\"(flecs.doc.Description,flecs.core.Name)\":{\"value\":\"Doc \\\"name\\\"\"}, \"(flecs.doc.Description,flecs.doc.Brief)\":{\"value\":\"Doc \\\"brief\\\"\"}, \"(flecs.doc.Description,flecs.doc.Link)\":{\"value\":\"Doc \\\"link\\\"\"}, \"(flecs.doc.Description,flecs.doc.Color)\":{\"value\":\"Doc \\\"color\\\"\"}}}");
 
     ecs_os_free(json);
 
@@ -715,7 +715,7 @@ void SerializeEntityToJson_serialize_from_core(void) {
 
     char *json = ecs_entity_to_json(world, EcsWorld, NULL);
     test_assert(json != NULL);
-    test_json(json, "{\"parent\":\"flecs.core\", \"name\":\"World\", \"pairs\":{\"ChildOf\":\"core\"}, \"components\":{\"(Identifier,Name)\":null, \"(Identifier,Symbol)\":null, \"(Description,Brief)\":{\"value\":\"Entity associated with world\"}}}");
+    test_json(json, "{\"parent\":\"flecs.core\", \"name\":\"World\", \"components\":{\"(flecs.core.Identifier,flecs.core.Symbol)\":null, \"(flecs.doc.Description,flecs.doc.Brief)\":{\"value\":\"Entity associated with world\"}}}");
     ecs_os_free(json);
 
     ecs_fini(world);
@@ -750,7 +750,7 @@ void SerializeEntityToJson_serialize_w_1_alert(void) {
     char *json = ecs_entity_to_json(world, e1, &desc);
     test_assert(json != NULL);
 
-    test_json(json, "{\"name\":\"e1\", \"alerts\":true, \"components\":{\"AlertsActive\":{\"info_count\":0, \"warning_count\":0, \"error_count\":1}, \"Position\":null, \"(Identifier,Name)\":null}, \"alerts\":[{\"alert\":\"position_without_velocity.e1_alert\", \"message\":\"e1 has Position but not Velocity\", \"severity\":\"Error\"}]}");
+    test_json(json, "{\"name\":\"e1\", \"alerts\":true, \"components\":{\"flecs.alerts.AlertsActive\":{\"info_count\":0, \"warning_count\":0, \"error_count\":1}, \"Position\":null}, \"alerts\":[{\"alert\":\"position_without_velocity.e1_alert\", \"message\":\"e1 has Position but not Velocity\", \"severity\":\"Error\"}]}");
     ecs_os_free(json);
 
     ecs_fini(world);
@@ -796,8 +796,8 @@ void SerializeEntityToJson_serialize_w_2_alerts(void) {
     char *json = ecs_entity_to_json(world, e1, &desc);
     test_assert(json != NULL);
 
-    test_json(json, "{\"name\":\"e1\", \"alerts\":true, \"components\":{\"AlertsActive\":{\"info_count\":0, \"warning_count\":0, \"error_count\":2}, \"Position\":null, \"(Identifier,Name)\":null}, \"alerts\":[{\"alert\":\"position_without_velocity.e1_alert_1\", \"message\":\"e1 has Position but not Velocity\", \"severity\":\"Error\"}, {\"alert\":\"position_without_mass.e1_alert_2\", \"message\":\"e1 has Position but not Mass\", \"severity\":\"Error\"}]}");
-    // test_json(json, "{\"name\":\"e1\", \"alerts\":true, \"components\":{\"AlertsActive\":{\"info_count\":0, \"warning_count\":0, \"error_count\":2}, \"Position\":null, \"(Identifier,Name)\":null}, \"alerts\":[{\"alert\":\"position_without_mass.e1_alert_2\", \"message\":\"e1 has Position but not Mass\", \"severity\":\"Error\"}, {\"alert\":\"position_without_velocity.e1_alert_1\", \"message\":\"e1 has Position but not Velocity\", \"severity\":\"Error\"}]}");
+    test_json(json, "{\"name\":\"e1\", \"alerts\":true, \"components\":{\"flecs.alerts.AlertsActive\":{\"info_count\":0, \"warning_count\":0, \"error_count\":2}, \"Position\":null}, \"alerts\":[{\"alert\":\"position_without_mass.e1_alert_2\", \"message\":\"e1 has Position but not Mass\", \"severity\":\"Error\"}, {\"alert\":\"position_without_velocity.e1_alert_1\", \"message\":\"e1 has Position but not Velocity\", \"severity\":\"Error\"}]}");
+    // test_json(json, "{\"name\":\"e1\", \"alerts\":true, \"components\":{\"AlertsActive\":{\"info_count\":0, \"warning_count\":0, \"error_count\":2}, \"Position\":null, \"alerts\":[{\"alert\":\"position_without_mass.e1_alert_2\", \"message\":\"e1 has Position but not Mass\", \"severity\":\"Error\"}, {\"alert\":\"position_without_velocity.e1_alert_1\", \"message\":\"e1 has Position but not Velocity\", \"severity\":\"Error\"}]}");
     ecs_os_free(json);
 
     ecs_fini(world);
@@ -856,7 +856,7 @@ void SerializeEntityToJson_serialize_w_child_alerts(void) {
     char *json = ecs_entity_to_json(world, e1, &desc);
     test_assert(json != NULL);
 
-    test_json(json, "{\"name\":\"e1\", \"alerts\":true, \"components\":{\"AlertsActive\":{\"info_count\":0, \"warning_count\":0, \"error_count\":1}, \"Position\":null, \"(Identifier,Name)\":null}, \"alerts\":[{\"alert\":\"position_without_velocity.e1_alert\", \"message\":\"e1 has Position but not Velocity\", \"severity\":\"Error\"}, {\"alert\":\"position_without_velocity.child1_alert\", \"message\":\"e1.child1 has Position but not Velocity\", \"severity\":\"Error\", \"path\":\"e1.child1\"}, {\"alert\":\"position_without_velocity.grandchild1_alert\", \"message\":\"e1.child1.grandchild1 has Position but not Velocity\", \"severity\":\"Error\", \"path\":\"e1.child1.grandchild1\"}, {\"alert\":\"position_without_velocity.child2_alert\", \"message\":\"e1.child2 has Position but not Velocity\", \"severity\":\"Error\", \"path\":\"e1.child2\"}]}");
+    test_json(json, "{\"name\":\"e1\", \"alerts\":true, \"components\":{\"flecs.alerts.AlertsActive\":{\"info_count\":0, \"warning_count\":0, \"error_count\":1}, \"Position\":null}, \"alerts\":[{\"alert\":\"position_without_velocity.e1_alert\", \"message\":\"e1 has Position but not Velocity\", \"severity\":\"Error\"}, {\"alert\":\"position_without_velocity.child1_alert\", \"message\":\"e1.child1 has Position but not Velocity\", \"severity\":\"Error\", \"path\":\"e1.child1\"}, {\"alert\":\"position_without_velocity.grandchild1_alert\", \"message\":\"e1.child1.grandchild1 has Position but not Velocity\", \"severity\":\"Error\", \"path\":\"e1.child1.grandchild1\"}, {\"alert\":\"position_without_velocity.child2_alert\", \"message\":\"e1.child2 has Position but not Velocity\", \"severity\":\"Error\", \"path\":\"e1.child2\"}]}");
     ecs_os_free(json);
 
     ecs_fini(world);
@@ -897,7 +897,7 @@ void SerializeEntityToJson_serialize_w_severity_filter_alert(void) {
     char *json = ecs_entity_to_json(world, e1, &desc);
     test_assert(json != NULL);
 
-    test_json(json, "{\"name\":\"e1\", \"alerts\":true, \"tags\":[\"Tag\"], \"components\":{\"AlertsActive\":{\"info_count\":0, \"warning_count\":0, \"error_count\":1}, \"Position\":null, \"(Identifier,Name)\":null}, \"alerts\":[{\"alert\":\"position_without_velocity.e1_alert\", \"message\":\"e1 has Position but not Velocity\", \"severity\":\"Warning\"}]}");
+    test_json(json, "{\"name\":\"e1\", \"alerts\":true, \"tags\":[\"Tag\"], \"components\":{\"flecs.alerts.AlertsActive\":{\"info_count\":0, \"warning_count\":0, \"error_count\":1}, \"Position\":null}, \"alerts\":[{\"alert\":\"position_without_velocity.e1_alert\", \"message\":\"e1 has Position but not Velocity\", \"severity\":\"Warning\"}]}");
     ecs_os_free(json);
 
     ecs_fini(world);
@@ -917,7 +917,7 @@ void SerializeEntityToJson_serialize_w_alerts_not_imported(void) {
     char *json = ecs_entity_to_json(world, e1, &desc);
     test_assert(json != NULL);
 
-    test_json(json, "{\"name\":\"e1\", \"components\":{\"Position\":null, \"(Identifier,Name)\":null}}");
+    test_json(json, "{\"name\":\"e1\", \"components\":{\"Position\":null}}");
     ecs_os_free(json);
 
     ecs_fini(world);
@@ -953,7 +953,7 @@ void SerializeEntityToJson_serialize_w_alerts_no_message(void) {
     char *json = ecs_entity_to_json(world, e1, &desc);
     test_assert(json != NULL);
 
-    test_json(json, "{\"name\":\"e1\", \"alerts\":true, \"tags\":[\"Tag\"], \"components\":{\"AlertsActive\":{\"info_count\":0, \"warning_count\":0, \"error_count\":1}, \"Position\":null, \"(Identifier,Name)\":null}, \"alerts\":[{\"alert\":\"position_without_velocity.e1_alert\", \"severity\":\"Error\"}]}");
+    test_json(json, "{\"name\":\"e1\", \"alerts\":true, \"tags\":[\"Tag\"], \"components\":{\"flecs.alerts.AlertsActive\":{\"info_count\":0, \"warning_count\":0, \"error_count\":1}, \"Position\":null}, \"alerts\":[{\"alert\":\"position_without_velocity.e1_alert\", \"severity\":\"Error\"}]}");
     ecs_os_free(json);
 
     ecs_fini(world);
@@ -980,7 +980,7 @@ void SerializeEntityToJson_serialize_refs_childof(void) {
     char *json = ecs_entity_to_json(world, e1, &desc);
     test_assert(json != NULL);
 
-    test_json(json, "{\"name\":\"e1\", \"components\":{\"(Identifier,Name)\":null}, \"refs\":{\"ChildOf\":[\"e1.child1\", \"e1.child2\"]}}");
+    test_json(json, "{\"name\":\"e1\", \"refs\":{\"ChildOf\":[\"e1.child1\", \"e1.child2\"]}}");
     ecs_os_free(json);
 
     ecs_fini(world);
@@ -1007,7 +1007,7 @@ void SerializeEntityToJson_serialize_refs_custom(void) {
     char *json = ecs_entity_to_json(world, e1, &desc);
     test_assert(json != NULL);
 
-    test_json(json, "{\"name\":\"e1\", \"components\":{\"(Identifier,Name)\":null}, \"refs\":{\"Rel\":[\"child1\", \"child2\"]}}");
+    test_json(json, "{\"name\":\"e1\", \"refs\":{\"Rel\":[\"child1\", \"child2\"]}}");
     ecs_os_free(json);
 
     ecs_fini(world);
@@ -1034,7 +1034,7 @@ void SerializeEntityToJson_serialize_refs_wildcard(void) {
     char *json = ecs_entity_to_json(world, e1, &desc);
     test_assert(json != NULL);
 
-    test_json(json, "{\"name\":\"e1\", \"components\":{\"(Identifier,Name)\":null}, \"refs\":{\"ChildOf\":[\"e1.child3\"], \"Rel\":[\"child1\", \"child2\"]}}");
+    test_json(json, "{\"name\":\"e1\", \"refs\":{\"ChildOf\":[\"e1.child3\"], \"Rel\":[\"child1\", \"child2\"]}}");
     ecs_os_free(json);
 
     ecs_fini(world);
@@ -1074,7 +1074,7 @@ void SerializeEntityToJson_serialize_matches_filter(void) {
     desc.serialize_matches = true;
     char *json = ecs_entity_to_json(world, e1, &desc);
     test_assert(json != NULL);
-    test_json(json, "{\"name\":\"e1\", \"tags\":[\"TagA\"], \"components\":{\"(Identifier,Name)\":null}, \"matches\":[\"f_a\"]}");
+    test_json(json, "{\"name\":\"e1\", \"tags\":[\"TagA\"], \"matches\":[\"f_a\"]}");
     ecs_os_free(json);
 
     ecs_query_fini(f_a);
@@ -1118,7 +1118,7 @@ void SerializeEntityToJson_serialize_matches_query(void) {
     desc.serialize_matches = true;
     char *json = ecs_entity_to_json(world, e1, &desc);
     test_assert(json != NULL);
-    test_json(json, "{\"name\":\"e1\", \"tags\":[\"TagA\"], \"components\":{\"(Identifier,Name)\":null}, \"matches\":[\"f_a\"]}");
+    test_json(json, "{\"name\":\"e1\", \"tags\":[\"TagA\"], \"matches\":[\"f_a\"]}");
     ecs_os_free(json);
 
     ecs_query_fini(f_a);
@@ -1162,7 +1162,7 @@ void SerializeEntityToJson_serialize_matches_rule(void) {
     desc.serialize_matches = true;
     char *json = ecs_entity_to_json(world, e1, &desc);
     test_assert(json != NULL);
-    test_json(json, "{\"name\":\"e1\", \"tags\":[\"TagA\"], \"components\":{\"(Identifier,Name)\":null}, \"matches\":[\"f_a\"]}");
+    test_json(json, "{\"name\":\"e1\", \"tags\":[\"TagA\"], \"matches\":[\"f_a\"]}");
     ecs_os_free(json);
 
     ecs_query_fini(f_a);
@@ -1200,7 +1200,7 @@ void SerializeEntityToJson_serialize_no_matches(void) {
     desc.serialize_matches = true;
     char *json = ecs_entity_to_json(world, e1, &desc);
     test_assert(json != NULL);
-    test_json(json, "{\"name\":\"e1\", \"tags\":[\"TagA\"], \"components\":{\"(Identifier,Name)\":null}, \"matches\":[]}");
+    test_json(json, "{\"name\":\"e1\", \"tags\":[\"TagA\"], \"matches\":[]}");
     ecs_os_free(json);
 
     ecs_query_fini(f_b);
@@ -1218,7 +1218,7 @@ void SerializeEntityToJson_serialize_id_recycled(void) {
 
     ecs_entity_to_json_desc_t desc = ECS_ENTITY_TO_JSON_INIT;
     desc.serialize_entity_id = true;
-    char *expect = flecs_asprintf("{\"name\":\"Foo\", \"id\":%u, \"components\":{\"(Identifier,Name)\":null}}",
+    char *expect = flecs_asprintf("{\"name\":\"Foo\", \"id\":%u}",
         (uint32_t)e);
     char *json = ecs_entity_to_json(world, e, &desc);
     test_assert(json != NULL);
@@ -1247,19 +1247,19 @@ void SerializeEntityToJson_serialize_union_target(void) {
     {
         char *json = ecs_entity_to_json(world, e1, NULL);
         test_assert(json != NULL);
-        test_json(json, "{\"name\":\"e1\", \"pairs\":{\"Rel\":\"TgtA\"}, \"components\":{\"(Identifier,Name)\":null}}");
+        test_json(json, "{\"name\":\"e1\", \"pairs\":{\"Rel\":\"TgtA\"}}");
         ecs_os_free(json);
     }
     {
         char *json = ecs_entity_to_json(world, e2, NULL);
         test_assert(json != NULL);
-        test_json(json, "{\"name\":\"e2\", \"pairs\":{\"Rel\":\"TgtB\"}, \"components\":{\"(Identifier,Name)\":null}}");
+        test_json(json, "{\"name\":\"e2\", \"pairs\":{\"Rel\":\"TgtB\"}}");
         ecs_os_free(json);
     }
     {
         char *json = ecs_entity_to_json(world, e3, NULL);
         test_assert(json != NULL);
-        test_json(json, "{\"name\":\"e3\", \"pairs\":{\"Rel\":\"TgtC\"}, \"components\":{\"(Identifier,Name)\":null}}");
+        test_json(json, "{\"name\":\"e3\", \"pairs\":{\"Rel\":\"TgtC\"}}");
         ecs_os_free(json);
     }
 
@@ -1283,7 +1283,92 @@ void SerializeEntityToJson_serialize_union_target_recycled(void) {
     {
         char *json = ecs_entity_to_json(world, e1, NULL);
         test_assert(json != NULL);
-        test_json(json, "{\"name\":\"e1\", \"pairs\":{\"Rel\":\"TgtA\"}, \"components\":{\"(Identifier,Name)\":null}}");
+        test_json(json, "{\"name\":\"e1\", \"pairs\":{\"Rel\":\"TgtA\"}}");
+        ecs_os_free(json);
+    }
+
+    ecs_fini(world);
+}
+
+void SerializeEntityToJson_serialize_anonymous_w_builtin(void) {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, Foo);
+
+    ecs_entity_t e = ecs_new(world);
+    ecs_add(world, e, Foo);
+
+    {
+        char *expect = flecs_asprintf("{\"name\":\"#%u\", \"tags\":[\"Foo\"]}",
+            (uint32_t)e);
+        ecs_entity_to_json_desc_t desc = ECS_ENTITY_TO_JSON_INIT;
+        desc.serialize_builtin = true;
+        char *json = ecs_entity_to_json(world, e, &desc);
+        test_json(json, expect);
+        ecs_os_free(json);
+        ecs_os_free(expect);
+    }
+
+    ecs_fini(world);
+}
+
+void SerializeEntityToJson_serialize_named_w_builtin(void) {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, Foo);
+
+    ecs_entity_t e = ecs_entity(world, { .name = "e" });
+    ecs_add(world, e, Foo);
+
+    {
+        ecs_entity_to_json_desc_t desc = ECS_ENTITY_TO_JSON_INIT;
+        desc.serialize_builtin = true;
+        char *json = ecs_entity_to_json(world, e, &desc);
+        test_assert(json != NULL);
+        test_json(json, "{\"name\":\"e\", \"tags\":[\"Foo\"], \"components\":{\"(flecs.core.Identifier,flecs.core.Name)\":null}}");
+        ecs_os_free(json);
+    }
+
+    ecs_fini(world);
+}
+
+void SerializeEntityToJson_serialize_named_child_w_builtin(void) {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, Foo);
+
+    ecs_entity_t p = ecs_entity(world, { .name = "p" });
+    ecs_entity_t e = ecs_entity(world, { .parent = p, .name = "e" });
+    ecs_add(world, e, Foo);
+
+    {
+        ecs_entity_to_json_desc_t desc = ECS_ENTITY_TO_JSON_INIT;
+        desc.serialize_builtin = true;
+        char *json = ecs_entity_to_json(world, e, &desc);
+        test_assert(json != NULL);
+        test_json(json, "{\"parent\":\"p\", \"name\":\"e\", \"tags\":[\"Foo\"],\"pairs\":{\"flecs.core.ChildOf\":\"p\"}, \"components\":{\"(flecs.core.Identifier,flecs.core.Name)\":null}}");
+        ecs_os_free(json);
+    }
+
+    ecs_fini(world);
+}
+
+void SerializeEntityToJson_serialize_named_child_w_builtin_w_type_info(void) {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, Foo);
+
+    ecs_entity_t p = ecs_entity(world, { .name = "p" });
+    ecs_entity_t e = ecs_entity(world, { .parent = p, .name = "e" });
+    ecs_add(world, e, Foo);
+
+    {
+        ecs_entity_to_json_desc_t desc = ECS_ENTITY_TO_JSON_INIT;
+        desc.serialize_builtin = true;
+        desc.serialize_type_info = true;
+        char *json = ecs_entity_to_json(world, e, &desc);
+        test_assert(json != NULL);
+        test_json(json, "{\"parent\":\"p\", \"name\":\"e\", \"tags\":[\"Foo\"],\"pairs\":{\"flecs.core.ChildOf\":\"p\"},\"type_info\":{\"(flecs.core.Identifier,flecs.core.Name)\":0}, \"components\":{\"(flecs.core.Identifier,flecs.core.Name)\":null}}");
         ecs_os_free(json);
     }
 

--- a/test/meta/src/SerializeIterToJson.c
+++ b/test/meta/src/SerializeIterToJson.c
@@ -848,6 +848,7 @@ void SerializeIterToJson_serialize_w_var_labels(void) {
 
     ecs_iter_to_json_desc_t desc = ECS_ITER_TO_JSON_INIT;
     desc.serialize_doc = true;
+    desc.serialize_full_paths = false;
     char *json = ecs_iter_to_json(&it, &desc);
 
     test_json(json, "{\"results\":[{\"name\":\"Foo\", \"doc\":{\"label\":\"Foo\"}, \"vars\":{\"X\":\"Object A\"},\"fields\":{\"ids\":[[\"Rel\",\"ObjA\"]]}}, {\"name\":\"Bar\", \"doc\":{\"label\":\"Bar\"}, \"vars\":{\"X\":\"ObjB\"},\"fields\":{\"ids\":[[\"Rel\",\"ObjB\"]]}}]}");
@@ -1400,7 +1401,37 @@ void SerializeIterToJson_serialize_variable_anonymous(void) {
     test_assert(json != NULL);
 
     char *expect = flecs_asprintf(
-        "{\"results\":[{\"vars\":{\"Entity\":#10000},\"fields\":{\"sources\":[\"#10000\"]}}]}");
+        "{\"results\":[{\"vars\":{\"Entity\":\"#10000\"},\"fields\":{\"sources\":[\"#10000\"]}}]}");
+    test_json(json, expect);
+
+    ecs_os_free(json);
+    ecs_os_free(expect);
+
+    ecs_query_fini(q);
+
+    ecs_fini(world);
+}
+
+void SerializeIterToJson_serialize_variable_anonymous_no_full_path(void) {
+    ecs_world_t *world = ecs_init();
+
+    ECS_TAG(world, Tag);
+
+    ecs_query_t *q = ecs_query(world, { .expr = "Tag($Entity)" });
+
+    ecs_entity_t e = 10000;
+    ecs_make_alive(world, 10000);
+    ecs_add(world, e, Tag);
+
+    ecs_iter_t it = ecs_query_iter(world, q);
+    ecs_iter_to_json_desc_t desc = ECS_ITER_TO_JSON_INIT;
+    desc.serialize_values = false;
+    desc.serialize_full_paths = false;
+    char *json = ecs_iter_to_json(&it, &desc);
+    test_assert(json != NULL);
+
+    char *expect = flecs_asprintf(
+        "{\"results\":[{\"vars\":{\"Entity\":\"#10000\"},\"fields\":{\"sources\":[\"#10000\"]}}]}");
     test_json(json, expect);
 
     ecs_os_free(json);
@@ -1904,7 +1935,7 @@ void SerializeIterToJson_serialize_table(void) {
     char *json = ecs_iter_to_json(&it, &desc);
     test_assert(json != NULL);
 
-    test_json(json, "{\"results\":[{\"name\":\"e1\", \"tags\":[\"Foo\"], \"components\":{\"Position\":{\"x\":10, \"y\":20}, \"(Identifier,Name)\":null}}, {\"name\":\"e2\", \"tags\":[\"Foo\", \"Bar\"], \"components\":{\"Position\":{\"x\":20, \"y\":30}, \"Velocity\":{\"x\":1, \"y\":1}, \"(Identifier,Name)\":null}}, {\"name\":\"e3\", \"components\":{\"Position\":{\"x\":30, \"y\":40}, \"Mass\":{\"value\":100}, \"(Identifier,Name)\":null}}]}");
+    test_json(json, "{\"results\":[{\"name\":\"e1\", \"tags\":[\"Foo\"], \"components\":{\"Position\":{\"x\":10, \"y\":20}}}, {\"name\":\"e2\", \"tags\":[\"Foo\", \"Bar\"], \"components\":{\"Position\":{\"x\":20, \"y\":30}, \"Velocity\":{\"x\":1, \"y\":1}}}, {\"name\":\"e3\", \"components\":{\"Position\":{\"x\":30, \"y\":40}, \"Mass\":{\"value\":100}}}]}");
     
     ecs_os_free(json);
 
@@ -1974,10 +2005,11 @@ void SerializeIterToJson_serialize_table_w_id_labels(void) {
 
     ecs_iter_to_json_desc_t desc = ECS_ITER_TO_JSON_INIT;
     desc.serialize_table = true;
+    desc.serialize_full_paths = false;
     char *json = ecs_iter_to_json(&it, &desc);
     test_assert(json != NULL);
 
-    test_json(json, "{\"results\":[{\"name\":\"e1\", \"tags\":[\"Foo\"], \"components\":{\"position\":{\"x\":10, \"y\":20}, \"(Identifier,Name)\":null}}, {\"name\":\"e2\", \"tags\":[\"Foo\", \"Bar\"], \"components\":{\"position\":{\"x\":20, \"y\":30}, \"velocity\":{\"x\":1, \"y\":1}, \"(Identifier,Name)\":null}}, {\"name\":\"e3\", \"components\":{\"position\":{\"x\":30, \"y\":40}, \"mass\":{\"value\":100}, \"(Identifier,Name)\":null}}]}");
+    test_json(json, "{\"results\":[{\"name\":\"e1\", \"tags\":[\"Foo\"], \"components\":{\"position\":{\"x\":10, \"y\":20}}}, {\"name\":\"e2\", \"tags\":[\"Foo\", \"Bar\"], \"components\":{\"position\":{\"x\":20, \"y\":30}, \"velocity\":{\"x\":1, \"y\":1}}}, {\"name\":\"e3\", \"components\":{\"position\":{\"x\":30, \"y\":40}, \"mass\":{\"value\":100}}}]}");
     
     ecs_os_free(json);
 
@@ -2051,11 +2083,11 @@ void SerializeIterToJson_serialize_table_w_var_labels(void) {
 
     ecs_iter_to_json_desc_t desc = ECS_ITER_TO_JSON_INIT;
     desc.serialize_table = true;
-    desc.serialize_var_labels = true;
+    desc.serialize_full_paths = false;
     char *json = ecs_iter_to_json(&it, &desc);
     test_assert(json != NULL);
 
-    test_json(json, "{\"results\":[{\"parent\":\"Parent\", \"name\":\"e1\", \"tags\":[\"Foo\"],\"pairs\":{\"ChildOf\":\"parent\"},\"vars\":{\"p\":\"parent\"}, \"components\":{\"Position\":{\"x\":10, \"y\":20}, \"(Identifier,Name)\":null}}, {\"parent\":\"Parent\", \"name\":\"e2\", \"tags\":[\"Foo\", \"Bar\"],\"pairs\":{\"ChildOf\":\"parent\"},\"vars\":{\"p\":\"parent\"}, \"components\":{\"Position\":{\"x\":20, \"y\":30}, \"Velocity\":{\"x\":1, \"y\":1}, \"(Identifier,Name)\":null}}, {\"parent\":\"Parent\", \"name\":\"e3\", \"pairs\":{\"ChildOf\":\"parent\"},\"vars\":{\"p\":\"parent\"}, \"components\":{\"Position\":{\"x\":30, \"y\":40}, \"Mass\":{\"value\":100}, \"(Identifier,Name)\":null}}]}");
+    test_json(json, "{\"results\":[{\"parent\":\"Parent\", \"name\":\"e1\", \"tags\":[\"Foo\"],\"vars\":{\"p\":\"parent\"}, \"components\":{\"Position\":{\"x\":10, \"y\":20}}}, {\"parent\":\"Parent\", \"name\":\"e2\", \"tags\":[\"Foo\", \"Bar\"],\"vars\":{\"p\":\"parent\"}, \"components\":{\"Position\":{\"x\":20, \"y\":30}, \"Velocity\":{\"x\":1, \"y\":1}}}, {\"parent\":\"Parent\", \"name\":\"e3\", \"vars\":{\"p\":\"parent\"}, \"components\":{\"Position\":{\"x\":30, \"y\":40}, \"Mass\":{\"value\":100}}}]}");
 
     ecs_os_free(json);
 
@@ -2256,6 +2288,7 @@ void SerializeIterToJson_serialize_var_labels_for_query(void) {
     ecs_add_id(world, e2, Foo);
 
     ecs_iter_to_json_desc_t desc = ECS_ITER_TO_JSON_INIT;
+    desc.serialize_full_paths = false;
     ecs_iter_t it = ecs_query_iter(world, q);
     char *json = ecs_iter_to_json(&it, &desc);
     test_assert(json != NULL);

--- a/test/meta/src/SerializeIterToRowJson.c
+++ b/test/meta/src/SerializeIterToRowJson.c
@@ -545,7 +545,9 @@ void SerializeIterToRowJson_serialize_this_w_2_var_doc_name(void) {
     ecs_add_pair(world, e3, RelB, TgtB);
 
     ecs_iter_t it = ecs_query_iter(world, q);
-    char *json = ecs_iter_to_json(&it, NULL);
+    ecs_iter_to_json_desc_t desc = ECS_ITER_TO_JSON_INIT;
+    desc.serialize_full_paths = false;
+    char *json = ecs_iter_to_json(&it, &desc);
     test_assert(json != NULL);
 
     char* expect = "{\"results\":[{\"name\":\"e1\", \"vars\":{\"a\":\"Target A\", \"b\":\"Target A\"},\"fields\":{\"ids\":[[\"RelA\",\"TgtA\"], [\"RelB\",\"TgtA\"]]}}, {\"name\":\"e2\", \"vars\":{\"a\":\"Target A\", \"b\":\"Target A\"},\"fields\":{\"ids\":[[\"RelA\",\"TgtA\"], [\"RelB\",\"TgtA\"]]}}, {\"name\":\"e3\", \"vars\":{\"a\":\"Target A\", \"b\":\"Target B\"},\"fields\":{\"ids\":[[\"RelA\",\"TgtA\"], [\"RelB\",\"TgtB\"]]}}]}";
@@ -1925,7 +1927,7 @@ void SerializeIterToRowJson_serialize_table(void) {
     char *json = ecs_iter_to_json(&it, &desc);
     test_assert(json != NULL);
 
-    char* expect = "{\"results\":[{\"name\":\"e1\", \"tags\":[\"TagA\", \"TagB\"],\"pairs\":{\"RelA\":\"TgtA\", \"RelB\":\"TgtA\"}, \"components\":{\"Position\":{\"x\":10, \"y\":20}, \"Mass\":{\"value\":1}, \"(Identifier,Name)\":null}}, {\"name\":\"e2\", \"tags\":[\"TagA\", \"TagB\"],\"pairs\":{\"RelA\":\"TgtA\", \"RelB\":\"TgtA\"}, \"components\":{\"Position\":{\"x\":20, \"y\":30}, \"Mass\":{\"value\":2}, \"(Identifier,Name)\":null}}, {\"name\":\"e3\", \"tags\":[\"TagA\", \"TagB\"],\"pairs\":{\"RelA\":\"TgtA\", \"RelB\":\"TgtB\"}, \"components\":{\"Position\":{\"x\":30, \"y\":40}, \"Mass\":{\"value\":3}, \"(Identifier,Name)\":null}}]}";
+    char* expect = "{\"results\":[{\"name\":\"e1\", \"tags\":[\"TagA\", \"TagB\"],\"pairs\":{\"RelA\":\"TgtA\", \"RelB\":\"TgtA\"}, \"components\":{\"Position\":{\"x\":10, \"y\":20}, \"Mass\":{\"value\":1}}}, {\"name\":\"e2\", \"tags\":[\"TagA\", \"TagB\"],\"pairs\":{\"RelA\":\"TgtA\", \"RelB\":\"TgtA\"}, \"components\":{\"Position\":{\"x\":20, \"y\":30}, \"Mass\":{\"value\":2}}}, {\"name\":\"e3\", \"tags\":[\"TagA\", \"TagB\"],\"pairs\":{\"RelA\":\"TgtA\", \"RelB\":\"TgtB\"}, \"components\":{\"Position\":{\"x\":30, \"y\":40}, \"Mass\":{\"value\":3}}}]}";
     test_json(json, expect);
 
     ecs_os_free(json);
@@ -2003,7 +2005,7 @@ void SerializeIterToRowJson_serialize_table_w_eq(void) {
     char *json = ecs_iter_to_json(&it, &desc);
     test_assert(json != NULL);
 
-    char* expect = "{\"results\":[{\"name\":\"e2\", \"tags\":[\"TagA\", \"TagB\"],\"pairs\":{\"RelA\":\"TgtA\", \"RelB\":\"TgtA\"}, \"components\":{\"Position\":{\"x\":20, \"y\":30}, \"Mass\":{\"value\":2}, \"(Identifier,Name)\":null}}]}";
+    char* expect = "{\"results\":[{\"name\":\"e2\", \"tags\":[\"TagA\", \"TagB\"],\"pairs\":{\"RelA\":\"TgtA\", \"RelB\":\"TgtA\"}, \"components\":{\"Position\":{\"x\":20, \"y\":30}, \"Mass\":{\"value\":2}}}]}";
     test_json(json, expect);
     ecs_os_free(json);
 
@@ -2080,7 +2082,7 @@ void SerializeIterToRowJson_serialize_table_w_neq(void) {
     char *json = ecs_iter_to_json(&it, &desc);
     test_assert(json != NULL);
 
-    char* expect = "{\"results\":[{\"name\":\"e1\", \"tags\":[\"TagA\", \"TagB\"],\"pairs\":{\"RelA\":\"TgtA\", \"RelB\":\"TgtA\"}, \"components\":{\"Position\":{\"x\":10, \"y\":20}, \"Mass\":{\"value\":1}, \"(Identifier,Name)\":null}}, {\"name\":\"e3\", \"tags\":[\"TagA\", \"TagB\"],\"pairs\":{\"RelA\":\"TgtA\", \"RelB\":\"TgtB\"}, \"components\":{\"Position\":{\"x\":30, \"y\":40}, \"Mass\":{\"value\":3}, \"(Identifier,Name)\":null}}]}";
+    char* expect = "{\"results\":[{\"name\":\"e1\", \"tags\":[\"TagA\", \"TagB\"],\"pairs\":{\"RelA\":\"TgtA\", \"RelB\":\"TgtA\"}, \"components\":{\"Position\":{\"x\":10, \"y\":20}, \"Mass\":{\"value\":1}}}, {\"name\":\"e3\", \"tags\":[\"TagA\", \"TagB\"],\"pairs\":{\"RelA\":\"TgtA\", \"RelB\":\"TgtB\"}, \"components\":{\"Position\":{\"x\":30, \"y\":40}, \"Mass\":{\"value\":3}}}]}";
     test_json(json, expect);
 
     ecs_os_free(json);
@@ -2124,7 +2126,7 @@ void SerializeIterToRowJson_serialize_table_w_2_pair_targets(void) {
     });
     test_assert(json != NULL);
 
-    char* expect = "{\"results\":[{\"name\":\"e1\", \"tags\":[\"TagA\"],\"pairs\":{\"RelA\":\"TgtA\"}, \"components\":{\"(Identifier,Name)\":null}}, {\"name\":\"e2\", \"tags\":[\"TagA\"],\"pairs\":{\"RelA\":\"TgtA\"}, \"components\":{\"(Identifier,Name)\":null}}, {\"name\":\"e3\", \"tags\":[\"TagA\"],\"pairs\":{\"RelA\":[\"TgtA\", \"TgtB\"]}, \"components\":{\"(Identifier,Name)\":null}}]}";
+    char* expect = "{\"results\":[{\"name\":\"e1\", \"tags\":[\"TagA\"],\"pairs\":{\"RelA\":\"TgtA\"}}, {\"name\":\"e2\", \"tags\":[\"TagA\"],\"pairs\":{\"RelA\":\"TgtA\"}}, {\"name\":\"e3\", \"tags\":[\"TagA\"],\"pairs\":{\"RelA\":[\"TgtA\", \"TgtB\"]}}]}";
     test_json(json, expect);
 
     ecs_os_free(json);
@@ -2172,7 +2174,7 @@ void SerializeIterToRowJson_serialize_table_w_2_pair_targets_2_rel(void) {
     });
     test_assert(json != NULL);
 
-    char* expect = "{\"results\":[{\"name\":\"e1\", \"tags\":[\"TagA\"],\"pairs\":{\"RelA\":\"TgtA\"}, \"components\":{\"(Identifier,Name)\":null}}, {\"name\":\"e2\", \"tags\":[\"TagA\"],\"pairs\":{\"RelA\":\"TgtA\"}, \"components\":{\"(Identifier,Name)\":null}}, {\"name\":\"e3\", \"tags\":[\"TagA\"],\"pairs\":{\"RelA\":[\"TgtA\", \"TgtB\"], \"RelB\":[\"TgtB\", \"TgtC\"]}, \"components\":{\"(Identifier,Name)\":null}}]}";
+    char* expect = "{\"results\":[{\"name\":\"e1\", \"tags\":[\"TagA\"],\"pairs\":{\"RelA\":\"TgtA\"}}, {\"name\":\"e2\", \"tags\":[\"TagA\"],\"pairs\":{\"RelA\":\"TgtA\"}}, {\"name\":\"e3\", \"tags\":[\"TagA\"],\"pairs\":{\"RelA\":[\"TgtA\", \"TgtB\"], \"RelB\":[\"TgtB\", \"TgtC\"]}}]}";
     test_json(json, expect);
 
     ecs_os_free(json);
@@ -2222,7 +2224,7 @@ void SerializeIterToRowJson_serialize_table_w_3_pair_targets(void) {
     });
     test_assert(json != NULL);
 
-    char* expect = "{\"results\":[{\"name\":\"e1\", \"tags\":[\"TagA\"],\"pairs\":{\"RelA\":\"TgtA\"}, \"components\":{\"(Identifier,Name)\":null}}, {\"name\":\"e2\", \"tags\":[\"TagA\"],\"pairs\":{\"RelA\":[\"TgtA\", \"TgtB\"]}, \"components\":{\"(Identifier,Name)\":null}}, {\"name\":\"e3\", \"tags\":[\"TagA\"],\"pairs\":{\"RelA\":[\"TgtB\", \"TgtC\", \"TgtD\"]}, \"components\":{\"(Identifier,Name)\":null}}]}";
+    char* expect = "{\"results\":[{\"name\":\"e1\", \"tags\":[\"TagA\"],\"pairs\":{\"RelA\":\"TgtA\"}}, {\"name\":\"e2\", \"tags\":[\"TagA\"],\"pairs\":{\"RelA\":[\"TgtA\", \"TgtB\"]}}, {\"name\":\"e3\", \"tags\":[\"TagA\"],\"pairs\":{\"RelA\":[\"TgtB\", \"TgtC\", \"TgtD\"]}}]}";
     test_json(json, expect);
 
     ecs_os_free(json);
@@ -2276,7 +2278,7 @@ void SerializeIterToRowJson_serialize_table_w_3_pair_targets_2_rel(void) {
     });
     test_assert(json != NULL);
 
-    char* expect = "{\"results\":[{\"name\":\"e1\", \"tags\":[\"TagA\"],\"pairs\":{\"RelA\":\"TgtA\"}, \"components\":{\"(Identifier,Name)\":null}}, {\"name\":\"e2\", \"tags\":[\"TagA\"],\"pairs\":{\"RelA\":[\"TgtA\", \"TgtB\"]}, \"components\":{\"(Identifier,Name)\":null}}, {\"name\":\"e3\", \"tags\":[\"TagA\"],\"pairs\":{\"RelA\":[\"TgtA\", \"TgtB\", \"TgtC\"], \"RelB\":[\"TgtB\", \"TgtC\", \"TgtD\"]}, \"components\":{\"(Identifier,Name)\":null}}]}";
+    char* expect = "{\"results\":[{\"name\":\"e1\", \"tags\":[\"TagA\"],\"pairs\":{\"RelA\":\"TgtA\"}}, {\"name\":\"e2\", \"tags\":[\"TagA\"],\"pairs\":{\"RelA\":[\"TgtA\", \"TgtB\"]}}, {\"name\":\"e3\", \"tags\":[\"TagA\"],\"pairs\":{\"RelA\":[\"TgtA\", \"TgtB\", \"TgtC\"], \"RelB\":[\"TgtB\", \"TgtC\", \"TgtD\"]}}]}";
     test_json(json, expect);
 
     ecs_os_free(json);
@@ -2581,7 +2583,7 @@ void SerializeIterToRowJson_serialize_w_field_info_pair_w_0_target(void) {
     });
     test_assert(json != NULL);
 
-    char* expect = "{\"field_info\":[{\"id\":\"Position\", \"type\":\"Position\", \"symbol\":\"Position\", \"schema\":{\"x\":[\"int\"], \"y\":[\"int\"]}}, {\"id\":\"Mass\", \"optional\":true, \"type\":\"Mass\", \"symbol\":\"Mass\", \"schema\":{\"value\":[\"int\"]}}, {\"id\":\"(ChildOf,#0)\", \"exclusive\":true}], \"results\":[{\"name\":\"e1\", \"fields\":{\"is_set\":[true, false, true]}}, {\"name\":\"e2\", \"fields\":{\"is_set\":[true, false, true]}}, {\"name\":\"e3\", \"fields\":{\"is_set\":[true, true, true]}}]}";
+    char* expect = "{\"field_info\":[{\"id\":\"Position\", \"type\":\"Position\", \"symbol\":\"Position\", \"schema\":{\"x\":[\"int\"], \"y\":[\"int\"]}}, {\"id\":\"Mass\", \"optional\":true, \"type\":\"Mass\", \"symbol\":\"Mass\", \"schema\":{\"value\":[\"int\"]}}, {\"id\":\"(flecs.core.ChildOf,#0)\", \"exclusive\":true}], \"results\":[{\"name\":\"e1\", \"fields\":{\"is_set\":[true, false, true]}}, {\"name\":\"e2\", \"fields\":{\"is_set\":[true, false, true]}}, {\"name\":\"e3\", \"fields\":{\"is_set\":[true, true, true]}}]}";
     test_json(json, expect);
 
     ecs_os_free(json);
@@ -2675,7 +2677,7 @@ void SerializeIterToRowJson_serialize_w_field_info_pair_w_not_pair(void) {
     });
     test_assert(json != NULL);
 
-    char* expect = "{\"field_info\":[{\"id\":\"Position\", \"type\":\"Position\", \"symbol\":\"Position\", \"schema\":{\"x\":[\"int\"], \"y\":[\"int\"]}}, {\"id\":\"(ChildOf,flecs)\", \"not\":true}], \"results\":[{\"name\":\"e1\", \"fields\":{\"is_set\":[true, false]}}, {\"name\":\"e2\", \"fields\":{\"is_set\":[true, false]}}, {\"name\":\"e3\", \"fields\":{\"is_set\":[true, false]}}]}";
+    char* expect = "{\"field_info\":[{\"id\":\"Position\", \"type\":\"Position\", \"symbol\":\"Position\", \"schema\":{\"x\":[\"int\"], \"y\":[\"int\"]}}, {\"id\":\"(flecs.core.ChildOf,flecs)\", \"not\":true}], \"results\":[{\"name\":\"e1\", \"fields\":{\"is_set\":[true, false]}}, {\"name\":\"e2\", \"fields\":{\"is_set\":[true, false]}}, {\"name\":\"e3\", \"fields\":{\"is_set\":[true, false]}}]}";
     test_json(json, expect);
 
     ecs_os_free(json);

--- a/test/meta/src/main.c
+++ b/test/meta/src/main.c
@@ -439,6 +439,8 @@ void DeserializeFromJson_struct_w_2_nested_members_i32(void);
 void DeserializeFromJson_struct_w_nested_members_struct(void);
 void DeserializeFromJson_struct_w_2_nested_members_struct(void);
 void DeserializeFromJson_ser_deser_entity_named(void);
+void DeserializeFromJson_ser_deser_entity_named_child(void);
+void DeserializeFromJson_ser_deser_entity_namespaced_component(void);
 void DeserializeFromJson_deser_entity_1_component_1_member(void);
 void DeserializeFromJson_deser_entity_1_component_1_member_w_spaces(void);
 void DeserializeFromJson_deser_entity_1_component_2_members(void);
@@ -628,6 +630,10 @@ void SerializeEntityToJson_serialize_no_matches(void);
 void SerializeEntityToJson_serialize_id_recycled(void);
 void SerializeEntityToJson_serialize_union_target(void);
 void SerializeEntityToJson_serialize_union_target_recycled(void);
+void SerializeEntityToJson_serialize_anonymous_w_builtin(void);
+void SerializeEntityToJson_serialize_named_w_builtin(void);
+void SerializeEntityToJson_serialize_named_child_w_builtin(void);
+void SerializeEntityToJson_serialize_named_child_w_builtin_w_type_info(void);
 
 // Testsuite 'SerializeIterToJson'
 void SerializeIterToJson_serialize_1_comps_empty(void);
@@ -670,6 +676,7 @@ void SerializeIterToJson_serialize_ids(void);
 void SerializeIterToJson_serialize_ids_2_entities(void);
 void SerializeIterToJson_serialize_anonymous(void);
 void SerializeIterToJson_serialize_anonymous_ids(void);
+void SerializeIterToJson_serialize_variable_anonymous_no_full_path(void);
 void SerializeIterToJson_serialize_variable_anonymous(void);
 void SerializeIterToJson_serialize_anonymous_tag(void);
 void SerializeIterToJson_serialize_anonymous_component(void);
@@ -2587,6 +2594,14 @@ bake_test_case DeserializeFromJson_testcases[] = {
         DeserializeFromJson_ser_deser_entity_named
     },
     {
+        "ser_deser_entity_named_child",
+        DeserializeFromJson_ser_deser_entity_named_child
+    },
+    {
+        "ser_deser_entity_namespaced_component",
+        DeserializeFromJson_ser_deser_entity_namespaced_component
+    },
+    {
         "deser_entity_1_component_1_member",
         DeserializeFromJson_deser_entity_1_component_1_member
     },
@@ -3331,6 +3346,22 @@ bake_test_case SerializeEntityToJson_testcases[] = {
     {
         "serialize_union_target_recycled",
         SerializeEntityToJson_serialize_union_target_recycled
+    },
+    {
+        "serialize_anonymous_w_builtin",
+        SerializeEntityToJson_serialize_anonymous_w_builtin
+    },
+    {
+        "serialize_named_w_builtin",
+        SerializeEntityToJson_serialize_named_w_builtin
+    },
+    {
+        "serialize_named_child_w_builtin",
+        SerializeEntityToJson_serialize_named_child_w_builtin
+    },
+    {
+        "serialize_named_child_w_builtin_w_type_info",
+        SerializeEntityToJson_serialize_named_child_w_builtin_w_type_info
     }
 };
 
@@ -3494,6 +3525,10 @@ bake_test_case SerializeIterToJson_testcases[] = {
     {
         "serialize_anonymous_ids",
         SerializeIterToJson_serialize_anonymous_ids
+    },
+    {
+        "serialize_variable_anonymous_no_full_path",
+        SerializeIterToJson_serialize_variable_anonymous_no_full_path
     },
     {
         "serialize_variable_anonymous",
@@ -4519,7 +4554,7 @@ static bake_test_suite suites[] = {
         "DeserializeFromJson",
         NULL,
         NULL,
-        132,
+        134,
         DeserializeFromJson_testcases
     },
     {
@@ -4533,14 +4568,14 @@ static bake_test_suite suites[] = {
         "SerializeEntityToJson",
         NULL,
         NULL,
-        45,
+        49,
         SerializeEntityToJson_testcases
     },
     {
         "SerializeIterToJson",
         NULL,
         NULL,
-        68,
+        69,
         SerializeIterToJson_testcases
     },
     {


### PR DESCRIPTION
- Make full path serialization the default
- This fixes an issue where `to_json`/`from_json` weren't symmetric
- Hide name/`ChildOf` components by default since they're serialized as `name`/`parent` fields
- Fix issue where anonymous variable entity could result in invalid JSON
- Other minor bugfixes