### PR TITLE
chore: create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto eol=lf


### PR DESCRIPTION
preserve line endings when building and testing on windows.