### PR TITLE
add option to explicitly use provided offset, even when 0.

### DIFF
--- a/flecs.c
+++ b/flecs.c
@@ -48211,7 +48211,8 @@ void flecs_meta_import_meta_definitions(
             { .name = "type", .type = ecs_id(ecs_entity_t) },
             { .name = "count", .type = ecs_id(ecs_i32_t) },
             { .name = "unit", .type = ecs_id(ecs_entity_t) },
-            { .name = "offset", .type = ecs_id(ecs_i32_t) }
+            { .name = "offset", .type = ecs_id(ecs_i32_t) },
+            { .name = "explicit_offset", .type = ecs_id(ecs_bool_t) }
         }
     });
 
@@ -48765,7 +48766,7 @@ int flecs_add_member_to_struct(
     }
 
     bool explicit_offset = false;
-    if (m->offset) {
+    if (m->offset || m->explicit_offset) { 
         explicit_offset = true;
     }
 

--- a/flecs.c
+++ b/flecs.c
@@ -48212,7 +48212,7 @@ void flecs_meta_import_meta_definitions(
             { .name = "count", .type = ecs_id(ecs_i32_t) },
             { .name = "unit", .type = ecs_id(ecs_entity_t) },
             { .name = "offset", .type = ecs_id(ecs_i32_t) },
-            { .name = "explicit_offset", .type = ecs_id(ecs_bool_t) }
+            { .name = "use_offset", .type = ecs_id(ecs_bool_t) }
         }
     });
 
@@ -48765,7 +48765,7 @@ int flecs_add_member_to_struct(
         count ++;
     }
 
-    bool explicit_offset = m->offset || m->explicit_offset;
+    bool explicit_offset = m->offset || m->use_offset;
 
     /* Compute member offsets and size & alignment of struct */
     ecs_size_t size = 0;

--- a/flecs.c
+++ b/flecs.c
@@ -48765,10 +48765,7 @@ int flecs_add_member_to_struct(
         count ++;
     }
 
-    bool explicit_offset = false;
-    if (m->offset || m->explicit_offset) { 
-        explicit_offset = true;
-    }
+    bool explicit_offset = m->offset || m->explicit_offset;
 
     /* Compute member offsets and size & alignment of struct */
     ecs_size_t size = 0;

--- a/flecs.h
+++ b/flecs.h
@@ -26815,8 +26815,8 @@ untyped_component& internal_member(flecs::entity_t type_id, flecs::entity_t unit
 public: 
 
 /** Add member with unit. */
-untyped_component& member(flecs::entity_t type_id, flecs::entity_t unit, const char *name) {
-    return internal_member(type_id, unit, name, 0, 0, false);
+untyped_component& member(flecs::entity_t type_id, flecs::entity_t unit, const char *name, int32_t count = 0) {
+    return internal_member(type_id, unit, name, count, 0, false);
 }
 
 /** Add member with unit. */
@@ -26825,8 +26825,8 @@ untyped_component& member(flecs::entity_t type_id, flecs::entity_t unit, const c
 }
 
 /** Add member. */
-untyped_component& member(flecs::entity_t type_id, const char* name) {
-    return member(type_id, 0, name);
+untyped_component& member(flecs::entity_t type_id, const char* name, int32_t count = 0) {
+    return member(type_id, 0, name, count);
 }
 
 /** Add member. */
@@ -26836,9 +26836,9 @@ untyped_component& member(flecs::entity_t type_id, const char* name, int32_t cou
 
 /** Add member. */
 template <typename MemberType>
-untyped_component& member(const char *name) {
+untyped_component& member(const char *name, int32_t count = 0) {
     flecs::entity_t type_id = _::type<MemberType>::id(world_);
-    return member(type_id, name);
+    return member(type_id, name, count);
 }
 
 /** Add member. */
@@ -26850,9 +26850,9 @@ untyped_component& member(const char *name, int32_t count, size_t offset) {
 
 /** Add member with unit. */
 template <typename MemberType>
-untyped_component& member(flecs::entity_t unit, const char *name) {
+untyped_component& member(flecs::entity_t unit, const char *name, int32_t count = 0) {
     flecs::entity_t type_id = _::type<MemberType>::id(world_);
-    return member(type_id, unit, name);
+    return member(type_id, unit, name, count);
 }
 
 /** Add member with unit. */
@@ -26864,10 +26864,10 @@ untyped_component& member(flecs::entity_t unit, const char *name, int32_t count,
 
 /** Add member with unit. */
 template <typename MemberType, typename UnitType>
-untyped_component& member(const char *name) {
+untyped_component& member(const char *name, int32_t count = 0) {
     flecs::entity_t type_id = _::type<MemberType>::id(world_);
     flecs::entity_t unit_id = _::type<UnitType>::id(world_);
-    return member(type_id, unit_id, name);
+    return member(type_id, unit_id, name, count);
 }
 
 /** Add member with unit. */

--- a/flecs.h
+++ b/flecs.h
@@ -14973,7 +14973,7 @@ typedef struct EcsMember {
     int32_t count;                                 /**< Number of elements (for inline arrays). */
     ecs_entity_t unit;                             /**< Member unit. */
     int32_t offset;                                /**< Member offset. */
-    bool explicit_offset;                          /**< If offset should be explicitly used. */
+    bool use_offset;                          /**< If offset should be explicitly used. */
 } EcsMember;
 
 /** Type expressing a range for a member value */
@@ -26789,8 +26789,10 @@ struct untyped_component : entity {
  * @{
  */
 
-/** Add member with unit. */
-untyped_component& member(flecs::entity_t type_id, flecs::entity_t unit, const char *name, int32_t count = 0, size_t offset = 0) {
+private:
+
+/** internal add member to unit */
+untyped_component& internal_member(flecs::entity_t type_id, flecs::entity_t unit, const char *name, int32_t count = 0, size_t offset = 0, bool use_offset = false) {
     ecs_entity_desc_t desc = {};
     desc.name = name;
     desc.parent = id_;
@@ -26804,33 +26806,73 @@ untyped_component& member(flecs::entity_t type_id, flecs::entity_t unit, const c
     m.unit = unit;
     m.count = count;
     m.offset = static_cast<int32_t>(offset);
+    m.use_offset = use_offset;
     e.set<Member>(m);
 
     return *this;
 }
 
+public: 
+
+/** Add member with unit. */
+untyped_component& member(flecs::entity_t type_id, flecs::entity_t unit, const char *name) {
+    return internal_member(type_id, unit, name, 0, 0, false);
+}
+
+/** Add member with unit. */
+untyped_component& member(flecs::entity_t type_id, flecs::entity_t unit, const char *name, int32_t count, size_t offset) {
+    return internal_member(type_id, unit, name, count, offset, true);
+}
+
 /** Add member. */
-untyped_component& member(flecs::entity_t type_id, const char* name, int32_t count = 0, size_t offset = 0) {
+untyped_component& member(flecs::entity_t type_id, const char* name) {
+    return member(type_id, 0, name);
+}
+
+/** Add member. */
+untyped_component& member(flecs::entity_t type_id, const char* name, int32_t count, size_t offset) {
     return member(type_id, 0, name, count, offset);
 }
 
 /** Add member. */
 template <typename MemberType>
-untyped_component& member(const char *name, int32_t count = 0, size_t offset = 0) {
+untyped_component& member(const char *name) {
+    flecs::entity_t type_id = _::type<MemberType>::id(world_);
+    return member(type_id, name);
+}
+
+/** Add member. */
+template <typename MemberType>
+untyped_component& member(const char *name, int32_t count, size_t offset) {
     flecs::entity_t type_id = _::type<MemberType>::id(world_);
     return member(type_id, name, count, offset);
 }
 
 /** Add member with unit. */
 template <typename MemberType>
-untyped_component& member(flecs::entity_t unit, const char *name, int32_t count = 0, size_t offset = 0) {
+untyped_component& member(flecs::entity_t unit, const char *name) {
+    flecs::entity_t type_id = _::type<MemberType>::id(world_);
+    return member(type_id, unit, name);
+}
+
+/** Add member with unit. */
+template <typename MemberType>
+untyped_component& member(flecs::entity_t unit, const char *name, int32_t count, size_t offset) {
     flecs::entity_t type_id = _::type<MemberType>::id(world_);
     return member(type_id, unit, name, count, offset);
 }
 
 /** Add member with unit. */
 template <typename MemberType, typename UnitType>
-untyped_component& member(const char *name, int32_t count = 0, size_t offset = 0) {
+untyped_component& member(const char *name) {
+    flecs::entity_t type_id = _::type<MemberType>::id(world_);
+    flecs::entity_t unit_id = _::type<UnitType>::id(world_);
+    return member(type_id, unit_id, name);
+}
+
+/** Add member with unit. */
+template <typename MemberType, typename UnitType>
+untyped_component& member(const char *name, int32_t count, size_t offset) {
     flecs::entity_t type_id = _::type<MemberType>::id(world_);
     flecs::entity_t unit_id = _::type<UnitType>::id(world_);
     return member(type_id, unit_id, name, count, offset);

--- a/flecs.h
+++ b/flecs.h
@@ -14973,7 +14973,7 @@ typedef struct EcsMember {
     int32_t count;                                 /**< Number of elements (for inline arrays). */
     ecs_entity_t unit;                             /**< Member unit. */
     int32_t offset;                                /**< Member offset. */
-    bool use_offset;                          /**< If offset should be explicitly used. */
+    bool use_offset;                               /**< If offset should be explicitly used. */
 } EcsMember;
 
 /** Type expressing a range for a member value */

--- a/flecs.h
+++ b/flecs.h
@@ -14973,6 +14973,7 @@ typedef struct EcsMember {
     int32_t count;                                 /**< Number of elements (for inline arrays). */
     ecs_entity_t unit;                             /**< Member unit. */
     int32_t offset;                                /**< Member offset. */
+    bool explicit_offset;                          /**< if Offset should be explicitly used. */
 } EcsMember;
 
 /** Type expressing a range for a member value */

--- a/flecs.h
+++ b/flecs.h
@@ -14973,7 +14973,7 @@ typedef struct EcsMember {
     int32_t count;                                 /**< Number of elements (for inline arrays). */
     ecs_entity_t unit;                             /**< Member unit. */
     int32_t offset;                                /**< Member offset. */
-    bool explicit_offset;                          /**< if Offset should be explicitly used. */
+    bool explicit_offset;                          /**< If offset should be explicitly used. */
 } EcsMember;
 
 /** Type expressing a range for a member value */

--- a/include/flecs/addons/cpp/mixins/meta/untyped_component.inl
+++ b/include/flecs/addons/cpp/mixins/meta/untyped_component.inl
@@ -10,8 +10,10 @@
  * @{
  */
 
-/** Add member with unit. */
-untyped_component& member(flecs::entity_t type_id, flecs::entity_t unit, const char *name, int32_t count = 0, size_t offset = 0) {
+private:
+
+/** internal add member to unit */
+untyped_component& internal_member(flecs::entity_t type_id, flecs::entity_t unit, const char *name, int32_t count = 0, size_t offset = 0, bool use_offset = false) {
     ecs_entity_desc_t desc = {};
     desc.name = name;
     desc.parent = id_;
@@ -25,33 +27,73 @@ untyped_component& member(flecs::entity_t type_id, flecs::entity_t unit, const c
     m.unit = unit;
     m.count = count;
     m.offset = static_cast<int32_t>(offset);
+    m.use_offset = use_offset;
     e.set<Member>(m);
 
     return *this;
 }
 
+public: 
+
+/** Add member with unit. */
+untyped_component& member(flecs::entity_t type_id, flecs::entity_t unit, const char *name) {
+    return internal_member(type_id, unit, name, 0, 0, false);
+}
+
+/** Add member with unit. */
+untyped_component& member(flecs::entity_t type_id, flecs::entity_t unit, const char *name, int32_t count, size_t offset) {
+    return internal_member(type_id, unit, name, count, offset, true);
+}
+
 /** Add member. */
-untyped_component& member(flecs::entity_t type_id, const char* name, int32_t count = 0, size_t offset = 0) {
+untyped_component& member(flecs::entity_t type_id, const char* name) {
+    return member(type_id, 0, name);
+}
+
+/** Add member. */
+untyped_component& member(flecs::entity_t type_id, const char* name, int32_t count, size_t offset) {
     return member(type_id, 0, name, count, offset);
 }
 
 /** Add member. */
 template <typename MemberType>
-untyped_component& member(const char *name, int32_t count = 0, size_t offset = 0) {
+untyped_component& member(const char *name) {
+    flecs::entity_t type_id = _::type<MemberType>::id(world_);
+    return member(type_id, name);
+}
+
+/** Add member. */
+template <typename MemberType>
+untyped_component& member(const char *name, int32_t count, size_t offset) {
     flecs::entity_t type_id = _::type<MemberType>::id(world_);
     return member(type_id, name, count, offset);
 }
 
 /** Add member with unit. */
 template <typename MemberType>
-untyped_component& member(flecs::entity_t unit, const char *name, int32_t count = 0, size_t offset = 0) {
+untyped_component& member(flecs::entity_t unit, const char *name) {
+    flecs::entity_t type_id = _::type<MemberType>::id(world_);
+    return member(type_id, unit, name);
+}
+
+/** Add member with unit. */
+template <typename MemberType>
+untyped_component& member(flecs::entity_t unit, const char *name, int32_t count, size_t offset) {
     flecs::entity_t type_id = _::type<MemberType>::id(world_);
     return member(type_id, unit, name, count, offset);
 }
 
 /** Add member with unit. */
 template <typename MemberType, typename UnitType>
-untyped_component& member(const char *name, int32_t count = 0, size_t offset = 0) {
+untyped_component& member(const char *name) {
+    flecs::entity_t type_id = _::type<MemberType>::id(world_);
+    flecs::entity_t unit_id = _::type<UnitType>::id(world_);
+    return member(type_id, unit_id, name);
+}
+
+/** Add member with unit. */
+template <typename MemberType, typename UnitType>
+untyped_component& member(const char *name, int32_t count, size_t offset) {
     flecs::entity_t type_id = _::type<MemberType>::id(world_);
     flecs::entity_t unit_id = _::type<UnitType>::id(world_);
     return member(type_id, unit_id, name, count, offset);

--- a/include/flecs/addons/cpp/mixins/meta/untyped_component.inl
+++ b/include/flecs/addons/cpp/mixins/meta/untyped_component.inl
@@ -36,8 +36,8 @@ untyped_component& internal_member(flecs::entity_t type_id, flecs::entity_t unit
 public: 
 
 /** Add member with unit. */
-untyped_component& member(flecs::entity_t type_id, flecs::entity_t unit, const char *name) {
-    return internal_member(type_id, unit, name, 0, 0, false);
+untyped_component& member(flecs::entity_t type_id, flecs::entity_t unit, const char *name, int32_t count = 0) {
+    return internal_member(type_id, unit, name, count, 0, false);
 }
 
 /** Add member with unit. */
@@ -46,8 +46,8 @@ untyped_component& member(flecs::entity_t type_id, flecs::entity_t unit, const c
 }
 
 /** Add member. */
-untyped_component& member(flecs::entity_t type_id, const char* name) {
-    return member(type_id, 0, name);
+untyped_component& member(flecs::entity_t type_id, const char* name, int32_t count = 0) {
+    return member(type_id, 0, name, count);
 }
 
 /** Add member. */
@@ -57,9 +57,9 @@ untyped_component& member(flecs::entity_t type_id, const char* name, int32_t cou
 
 /** Add member. */
 template <typename MemberType>
-untyped_component& member(const char *name) {
+untyped_component& member(const char *name, int32_t count = 0) {
     flecs::entity_t type_id = _::type<MemberType>::id(world_);
-    return member(type_id, name);
+    return member(type_id, name, count);
 }
 
 /** Add member. */
@@ -71,9 +71,9 @@ untyped_component& member(const char *name, int32_t count, size_t offset) {
 
 /** Add member with unit. */
 template <typename MemberType>
-untyped_component& member(flecs::entity_t unit, const char *name) {
+untyped_component& member(flecs::entity_t unit, const char *name, int32_t count = 0) {
     flecs::entity_t type_id = _::type<MemberType>::id(world_);
-    return member(type_id, unit, name);
+    return member(type_id, unit, name, count);
 }
 
 /** Add member with unit. */
@@ -85,10 +85,10 @@ untyped_component& member(flecs::entity_t unit, const char *name, int32_t count,
 
 /** Add member with unit. */
 template <typename MemberType, typename UnitType>
-untyped_component& member(const char *name) {
+untyped_component& member(const char *name, int32_t count = 0) {
     flecs::entity_t type_id = _::type<MemberType>::id(world_);
     flecs::entity_t unit_id = _::type<UnitType>::id(world_);
-    return member(type_id, unit_id, name);
+    return member(type_id, unit_id, name, count);
 }
 
 /** Add member with unit. */

--- a/include/flecs/addons/meta.h
+++ b/include/flecs/addons/meta.h
@@ -202,7 +202,7 @@ typedef struct EcsMember {
     int32_t count;                                 /**< Number of elements (for inline arrays). */
     ecs_entity_t unit;                             /**< Member unit. */
     int32_t offset;                                /**< Member offset. */
-    bool explicit_offset;                          /**< if Offset should be explicitly used. */
+    bool explicit_offset;                          /**< If offset should be explicitly used. */
 } EcsMember;
 
 /** Type expressing a range for a member value */

--- a/include/flecs/addons/meta.h
+++ b/include/flecs/addons/meta.h
@@ -202,7 +202,7 @@ typedef struct EcsMember {
     int32_t count;                                 /**< Number of elements (for inline arrays). */
     ecs_entity_t unit;                             /**< Member unit. */
     int32_t offset;                                /**< Member offset. */
-    bool explicit_offset;                          /**< If offset should be explicitly used. */
+    bool use_offset;                          /**< If offset should be explicitly used. */
 } EcsMember;
 
 /** Type expressing a range for a member value */

--- a/include/flecs/addons/meta.h
+++ b/include/flecs/addons/meta.h
@@ -202,7 +202,7 @@ typedef struct EcsMember {
     int32_t count;                                 /**< Number of elements (for inline arrays). */
     ecs_entity_t unit;                             /**< Member unit. */
     int32_t offset;                                /**< Member offset. */
-    bool use_offset;                          /**< If offset should be explicitly used. */
+    bool use_offset;                               /**< If offset should be explicitly used. */
 } EcsMember;
 
 /** Type expressing a range for a member value */

--- a/include/flecs/addons/meta.h
+++ b/include/flecs/addons/meta.h
@@ -202,6 +202,7 @@ typedef struct EcsMember {
     int32_t count;                                 /**< Number of elements (for inline arrays). */
     ecs_entity_t unit;                             /**< Member unit. */
     int32_t offset;                                /**< Member offset. */
+    bool explicit_offset;                          /**< if Offset should be explicitly used. */
 } EcsMember;
 
 /** Type expressing a range for a member value */

--- a/src/addons/meta/definitions.c
+++ b/src/addons/meta/definitions.c
@@ -174,7 +174,7 @@ void flecs_meta_import_meta_definitions(
             { .name = "count", .type = ecs_id(ecs_i32_t) },
             { .name = "unit", .type = ecs_id(ecs_entity_t) },
             { .name = "offset", .type = ecs_id(ecs_i32_t) },
-            { .name = "explicit_offset", .type = ecs_id(ecs_bool_t) }
+            { .name = "use_offset", .type = ecs_id(ecs_bool_t) }
         }
     });
 

--- a/src/addons/meta/definitions.c
+++ b/src/addons/meta/definitions.c
@@ -173,7 +173,8 @@ void flecs_meta_import_meta_definitions(
             { .name = "type", .type = ecs_id(ecs_entity_t) },
             { .name = "count", .type = ecs_id(ecs_i32_t) },
             { .name = "unit", .type = ecs_id(ecs_entity_t) },
-            { .name = "offset", .type = ecs_id(ecs_i32_t) }
+            { .name = "offset", .type = ecs_id(ecs_i32_t) },
+            { .name = "explicit_offset", .type = ecs_id(ecs_bool_t) }
         }
     });
 

--- a/src/addons/meta/meta.c
+++ b/src/addons/meta/meta.c
@@ -437,7 +437,7 @@ int flecs_add_member_to_struct(
         count ++;
     }
 
-    bool explicit_offset = m->offset || m->explicit_offset;
+    bool explicit_offset = m->offset || m->use_offset;
 
     /* Compute member offsets and size & alignment of struct */
     ecs_size_t size = 0;

--- a/src/addons/meta/meta.c
+++ b/src/addons/meta/meta.c
@@ -437,10 +437,7 @@ int flecs_add_member_to_struct(
         count ++;
     }
 
-    bool explicit_offset = false;
-    if (m->offset || m->explicit_offset) { 
-        explicit_offset = true;
-    }
+    bool explicit_offset = m->offset || m->explicit_offset;
 
     /* Compute member offsets and size & alignment of struct */
     ecs_size_t size = 0;

--- a/src/addons/meta/meta.c
+++ b/src/addons/meta/meta.c
@@ -438,7 +438,7 @@ int flecs_add_member_to_struct(
     }
 
     bool explicit_offset = false;
-    if (m->offset) {
+    if (m->offset || m->explicit_offset) { 
         explicit_offset = true;
     }
 

--- a/test/cpp/project.json
+++ b/test/cpp/project.json
@@ -1337,7 +1337,8 @@
                 "error_range",
                 "struct_member_ptr",
                 "struct_member_ptr_packed_struct",
-                "component_as_array"
+                "component_as_array",
+                "out_of_order_member_declaration"
             ]
         }, {
             "id": "Table",

--- a/test/cpp/src/Enum.cpp
+++ b/test/cpp/src/Enum.cpp
@@ -1001,14 +1001,14 @@ void Enum_query_union_enum(void) {
         while (it.next()) {
             test_int(it.count(), 1);
             if (count == 0) {
-                test_int(it.entity(0), e2);
-                test_assert(it.id(0) == 
-                    ecs.pair<StandardEnum>(ecs.to_entity(StandardEnum::Green)));
-            }
-            if (count == 2) {
                 test_int(it.entity(0), e1);
                 test_assert(it.id(0) == 
                     ecs.pair<StandardEnum>(ecs.to_entity(StandardEnum::Red)));
+            }
+            if (count == 2) {
+                test_int(it.entity(0), e2);
+                test_assert(it.id(0) == 
+                    ecs.pair<StandardEnum>(ecs.to_entity(StandardEnum::Green)));
             }
             if (count == 1) {
                 test_int(it.entity(0), e3);

--- a/test/cpp/src/main.cpp
+++ b/test/cpp/src/main.cpp
@@ -1287,6 +1287,7 @@ void Meta_error_range(void);
 void Meta_struct_member_ptr(void);
 void Meta_struct_member_ptr_packed_struct(void);
 void Meta_component_as_array(void);
+void Meta_out_of_order_member_declaration(void);
 
 // Testsuite 'Table'
 void Table_each(void);
@@ -6328,6 +6329,10 @@ bake_test_case Meta_testcases[] = {
     {
         "component_as_array",
         Meta_component_as_array
+    },
+    {
+        "out_of_order_member_declaration",
+        Meta_out_of_order_member_declaration
     }
 };
 
@@ -6644,7 +6649,7 @@ static bake_test_suite suites[] = {
         "Meta",
         NULL,
         NULL,
-        55,
+        56,
         Meta_testcases
     },
     {

--- a/test/meta/src/SerializeEntityToJson.c
+++ b/test/meta/src/SerializeEntityToJson.c
@@ -796,7 +796,7 @@ void SerializeEntityToJson_serialize_w_2_alerts(void) {
     char *json = ecs_entity_to_json(world, e1, &desc);
     test_assert(json != NULL);
 
-    test_json(json, "{\"name\":\"e1\", \"alerts\":true, \"components\":{\"flecs.alerts.AlertsActive\":{\"info_count\":0, \"warning_count\":0, \"error_count\":2}, \"Position\":null}, \"alerts\":[{\"alert\":\"position_without_mass.e1_alert_2\", \"message\":\"e1 has Position but not Mass\", \"severity\":\"Error\"}, {\"alert\":\"position_without_velocity.e1_alert_1\", \"message\":\"e1 has Position but not Velocity\", \"severity\":\"Error\"}]}");
+    test_json(json, "{\"name\":\"e1\", \"alerts\":true, \"components\":{\"flecs.alerts.AlertsActive\":{\"info_count\":0, \"warning_count\":0, \"error_count\":2}, \"Position\":null}, \"alerts\":[{\"alert\":\"position_without_velocity.e1_alert_1\", \"message\":\"e1 has Position but not Velocity\", \"severity\":\"Error\"}, {\"alert\":\"position_without_mass.e1_alert_2\", \"message\":\"e1 has Position but not Mass\", \"severity\":\"Error\"}]}");
     // test_json(json, "{\"name\":\"e1\", \"alerts\":true, \"components\":{\"AlertsActive\":{\"info_count\":0, \"warning_count\":0, \"error_count\":2}, \"Position\":null, \"alerts\":[{\"alert\":\"position_without_mass.e1_alert_2\", \"message\":\"e1 has Position but not Mass\", \"severity\":\"Error\"}, {\"alert\":\"position_without_velocity.e1_alert_1\", \"message\":\"e1 has Position but not Velocity\", \"severity\":\"Error\"}]}");
     ecs_os_free(json);
 


### PR DESCRIPTION
This allows to register fields in arbitrary order for reflection. This is useful for example where in Rust fields are not guaranteed to be in the same order as represented.