### PR TITLE
add a constructor for flecs::ref<T> that just takes the entity

### DIFF
--- a/flecs.h
+++ b/flecs.h
@@ -16457,6 +16457,9 @@ struct untyped_component;
 template <typename T>
 struct component;
 
+template <typename T>
+struct ref;
+
 namespace _
 {
 template <typename T, typename U = int>
@@ -20238,82 +20241,6 @@ ecs_move_t move_dtor() {
 
 } // _
 } // flecs
-
-/**
- * @file addons/cpp/ref.hpp
- * @brief Class that caches data to speedup get operations.
- */
-
-#pragma once
-
-namespace flecs
-{
-
-/**
- * @defgroup cpp_ref Refs
- * @ingroup cpp_core
- * Refs are a fast mechanism for referring to a specific entity/component.
- *
- * @{
- */
-
-/** Component reference.
- * Reference to a component from a specific entity.
- */
-template <typename T>
-struct ref {
-    ref() : world_(nullptr), ref_{} { }
-
-    ref(world_t *world, entity_t entity, flecs::id_t id = 0)
-        : ref_()
-    {
-        // the world we were called with may be a stage; convert it to a world
-        // here if that is the case
-        world_ = world ? const_cast<flecs::world_t *>(ecs_get_world(world))
-            : nullptr;
-        if (!id) {
-            id = _::type<T>::id(world);
-        }
-
-        ecs_assert(_::type<T>::size() != 0, ECS_INVALID_PARAMETER,
-            "operation invalid for empty type");
-
-        ref_ = ecs_ref_init_id(world_, entity, id);
-    }
-
-    T* operator->() {
-        T* result = static_cast<T*>(ecs_ref_get_id(
-            world_, &ref_, this->ref_.id));
-
-        ecs_assert(result != NULL, ECS_INVALID_PARAMETER,
-            "nullptr dereference by flecs::ref");
-
-        return result;
-    }
-
-    T* get() {
-        return static_cast<T*>(ecs_ref_get_id(
-            world_, &ref_, this->ref_.id));
-    }
-
-    T* try_get() {
-        if (!world_ || !ref_.entity) {
-            return nullptr;
-        }
-
-        return get();
-    }
-
-    flecs::entity entity() const;
-
-private:
-    world_t *world_;
-    flecs::ref_t ref_;
-};
-
-/** @} */
-
-}
 
 /**
  * @file addons/cpp/world.hpp
@@ -27200,6 +27127,85 @@ inline void reset() {
 }
 
 /** @} */
+
+/**
+ * @file addons/cpp/ref.hpp
+ * @brief Class that caches data to speedup get operations.
+ */
+
+#pragma once
+
+namespace flecs
+{
+
+/**
+ * @defgroup cpp_ref Refs
+ * @ingroup cpp_core
+ * Refs are a fast mechanism for referring to a specific entity/component.
+ *
+ * @{
+ */
+
+/** Component reference.
+ * Reference to a component from a specific entity.
+ */
+template <typename T>
+struct ref {
+    ref() : world_(nullptr), ref_{} { }
+
+    ref(world_t *world, entity_t entity, flecs::id_t id = 0)
+        : ref_()
+    {
+        // the world we were called with may be a stage; convert it to a world
+        // here if that is the case
+        world_ = world ? const_cast<flecs::world_t *>(ecs_get_world(world))
+            : nullptr;
+        if (!id) {
+            id = _::type<T>::id(world);
+        }
+
+        ecs_assert(_::type<T>::size() != 0, ECS_INVALID_PARAMETER,
+            "operation invalid for empty type");
+
+        ref_ = ecs_ref_init_id(world_, entity, id);
+    }
+
+    ref(flecs::entity entity, flecs::id_t id = 0)
+        : ref(entity.world(), entity.id(), id) { }
+
+    T* operator->() {
+        T* result = static_cast<T*>(ecs_ref_get_id(
+            world_, &ref_, this->ref_.id));
+
+        ecs_assert(result != NULL, ECS_INVALID_PARAMETER,
+            "nullptr dereference by flecs::ref");
+
+        return result;
+    }
+
+    T* get() {
+        return static_cast<T*>(ecs_ref_get_id(
+            world_, &ref_, this->ref_.id));
+    }
+
+    T* try_get() {
+        if (!world_ || !ref_.entity) {
+            return nullptr;
+        }
+
+        return get();
+    }
+
+    flecs::entity entity() const;
+
+private:
+    world_t *world_;
+    flecs::ref_t ref_;
+};
+
+/** @} */
+
+}
 
 /**
  * @file addons/cpp/type.hpp

--- a/flecs.h
+++ b/flecs.h
@@ -27196,6 +27196,11 @@ struct ref {
         return get();
     }
 
+    /** implicit conversion to bool.  return true if there is a valid T* being referred to **/
+    operator bool() {       
+        return !!try_get();
+    }
+
     flecs::entity entity() const;
 
 private:

--- a/include/flecs/addons/cpp/flecs.hpp
+++ b/include/flecs/addons/cpp/flecs.hpp
@@ -29,6 +29,9 @@ struct untyped_component;
 template <typename T>
 struct component;
 
+template <typename T>
+struct ref;
+
 namespace _
 {
 template <typename T, typename U = int>
@@ -95,13 +98,13 @@ struct each_delegate;
 #include "log.hpp"
 #include "pair.hpp"
 #include "lifecycle_traits.hpp"
-#include "ref.hpp"
 #include "world.hpp"
 #include "field.hpp"
 #include "iter.hpp"
 #include "entity.hpp"
 #include "delegate.hpp"
 #include "component.hpp"
+#include "ref.hpp"
 #include "type.hpp"
 #include "table.hpp"
 #include "utils/iterable.hpp"

--- a/include/flecs/addons/cpp/ref.hpp
+++ b/include/flecs/addons/cpp/ref.hpp
@@ -66,6 +66,11 @@ struct ref {
         return get();
     }
 
+    /** implicit conversion to bool.  return true if there is a valid T* being referred to **/
+    operator bool() {       
+        return !!try_get();
+    }
+
     flecs::entity entity() const;
 
 private:

--- a/include/flecs/addons/cpp/ref.hpp
+++ b/include/flecs/addons/cpp/ref.hpp
@@ -40,6 +40,9 @@ struct ref {
         ref_ = ecs_ref_init_id(world_, entity, id);
     }
 
+    ref(flecs::entity entity, flecs::id_t id = 0)
+        : ref(entity.world(), entity.id(), id) { }
+
     T* operator->() {
         T* result = static_cast<T*>(ecs_ref_get_id(
             world_, &ref_, this->ref_.id));

--- a/test/cpp/project.json
+++ b/test/cpp/project.json
@@ -1015,6 +1015,7 @@
                 "pair_ref_second",
                 "from_stage",
                 "default_ctor",
+                "ctor_from_entity",
                 "try_get"
             ]
         }, {

--- a/test/cpp/project.json
+++ b/test/cpp/project.json
@@ -1016,6 +1016,7 @@
                 "from_stage",
                 "default_ctor",
                 "ctor_from_entity",
+                "implicit_operator_bool",
                 "try_get"
             ]
         }, {

--- a/test/cpp/src/Refs.cpp
+++ b/test/cpp/src/Refs.cpp
@@ -162,6 +162,17 @@ void Refs_default_ctor(void) {
     test_int(p->y, 20);
 }
 
+void Refs_ctor_from_entity(void) {
+    flecs::world world;
+
+    flecs::entity e = world.entity().set<Position>({10, 20});
+
+    flecs::ref<Position> p(e);
+
+    test_int(p->x, 10);
+    test_int(p->y, 20);
+}
+
 void Refs_try_get(void) {
     flecs::world world;
 

--- a/test/cpp/src/Refs.cpp
+++ b/test/cpp/src/Refs.cpp
@@ -173,6 +173,16 @@ void Refs_ctor_from_entity(void) {
     test_int(p->y, 20);
 }
 
+void Refs_implicit_operator_bool(void) {
+    flecs::world world;
+
+    flecs::entity e = world.entity().set<Position>({10, 20});
+
+    flecs::ref<Position> p(e);
+
+    test_assert(p);
+}
+
 void Refs_try_get(void) {
     flecs::world world;
 

--- a/test/cpp/src/main.cpp
+++ b/test/cpp/src/main.cpp
@@ -979,6 +979,7 @@ void Refs_pair_ref_second(void);
 void Refs_from_stage(void);
 void Refs_default_ctor(void);
 void Refs_ctor_from_entity(void);
+void Refs_implicit_operator_bool(void);
 void Refs_try_get(void);
 
 // Testsuite 'Module'
@@ -5142,6 +5143,10 @@ bake_test_case Refs_testcases[] = {
         Refs_ctor_from_entity
     },
     {
+        "implicit_operator_bool",
+        Refs_implicit_operator_bool
+    },
+    {
         "try_get",
         Refs_try_get
     }
@@ -6620,7 +6625,7 @@ static bake_test_suite suites[] = {
         "Refs",
         NULL,
         NULL,
-        14,
+        15,
         Refs_testcases
     },
     {

--- a/test/cpp/src/main.cpp
+++ b/test/cpp/src/main.cpp
@@ -978,6 +978,7 @@ void Refs_pair_ref_w_entity(void);
 void Refs_pair_ref_second(void);
 void Refs_from_stage(void);
 void Refs_default_ctor(void);
+void Refs_ctor_from_entity(void);
 void Refs_try_get(void);
 
 // Testsuite 'Module'
@@ -5137,6 +5138,10 @@ bake_test_case Refs_testcases[] = {
         Refs_default_ctor
     },
     {
+        "ctor_from_entity",
+        Refs_ctor_from_entity
+    },
+    {
         "try_get",
         Refs_try_get
     }
@@ -6615,7 +6620,7 @@ static bake_test_suite suites[] = {
         "Refs",
         NULL,
         NULL,
-        13,
+        14,
         Refs_testcases
     },
     {


### PR DESCRIPTION
flecs::ref<T> is a really useful object, but it's constructor is a bit weird.  It only takes a world_t* and an entity_t, both are encapsulated in the flecs::entity struct.  

So I added a constructor that simply takes a flecs::entity and extracts the world_t* and entity_t from that.  

There was a slight issue adding it because of how the flecs.hpp includes were laid out.  flecs::world has a get_ref<T>() which returns singletons, and expects ref to be declared before it.  I simply forward declared it in flecs.hpp like component is, and it seemed to like that.  

Also I'm kinda yoloing this PR cause I dont have bake setup on this new dev environment.  Hopefully the tests pass :)

Ok, tests passed, and I slipped in an operator bool() overload so 

```cpp
flecs::ref<Position> r(e);
if(r)
{
  //...
}
```

works.  