### PR TITLE
Fix C++ API observers with sparse components by filling out iterator field flags in flecs_uni_observer_invoke

### DIFF
--- a/flecs.c
+++ b/flecs.c
@@ -14093,8 +14093,10 @@ void flecs_uni_observer_invoke(
     it->callback_ctx = o->callback_ctx;
     it->run_ctx = o->run_ctx;
     it->term_index = impl->term_index;
-    it->query = o->query;
-
+    it->query = query;
+    it->ref_fields = query->fixed_fields | query->row_fields;
+    it->row_fields = query->row_fields;
+    
     ecs_entity_t event = it->event;
     int32_t event_cur = it->event_cur;
     it->event = flecs_get_observer_event(term, event);

--- a/src/observer.c
+++ b/src/observer.c
@@ -400,8 +400,10 @@ void flecs_uni_observer_invoke(
     it->callback_ctx = o->callback_ctx;
     it->run_ctx = o->run_ctx;
     it->term_index = impl->term_index;
-    it->query = o->query;
-
+    it->query = query;
+    it->ref_fields = query->fixed_fields | query->row_fields;
+    it->row_fields = query->row_fields;
+    
     ecs_entity_t event = it->event;
     int32_t event_cur = it->event_cur;
     it->event = flecs_get_observer_event(term, event);

--- a/test/cpp/project.json
+++ b/test/cpp/project.json
@@ -896,6 +896,7 @@
                 "get_query",
                 "on_set_w_set",
                 "on_set_w_defer_set",
+                "on_set_w_set_sparse",
                 "on_add_singleton",
                 "on_add_pair_singleton",
                 "on_add_pair_wildcard_singleton",

--- a/test/cpp/src/Observer.cpp
+++ b/test/cpp/src/Observer.cpp
@@ -778,6 +778,26 @@ void Observer_on_set_w_defer_set(void) {
     test_int(count, 1);
 }
 
+void Observer_on_set_w_set_sparse(void) {
+    flecs::world world;
+
+    world.component<Position>().add(flecs::Sparse);
+
+    int32_t count = 0;
+
+    world.observer<Position>()
+        .event(flecs::OnSet)
+        .each([&](flecs::entity e, Position& p) {
+            count ++;          
+        });
+
+    flecs::entity e = world.entity();
+    test_int(count, 0);
+
+    e.set<Position>({10, 20});
+    test_int(count, 1);
+}
+
 #include <iostream>
 
 void Observer_on_add_singleton(void) {

--- a/test/cpp/src/main.cpp
+++ b/test/cpp/src/main.cpp
@@ -863,6 +863,7 @@ void Observer_run_callback_w_yield_existing_2_fields(void);
 void Observer_get_query(void);
 void Observer_on_set_w_set(void);
 void Observer_on_set_w_defer_set(void);
+void Observer_on_set_w_set_sparse(void);
 void Observer_on_add_singleton(void);
 void Observer_on_add_pair_singleton(void);
 void Observer_on_add_pair_wildcard_singleton(void);
@@ -4684,6 +4685,10 @@ bake_test_case Observer_testcases[] = {
         Observer_on_set_w_defer_set
     },
     {
+        "on_set_w_set_sparse",
+        Observer_on_set_w_set_sparse
+    },
+    {
         "on_add_singleton",
         Observer_on_add_singleton
     },
@@ -6586,7 +6591,7 @@ static bake_test_suite suites[] = {
         "Observer",
         NULL,
         NULL,
-        45,
+        46,
         Observer_testcases
     },
     {


### PR DESCRIPTION
I noticed C++ observers with sparse components cause this assert to fire: 

`fatal: flecs.c: 10947: assert: !(idr->flags & EcsIdIsSparse) use ecs_field_at to access fields for sparse components (INVALID_OPERATION)`

A simple repro:

```cc
#include "flecs.h"
#include <iostream>

int main(int, char *[])
{
    struct Position {
        double x, y;
    };
    
    flecs::world ecs;
    ecs.component<Position>().add(flecs::Sparse);

    ecs.observer<Position>().event(flecs::OnSet).each([](flecs::entity e, Position& Pos)
    {
       std::cout << " - Position: {" << Pos.x << ", " << Pos.y << "}\n";
    });

    for (int i = 0; i < 4; ++i)
    {
        flecs::entity MeshEntity1 = ecs.entity();
        MeshEntity1.set<Position>({1,2});
    }
    
    ecs.progress();
}
```

After some messing around I found that `each_delegate::invoke(ecs_iter_t *iter)` seems to expect `ref_fields` to be set to determine if it uses `terms.populate` rather than `terms.populate_self`. I am not sure if this is the correct fix as this is the first time I've really done anything in flecs internals.

I think it would be useful to run the test cases with different combinations of sparse and non-sparse components to catch things like this ahead of time for commonly used API things.