### PR TITLE
yield_existing: Examples refer to `EcsIterable`

### DIFF
--- a/examples/c/observers/yield_existing/src/main.c
+++ b/examples/c/observers/yield_existing/src/main.c
@@ -4,9 +4,6 @@
 // Observers can enable a "yield_existing" feature that upon creation of the
 // observer produces events for all entities that match the observer query. The
 // feature is only implemented for the builtin EcsOnAdd and EcsOnSet events.
-//
-// Custom events can also implement behavior for yield_existing by adding the
-// Iterable component to the event (see EcsIterable for more details).
 
 typedef struct {
     double x, y;

--- a/examples/cpp/observers/yield_existing/src/main.cpp
+++ b/examples/cpp/observers/yield_existing/src/main.cpp
@@ -4,9 +4,6 @@
 // Observers can enable a "yield_existing" feature that upon creation of the
 // observer produces events for all entities that match the observer query. The
 // feature is only implemented for the builtin EcsOnAdd and EcsOnSet events.
-//
-// Custom events can also implement behavior for yield_existing by adding the
-// Iterable component to the event (see EcsIterable for more details).
 
 struct Position {
     double x, y;


### PR DESCRIPTION
This feature was removed in v4, so shouldn't be mentioned in the examples.