### PR TITLE
Query iterator performance improvements

### DIFF
--- a/flecs.c
+++ b/flecs.c
@@ -73741,7 +73741,8 @@ bool flecs_query_trivial_search(
         return false;
     }
 
-    do {
+next:
+    {
         const ecs_table_record_t *tr = flecs_table_cache_next(
             &op_ctx->it, ecs_table_record_t);
         if (!tr) {
@@ -73750,7 +73751,7 @@ bool flecs_query_trivial_search(
 
         ecs_table_t *table = tr->hdr.table;
         if (table->flags & (EcsTableNotQueryable|EcsTableIsPrefab|EcsTableIsDisabled)) {
-            continue;
+            goto next;
         }
 
         int32_t first_term = op_ctx->first_to_eval;
@@ -73769,7 +73770,7 @@ bool flecs_query_trivial_search(
             const ecs_table_record_t *tr_with = flecs_id_record_get_table(
                 idr, table);
             if (!tr_with) {
-                break;
+                goto next;
             }
 
             it->columns[term->field_index] = tr_with->index;
@@ -73781,22 +73782,19 @@ bool flecs_query_trivial_search(
             }
         }
 
-        if (t == term_count) {
-            ctx->vars[0].range.table = table;
-            ctx->vars[0].range.count = 0;
-            ctx->vars[0].range.offset = 0;
+        ctx->vars[0].range.table = table;
+        ctx->vars[0].range.count = 0;
+        ctx->vars[0].range.offset = 0;
 
-            int32_t start_from = op_ctx->start_from;
-            it->columns[start_from] = tr->index;
-            if (!(terms[start_from].flags_ & EcsTermNoData)) {
-                if (tr->column != -1) {
-                    it->ptrs[start_from] = ecs_vec_first(
-                        &table->data.columns[tr->column].data);
-                }
+        int32_t start_from = op_ctx->start_from;
+        it->columns[start_from] = tr->index;
+        if (!(terms[start_from].flags_ & EcsTermNoData)) {
+            if (tr->column != -1) {
+                it->ptrs[start_from] = ecs_vec_first(
+                    &table->data.columns[tr->column].data);
             }
-            break;
         }
-    } while (true);
+    }
 
     return true;
 }

--- a/flecs.h
+++ b/flecs.h
@@ -432,10 +432,8 @@ extern "C" {
 #define EcsIterProfile                 (1u << 7u)  /* Profile iterator performance */
 #define EcsIterTrivialSearch           (1u << 8u)  /* Trivial iterator mode */
 #define EcsIterTrivialSearchNoData     (1u << 9u)  /* Trivial iterator w/no data */
-#define EcsIterTrivialSearchWildcard   (1u << 10u) /* Trivial search with wildcard ids */
 #define EcsIterTrivialTest             (1u << 11u) /* Trivial test mode (constrained $this) */
 #define EcsIterTrivialTestNoData       (1u << 12u) /* Trivial test mode w/no data (constrained $this) */
-#define EcsIterTrivialTestWildcard     (1u << 13u) /* Trivial test w/wildcards */
 #define EcsIterTrivialCached           (1u << 14u) /* Trivial search for cached query */
 #define EcsIterCacheSearch             (1u << 15u) /* Cache search */
 #define EcsIterFixedInChangeComputed   (1u << 16u) /* Change detection for fixed in terms is done */

--- a/include/flecs/private/api_flags.h
+++ b/include/flecs/private/api_flags.h
@@ -118,10 +118,8 @@ extern "C" {
 #define EcsIterProfile                 (1u << 7u)  /* Profile iterator performance */
 #define EcsIterTrivialSearch           (1u << 8u)  /* Trivial iterator mode */
 #define EcsIterTrivialSearchNoData     (1u << 9u)  /* Trivial iterator w/no data */
-#define EcsIterTrivialSearchWildcard   (1u << 10u) /* Trivial search with wildcard ids */
 #define EcsIterTrivialTest             (1u << 11u) /* Trivial test mode (constrained $this) */
 #define EcsIterTrivialTestNoData       (1u << 12u) /* Trivial test mode w/no data (constrained $this) */
-#define EcsIterTrivialTestWildcard     (1u << 13u) /* Trivial test w/wildcards */
 #define EcsIterTrivialCached           (1u << 14u) /* Trivial search for cached query */
 #define EcsIterCacheSearch             (1u << 15u) /* Cache search */
 #define EcsIterFixedInChangeComputed   (1u << 16u) /* Change detection for fixed in terms is done */

--- a/src/query/compiler/compiler.c
+++ b/src/query/compiler/compiler.c
@@ -601,11 +601,12 @@ void flecs_query_insert_trivial_search(
             continue;
         }
 
-        trivial_set |= (1llu << i);
-
+        /* Wildcards are not supported for trivial queries */
         if (ecs_id_is_wildcard(term->id)) {
-            trivial_wildcard_terms ++;
+            continue;
         }
+
+        trivial_set |= (1llu << i);
 
         if (populate) {
             if (q->data_fields & (1llu << term->field_index)) {
@@ -629,9 +630,7 @@ void flecs_query_insert_trivial_search(
 
         /* If there's more than 1 trivial term, batch them in trivial search */
         ecs_query_op_t trivial = {0};
-        if (trivial_wildcard_terms) {
-            trivial.kind = EcsQueryTrivWildcard;
-        } else {
+        if (!trivial_wildcard_terms) {
             if (trivial_data_terms) {
                 trivial.kind = EcsQueryTrivData;
             }

--- a/src/query/engine/cache_iter.c
+++ b/src/query/engine/cache_iter.c
@@ -6,7 +6,7 @@
 #include "../../private_api.h"
 
 static
-ecs_query_cache_table_match_t* flecs_query_next(
+ecs_query_cache_table_match_t* flecs_query_cache_next(
     const ecs_query_run_ctx_t *ctx)
 {
     ecs_iter_t *it = ctx->it;
@@ -51,7 +51,7 @@ ecs_query_cache_table_match_t* flecs_query_test(
         qit->last = qt->last;
     }
 
-    return flecs_query_next(ctx);
+    return flecs_query_cache_next(ctx);
 }
 
 static
@@ -244,7 +244,7 @@ void flecs_query_cache_init_mapped_fields(
 bool flecs_query_cache_search(
     const ecs_query_run_ctx_t *ctx)
 {
-    ecs_query_cache_table_match_t *node = flecs_query_next(ctx);
+    ecs_query_cache_table_match_t *node = flecs_query_cache_next(ctx);
     if (!node) {
         return false;
     }
@@ -260,7 +260,7 @@ bool flecs_query_cache_search(
 bool flecs_query_is_cache_search(
     const ecs_query_run_ctx_t *ctx)
 {
-    ecs_query_cache_table_match_t *node = flecs_query_next(ctx);
+    ecs_query_cache_table_match_t *node = flecs_query_cache_next(ctx);
     if (!node) {
         return false;
     }
@@ -272,8 +272,6 @@ bool flecs_query_is_cache_search(
     it->set_fields = node->set_fields;
     it->up_fields = node->up_fields;
 
-    ctx->vars[0].range.count = node->count;
-    ctx->vars[0].range.offset = node->offset;
     return true;
 }
 

--- a/src/query/engine/eval.c
+++ b/src/query/engine/eval.c
@@ -665,26 +665,6 @@ bool flecs_query_triv_data(
 }
 
 static
-bool flecs_query_triv_wildcard(
-    const ecs_query_op_t *op,
-    bool redo,
-    const ecs_query_run_ctx_t *ctx)
-{
-    ecs_query_trivial_ctx_t *op_ctx = flecs_op_ctx(ctx, trivial);
-    ecs_flags64_t termset = op->src.entity;
-    uint64_t written = ctx->written[ctx->op_index];
-    ctx->written[ctx->op_index + 1] |= 1ull;
-    if (written & 1ull) {
-        flecs_query_set_iter_this(ctx->it, ctx);
-        return flecs_query_trivial_test_w_wildcards(
-            ctx, redo, termset);
-    } else {
-        return flecs_query_trivial_search_w_wildcards(
-            ctx, op_ctx, redo, termset);
-    }
-}
-
-static
 bool flecs_query_cache(
     const ecs_query_op_t *op,
     bool redo,
@@ -1710,7 +1690,6 @@ bool flecs_query_dispatch(
     case EcsQueryAndAny: return flecs_query_and_any(op, redo, ctx);
     case EcsQueryTriv: return flecs_query_triv(op, redo, ctx);
     case EcsQueryTrivData: return flecs_query_triv_data(op, redo, ctx);
-    case EcsQueryTrivWildcard: return flecs_query_triv_wildcard(op, redo, ctx);
     case EcsQueryCache: return flecs_query_cache(op, redo, ctx);
     case EcsQueryIsCache: return flecs_query_is_cache(op, redo, ctx);
     case EcsQueryCacheData: return flecs_query_cache_data(op, redo, ctx);

--- a/src/query/engine/trivial_iter.c
+++ b/src/query/engine/trivial_iter.c
@@ -71,7 +71,8 @@ bool flecs_query_trivial_search(
         return false;
     }
 
-    do {
+next:
+    {
         const ecs_table_record_t *tr = flecs_table_cache_next(
             &op_ctx->it, ecs_table_record_t);
         if (!tr) {
@@ -80,7 +81,7 @@ bool flecs_query_trivial_search(
 
         ecs_table_t *table = tr->hdr.table;
         if (table->flags & (EcsTableNotQueryable|EcsTableIsPrefab|EcsTableIsDisabled)) {
-            continue;
+            goto next;
         }
 
         int32_t first_term = op_ctx->first_to_eval;
@@ -99,7 +100,7 @@ bool flecs_query_trivial_search(
             const ecs_table_record_t *tr_with = flecs_id_record_get_table(
                 idr, table);
             if (!tr_with) {
-                break;
+                goto next;
             }
 
             it->columns[term->field_index] = tr_with->index;
@@ -111,22 +112,19 @@ bool flecs_query_trivial_search(
             }
         }
 
-        if (t == term_count) {
-            ctx->vars[0].range.table = table;
-            ctx->vars[0].range.count = 0;
-            ctx->vars[0].range.offset = 0;
+        ctx->vars[0].range.table = table;
+        ctx->vars[0].range.count = 0;
+        ctx->vars[0].range.offset = 0;
 
-            int32_t start_from = op_ctx->start_from;
-            it->columns[start_from] = tr->index;
-            if (!(terms[start_from].flags_ & EcsTermNoData)) {
-                if (tr->column != -1) {
-                    it->ptrs[start_from] = ecs_vec_first(
-                        &table->data.columns[tr->column].data);
-                }
+        int32_t start_from = op_ctx->start_from;
+        it->columns[start_from] = tr->index;
+        if (!(terms[start_from].flags_ & EcsTermNoData)) {
+            if (tr->column != -1) {
+                it->ptrs[start_from] = ecs_vec_first(
+                    &table->data.columns[tr->column].data);
             }
-            break;
         }
-    } while (true);
+    }
 
     return true;
 }

--- a/src/query/engine/trivial_iter.c
+++ b/src/query/engine/trivial_iter.c
@@ -23,6 +23,7 @@ bool flecs_query_trivial_search_init(
         }
 
         ecs_assert(t != query->term_count, ECS_INTERNAL_ERROR, NULL);
+        op_ctx->start_from = t;
 
         const ecs_term_t *term = &query->terms[t];
         ecs_id_record_t *idr = flecs_id_record_get(ctx->world, term->id);
@@ -41,7 +42,8 @@ bool flecs_query_trivial_search_init(
         }
 
         /* Find next term to evaluate once */
-        for (; t < query->term_count; t ++) {
+        
+        for (t = t + 1; t < query->term_count; t ++) {
             if (term_set & (1llu << t)) {
                 break;
             }
@@ -113,10 +115,12 @@ bool flecs_query_trivial_search(
             ctx->vars[0].range.table = table;
             ctx->vars[0].range.count = 0;
             ctx->vars[0].range.offset = 0;
-            it->columns[first_term] = tr->index;
-            if (!(terms[first_term].flags_ & EcsTermNoData)) {
+
+            int32_t start_from = op_ctx->start_from;
+            it->columns[start_from] = tr->index;
+            if (!(terms[start_from].flags_ & EcsTermNoData)) {
                 if (tr->column != -1) {
-                    it->ptrs[first_term] = ecs_vec_first(
+                    it->ptrs[start_from] = ecs_vec_first(
                         &table->data.columns[tr->column].data);
                 }
             }

--- a/src/query/engine/trivial_iter.h
+++ b/src/query/engine/trivial_iter.h
@@ -5,35 +5,34 @@
 
 #include "../types.h"
 
-/* Iterator for trivial queries. */
+/* Iterator for queries with trivial terms. */
 bool flecs_query_trivial_search(
     const ecs_query_run_ctx_t *ctx,
     ecs_query_trivial_ctx_t *op_ctx,
     bool redo,
     ecs_flags64_t field_set);
 
-/* Iterator for trivial queries. */
+/* Iterator for queries with only trivial terms. */
+bool flecs_query_is_trivial_search(
+    const ecs_query_run_ctx_t *ctx,
+    ecs_query_trivial_ctx_t *op_ctx,
+    bool redo);
+
+/* Iterator for trivial queries, don't return data fields. */
 bool flecs_query_trivial_search_nodata(
     const ecs_query_run_ctx_t *ctx,
     ecs_query_trivial_ctx_t *op_ctx,
     bool redo,
     ecs_flags64_t field_set);
 
-/* Iterator for trivial queries with wildcard matching. */
-bool flecs_query_trivial_search_w_wildcards(
+/* Iterator for queries with only trivial terms, don't return data fields. */
+bool flecs_query_is_trivial_search_nodata(
     const ecs_query_run_ctx_t *ctx,
     ecs_query_trivial_ctx_t *op_ctx,
-    bool redo,
-    ecs_flags64_t field_set);
+    bool redo);
 
 /* Trivial test for constrained $this. */
 bool flecs_query_trivial_test(
     const ecs_query_run_ctx_t *ctx,
     bool first,
-    ecs_flags64_t field_set);
-
-/* Trivial test for constrained $this with wildcard matching. */
-bool flecs_query_trivial_test_w_wildcards(
-    const ecs_query_run_ctx_t *ctx,
-    bool redo,
     ecs_flags64_t field_set);

--- a/src/query/types.h
+++ b/src/query/types.h
@@ -45,7 +45,6 @@ typedef enum {
     EcsQueryOnlyAny,        /* Dedicated instruction for _ queries where the src is unknown */
     EcsQueryTriv,           /* Trivial search (batches multiple terms) */
     EcsQueryTrivData,       /* Trivial search with setting data fields */
-    EcsQueryTrivWildcard,   /* Trivial search with (exclusive) wildcard ids */
     EcsQueryCache,          /* Cached search */
     EcsQueryCacheData,      /* Cached search with setting data fields */
     EcsQueryIsCache,        /* Cached search for queries that are entirely cached */

--- a/src/query/types.h
+++ b/src/query/types.h
@@ -258,6 +258,7 @@ typedef struct {
 typedef struct {
     ecs_table_cache_iter_t it;
     const ecs_table_record_t *tr;
+    int32_t start_from;
     int32_t first_to_eval;
 } ecs_query_trivial_ctx_t;
 

--- a/src/query/util.c
+++ b/src/query/util.c
@@ -179,7 +179,6 @@ const char* flecs_query_op_str(
     case EcsQueryAndAny:         return "andany    ";
     case EcsQueryTriv:           return "triv      ";
     case EcsQueryTrivData:       return "trivpop   ";
-    case EcsQueryTrivWildcard:   return "trivwc    ";
     case EcsQueryCache:          return "cache     ";
     case EcsQueryCacheData:      return "cachepop  ";
     case EcsQueryIsCache:        return "xcache    ";
@@ -358,8 +357,7 @@ void flecs_query_plan_w_profile(
             op->kind == EcsQueryPopulateSelf ||
             op->kind == EcsQueryPopulateSparse ||
             op->kind == EcsQueryTriv ||
-            op->kind == EcsQueryTrivData ||
-            op->kind == EcsQueryTrivWildcard)
+            op->kind == EcsQueryTrivData)
         {
             flecs_query_str_append_bitset(buf, op->src.entity);
         }

--- a/src/query/validator.c
+++ b/src/query/validator.c
@@ -1430,8 +1430,13 @@ int flecs_query_finalize_terms(
     /* Set cacheable flags */
     ECS_BIT_COND(q->flags, EcsQueryHasCacheable, 
         cacheable_terms != 0);
+
+    /* Exclude queries with order_by from setting the IsCacheable flag. This 
+     * allows the routine that evaluates entirely cached queries to use more
+     * optimized logic as it doesn't have to deal with order_by edge cases */
     ECS_BIT_COND(q->flags, EcsQueryIsCacheable, 
-        cacheable && (cacheable_terms == term_count));
+        cacheable && (cacheable_terms == term_count) &&
+            !desc->order_by_callback);
 
     for (i = 0; i < q->term_count; i ++) {
         ecs_term_t *term = &q->terms[i];

--- a/test/query/src/Plan.c
+++ b/test/query/src/Plan.c
@@ -421,9 +421,10 @@ void Plan_3_trivial_plan_w_wildcard(void) {
     ecs_log_enable_colors(false);
 
     const char *expect = 
-    HEAD " 0. [-1,  1]  setids      " 
-    LINE " 1. [ 0,  2]  trivwc      {0,1,2}"
-    LINE " 2. [ 1,  3]  yield       "
+    HEAD " 0. [-1,  1]  setids      "
+    LINE " 1. [ 0,  2]  triv        {0,1}"
+    LINE " 2. [ 1,  3]  and         $[this]           (ChildOf, $*'1)"
+    LINE " 3. [ 2,  4]  yield       "
     LINE "";
     char *plan = ecs_query_plan(r);
 
@@ -519,9 +520,10 @@ void Plan_3_trivial_plan_w_wildcard_component(void) {
     ecs_log_enable_colors(false);
 
     const char *expect = 
-    HEAD " 0. [-1,  1]  setids      " 
-    LINE " 1. [ 0,  2]  trivwc      {0,1,2}"
-    LINE " 2. [ 1,  3]  yield       "
+    HEAD " 0. [-1,  1]  setids      "
+    LINE " 1. [ 0,  2]  trivpop     {0,1}"
+    LINE " 2. [ 1,  3]  and         $[this]           (ChildOf, $*'1)"
+    LINE " 3. [ 2,  4]  yield       "
     LINE "";
     char *plan = ecs_query_plan(r);
 
@@ -647,9 +649,10 @@ void Plan_2_trivial_plan_w_wildcard(void) {
     ecs_log_enable_colors(false);
 
     const char *expect = 
-    HEAD " 0. [-1,  1]  setids      " 
-    LINE " 1. [ 0,  2]  trivwc      {0,1}"
-    LINE " 2. [ 1,  3]  yield       "
+    HEAD " 0. [-1,  1]  setids      "
+    LINE " 1. [ 0,  2]  andid       $[this]           (Foo)"
+    LINE " 2. [ 1,  3]  and         $[this]           (ChildOf, $*'1)"
+    LINE " 3. [ 2,  4]  yield       "
     LINE "";
     char *plan = ecs_query_plan(r);
 


### PR DESCRIPTION
This PR:
- Fixes an issue where the first term of an uncached query was evaluated twice
- Reduces branching in iterator code
- Add dedicated functions for uncached queries that are entirely trivial
- Remove dedicated function for uncached wildcard queries