### PR TITLE
Reduce overhead of table columns vector

### DIFF
--- a/flecs.c
+++ b/flecs.c
@@ -384,6 +384,50 @@ void flecs_table_diff_build_noalloc(
 #endif
 
 
+#ifdef FLECS_SANITIZE
+#define ecs_vec_from_column(arg_column, table, arg_elem_size) {\
+    .array = (arg_column)->data,\
+    .count = table->data.count,\
+    .size = table->data.size,\
+    .elem_size = arg_elem_size\
+}
+
+#define ecs_vec_from_column_ext(arg_column, arg_count, arg_size, arg_elem_size) {\
+    .array = (arg_column)->data,\
+    .count = arg_count,\
+    .size = arg_size,\
+    .elem_size = arg_elem_size\
+}
+
+#define ecs_vec_from_entities(table) {\
+    .array = table->data.entities,\
+    .count = table->data.count,\
+    .size = table->data.size,\
+    .elem_size = ECS_SIZEOF(ecs_entity_t)\
+}
+#else
+#define ecs_vec_from_column(arg_column, table, arg_elem_size) {\
+    .array = (arg_column)->data,\
+    .count = table->data.count,\
+    .size = table->data.size,\
+}
+
+#define ecs_vec_from_column_ext(arg_column, arg_count, arg_size, arg_elem_size) {\
+    .array = (arg_column)->data,\
+    .count = arg_count,\
+    .size = arg_size,\
+}
+
+#define ecs_vec_from_entities(table) {\
+    .array = table->data.entities,\
+    .count = table->data.count,\
+    .size = table->data.size,\
+}
+#endif
+
+#define ecs_vec_from_column_t(arg_column, table, T)\
+    ecs_vec_from_column(arg_column, table, ECS_SIZEOF(T))
+
 /* Table event type for notifying tables of world events */
 typedef enum ecs_table_eventkind_t {
     EcsTableTriggersForId,
@@ -423,14 +467,16 @@ typedef struct ecs_table__t {
 
 /** Table column */
 typedef struct ecs_column_t {
-    ecs_vec_t data;                  /* Vector with component data */
+    void *data;                      /* Array with component data */
     ecs_type_info_t *ti;             /* Component type info */
 } ecs_column_t;
 
 /** Table data */
 struct ecs_data_t {
-    ecs_vec_t entities;              /* Entity ids */
+    ecs_entity_t *entities;          /* Entity ids */
     ecs_column_t *columns;           /* Component data */
+    int32_t count;
+    int32_t size;
 };
 
 /** A table is the Flecs equivalent of an archetype. Tables store all entities
@@ -496,10 +542,6 @@ void flecs_table_clear_entities_silent(
     ecs_world_t *world,
     ecs_table_t *table);
 
-/* Return number of entities in data */
-int32_t flecs_table_data_count(
-    const ecs_data_t *data);
-
 /* Add a new entry to the table for the specified entity */
 int32_t flecs_table_append(
     ecs_world_t *world,
@@ -535,16 +577,8 @@ void flecs_table_move(
 int32_t flecs_table_appendn(
     ecs_world_t *world,
     ecs_table_t *table,
-    ecs_data_t *data,
     int32_t count,
     const ecs_entity_t *ids);
-
-/* Set table to a fixed size. Useful for preallocating memory in advance. */
-void flecs_table_set_size(
-    ecs_world_t *world,
-    ecs_table_t *table,
-    ecs_data_t *data,
-    int32_t count);
 
 /* Shrink table to contents */
 bool flecs_table_shrink(
@@ -605,12 +639,6 @@ void flecs_table_delete_entities(
 void flecs_table_traversable_add(
     ecs_table_t *table,
     int32_t value);
-
-const ecs_vec_t* flecs_table_entities(
-    const ecs_table_t *table);
-
-ecs_entity_t* flecs_table_entities_array(
-    const ecs_table_t *table);
 
 void flecs_table_emit(
     ecs_world_t *world,
@@ -3735,7 +3763,7 @@ void flecs_bootstrap_builtin(
     int32_t index = flecs_table_append(world, table, entity, false, false);
     record->row = ECS_ROW_TO_RECORD(index, 0);
 
-    EcsComponent *component = ecs_vec_first(&columns[0].data);
+    EcsComponent *component = columns[0].data;
     component[index].size = size;
     component[index].alignment = alignment;
 
@@ -3743,7 +3771,7 @@ void flecs_bootstrap_builtin(
     ecs_size_t symbol_length = ecs_os_strlen(symbol);
     ecs_size_t name_length = symbol_length - 3;
 
-    EcsIdentifier *name_col = ecs_vec_first(&columns[1].data);
+    EcsIdentifier *name_col = columns[1].data;
     uint64_t name_hash = flecs_hash(name, name_length);
     name_col[index].value = ecs_os_strdup(name);
     name_col[index].length = name_length;
@@ -3753,7 +3781,7 @@ void flecs_bootstrap_builtin(
     flecs_name_index_ensure(
         table->_->name_index, entity, name, name_length, name_hash);
 
-    EcsIdentifier *symbol_col = ecs_vec_first(&columns[2].data);
+    EcsIdentifier *symbol_col = columns[2].data;
     symbol_col[index].value = ecs_os_strdup(symbol);
     symbol_col[index].length = symbol_length;
     symbol_col[index].hash = flecs_hash(symbol, symbol_length);    
@@ -3804,14 +3832,40 @@ ecs_table_t* flecs_bootstrap_component_table(
     };
 
     ecs_table_t *result = flecs_table_find_or_create(world, &array);
-    ecs_data_t *data = &result->data;
 
     /* Preallocate enough memory for initial components */
     ecs_allocator_t *a = &world->allocator;
-    ecs_vec_init_t(a, &data->entities, ecs_entity_t, EcsFirstUserComponentId);
-    ecs_vec_init_t(a, &data->columns[0].data, EcsComponent, EcsFirstUserComponentId);
-    ecs_vec_init_t(a, &data->columns[1].data, EcsIdentifier, EcsFirstUserComponentId);
-    ecs_vec_init_t(a, &data->columns[2].data, EcsIdentifier, EcsFirstUserComponentId);
+    ecs_vec_t v_entities = ecs_vec_from_entities(result);
+    ecs_vec_init_t(a, &v_entities, ecs_entity_t, EcsFirstUserComponentId);
+    
+    {
+        ecs_column_t *column = &result->data.columns[0];
+        ecs_vec_t v = ecs_vec_from_column_t(column, result, EcsComponent);
+        ecs_vec_init_t(a, &v, EcsComponent, EcsFirstUserComponentId);
+        ecs_assert(v.count == v_entities.count, ECS_INTERNAL_ERROR, NULL);
+        ecs_assert(v.size == v_entities.size, ECS_INTERNAL_ERROR, NULL);
+        column->data = v.array;
+    }
+    {
+        ecs_column_t *column = &result->data.columns[1];
+        ecs_vec_t v = ecs_vec_from_column_t(column, result, EcsIdentifier);
+        ecs_vec_init_t(a, &v, EcsIdentifier, EcsFirstUserComponentId);
+        ecs_assert(v.count == v_entities.count, ECS_INTERNAL_ERROR, NULL);
+        ecs_assert(v.size == v_entities.size, ECS_INTERNAL_ERROR, NULL);
+        column->data = v.array;
+    }
+    {
+        ecs_column_t *column = &result->data.columns[2];
+        ecs_vec_t v = ecs_vec_from_column_t(column, result, EcsIdentifier);
+        ecs_vec_init_t(a, &v, EcsIdentifier, EcsFirstUserComponentId);
+        ecs_assert(v.count == v_entities.count, ECS_INTERNAL_ERROR, NULL);
+        ecs_assert(v.size == v_entities.size, ECS_INTERNAL_ERROR, NULL);
+        column->data = v.array;
+    }
+
+    result->data.entities = v_entities.array;
+    result->data.count = 0;
+    result->data.size = v_entities.size;
     
     return result;
 }
@@ -4320,7 +4374,7 @@ bool ecs_each_next(
         ecs_table_t *table = next->hdr.table;
         it->table = table;
         it->count = ecs_table_count(table);
-        it->entities = flecs_table_entities_array(table);
+        it->entities = ecs_table_entities(table);
         it->ids = &table->type.array[next->index];
         it->trs = &each_iter->trs;
         it->sources = &each_iter->sources;
@@ -4942,7 +4996,7 @@ flecs_component_ptr_t flecs_table_get_component(
     ecs_column_t *column = &table->data.columns[column_index];
     return (flecs_component_ptr_t){
         .ti = column->ti,
-        .ptr = ecs_vec_get(&column->data, column->ti->size, row)
+        .ptr = ECS_ELEM(column->data, column->ti->size, row)
     };
 error:
     return (flecs_component_ptr_t){0};
@@ -4961,7 +5015,7 @@ flecs_component_ptr_t flecs_get_component_ptr(
     }
 
     if (idr->flags & EcsIdIsSparse) {
-        ecs_entity_t entity = flecs_table_entities_array(table)[row];
+        ecs_entity_t entity = ecs_table_entities(table)[row];
         return (flecs_component_ptr_t){
             .ti = idr->type_info,
             .ptr = flecs_sparse_get_any(idr->sparse, 0, entity)
@@ -5265,8 +5319,8 @@ void flecs_instantiate_children(
 
         int32_t storage_index = ecs_table_type_to_column_index(child_table, i);
         if (storage_index != -1) {
-            ecs_vec_t *column = &child_data->columns[storage_index].data;
-            component_data[diff.added.count] = ecs_vec_first(column);
+            component_data[diff.added.count] = 
+                child_data->columns[storage_index].data;
         } else {
             component_data[diff.added.count] = NULL;
         }
@@ -5288,8 +5342,8 @@ void flecs_instantiate_children(
     }
 
     /* Instantiate the prefab child table for each new instance */
-    ecs_entity_t *instances = ecs_vec_first(&table->data.entities);
-    int32_t child_count = ecs_vec_count(&child_data->entities);
+    ecs_entity_t *instances = ecs_table_entities(table);
+    int32_t child_count = ecs_table_count(child_table);
 
     for (i = row; i < count + row; i ++) {
         ecs_entity_t instance = instances[i];
@@ -5308,7 +5362,7 @@ void flecs_instantiate_children(
         /* The instance is trying to instantiate from a base that is also
          * its parent. This would cause the hierarchy to instantiate itself
          * which would cause infinite recursion. */
-        ecs_entity_t *children = ecs_vec_first(&child_data->entities);
+        ecs_entity_t *children = ecs_table_entities(child_table);
 
 #ifdef FLECS_DEBUG
         for (j = 0; j < child_count; j ++) {
@@ -5389,7 +5443,7 @@ void flecs_sparse_on_add(
             const ecs_type_info_t *ti = idr->type_info;
             ecs_xtor_t ctor = ti->hooks.ctor;
             ecs_iter_action_t on_add = ti->hooks.on_add;
-            ecs_entity_t *entities = flecs_table_entities_array(table);
+            ecs_entity_t *entities = ecs_table_entities(table);
             for (j = 0; j < count; j ++) {
                 ecs_entity_t e = entities[row + j];
                 void *ptr = flecs_sparse_ensure(idr->sparse, 0, e);
@@ -5427,7 +5481,7 @@ void flecs_sparse_on_remove(
                 flecs_id_record_get_table(idr, table);
             ecs_xtor_t dtor = ti->hooks.dtor;
             ecs_iter_action_t on_remove = ti->hooks.on_remove;
-            ecs_entity_t *entities = flecs_table_entities_array(table);
+            ecs_entity_t *entities = ecs_table_entities(table);
             for (j = 0; j < count; j ++) {
                 ecs_entity_t e = entities[row + j];
                 if (on_remove) {
@@ -5459,7 +5513,7 @@ void flecs_union_on_add(
             ecs_id_t wc = ecs_pair(ECS_PAIR_FIRST(id), EcsUnion);
             ecs_id_record_t *idr = flecs_id_record_get(world, wc);
             if (idr && idr->flags & EcsIdIsUnion) {
-                ecs_entity_t *entities = flecs_table_entities_array(table);
+                ecs_entity_t *entities = ecs_table_entities(table);
                 for (j = 0; j < count; j ++) {
                     ecs_entity_t e = entities[row + j];
                     flecs_switch_set(
@@ -5485,7 +5539,7 @@ void flecs_union_on_remove(
             ecs_id_t wc = ecs_pair(ECS_PAIR_FIRST(id), EcsUnion);
             ecs_id_record_t *idr = flecs_id_record_get(world, wc);
             if (idr && idr->flags & EcsIdIsUnion) {
-                ecs_entity_t *entities = flecs_table_entities_array(table);
+                ecs_entity_t *entities = ecs_table_entities(table);
                 for (j = 0; j < count; j ++) {
                     ecs_entity_t e = entities[row + j];
                     flecs_switch_reset(idr->sparse, (uint32_t)e);
@@ -5604,8 +5658,7 @@ void flecs_update_name_index(
     ecs_assert(names != NULL, ECS_INTERNAL_ERROR, NULL);
 
     int32_t i;
-    ecs_entity_t *entities = ecs_vec_get_t(
-        &dst->data.entities, ecs_entity_t, offset);
+    ecs_entity_t *entities = &ecs_table_entities(dst)[offset];
     for (i = 0; i < count; i ++) {
         ecs_entity_t e = entities[i];
         EcsIdentifier *name = &names[i];
@@ -5640,10 +5693,10 @@ ecs_record_t* flecs_new_entity(
     record->table = table;
     record->row = ECS_ROW_TO_RECORD(row, record->row & ECS_ROW_FLAGS_MASK);
 
-    ecs_assert(ecs_vec_count(&table->data.entities) > row, 
-        ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(ecs_table_count(table) > row, ECS_INTERNAL_ERROR, NULL);
     flecs_notify_on_add(
         world, table, NULL, row, 1, &diff->added, evt_flags, 0, ctor, true);
+    ecs_assert(table == record->table, ECS_INTERNAL_ERROR, NULL);
 
     return record;
 }
@@ -5665,12 +5718,12 @@ void flecs_move_entity(
     ecs_assert(src_table != dst_table, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(src_table->type.count > 0, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(src_row >= 0, ECS_INTERNAL_ERROR, NULL);
-    ecs_assert(ecs_vec_count(&src_table->data.entities) > src_row, 
-        ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(ecs_table_count(src_table) > src_row, ECS_INTERNAL_ERROR, NULL);
     ecs_check(ecs_is_alive(world, entity), ECS_INVALID_PARAMETER, NULL);
     ecs_assert(record != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(record == flecs_entities_get(world, entity), 
         ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(record->table == src_table, ECS_INTERNAL_ERROR, NULL);
 
     /* Append new row to destination table */
     int32_t dst_row = flecs_table_append(world, dst_table, entity, 
@@ -5683,17 +5736,19 @@ void flecs_move_entity(
     /* Copy entity & components from src_table to dst_table */
     flecs_table_move(world, entity, entity, dst_table, dst_row, 
         src_table, src_row, ctor);
+    ecs_assert(record->table == src_table, ECS_INTERNAL_ERROR, NULL);
 
     /* Update entity index & delete old data after running remove actions */
     record->table = dst_table;
     record->row = ECS_ROW_TO_RECORD(dst_row, record->row & ECS_ROW_FLAGS_MASK);
     
     flecs_table_delete(world, src_table, src_row, false);
-    flecs_notify_on_add(
-        world, dst_table, src_table, dst_row, 1, &diff->added, evt_flags, 0, ctor, true);
+    flecs_notify_on_add(world, dst_table, src_table, dst_row, 1, &diff->added, 
+        evt_flags, 0, ctor, true);
 
     flecs_update_name_index(world, src_table, dst_table, dst_row, 1);
 
+    ecs_assert(record->table == dst_table, ECS_INTERNAL_ERROR, NULL);
 error:
     return;
 }
@@ -5859,8 +5914,7 @@ const ecs_entity_t* flecs_bulk_new(
         component_array.count = type.count;
     }
 
-    ecs_data_t *data = &table->data;
-    int32_t row = flecs_table_appendn(world, table, data, count, entities);
+    int32_t row = flecs_table_appendn(world, table, count, entities);
 
     /* Update entity index. */
     int i;
@@ -5899,7 +5953,7 @@ const ecs_entity_t* flecs_bulk_new(
             ecs_type_info_t *ti = column->ti;
             int32_t size = ti->size;
             ecs_assert(size != 0, ECS_INTERNAL_ERROR, NULL);
-            void *ptr = ecs_vec_get(&column->data, size, row);
+            void *ptr = ECS_ELEM(column->data, size, row);
 
             ecs_copy_t copy;
             ecs_move_t move;
@@ -6095,12 +6149,9 @@ void flecs_notify_on_set(
     bool owned)
 {
     ecs_assert(ids != NULL, ECS_INTERNAL_ERROR, NULL);
-    ecs_data_t *data = &table->data;
-
-    ecs_entity_t *entities = ecs_vec_get_t(
-        &data->entities, ecs_entity_t, row);
+    ecs_entity_t *entities = &ecs_table_entities(table)[row];
     ecs_assert(entities != NULL, ECS_INTERNAL_ERROR, NULL);
-    ecs_assert((row + count) <= ecs_vec_count(&data->entities), 
+    ecs_assert((row + count) <= ecs_table_count(table), 
         ECS_INTERNAL_ERROR, NULL);
 
     if (owned) {
@@ -7139,8 +7190,8 @@ void flecs_targets_mark_for_delete(
     ecs_table_t *table)
 {
     ecs_id_record_t *idr;
-    ecs_entity_t *entities = ecs_vec_first(&table->data.entities);
-    int32_t i, count = ecs_vec_count(&table->data.entities);
+    ecs_entity_t *entities = ecs_table_entities(table);
+    int32_t i, count = ecs_table_count(table);
     for (i = 0; i < count; i ++) {
         ecs_record_t *r = flecs_entities_get(world, entities[i]);
         if (!r) {
@@ -7955,8 +8006,7 @@ ecs_entity_t ecs_record_get_entity(
         return 0;
     }
 
-    return ecs_vec_get_t(&table->data.entities, ecs_entity_t, 
-        ECS_RECORD_TO_ROW(record->row))[0];
+    return table->data.entities[ECS_RECORD_TO_ROW(record->row)];
 error:
     return 0;
 }
@@ -8933,7 +8983,7 @@ void ecs_set_version(
     ecs_record_t *r = flecs_entities_get(world, entity_with_generation);
     if (r && r->table) {
         int32_t row = ECS_RECORD_TO_ROW(r->row);
-        ecs_entity_t *entities = r->table->data.entities.array;
+        ecs_entity_t *entities = ecs_table_entities(r->table);
         entities[row] = entity_with_generation;
     }
 }
@@ -10973,16 +11023,15 @@ void* ecs_field_w_size(
     ecs_assert(column_index < table->column_count, ECS_INTERNAL_ERROR, NULL);
 
     ecs_column_t *column = &table->data.columns[column_index];
-    ecs_assert((row < ecs_vec_count(&column->data)) ||
+    ecs_assert((row < table->data.count) ||
         (it->query && (it->query->flags & EcsQueryMatchEmptyTables)),
             ECS_INTERNAL_ERROR, NULL);
 
     if (!size) {
-        size = column->ti->size;
+        size = (size_t)column->ti->size;
     }
 
-    void *data = ecs_vec_first(&column->data);
-    return ECS_ELEM(data, (ecs_size_t)size, row);
+    return ECS_ELEM(column->data, (ecs_size_t)size, row);
 error:
     return NULL;
 }
@@ -11016,7 +11065,7 @@ void* ecs_field_at_w_size(
 
     ecs_entity_t src = it->sources[index];
     if (!src) {
-        src = flecs_table_entities_array(it->table)[row];
+        src = ecs_table_entities(it->table)[row];
     }
 
     return flecs_sparse_get_any(idr->sparse, flecs_uto(int32_t, size), src);
@@ -11337,8 +11386,7 @@ ecs_entity_t ecs_iter_get_var(
             if ((var->range.count == 1) || (ecs_table_count(table) == 1)) {
                 ecs_assert(ecs_table_count(table) > var->range.offset,
                     ECS_INTERNAL_ERROR, NULL);
-                e = ecs_vec_get_t(&table->data.entities, ecs_entity_t,
-                    var->range.offset)[0];
+                e = ecs_table_entities(table)[var->range.offset];
             }
         }
     } else {
@@ -11513,8 +11561,7 @@ void ecs_iter_set_var_as_range(
 
     if (range->count == 1) {
         ecs_table_t *table = range->table;
-        var->entity = ecs_vec_get_t(
-            &table->data.entities, ecs_entity_t, range->offset)[0];
+        var->entity = ecs_table_entities(table)[range->offset];
     } else {
         var->entity = 0;
     }
@@ -11619,7 +11666,7 @@ bool ecs_page_next(
                 it->offset = offset;
                 count = it->count -= offset;
                 it->entities = 
-                    &(flecs_table_entities_array(it->table)[it->offset]);
+                    &(ecs_table_entities(it->table)[it->offset]);
             }
         }
 
@@ -11726,7 +11773,7 @@ bool ecs_worker_next(
     it->count = per_worker;
     it->offset += first;
 
-    it->entities = &(flecs_table_entities_array(it->table)[it->offset]);
+    it->entities = &(ecs_table_entities(it->table)[it->offset]);
 
     return true;
 error:
@@ -12477,7 +12524,7 @@ void flecs_emit_propagate_id(
         it->offset = 0;
         it->count = entity_count;
         if (entity_count) {
-            it->entities = ecs_vec_first(&table->data.entities);
+            it->entities = ecs_table_entities(table);
         }
 
         /* Treat as new event as this could invoke observers again for
@@ -12499,7 +12546,7 @@ void flecs_emit_propagate_id(
             continue;
         }
 
-        ecs_entity_t *entities = ecs_vec_first(&table->data.entities);
+        ecs_entity_t *entities = ecs_table_entities(table);
         for (e = 0; e < entity_count; e ++) {
             ecs_record_t *r = flecs_entities_get(world, entities[e]);
             ecs_assert(r != NULL, ECS_INTERNAL_ERROR, NULL);
@@ -12593,7 +12640,7 @@ void flecs_emit_propagate_invalidate_tables(
             }
 
             int32_t e, entity_count = ecs_table_count(table);
-            ecs_entity_t *entities = ecs_vec_first(&table->data.entities);
+            ecs_entity_t *entities = ecs_table_entities(table);
 
             for (e = 0; e < entity_count; e ++) {
                 ecs_record_t *r = flecs_entities_get(world, entities[e]);
@@ -12614,8 +12661,7 @@ void flecs_emit_propagate_invalidate(
     int32_t offset,
     int32_t count)
 {
-    ecs_entity_t *entities = ecs_vec_get_t(&table->data.entities, 
-        ecs_entity_t, offset);
+    ecs_entity_t *entities = &ecs_table_entities(table)[offset];
     int32_t i;
     for (i = 0; i < count; i ++) {
         ecs_record_t *record = flecs_entities_get(world, entities[i]);
@@ -12712,8 +12758,7 @@ void flecs_override_copy(
 
     ecs_iter_action_t on_set = ti->hooks.on_set;
     if (on_set) {
-        ecs_entity_t *entities = ecs_vec_get_t(
-            &table->data.entities, ecs_entity_t, offset);
+        ecs_entity_t *entities = &ecs_table_entities(table)[offset];
         flecs_invoke_hook(world, table, tr, count, offset, entities,
             ti->component, ti, EcsOnSet, on_set);
     }
@@ -12754,7 +12799,7 @@ void* flecs_override(
 
             ecs_column_t *column = &table->data.columns[index];
             ecs_size_t size = column->ti->size;
-            return ecs_vec_get(&column->data, size, it->offset);
+            return ECS_ELEM(column->data, size, it->offset);
         }
     }
 
@@ -13244,7 +13289,7 @@ void flecs_emit_forward(
     /* Propagate events for new reachable ids downwards */
     if (table->_->traversable_count) {
         int32_t i;
-        ecs_entity_t *entities = flecs_table_entities_array(table);
+        ecs_entity_t *entities = ecs_table_entities(table);
         entities = ECS_ELEM_T(entities, ecs_entity_t, it->offset);
         for (i = 0; i < it->count; i ++) {
             ecs_record_t *r = flecs_entities_get(world, entities[i]);
@@ -13378,7 +13423,7 @@ void flecs_emit(
     if (count) {
         storage = &table->data;
         columns = storage->columns;
-        it.entities = ecs_vec_get_t(&storage->entities, ecs_entity_t, offset);
+        it.entities = &ecs_table_entities(table)[offset];
     }
 
     int32_t id_count = ids->count;
@@ -13492,8 +13537,8 @@ repeat_event:
                             ecs_record_t *base_r = flecs_entities_get(world, base);
                             ecs_assert(base_r != NULL, ECS_INTERNAL_ERROR, NULL);
                             int32_t base_row = ECS_RECORD_TO_ROW(base_r->row);
-                            ecs_vec_t *base_v = &base_table->data.columns[base_column].data;
-                            override_ptr = ecs_vec_get(base_v, ti->size, base_row);
+                            override_ptr = base_table->data.columns[base_column].data;
+                            override_ptr = ECS_ELEM(override_ptr, ti->size, base_row);
                         }
                     }
                 }
@@ -13542,12 +13587,12 @@ repeat_event:
                     ecs_assert(count == 1, ECS_UNSUPPORTED, 
                         "events for multiple entities are currently unsupported"
                         " for sparse components");
-                    ecs_entity_t e = flecs_table_entities_array(table)[offset];
+                    ecs_entity_t e = ecs_table_entities(table)[offset];
                     ptr = flecs_sparse_get(idr->sparse, 0, e);
                 } else{
                     ecs_assert(idr->type_info != NULL, ECS_INTERNAL_ERROR, NULL);
                     ecs_column_t *c = &columns[storage_i];
-                    ptr = ecs_vec_get(&c->data, size, offset);
+                    ptr = ECS_ELEM(c->data, size, offset);
                 }
 
                 /* safe, owned by observer */
@@ -16405,8 +16450,8 @@ void* flecs_defer_set(
             if (tr) {
                 if (tr->column != -1) {
                     /* Entity has the component */
-                    ecs_vec_t *column = &table->data.columns[tr->column].data;
-                    existing = ecs_vec_get(column, size, 
+                    existing = table->data.columns[tr->column].data;
+                    existing = ECS_ELEM(existing, size, 
                         ECS_RECORD_TO_ROW(r->row));
                 } else {
                     ecs_assert(idr->flags & EcsIdIsSparse, 
@@ -17813,8 +17858,8 @@ void flecs_fini_root_tables(
             continue; /* Query out modules */
         }
 
-        int32_t i, count = table->data.entities.count;
-        ecs_entity_t *entities = table->data.entities.array;
+        int32_t i, count = ecs_table_count(table);
+        ecs_entity_t *entities = ecs_table_entities(table);
 
         if (fini_targets) {
             /* Only delete entities that are used as pair target. Iterate
@@ -17822,6 +17867,7 @@ void flecs_fini_root_tables(
             for (i = count - 1; i >= 0; i --) {
                 ecs_record_t *r = flecs_entities_get(world, entities[i]);
                 ecs_assert(r != NULL, ECS_INTERNAL_ERROR, NULL);
+                ecs_assert(r->table == table, ECS_INTERNAL_ERROR, NULL);
                 if (ECS_RECORD_TO_ROW_FLAGS(r->row) & EcsEntityIsTarget) {
                     ecs_delete(world, entities[i]);
                 }
@@ -17833,6 +17879,7 @@ void flecs_fini_root_tables(
             for (i = count - 1; i >= 0; i --) {
                 ecs_record_t *r = flecs_entities_get(world, entities[i]);
                 ecs_assert(r != NULL, ECS_INTERNAL_ERROR, NULL);
+                ecs_assert(r->table == table, ECS_INTERNAL_ERROR, NULL);
                 if (!ECS_RECORD_TO_ROW_FLAGS(r->row)) {
                     ecs_delete(world, entities[i]);
                 }
@@ -19137,7 +19184,7 @@ void flecs_process_empty_queries(
 
             for (i = 0; i < count; i ++) {
                 ecs_query_t *query = queries[i].poly;
-                ecs_entity_t *entities = table->data.entities.array;
+                ecs_entity_t *entities = ecs_table_entities(table);
                 if (!ecs_query_is_true(query)) {
                     ecs_add_id(world, entities[i], EcsEmpty);
                 }
@@ -25892,16 +25939,17 @@ void flecs_rest_reply_table_append_memory(
     const ecs_table_t *table)
 {
     int32_t used = 0, allocated = 0;
+    int32_t count = ecs_table_count(table), size = ecs_table_size(table);
 
-    used += table->data.entities.count * ECS_SIZEOF(ecs_entity_t);
-    allocated += table->data.entities.size * ECS_SIZEOF(ecs_entity_t);
+    used += count * ECS_SIZEOF(ecs_entity_t);
+    allocated += size * ECS_SIZEOF(ecs_entity_t);
 
     int32_t i, storage_count = table->column_count;
     ecs_column_t *columns = table->data.columns;
 
     for (i = 0; i < storage_count; i ++) {
-        used += columns[i].data.count * columns[i].ti->size;
-        allocated += columns[i].data.size * columns[i].ti->size;
+        used += count * columns[i].ti->size;
+        allocated += size * columns[i].ti->size;
     }
 
     ecs_strbuf_list_push(reply, "{", ",");
@@ -35607,11 +35655,14 @@ void flecs_fini_id_records(
  * this can severely slow down many ECS operations. */
 #ifdef FLECS_SANITIZE
 static
-void flecs_table_check_sanity(ecs_table_t *table) {
-    int32_t size = ecs_vec_size(&table->data.entities);
-    int32_t count = ecs_vec_count(&table->data.entities);
+void flecs_table_check_sanity(
+    ecs_world_t *world,
+    ecs_table_t *table) 
+{
+    int32_t i, count = ecs_table_count(table);
+    int32_t size = ecs_table_size(table);
+    ecs_assert(count <= size, ECS_INTERNAL_ERROR, NULL);
 
-    int32_t i;
     int32_t bs_offset = table->_ ? table->_->bs_offset : 0;
     int32_t bs_count = table->_ ? table->_->bs_count : 0;
     int32_t type_count = table->type.count;
@@ -35619,29 +35670,39 @@ void flecs_table_check_sanity(ecs_table_t *table) {
 
     ecs_assert((bs_count + bs_offset) <= type_count, ECS_INTERNAL_ERROR, NULL);
 
+    if (size) {
+        ecs_assert(table->data.entities != NULL, ECS_INTERNAL_ERROR, NULL);
+    } else {
+        ecs_assert(table->data.entities == NULL, ECS_INTERNAL_ERROR, NULL);
+    }
+
     if (table->column_count) {
         int32_t column_count = table->column_count;
         ecs_assert(type_count >= column_count, ECS_INTERNAL_ERROR, NULL);
 
         int32_t *column_map = table->column_map;
         ecs_assert(column_map != NULL, ECS_INTERNAL_ERROR, NULL);
-
         ecs_assert(table->data.columns != NULL, ECS_INTERNAL_ERROR, NULL);
 
         for (i = 0; i < column_count; i ++) {
-            ecs_vec_t *column = &table->data.columns[i].data;
-            ecs_assert(size == column->size, ECS_INTERNAL_ERROR, NULL);
-            ecs_assert(count == column->count, ECS_INTERNAL_ERROR, NULL);
             int32_t column_map_id = column_map[i + type_count];
             ecs_assert(column_map_id >= 0, ECS_INTERNAL_ERROR, NULL);
+            ecs_assert(table->data.columns[i].ti != NULL,
+                ECS_INTERNAL_ERROR, NULL);
+            if (size) {
+                ecs_assert(table->data.columns[i].data != NULL, 
+                    ECS_INTERNAL_ERROR, NULL);
+            } else {
+                ecs_assert(table->data.columns[i].data == NULL, 
+                    ECS_INTERNAL_ERROR, NULL);
+            }
         }
     } else {
         ecs_assert(table->column_map == NULL, ECS_INTERNAL_ERROR, NULL);
     }
 
     if (bs_count) {
-        ecs_assert(table->_->bs_columns != NULL, 
-            ECS_INTERNAL_ERROR, NULL);
+        ecs_assert(table->_->bs_columns != NULL, ECS_INTERNAL_ERROR, NULL);
         for (i = 0; i < bs_count; i ++) {
             ecs_bitset_t *bs = &table->_->bs_columns[i];
             ecs_assert(flecs_bitset_count(bs) == count,
@@ -35655,7 +35716,7 @@ void flecs_table_check_sanity(ecs_table_t *table) {
         (table->flags & EcsTableHasTraversable), ECS_INTERNAL_ERROR, NULL);
 }
 #else
-#define flecs_table_check_sanity(table)
+#define flecs_table_check_sanity(world, table)
 #endif
 
 /* Set flags for type hooks so table operations can quickly check whether a
@@ -35730,10 +35791,6 @@ void flecs_table_init_columns(
             }
         }
 
-#ifdef FLECS_DEBUG
-        ecs_vec_init(NULL, &columns[cur].data, ti->size, 0);
-#endif
-
         table->flags |= flecs_type_info_flags(ti);
         cur ++;
     }
@@ -35744,9 +35801,6 @@ void flecs_table_init_data(
     ecs_world_t *world,
     ecs_table_t *table)
 {
-    ecs_data_t *storage = &table->data;
-    ecs_vec_init_t(NULL, &storage->entities, ecs_entity_t, 0);
-
     flecs_table_init_columns(world, table, table->column_count);
 
     ecs_table__t *meta = table->_;
@@ -36205,10 +36259,9 @@ void flecs_table_add_trigger_flags(
 static
 void flecs_table_notify_on_remove(
     ecs_world_t *world,
-    ecs_table_t *table,
-    ecs_data_t *data)
+    ecs_table_t *table)
 {
-    int32_t count = data->entities.count;
+    int32_t count = ecs_table_count(table);
     if (count) {
         flecs_notify_on_remove(world, table, NULL, 0, count, &table->type);
     }
@@ -36244,11 +36297,13 @@ void flecs_table_invoke_ctor(
     int32_t row,
     int32_t count)
 {
+    ecs_assert(column != NULL, ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(column->data != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_type_info_t *ti = column->ti;
     ecs_assert(ti != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_xtor_t ctor = ti->hooks.ctor;
     if (ctor) {
-        void *ptr = ecs_vec_get(&column->data, ti->size, row);
+        void *ptr = ECS_ELEM(column->data, ti->size, row);
         ctor(ptr, count, ti);
     }
 }
@@ -36260,11 +36315,13 @@ void flecs_table_invoke_dtor(
     int32_t row,
     int32_t count)
 {
+    ecs_assert(column != NULL, ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(column->data != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_type_info_t *ti = column->ti;
     ecs_assert(ti != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_xtor_t dtor = ti->hooks.dtor;
     if (dtor) {
-        void *ptr = ecs_vec_get(&column->data, ti->size, row);
+        void *ptr = ECS_ELEM(column->data, ti->size, row);
         dtor(ptr, count, ti);
     }
 }
@@ -36280,6 +36337,8 @@ void flecs_table_invoke_add_hooks(
     int32_t count,
     bool construct)
 {
+    ecs_assert(column != NULL, ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(column->data != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_type_info_t *ti = column->ti;
     ecs_assert(ti != NULL, ECS_INTERNAL_ERROR, NULL);
 
@@ -36305,6 +36364,8 @@ void flecs_table_invoke_remove_hooks(
     int32_t count,
     bool dtor)
 {
+    ecs_assert(column != NULL, ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(column->data != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_type_info_t *ti = column->ti;
     ecs_assert(ti != NULL, ECS_INTERNAL_ERROR, NULL);
 
@@ -36324,14 +36385,16 @@ static
 void flecs_table_dtor_all(
     ecs_world_t *world,
     ecs_table_t *table,
-    ecs_data_t *data,
     int32_t row,
     int32_t count,
     bool is_delete)
 {
-    int32_t ids_count = table->column_count;
-    ecs_entity_t *entities = data->entities.array;
+    ecs_entity_t *entities = ecs_table_entities(table);
+    int32_t column_count = table->column_count;
     int32_t i, c, end = row + count;
+
+    ecs_assert(!column_count || table->data.columns != NULL, 
+        ECS_INTERNAL_ERROR, NULL);
 
     if (is_delete && table->_->traversable_count) {
         /* If table contains monitored entities with traversable relationships,
@@ -36345,8 +36408,8 @@ void flecs_table_dtor_all(
         table->_->lock = true;
 
         /* Run on_remove callbacks first before destructing components */
-        for (c = 0; c < ids_count; c++) {
-            ecs_column_t *column = &data->columns[c];
+        for (c = 0; c < column_count; c++) {
+            ecs_column_t *column = &table->data.columns[c];
             ecs_iter_action_t on_remove = column->ti->hooks.on_remove;
             if (on_remove) {
                 flecs_table_invoke_hook(world, table, on_remove, EcsOnRemove, 
@@ -36355,8 +36418,8 @@ void flecs_table_dtor_all(
         }
 
         /* Destruct components */
-        for (c = 0; c < ids_count; c++) {
-            flecs_table_invoke_dtor(&data->columns[c], row, count);
+        for (c = 0; c < column_count; c++) {
+            flecs_table_invoke_dtor(&table->data.columns[c], row, count);
         }
 
         /* Iterate entities first, then components. This ensures that only one
@@ -36413,38 +36476,33 @@ static
 void flecs_table_fini_data(
     ecs_world_t *world,
     ecs_table_t *table,
-    ecs_data_t *data,
     bool do_on_remove,
     bool is_delete,
     bool deactivate)
 {
     ecs_assert(!table->_->lock, ECS_LOCKED_STORAGE, FLECS_LOCKED_STORAGE_MSG);
 
-    if (!data) {
-        return;
-    }
-
     if (do_on_remove) {
-        flecs_table_notify_on_remove(world, table, data);        
+        flecs_table_notify_on_remove(world, table);        
     }
 
-    int32_t count = flecs_table_data_count(data);
+    int32_t count = ecs_table_count(table);
     if (count) {
-        flecs_table_dtor_all(world, table, data, 0, count, is_delete);
+        flecs_table_dtor_all(world, table, 0, count, is_delete);
     }
 
-    ecs_column_t *columns = data->columns;
+    ecs_column_t *columns = table->data.columns;
     if (columns) {
         int32_t c, column_count = table->column_count;
         for (c = 0; c < column_count; c ++) {
-            /* Sanity check */
-            ecs_assert(columns[c].data.count == data->entities.count,
-                ECS_INTERNAL_ERROR, NULL);
-            ecs_vec_fini(&world->allocator,
-                &columns[c].data, columns[c].ti->size);
+            ecs_column_t *column = &columns[c];
+            ecs_vec_t v = ecs_vec_from_column(column, table, column->ti->size);
+            ecs_vec_fini(&world->allocator, &v, column->ti->size);
+            column->data = NULL;
         }
-        flecs_wfree_n(world, ecs_column_t, column_count, columns);
-        data->columns = NULL;
+
+        flecs_wfree_n(world, ecs_column_t, table->column_count, columns);
+        table->data.columns = NULL;
     }
 
     ecs_table__t *meta = table->_;
@@ -36458,7 +36516,11 @@ void flecs_table_fini_data(
         meta->bs_columns = NULL;
     }
 
-    ecs_vec_fini_t(&world->allocator, &data->entities, ecs_entity_t);
+    ecs_vec_t v = ecs_vec_from_entities(table);
+    ecs_vec_fini_t(&world->allocator, &v, ecs_entity_t);
+    table->data.entities = NULL;
+    table->data.count = 0;
+    table->data.size = 0;
 
     if (deactivate && count) {
         flecs_table_set_empty(world, table);
@@ -36468,16 +36530,10 @@ void flecs_table_fini_data(
     table->flags &= ~EcsTableHasTraversable;
 }
 
-const ecs_vec_t* flecs_table_entities(
+ecs_entity_t* ecs_table_entities(
     const ecs_table_t *table)
 {
-    return &table->data.entities;
-}
-
-ecs_entity_t* flecs_table_entities_array(
-    const ecs_table_t *table)
-{
-    return ecs_vec_first(flecs_table_entities(table));
+    return table->data.entities;
 }
 
 /* Cleanup, no OnRemove, clear entity index, deactivate table */
@@ -36485,7 +36541,7 @@ void flecs_table_clear_entities_silent(
     ecs_world_t *world,
     ecs_table_t *table)
 {
-    flecs_table_fini_data(world, table, &table->data, false, false, true);
+    flecs_table_fini_data(world, table, false, false, true);
 }
 
 /* Cleanup, run OnRemove, clear entity index, deactivate table */
@@ -36493,7 +36549,7 @@ void flecs_table_clear_entities(
     ecs_world_t *world,
     ecs_table_t *table)
 {
-    flecs_table_fini_data(world, table, &table->data, true, false, true);
+    flecs_table_fini_data(world, table, true, false, true);
 }
 
 /* Cleanup, run OnRemove, delete from entity index, deactivate table */
@@ -36501,7 +36557,7 @@ void flecs_table_delete_entities(
     ecs_world_t *world,
     ecs_table_t *table)
 {
-    flecs_table_fini_data(world, table, &table->data, true, true, true);
+    flecs_table_fini_data(world, table, true, true, true);
 }
 
 /* Unset all components in table. This function is called before a table is 
@@ -36511,7 +36567,7 @@ void flecs_table_remove_actions(
     ecs_table_t *table)
 {
     (void)world;
-    flecs_table_notify_on_remove(world, table, &table->data);
+    flecs_table_notify_on_remove(world, table);
 }
 
 /* Free table resources. */
@@ -36544,7 +36600,7 @@ void flecs_table_fini(
     world->info.empty_table_count -= (ecs_table_count(table) == 0);
 
     /* Cleanup data, no OnRemove, delete from entity index, don't deactivate */
-    flecs_table_fini_data(world, table, &table->data, false, true, false);
+    flecs_table_fini_data(world, table, false, true, false);
     flecs_table_clear_edges(world, table);
 
     if (!is_root) {
@@ -36750,19 +36806,19 @@ void flecs_table_move_bitset_columns(
 static
 void flecs_table_grow_column(
     ecs_world_t *world,
-    ecs_column_t *column,
+    ecs_vec_t *column,
+    const ecs_type_info_t *ti,
     int32_t to_add,
     int32_t dst_size,
     bool construct)
 {
     ecs_assert(column != NULL, ECS_INTERNAL_ERROR, NULL);
 
-    ecs_type_info_t *ti = column->ti;
-    int32_t size = ti->size;
-    int32_t count = column->data.count;
-    int32_t src_size = column->data.size;
+    int32_t count = ecs_vec_count(column);
+    int32_t size = ecs_vec_size(column);
+    int32_t elem_size = ti->size;
     int32_t dst_count = count + to_add;
-    bool can_realloc = dst_size != src_size;
+    bool can_realloc = dst_size != size;
     void *result = NULL;
 
     ecs_assert(dst_size >= dst_count, ECS_INTERNAL_ERROR, NULL);
@@ -36777,10 +36833,10 @@ void flecs_table_grow_column(
 
         /* Create  vector */
         ecs_vec_t dst;
-        ecs_vec_init(&world->allocator, &dst, size, dst_size);
+        ecs_vec_init(&world->allocator, &dst, elem_size, dst_size);
         dst.count = dst_count;
 
-        void *src_buffer = column->data.array;
+        void *src_buffer = column->array;
         void *dst_buffer = dst.array;
 
         /* Move (and construct) existing elements to new vector */
@@ -36788,21 +36844,21 @@ void flecs_table_grow_column(
 
         if (construct) {
             /* Construct new element(s) */
-            result = ECS_ELEM(dst_buffer, size, count);
+            result = ECS_ELEM(dst_buffer, elem_size, count);
             ctor(result, to_add, ti);
         }
 
         /* Free old vector */
-        ecs_vec_fini(&world->allocator, &column->data, size);
+        ecs_vec_fini(&world->allocator, column, elem_size);
 
-        column->data = dst;
+        *column = dst;
     } else {
         /* If array won't realloc or has no move, simply add new elements */
         if (can_realloc) {
-            ecs_vec_set_size(&world->allocator, &column->data, size, dst_size);
+            ecs_vec_set_size(&world->allocator, column, elem_size, dst_size);
         }
 
-        result = ecs_vec_grow(&world->allocator, &column->data, size, to_add);
+        result = ecs_vec_grow(&world->allocator, column, elem_size, to_add);
 
         ecs_xtor_t ctor;
         if (construct && (ctor = ti->hooks.ctor)) {
@@ -36812,7 +36868,7 @@ void flecs_table_grow_column(
         }
     }
 
-    ecs_assert(column->data.size == dst_size, ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(column->size == dst_size, ECS_INTERNAL_ERROR, NULL);
 }
 
 /* Grow all data structures in a table */
@@ -36820,24 +36876,30 @@ static
 int32_t flecs_table_grow_data(
     ecs_world_t *world,
     ecs_table_t *table,
-    ecs_data_t *data,
     int32_t to_add,
     int32_t size,
     const ecs_entity_t *ids)
 {
     ecs_assert(table != NULL, ECS_INTERNAL_ERROR, NULL);
-    ecs_assert(data != NULL, ECS_INTERNAL_ERROR, NULL);
 
-    int32_t cur_count = flecs_table_data_count(data);
+    int32_t count = ecs_table_count(table);
     int32_t column_count = table->column_count;
 
     /* Add entity to column with entity ids */
-    ecs_vec_set_size_t(&world->allocator, &data->entities, ecs_entity_t, size);
-    ecs_entity_t *e = ecs_vec_last_t(&data->entities, ecs_entity_t) + 1;
-    data->entities.count += to_add;
-    if (data->entities.size > size) {
-        size = data->entities.size;
+    ecs_vec_t v_entities = ecs_vec_from_entities(table);
+    ecs_vec_set_size_t(&world->allocator, &v_entities, ecs_entity_t, size);
+
+    ecs_entity_t *e = ecs_vec_last_t(&v_entities, ecs_entity_t) + 1;
+    v_entities.count += to_add;
+    if (v_entities.size > size) {
+        size = v_entities.size;
     }
+
+    /* Update table entities/count/size */
+    int32_t prev_count = table->data.count, prev_size = table->data.size;
+    table->data.entities = v_entities.array;
+    table->data.count = v_entities.count;
+    table->data.size = v_entities.size;
 
     /* Initialize entity ids and record ptrs */
     int32_t i;
@@ -36848,12 +36910,18 @@ int32_t flecs_table_grow_data(
     }
 
     /* Add elements to each column array */
-    ecs_column_t *columns = data->columns;
+    ecs_column_t *columns = table->data.columns;
     for (i = 0; i < column_count; i ++) {
-        flecs_table_grow_column(world, &columns[i], to_add, size, true);
-        ecs_assert(columns[i].data.size == size, ECS_INTERNAL_ERROR, NULL);
-        flecs_table_invoke_add_hooks(world, table, &columns[i], e, 
-            cur_count, to_add, false);
+        ecs_column_t *column = &columns[i];
+        const ecs_type_info_t *ti = column->ti;
+        ecs_vec_t v_column = ecs_vec_from_column_ext(column, prev_count, prev_size, ti->size);
+        flecs_table_grow_column(world, &v_column, ti, to_add, size, true);
+        ecs_assert(v_column.size == size, ECS_INTERNAL_ERROR, NULL);
+        ecs_assert(v_column.size == v_entities.size, ECS_INTERNAL_ERROR, NULL);
+        ecs_assert(v_column.count == v_entities.count, ECS_INTERNAL_ERROR, NULL);
+        column->data = v_column.array;
+        flecs_table_invoke_add_hooks(world, table, column, e, 
+            count, to_add, false);
     }
 
     ecs_table__t *meta = table->_;
@@ -36869,26 +36937,29 @@ int32_t flecs_table_grow_data(
     /* If the table is monitored indicate that there has been a change */
     flecs_table_mark_table_dirty(world, table, 0);
 
-    if (!(world->flags & EcsWorldReadonly) && !cur_count) {
+    if (!(world->flags & EcsWorldReadonly) && !count) {
         flecs_table_set_empty(world, table);
     }
 
     /* Return index of first added entity */
-    return cur_count;
+    return count;
 }
 
 /* Append operation for tables that don't have any complex logic */
 static
 void flecs_table_fast_append(
     ecs_world_t *world,
-    ecs_column_t *columns,
-    int32_t count)
+    ecs_table_t *table)
 {
     /* Add elements to each column array */
-    int32_t i;
+    ecs_column_t *columns = table->data.columns;
+    int32_t i, count = table->column_count;
     for (i = 0; i < count; i ++) {
         ecs_column_t *column = &columns[i];
-        ecs_vec_append(&world->allocator, &column->data, column->ti->size);
+        const ecs_type_info_t *ti = column->ti;
+        ecs_vec_t v = ecs_vec_from_column(column, table, ti->size);
+        ecs_vec_append(&world->allocator, &v, ti->size);
+        column->data = v.array;
     }
 }
 
@@ -36903,19 +36974,21 @@ int32_t flecs_table_append(
     ecs_assert(table != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(!table->_->lock, ECS_LOCKED_STORAGE, FLECS_LOCKED_STORAGE_MSG);
 
-    flecs_table_check_sanity(table);
+    flecs_table_check_sanity(world, table);
 
     /* Get count & size before growing entities array. This tells us whether the
      * arrays will realloc */
-    ecs_data_t *data = &table->data;
-    int32_t count = data->entities.count;
+    int32_t count = ecs_table_count(table);
     int32_t column_count = table->column_count;
     ecs_column_t *columns = table->data.columns;
 
     /* Grow buffer with entity ids, set new element to new entity */
+    ecs_vec_t v_entities = ecs_vec_from_entities(table);
     ecs_entity_t *e = ecs_vec_append_t(&world->allocator, 
-        &data->entities, ecs_entity_t);
+        &v_entities, ecs_entity_t);
+        
     ecs_assert(e != NULL, ECS_INTERNAL_ERROR, NULL);
+    ecs_entity_t *entities = table->data.entities = v_entities.array;
     *e = entity;
  
     /* If the table is monitored indicate that there has been a change */
@@ -36924,25 +36997,36 @@ int32_t flecs_table_append(
 
     /* Fast path: no switch columns, no lifecycle actions */
     if (!(table->flags & EcsTableIsComplex)) {
-        flecs_table_fast_append(world, columns, column_count);
+        flecs_table_fast_append(world, table);
+        table->data.count = v_entities.count;
+        table->data.size = v_entities.size;
         if (!count) {
             flecs_table_set_empty(world, table); /* See below */
         }
         return count;
     }
 
-    ecs_entity_t *entities = data->entities.array;
+    int32_t prev_count = table->data.count;
+    int32_t prev_size = table->data.size;
+
+    ecs_assert(table->data.count == v_entities.count - 1, 
+        ECS_INTERNAL_ERROR, NULL);
+    table->data.count = v_entities.count;
+    table->data.size = v_entities.size;
 
     /* Reobtain size to ensure that the columns have the same size as the 
      * entities and record vectors. This keeps reasoning about when allocations
      * occur easier. */
-    int32_t size = data->entities.size;
+    int32_t size = v_entities.size;
 
     /* Grow component arrays with 1 element */
     int32_t i;
     for (i = 0; i < column_count; i ++) {
         ecs_column_t *column = &columns[i];
-        flecs_table_grow_column(world, column, 1, size, construct);
+        const ecs_type_info_t *ti = column->ti;
+        ecs_vec_t v_column = ecs_vec_from_column_ext(column, prev_count, prev_size, ti->size);
+        flecs_table_grow_column(world, &v_column, ti, 1, size, construct);
+        column->data = v_column.array;
 
         ecs_iter_action_t on_add_hook;
         if (on_add && (on_add_hook = column->ti->hooks.on_add)) {
@@ -36950,10 +37034,9 @@ int32_t flecs_table_append(
                 &entities[count], count, 1);
         }
 
-        ecs_assert(columns[i].data.size == 
-            data->entities.size, ECS_INTERNAL_ERROR, NULL); 
-        ecs_assert(columns[i].data.count == 
-            data->entities.count, ECS_INTERNAL_ERROR, NULL);
+        ecs_assert(v_column.size == v_entities.size, ECS_INTERNAL_ERROR, NULL);
+        ecs_assert(v_column.count == v_entities.count, 
+            ECS_INTERNAL_ERROR, NULL);
     }
 
     ecs_table__t *meta = table->_;
@@ -36973,34 +37056,25 @@ int32_t flecs_table_append(
         flecs_table_set_empty(world, table);
     }
 
-    flecs_table_check_sanity(table);
+    flecs_table_check_sanity(world, table);
 
     return count;
-}
-
-/* Delete last operation for tables that don't have any complex logic */
-static
-void flecs_table_fast_delete_last(
-    ecs_column_t *columns,
-    int32_t column_count) 
-{
-    int i;
-    for (i = 0; i < column_count; i ++) {
-        ecs_vec_remove_last(&columns[i].data);
-    }
 }
 
 /* Delete operation for tables that don't have any complex logic */
 static
 void flecs_table_fast_delete(
-    ecs_column_t *columns,
-    int32_t column_count,
-    int32_t index) 
+    ecs_table_t *table,
+    int32_t row)
 {
-    int i;
-    for (i = 0; i < column_count; i ++) {
+    ecs_column_t *columns = table->data.columns;
+    int32_t i, count = table->column_count;
+    for (i = 0; i < count; i ++) {
         ecs_column_t *column = &columns[i];
-        ecs_vec_remove(&column->data, column->ti->size, index);
+        const ecs_type_info_t *ti = column->ti;
+        ecs_vec_t v = ecs_vec_from_column(column, table, ti->size);
+        ecs_vec_remove(&v, ti->size, row);
+        column->data = v.array;
     }
 }
 
@@ -37008,35 +37082,32 @@ void flecs_table_fast_delete(
 void flecs_table_delete(
     ecs_world_t *world,
     ecs_table_t *table,
-    int32_t index,
+    int32_t row,
     bool destruct)
 {
     ecs_assert(world != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(table != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(!table->_->lock, ECS_LOCKED_STORAGE, FLECS_LOCKED_STORAGE_MSG);
 
-    flecs_table_check_sanity(table);
+    flecs_table_check_sanity(world, table);
 
-    ecs_data_t *data = &table->data;
-    int32_t count = data->entities.count;
-
+    int32_t count = ecs_table_count(table);
     ecs_assert(count > 0, ECS_INTERNAL_ERROR, NULL);
     count --;
-    ecs_assert(index <= count, ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(row <= count, ECS_INTERNAL_ERROR, NULL);
 
-    /* Move last entity id to index */
-    ecs_entity_t *entities = data->entities.array;
+    /* Move last entity id to row */
+    ecs_entity_t *entities = ecs_table_entities(table);
     ecs_entity_t entity_to_move = entities[count];
-    ecs_entity_t entity_to_delete = entities[index];
-    entities[index] = entity_to_move;
-    ecs_vec_remove_last(&data->entities);
+    ecs_entity_t entity_to_delete = entities[row];
+    entities[row] = entity_to_move;
 
     /* Update record of moved entity in entity index */
-    if (index != count) {
+    if (row != count) {
         ecs_record_t *record_to_move = flecs_entities_get(world, entity_to_move);
         if (record_to_move) {
             uint32_t row_flags = record_to_move->row & ECS_ROW_FLAGS_MASK;
-            record_to_move->row = ECS_ROW_TO_RECORD(index, row_flags);
+            record_to_move->row = ECS_ROW_TO_RECORD(row, row_flags);
             ecs_assert(record_to_move->table != NULL, ECS_INTERNAL_ERROR, NULL);
             ecs_assert(record_to_move->table == table, ECS_INTERNAL_ERROR, NULL);
         }
@@ -37047,38 +37118,38 @@ void flecs_table_delete(
 
     /* If table is empty, deactivate it */
     if (!count) {
+        table->data.count --;
         flecs_table_set_empty(world, table);
+        table->data.count ++;
     }
 
     /* Destruct component data */
-    ecs_column_t *columns = data->columns;
+    ecs_column_t *columns = table->data.columns;
     int32_t column_count = table->column_count;
     int32_t i;
 
     /* If this is a table without lifecycle callbacks or special columns, take
      * fast path that just remove an element from the array(s) */
     if (!(table->flags & EcsTableIsComplex)) {
-        if (index == count) {
-            flecs_table_fast_delete_last(columns, column_count);
-        } else {
-            flecs_table_fast_delete(columns, column_count, index);
+        if (row != count) {
+            flecs_table_fast_delete(table, row);
         }
 
-        flecs_table_check_sanity(table);
+        table->data.count --;
+
+        flecs_table_check_sanity(world, table);
         return;
     }
 
     /* Last element, destruct & remove */
-    if (index == count) {
+    if (row == count) {
         /* If table has component destructors, invoke */
         if (destruct && (table->flags & EcsTableHasDtors)) {            
             for (i = 0; i < column_count; i ++) {
                 flecs_table_invoke_remove_hooks(world, table, &columns[i], 
-                    &entity_to_delete, index, 1, true);
+                    &entity_to_delete, row, 1, true);
             }
         }
-
-        flecs_table_fast_delete_last(columns, column_count);
 
     /* Not last element, move last element to deleted element & destruct */
     } else {
@@ -37088,21 +37159,22 @@ void flecs_table_delete(
                 ecs_column_t *column = &columns[i];
                 ecs_type_info_t *ti = column->ti;
                 ecs_size_t size = ti->size;
-                void *dst = ecs_vec_get(&column->data, size, index);
-                void *src = ecs_vec_last(&column->data, size);
+                void *dst = ECS_ELEM(column->data, size, row);
+                void *src = ECS_ELEM(column->data, size, count);
 
                 ecs_iter_action_t on_remove = ti->hooks.on_remove;
                 if (destruct && on_remove) {
-                    flecs_table_invoke_hook(world, table, on_remove, EcsOnRemove,
-                        column, &entity_to_delete, index, 1);
+                    flecs_table_invoke_hook(world, table, on_remove, 
+                        EcsOnRemove, column, &entity_to_delete, row, 1);
                 }
 
                 ecs_move_t move_dtor = ti->hooks.move_dtor;
                 
-                // If neither move nor move_ctor are set, this indicates that non-destructive move 
-                // semantics are not supported for this type. In such cases, we set the move_dtor
-                // as ctor_move_dtor, which indicates a destructive move operation. 
-                // This adjustment ensures compatibility with different language bindings.
+                /* If neither move nor move_ctor are set, this indicates that 
+                 * non-destructive move semantics are not supported for this 
+                 * type. In such cases, we set the move_dtor as ctor_move_dtor, 
+                 * which indicates a destructive move operation. This adjustment 
+                 * ensures compatibility with different language bindings. */
                 if (!ti->hooks.move_ctor && ti->hooks.ctor_move_dtor) {
                   move_dtor = ti->hooks.ctor_move_dtor;
                 }
@@ -37112,11 +37184,9 @@ void flecs_table_delete(
                 } else {
                     ecs_os_memcpy(dst, src, size);
                 }
-
-                ecs_vec_remove_last(&column->data);
             }
         } else {
-            flecs_table_fast_delete(columns, column_count, index);
+            flecs_table_fast_delete(table, row);
         }
     }
 
@@ -37125,10 +37195,12 @@ void flecs_table_delete(
     ecs_bitset_t *bs_columns = meta->bs_columns;
     int32_t bs_count = meta->bs_count;
     for (i = 0; i < bs_count; i ++) {
-        flecs_bitset_remove(&bs_columns[i], index);
+        flecs_bitset_remove(&bs_columns[i], row);
     }
 
-    flecs_table_check_sanity(table);
+    table->data.count --;
+
+    flecs_table_check_sanity(world, table);
 }
 
 /* Move operation for tables that don't have any complex logic */
@@ -37153,8 +37225,8 @@ void flecs_table_fast_move(
 
         if (dst_id == src_id) {
             int32_t size = dst_column->ti->size;
-            void *dst = ecs_vec_get(&dst_column->data, size, dst_index);
-            void *src = ecs_vec_get(&src_column->data, size, src_index);
+            void *dst = ECS_ELEM(dst_column->data, size, dst_index);
+            void *src = ECS_ELEM(src_column->data, size, src_index);
             ecs_os_memcpy(dst, src, size);
         }
 
@@ -37182,13 +37254,13 @@ void flecs_table_move(
     ecs_assert(src_index >= 0, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(dst_index >= 0, ECS_INTERNAL_ERROR, NULL);
 
-    flecs_table_check_sanity(dst_table);
-    flecs_table_check_sanity(src_table);
+    flecs_table_check_sanity(world, dst_table);
+    flecs_table_check_sanity(world, src_table);
 
     if (!((dst_table->flags | src_table->flags) & EcsTableIsComplex)) {
         flecs_table_fast_move(dst_table, dst_index, src_table, src_index);
-        flecs_table_check_sanity(dst_table);
-        flecs_table_check_sanity(src_table);
+        flecs_table_check_sanity(world, dst_table);
+        flecs_table_check_sanity(world, src_table);
         return;
     }
 
@@ -37223,8 +37295,8 @@ void flecs_table_move(
             int32_t size = ti->size;
 
             ecs_assert(size != 0, ECS_INTERNAL_ERROR, NULL);
-            void *dst = ecs_vec_get(&dst_column->data, size, dst_index);
-            void *src = ecs_vec_get(&src_column->data, size, src_index);
+            void *dst = ECS_ELEM(dst_column->data, size, dst_index);
+            void *src = ECS_ELEM(src_column->data, size, src_index);
 
             if (same_entity) {
                 ecs_move_t move = ti->hooks.move_ctor;
@@ -37274,47 +37346,26 @@ void flecs_table_move(
         }
     }
 
-    flecs_table_check_sanity(dst_table);
-    flecs_table_check_sanity(src_table);
+    flecs_table_check_sanity(world, dst_table);
+    flecs_table_check_sanity(world, src_table);
 }
 
 /* Append n entities to table */
 int32_t flecs_table_appendn(
     ecs_world_t *world,
     ecs_table_t *table,
-    ecs_data_t *data,
     int32_t to_add,
     const ecs_entity_t *ids)
 {
     ecs_assert(!table->_->lock, ECS_LOCKED_STORAGE, FLECS_LOCKED_STORAGE_MSG);
 
-    flecs_table_check_sanity(table);
-    int32_t cur_count = flecs_table_data_count(data);
+    flecs_table_check_sanity(world, table);
+    int32_t cur_count = ecs_table_count(table);
     int32_t result = flecs_table_grow_data(
-        world, table, data, to_add, cur_count + to_add, ids);
-    flecs_table_check_sanity(table);
+        world, table, to_add, cur_count + to_add, ids);
+    flecs_table_check_sanity(world, table);
 
     return result;
-}
-
-/* Set allocated table size */
-void flecs_table_set_size(
-    ecs_world_t *world,
-    ecs_table_t *table,
-    ecs_data_t *data,
-    int32_t size)
-{
-    ecs_assert(table != NULL, ECS_LOCKED_STORAGE, FLECS_LOCKED_STORAGE_MSG);
-    ecs_assert(!table->_->lock, ECS_LOCKED_STORAGE, FLECS_LOCKED_STORAGE_MSG);
-
-    flecs_table_check_sanity(table);
-
-    int32_t cur_count = flecs_table_data_count(data);
-
-    if (cur_count < size) {
-        flecs_table_grow_data(world, table, data, 0, size, NULL);
-        flecs_table_check_sanity(table);
-    }
 }
 
 /* Shrink table storage to fit number of entities */
@@ -37326,26 +37377,28 @@ bool flecs_table_shrink(
     ecs_assert(!table->_->lock, ECS_LOCKED_STORAGE, FLECS_LOCKED_STORAGE_MSG);
     (void)world;
 
-    flecs_table_check_sanity(table);
+    flecs_table_check_sanity(world, table);
 
-    ecs_data_t *data = &table->data;
-    bool has_payload = data->entities.array != NULL;
-    ecs_vec_reclaim_t(&world->allocator, &data->entities, ecs_entity_t);
+    bool has_payload = table->data.entities != NULL;
+    ecs_vec_t v_entities = ecs_vec_from_entities(table);
+    ecs_vec_reclaim_t(&world->allocator, &v_entities, ecs_entity_t);
 
     int32_t i, count = table->column_count;
     for (i = 0; i < count; i ++) {
-        ecs_column_t *column = &data->columns[i];
-        ecs_vec_reclaim(&world->allocator, &column->data, column->ti->size);
+        ecs_column_t *column = &table->data.columns[i];
+        const ecs_type_info_t *ti = column->ti;
+        ecs_vec_t v_column = ecs_vec_from_column(column, table, ti->size);
+        ecs_vec_reclaim(&world->allocator, &v_column, ti->size);
+        column->data = v_column.array;
     }
 
-    return has_payload;
-}
+    table->data.count = v_entities.count;
+    table->data.size = v_entities.size;
+    table->data.entities = v_entities.array;
 
-/* Return number of entities in table */
-int32_t flecs_table_data_count(
-    const ecs_data_t *data)
-{
-    return data ? data->entities.count : 0;
+    flecs_table_check_sanity(world, table);
+
+    return has_payload;
 }
 
 /* Swap operation for bitset (toggle component) columns */
@@ -37381,7 +37434,7 @@ void flecs_table_swap(
     ecs_assert(row_1 >= 0, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(row_2 >= 0, ECS_INTERNAL_ERROR, NULL);
 
-    flecs_table_check_sanity(table);
+    flecs_table_check_sanity(world, table);
     
     if (row_1 == row_2) {
         return;
@@ -37390,7 +37443,7 @@ void flecs_table_swap(
     /* If the table is monitored indicate that there has been a change */
     flecs_table_mark_table_dirty(world, table, 0);    
 
-    ecs_entity_t *entities = table->data.entities.array;
+    ecs_entity_t *entities = ecs_table_entities(table);
     ecs_entity_t e1 = entities[row_1];
     ecs_entity_t e2 = entities[row_2];
 
@@ -37414,7 +37467,7 @@ void flecs_table_swap(
 
     ecs_column_t *columns = table->data.columns;
     if (!columns) {
-        flecs_table_check_sanity(table);
+        flecs_table_check_sanity(world, table);
         return;
     }
 
@@ -37431,7 +37484,7 @@ void flecs_table_swap(
     for (i = 0; i < column_count; i ++) {
         int32_t size = columns[i].ti->size;
         ecs_column_t *column = &columns[i];
-        void *ptr = column->data.array;
+        void *ptr = column->data;
         const ecs_type_info_t *ti = column->ti;
         ecs_assert(ti != NULL, ECS_INTERNAL_ERROR, NULL);
 
@@ -37454,7 +37507,7 @@ void flecs_table_swap(
         }
     }
 
-    flecs_table_check_sanity(table);
+    flecs_table_check_sanity(world, table);
 }
 
 static
@@ -37495,41 +37548,44 @@ void flecs_table_merge_vec(
 static
 void flecs_table_merge_column(
     ecs_world_t *world,
+    ecs_vec_t *dst_vec,
+    ecs_vec_t *src_vec,
     ecs_column_t *dst,
     ecs_column_t *src,
     int32_t column_size)
 {
-    ecs_size_t size = dst->ti->size;
-    int32_t dst_count = dst->data.count;
+    const ecs_type_info_t *ti = dst->ti;
+    ecs_assert(ti == src->ti, ECS_INTERNAL_ERROR, NULL);
+    ecs_size_t elem_size = ti->size;
+    int32_t dst_count = ecs_vec_count(dst_vec);
 
     if (!dst_count) {
-        ecs_vec_fini(&world->allocator, &dst->data, size);
-        *dst = *src;
-        src->data.array = NULL;
-        src->data.count = 0;
-        src->data.size = 0;
+        ecs_vec_fini(&world->allocator, dst_vec, elem_size);
+        *dst_vec = *src_vec;
 
     /* If the new table is not empty, copy the contents from the
      * src into the dst. */
     } else {
-        int32_t src_count = src->data.count;
+        int32_t src_count = src_vec->count;
 
-        flecs_table_grow_column(world, dst, src_count, column_size, false);
-        void *dst_ptr = ECS_ELEM(dst->data.array, size, dst_count);
-        void *src_ptr = src->data.array;
+        flecs_table_grow_column(world, dst_vec, ti, src_count, column_size, false);
+        void *dst_ptr = ECS_ELEM(dst_vec->array, elem_size, dst_count);
+        void *src_ptr = src_vec->array;
 
         /* Move values into column */
-        ecs_type_info_t *ti = dst->ti;
         ecs_assert(ti != NULL, ECS_INTERNAL_ERROR, NULL);
         ecs_move_t move = ti->hooks.ctor_move_dtor;
         if (move) {
             move(dst_ptr, src_ptr, src_count, ti);
         } else {
-            ecs_os_memcpy(dst_ptr, src_ptr, size * src_count);
+            ecs_os_memcpy(dst_ptr, src_ptr, elem_size * src_count);
         }
 
-        ecs_vec_fini(&world->allocator, &src->data, size);
+        ecs_vec_fini(&world->allocator, src_vec, elem_size);
     }
+
+    dst->data = dst_vec->array;
+    src->data = NULL;
 }
 
 /* Merge storage of two tables. */
@@ -37538,15 +37594,13 @@ void flecs_table_merge_data(
     ecs_world_t *world,
     ecs_table_t *dst_table,
     ecs_table_t *src_table,
-    int32_t src_count,
     int32_t dst_count,
-    ecs_data_t *src_data,
-    ecs_data_t *dst_data)
+    int32_t src_count)
 {
     int32_t i_new = 0, dst_column_count = dst_table->column_count;
     int32_t i_old = 0, src_column_count = src_table->column_count;
-    ecs_column_t *src_columns = src_data->columns;
-    ecs_column_t *dst_columns = dst_data->columns;
+    ecs_column_t *src_columns = src_table->data.columns;
+    ecs_column_t *dst_columns = dst_table->data.columns;
 
     ecs_assert(!dst_column_count || dst_columns, ECS_INTERNAL_ERROR, NULL);
 
@@ -37555,11 +37609,13 @@ void flecs_table_merge_data(
     }
 
     /* Merge entities */
-    flecs_table_merge_vec(world, &dst_data->entities, &src_data->entities, 
+    ecs_vec_t dst_entities = ecs_vec_from_entities(dst_table);
+    ecs_vec_t src_entities = ecs_vec_from_entities(src_table);
+    flecs_table_merge_vec(world, &dst_entities, &src_entities, 
         ECS_SIZEOF(ecs_entity_t), 0);
-    ecs_assert(dst_data->entities.count == src_count + dst_count, 
+    ecs_assert(dst_entities.count == src_count + dst_count, 
         ECS_INTERNAL_ERROR, NULL);
-    int32_t column_size = dst_data->entities.size;
+    int32_t column_size = dst_entities.size;
     ecs_allocator_t *a = &world->allocator;
 
     for (; (i_new < dst_column_count) && (i_old < src_column_count); ) {
@@ -37567,48 +37623,70 @@ void flecs_table_merge_data(
         ecs_column_t *src_column = &src_columns[i_old];
         ecs_id_t dst_id = flecs_column_id(dst_table, i_new);
         ecs_id_t src_id = flecs_column_id(src_table, i_old);
+        ecs_size_t dst_elem_size = dst_column->ti->size;
+        ecs_size_t src_elem_size = src_column->ti->size;
     
+        ecs_vec_t dst_vec = ecs_vec_from_column(
+            dst_column, dst_table, dst_elem_size);
+        ecs_vec_t src_vec = ecs_vec_from_column(
+            src_column, src_table, src_elem_size);
+
         if (dst_id == src_id) {
-            flecs_table_merge_column(world, dst_column, src_column, column_size);
+            flecs_table_merge_column(world, &dst_vec, &src_vec, dst_column, 
+                src_column, column_size);
             flecs_table_mark_table_dirty(world, dst_table, i_new + 1);
             i_new ++;
             i_old ++;
         } else if (dst_id < src_id) {
             /* New column, make sure vector is large enough. */
-            ecs_size_t size = dst_column->ti->size;
-            ecs_vec_set_size(a, &dst_column->data, size, column_size);
-            ecs_vec_set_count(a, &dst_column->data, size, src_count + dst_count);
+            ecs_vec_set_size(a, &dst_vec, dst_elem_size, column_size);
+            dst_column->data = dst_vec.array;
             flecs_table_invoke_ctor(dst_column, dst_count, src_count);
             i_new ++;
         } else if (dst_id > src_id) {
             /* Old column does not occur in new table, destruct */
             flecs_table_invoke_dtor(src_column, 0, src_count);
-            ecs_vec_fini(a, &src_column->data, src_column->ti->size);
+            ecs_vec_fini(a, &src_vec, src_elem_size);
+            src_column->data = NULL;
             i_old ++;
         }
     }
 
-    flecs_table_move_bitset_columns(dst_table, dst_count, src_table, 0, src_count, true);
+    flecs_table_move_bitset_columns(
+        dst_table, dst_count, src_table, 0, src_count, true);
 
     /* Initialize remaining columns */
     for (; i_new < dst_column_count; i_new ++) {
         ecs_column_t *column = &dst_columns[i_new];
-        int32_t size = column->ti->size;
-        ecs_assert(size != 0, ECS_INTERNAL_ERROR, NULL);
-        ecs_vec_set_size(a, &column->data, size, column_size);
-        ecs_vec_set_count(a, &column->data, size, src_count + dst_count);
+        int32_t elem_size = column->ti->size;
+        ecs_assert(elem_size != 0, ECS_INTERNAL_ERROR, NULL);
+        ecs_vec_t vec = ecs_vec_from_column(column, dst_table, elem_size);
+        ecs_vec_set_size(a, &vec, elem_size, column_size);
+        column->data = vec.array;
         flecs_table_invoke_ctor(column, dst_count, src_count);
     }
 
     /* Destruct remaining columns */
     for (; i_old < src_column_count; i_old ++) {
         ecs_column_t *column = &src_columns[i_old];
+        int32_t elem_size = column->ti->size;
+        ecs_assert(elem_size != 0, ECS_INTERNAL_ERROR, NULL);
         flecs_table_invoke_dtor(column, 0, src_count);
-        ecs_vec_fini(a, &column->data, column->ti->size);
+        ecs_vec_t vec = ecs_vec_from_column(column, src_table, elem_size);
+        ecs_vec_fini(a, &vec, elem_size);
+        column->data = vec.array;
     }    
 
     /* Mark entity column as dirty */
-    flecs_table_mark_table_dirty(world, dst_table, 0); 
+    flecs_table_mark_table_dirty(world, dst_table, 0);
+
+    dst_table->data.entities = dst_entities.array;
+    dst_table->data.count = dst_entities.count;
+    dst_table->data.size = dst_entities.size;
+
+    src_table->data.entities = src_entities.array;
+    src_table->data.count = src_entities.count;
+    src_table->data.size = src_entities.size;
 }
 
 /* Merge source table into destination table. This typically happens as result
@@ -37624,15 +37702,12 @@ void flecs_table_merge(
     ecs_assert(!src_table->_->lock, ECS_LOCKED_STORAGE, FLECS_LOCKED_STORAGE_MSG);
     ecs_assert(!dst_table->_->lock, ECS_LOCKED_STORAGE, FLECS_LOCKED_STORAGE_MSG);
 
-    flecs_table_check_sanity(src_table);
-    flecs_table_check_sanity(dst_table);
+    flecs_table_check_sanity(world, src_table);
+    flecs_table_check_sanity(world, dst_table);
 
-    ecs_data_t *dst_data = &dst_table->data;
-    ecs_data_t *src_data = &src_table->data;
-
-    ecs_entity_t *src_entities = src_data->entities.array;
-    int32_t src_count = src_data->entities.count;
-    int32_t dst_count = dst_data->entities.count;
+    ecs_entity_t *src_entities = ecs_table_entities(src_table);
+    int32_t src_count = ecs_table_count(src_table);
+    int32_t dst_count = ecs_table_count(dst_table);
 
     /* First, update entity index so old entities point to new type */
     int32_t i;
@@ -37644,8 +37719,7 @@ void flecs_table_merge(
     }
 
     /* Merge table columns */
-    flecs_table_merge_data(world, dst_table, src_table, src_count, dst_count, 
-        src_data, dst_data);
+    flecs_table_merge_data(world, dst_table, src_table, dst_count, src_count);
 
     if (src_count) {
         if (!dst_count) {
@@ -37658,8 +37732,8 @@ void flecs_table_merge(
         ecs_assert(src_table->_->traversable_count == 0, ECS_INTERNAL_ERROR, NULL);
     }
 
-    flecs_table_check_sanity(src_table);
-    flecs_table_check_sanity(dst_table);
+    flecs_table_check_sanity(world, src_table);
+    flecs_table_check_sanity(world, dst_table);
 }
 
 /* Internal mechanism for propagating information to tables */
@@ -37845,7 +37919,7 @@ void* ecs_table_get_column(
     ecs_check(index < table->column_count, ECS_INVALID_PARAMETER, NULL);
 
     ecs_column_t *column = &table->data.columns[index];
-    void *result = column->data.array;
+    void *result = column->data;
     if (offset) {
         result = ECS_ELEM(result, column->ti->size, offset);
     }
@@ -37894,7 +37968,14 @@ int32_t ecs_table_count(
     const ecs_table_t *table)
 {
     ecs_assert(table != NULL, ECS_INTERNAL_ERROR, NULL);
-    return flecs_table_data_count(&table->data);
+    return table->data.count;
+}
+
+int32_t ecs_table_size(
+    const ecs_table_t *table)
+{
+    ecs_assert(table != NULL, ECS_INTERNAL_ERROR, NULL);
+    return table->data.size;
 }
 
 bool ecs_table_has_id(
@@ -37961,7 +38042,7 @@ void* ecs_record_get_by_column(
     ecs_check(!flecs_utosize(c_size) || flecs_utosize(c_size) == size, 
         ECS_INVALID_PARAMETER, NULL);
 
-    return ecs_vec_get(&column->data, size, ECS_RECORD_TO_ROW(r->row));
+    return ECS_ELEM(column->data, size, ECS_RECORD_TO_ROW(r->row));
 error:
     return NULL;
 }
@@ -41584,7 +41665,7 @@ int ecs_entity_to_json_buf(
         .table = r->table,
         .offset = row,
         .count = 1,
-        .entities = &flecs_table_entities_array(r->table)[row],
+        .entities = &ecs_table_entities(r->table)[row],
         .field_count = 0
     };
 
@@ -42134,8 +42215,8 @@ int flecs_json_serialize_matches(
                 ecs_table_t *table = tr->hdr.table;
                 EcsPoly *queries = ecs_table_get_column(table, tr->column, 0);
 
+                ecs_entity_t *entities = ecs_table_entities(table);
                 int32_t i, count = ecs_table_count(table);
-                ecs_entity_t *entities = ecs_vec_first(&table->data.entities);
                 for (i = 0; i < count; i ++) {
                     ecs_query_t *q = queries[i].poly;
                     if (!q) {
@@ -42188,8 +42269,8 @@ int flecs_json_serialize_refs_idr(
         const ecs_table_record_t *tr;
         while ((tr = flecs_table_cache_next(&it, ecs_table_record_t))) {
             ecs_table_t *table = tr->hdr.table;
+            ecs_entity_t *entities = ecs_table_entities(table);
             int32_t i, count = ecs_table_count(table);
-            ecs_entity_t *entities = ecs_vec_first(&table->data.entities);
             for (i = 0; i < count; i ++) {
                 ecs_entity_t e = entities[i];
                 flecs_json_next(buf);
@@ -42482,7 +42563,7 @@ int flecs_json_serialize_iter_result(
     } else {
         ecs_table_t *table = it->table;
         if (table) {
-            this_data.ids = &flecs_table_entities_array(table)[it->offset];
+            this_data.ids = &ecs_table_entities(table)[it->offset];
 
             /* Get path to parent once for entire table */
             if (table->flags & EcsTableHasChildOf) {
@@ -43063,7 +43144,7 @@ bool flecs_json_serialize_table_pairs(
         
         if (second == EcsUnion) {
             ecs_assert(row < ecs_table_count(table), ECS_INTERNAL_ERROR, NULL);
-            ecs_entity_t e = flecs_table_entities_array(table)[row];
+            ecs_entity_t e = ecs_table_entities(table)[row];
             second = ecs_get_target(world, e, first, 0);
         }
 
@@ -43113,14 +43194,14 @@ int flecs_json_serialize_table_components(
         if (column_index != -1) {
             ecs_column_t *column = &table->data.columns[column_index];
             ti = column->ti;
-            ptr = ecs_vec_get(&column->data, ti->size, row);
+            ptr = ECS_ELEM(column->data, ti->size, row);
         } else {
             const ecs_table_record_t *tr = &table->_->records[i];
             ecs_id_record_t *idr = (ecs_id_record_t*)tr->hdr.cache;
             if (!(idr->flags & EcsIdIsSparse)) {
                 continue;
             }
-            ecs_entity_t e = flecs_table_entities_array(table)[row];
+            ecs_entity_t e = ecs_table_entities(table)[row];
             ptr = flecs_sparse_get_any(idr->sparse, 0, e);
             ti = idr->type_info;
         }
@@ -58249,7 +58330,8 @@ void ecs_script_vars_from_iter(
             } else {
                 ecs_table_range_t *range = &query_var->range;
                 if (range->count == 1) {
-                    ecs_entity_t *entities = range->table->data.entities.array;
+                    ecs_entity_t *entities = 
+                        ecs_table_entities(range->table);
                     e_ptr = &entities[range->offset];
                 }
             }
@@ -66515,26 +66597,25 @@ void flecs_query_cache_sort_table(
     ecs_order_by_action_t compare,
     ecs_sort_table_action_t sort)
 {
-    ecs_data_t *data = &table->data;
-    if (!ecs_vec_count(&data->entities)) {
+    int32_t count = ecs_table_count(table);
+    if (!count) {
         /* Nothing to sort */
         return;
     }
-
-    int32_t count = flecs_table_data_count(data);
+    
     if (count < 2) {
         return;
     }
 
-    ecs_entity_t *entities = ecs_vec_first(&data->entities);
+    ecs_entity_t *entities = ecs_table_entities(table);
 
     void *ptr = NULL;
     int32_t size = 0;
     if (column_index != -1) {
-        ecs_column_t *column = &data->columns[column_index];
+        ecs_column_t *column = &table->data.columns[column_index];
         ecs_type_info_t *ti = column->ti;
         size = ti->size;
-        ptr = ecs_vec_first(&column->data);
+        ptr = column->data;
     }
 
     if (sort) {
@@ -66606,7 +66687,6 @@ void flecs_query_cache_build_sorted_table_range(
     ecs_query_cache_table_match_t *cur, *end = list->last->next;
     for (cur = list->first; cur != end; cur = cur->next) {
         ecs_table_t *table = cur->table;
-        ecs_data_t *data = &table->data;
 
         if (ecs_table_count(table) == 0) {
             continue;
@@ -66618,9 +66698,9 @@ void flecs_query_cache_build_sorted_table_range(
             ecs_size_t size = cache->query->sizes[field];
             ecs_entity_t src = cur->sources[field];
             if (src == 0) {
-                int32_t column = cur->trs[field]->column;
-                ecs_vec_t *vec = &data->columns[column].data;
-                helper[to_sort].ptr = ecs_vec_first(vec);
+                int32_t column_index = cur->trs[field]->column;
+                ecs_column_t *column = &table->data.columns[column_index];
+                helper[to_sort].ptr = column->data;
                 helper[to_sort].elem_size = size;
                 helper[to_sort].shared = false;
             } else {
@@ -66651,7 +66731,7 @@ void flecs_query_cache_build_sorted_table_range(
         }
 
         helper[to_sort].match = cur;
-        helper[to_sort].entities = ecs_vec_first(&data->entities);
+        helper[to_sort].entities = ecs_table_entities(table);
         helper[to_sort].row = 0;
         helper[to_sort].count = ecs_table_count(table);
         to_sort ++;      
@@ -67756,7 +67836,7 @@ bool flecs_query_up_select(
             } else {
                 int32_t row;
                 ecs_entity_t entity = 0;
-                ecs_entity_t *entities = flecs_table_entities_array(table);
+                ecs_entity_t *entities = ecs_table_entities(table);
 
                 for (row = op_ctx->row; row < op_ctx->end; row ++) {
                     entity = entities[row];
@@ -68418,7 +68498,7 @@ bool flecs_query_each(
         if (end) {
             end += range.offset;
         } else {
-            end = table->data.entities.count;
+            end = ecs_table_count(table);
         }
         row = ++ op_ctx->row;
         if (op_ctx->row >= end) {
@@ -68427,7 +68507,7 @@ bool flecs_query_each(
     }
 
     ecs_assert(row < ecs_table_count(table), ECS_INTERNAL_ERROR, NULL);
-    ecs_entity_t *entities = table->data.entities.array;
+    ecs_entity_t *entities = ecs_table_entities(table);
     flecs_query_var_set_entity(op, op->src.var, entities[row], ctx);
 
     return true;
@@ -69346,7 +69426,7 @@ bool ecs_query_next(
 trivial_search_yield:
     it->table = ctx.vars[0].range.table;
     it->count = ecs_table_count(it->table);
-    it->entities = flecs_table_entities_array(it->table);
+    it->entities = ecs_table_entities(it->table);
 
 yield:
     return true;
@@ -69607,7 +69687,7 @@ bool flecs_query_member_cmp(
 
     int32_t offset = (int32_t)op->first.entity;
     int32_t size = (int32_t)(op->first.entity >> 32);
-    ecs_entity_t *entities = table->data.entities.array;
+    ecs_entity_t *entities = ecs_table_entities(table);
     ecs_entity_t e = 0;
     ecs_entity_t *val;
 
@@ -69740,8 +69820,7 @@ bool flecs_query_pred_eq_w_range(
         ecs_var_id_t l = src_var;
         ctx->vars[l].range = r;
         if (r.count == 1) {
-            ctx->vars[l].entity = ecs_vec_get_t(&r.table->data.entities, 
-                ecs_entity_t, r.offset)[0];
+            ctx->vars[l].entity = ecs_table_entities(r.table)[r.offset];
         }
         return true;
     } else {
@@ -69913,7 +69992,7 @@ bool flecs_query_pred_match(
         l = op_ctx->range;
     }
 
-    const EcsIdentifier *names = l.table->data.columns[op_ctx->name_col].data.array;
+    const EcsIdentifier *names = l.table->data.columns[op_ctx->name_col].data;
     int32_t count = l.offset + l.count, offset = -1;
     for (; op_ctx->index < count; op_ctx->index ++) {
         const char *name = names[op_ctx->index].value;
@@ -70339,7 +70418,7 @@ bool flecs_query_trav_fixed_src_reflexive(
 {
     ecs_table_t *table = range->table;
     ecs_assert(table != NULL, ECS_INTERNAL_ERROR, NULL);
-    ecs_entity_t *entities = table->data.entities.array;
+    ecs_entity_t *entities = ecs_table_entities(table);
     int32_t count = range->count;
     if (!count) {
         count = ecs_table_count(table);
@@ -70527,8 +70606,7 @@ bool flecs_query_trav_yield_reflexive_src(
         return false;
     }
 
-    ecs_entity_t entity = ecs_vec_get_t(
-        &range->table->data.entities, ecs_entity_t, trav_ctx->index)[0];
+    ecs_entity_t entity = ecs_table_entities(range->table)[trav_ctx->index];
     flecs_query_set_trav_match(op, NULL, trav, entity, ctx);
 
     /* Hijack existing variable to return one result at a time */
@@ -70678,7 +70756,7 @@ next_row:
         return false;
     }
 
-    ecs_entity_t e = flecs_table_entities_array(range.table)
+    ecs_entity_t e = ecs_table_entities(range.table)
         [range.offset + op_ctx->row];
     ecs_entity_t tgt = flecs_switch_get(op_ctx->idr->sparse, (uint32_t)e);
     if (!tgt) {
@@ -70742,7 +70820,7 @@ next_row:
         return false;
     }
 
-    ecs_entity_t e = flecs_table_entities_array(range.table)
+    ecs_entity_t e = ecs_table_entities(range.table)
         [range.offset + op_ctx->row];
     ecs_entity_t e_tgt = flecs_switch_get(op_ctx->idr->sparse, (uint32_t)e);
     bool match = e_tgt == tgt;
@@ -71015,8 +71093,7 @@ void flecs_query_set_iter_this(
         it->table = table;
         it->offset = range->offset;
         it->count = count;
-        it->entities = ECS_ELEM_T(
-            table->data.entities.array, ecs_entity_t, it->offset);
+        it->entities = &ecs_table_entities(table)[it->offset];
     } else if (count == 1) {
         it->count = 1;
         it->entities = &ctx->vars[0].entity;
@@ -71150,7 +71227,7 @@ ecs_entity_t flecs_query_var_get_entity(
 
     ecs_assert(var->range.count == 1, ECS_INTERNAL_ERROR, NULL);
     ecs_table_t *table = var->range.table;
-    ecs_entity_t *entities = table->data.entities.array;
+    ecs_entity_t *entities = ecs_table_entities(table);
     var->entity = entities[var->range.offset];
     return var->entity;
 }
@@ -71204,7 +71281,7 @@ void flecs_query_var_narrow_range(
     ecs_assert(var_id < ctx->query->var_count, ECS_INTERNAL_ERROR, NULL);
     if (ctx->query_vars[var_id].kind != EcsVarTable) {    
         ecs_assert(count == 1, ECS_INTERNAL_ERROR, NULL);
-        var->entity = flecs_table_entities_array(table)[offset];
+        var->entity = ecs_table_entities(table)[offset];
     }
 }
 
@@ -71438,7 +71515,7 @@ void flecs_query_build_down_cache(
             }
 
             int32_t i, count = ecs_table_count(table);
-            ecs_entity_t *entities = table->data.entities.array;
+            ecs_entity_t *entities = ecs_table_entities(table);
             for (i = 0; i < count; i ++) {
                 ecs_record_t *r = flecs_entities_get(world, entities[i]);
                 if (r->row & EcsEntityIsTraversable) {
@@ -71617,7 +71694,7 @@ ecs_trav_down_t* flecs_trav_table_down(
 
     ecs_assert(idr_with != NULL, ECS_INTERNAL_ERROR, NULL);
 
-    ecs_entity_t *entities = ecs_vec_first(&table->data.entities);
+    ecs_entity_t *entities = ecs_table_entities(table);
     int32_t i, count = ecs_table_count(table);
     for (i = 0; i < count; i ++) {
         ecs_entity_t entity = entities[i];
@@ -71673,7 +71750,7 @@ void flecs_trav_entity_down_isa(
                 continue;
             }
 
-            ecs_entity_t *entities = ecs_vec_first(&table->data.entities);
+            ecs_entity_t *entities = ecs_table_entities(table);
             int32_t i, count = ecs_table_count(table);
             for (i = 0; i < count; i ++) {
                 ecs_entity_t e = entities[i];
@@ -72195,7 +72272,7 @@ next:
 
         it->table = table;
         it->count = ecs_table_count(table);
-        it->entities = flecs_table_entities_array(table);
+        it->entities = ecs_table_entities(table);
         it->trs[0] = tr;
     }
 
@@ -72239,7 +72316,7 @@ bool flecs_query_trivial_test(
             it->trs[term->field_index] = tr;
         }
 
-        it->entities = flecs_table_entities_array(table);
+        it->entities = ecs_table_entities(table);
         if (it->entities) {
             it->entities = &it->entities[it->offset];
         }

--- a/flecs.c
+++ b/flecs.c
@@ -3056,7 +3056,7 @@ void flecs_invoke_hook(
     const ecs_table_record_t *tr,
     int32_t count,
     int32_t row,
-    ecs_entity_t *entities,
+    const ecs_entity_t *entities,
     ecs_id_t id,
     const ecs_type_info_t *ti,
     ecs_entity_t event,
@@ -5342,7 +5342,7 @@ void flecs_instantiate_children(
     }
 
     /* Instantiate the prefab child table for each new instance */
-    ecs_entity_t *instances = ecs_table_entities(table);
+    const ecs_entity_t *instances = ecs_table_entities(table);
     int32_t child_count = ecs_table_count(child_table);
 
     for (i = row; i < count + row; i ++) {
@@ -5362,7 +5362,7 @@ void flecs_instantiate_children(
         /* The instance is trying to instantiate from a base that is also
          * its parent. This would cause the hierarchy to instantiate itself
          * which would cause infinite recursion. */
-        ecs_entity_t *children = ecs_table_entities(child_table);
+        const ecs_entity_t *children = ecs_table_entities(child_table);
 
 #ifdef FLECS_DEBUG
         for (j = 0; j < child_count; j ++) {
@@ -5443,7 +5443,7 @@ void flecs_sparse_on_add(
             const ecs_type_info_t *ti = idr->type_info;
             ecs_xtor_t ctor = ti->hooks.ctor;
             ecs_iter_action_t on_add = ti->hooks.on_add;
-            ecs_entity_t *entities = ecs_table_entities(table);
+            const ecs_entity_t *entities = ecs_table_entities(table);
             for (j = 0; j < count; j ++) {
                 ecs_entity_t e = entities[row + j];
                 void *ptr = flecs_sparse_ensure(idr->sparse, 0, e);
@@ -5481,7 +5481,7 @@ void flecs_sparse_on_remove(
                 flecs_id_record_get_table(idr, table);
             ecs_xtor_t dtor = ti->hooks.dtor;
             ecs_iter_action_t on_remove = ti->hooks.on_remove;
-            ecs_entity_t *entities = ecs_table_entities(table);
+            const ecs_entity_t *entities = ecs_table_entities(table);
             for (j = 0; j < count; j ++) {
                 ecs_entity_t e = entities[row + j];
                 if (on_remove) {
@@ -5513,7 +5513,7 @@ void flecs_union_on_add(
             ecs_id_t wc = ecs_pair(ECS_PAIR_FIRST(id), EcsUnion);
             ecs_id_record_t *idr = flecs_id_record_get(world, wc);
             if (idr && idr->flags & EcsIdIsUnion) {
-                ecs_entity_t *entities = ecs_table_entities(table);
+                const ecs_entity_t *entities = ecs_table_entities(table);
                 for (j = 0; j < count; j ++) {
                     ecs_entity_t e = entities[row + j];
                     flecs_switch_set(
@@ -5539,7 +5539,7 @@ void flecs_union_on_remove(
             ecs_id_t wc = ecs_pair(ECS_PAIR_FIRST(id), EcsUnion);
             ecs_id_record_t *idr = flecs_id_record_get(world, wc);
             if (idr && idr->flags & EcsIdIsUnion) {
-                ecs_entity_t *entities = ecs_table_entities(table);
+                const ecs_entity_t *entities = ecs_table_entities(table);
                 for (j = 0; j < count; j ++) {
                     ecs_entity_t e = entities[row + j];
                     flecs_switch_reset(idr->sparse, (uint32_t)e);
@@ -5658,7 +5658,7 @@ void flecs_update_name_index(
     ecs_assert(names != NULL, ECS_INTERNAL_ERROR, NULL);
 
     int32_t i;
-    ecs_entity_t *entities = &ecs_table_entities(dst)[offset];
+    const ecs_entity_t *entities = &ecs_table_entities(dst)[offset];
     for (i = 0; i < count; i ++) {
         ecs_entity_t e = entities[i];
         EcsIdentifier *name = &names[i];
@@ -6105,7 +6105,7 @@ void flecs_invoke_hook(
     const ecs_table_record_t *tr,
     int32_t count,
     int32_t row,
-    ecs_entity_t *entities,
+    const ecs_entity_t *entities,
     ecs_id_t id,
     const ecs_type_info_t *ti,
     ecs_entity_t event,
@@ -6149,7 +6149,7 @@ void flecs_notify_on_set(
     bool owned)
 {
     ecs_assert(ids != NULL, ECS_INTERNAL_ERROR, NULL);
-    ecs_entity_t *entities = &ecs_table_entities(table)[row];
+    const ecs_entity_t *entities = &ecs_table_entities(table)[row];
     ecs_assert(entities != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_assert((row + count) <= ecs_table_count(table), 
         ECS_INTERNAL_ERROR, NULL);
@@ -7190,7 +7190,7 @@ void flecs_targets_mark_for_delete(
     ecs_table_t *table)
 {
     ecs_id_record_t *idr;
-    ecs_entity_t *entities = ecs_table_entities(table);
+    const ecs_entity_t *entities = ecs_table_entities(table);
     int32_t i, count = ecs_table_count(table);
     for (i = 0; i < count; i ++) {
         ecs_record_t *r = flecs_entities_get(world, entities[i]);
@@ -8983,7 +8983,7 @@ void ecs_set_version(
     ecs_record_t *r = flecs_entities_get(world, entity_with_generation);
     if (r && r->table) {
         int32_t row = ECS_RECORD_TO_ROW(r->row);
-        ecs_entity_t *entities = ecs_table_entities(r->table);
+        ecs_entity_t *entities = r->table->data.entities;
         entities[row] = entity_with_generation;
     }
 }
@@ -12546,7 +12546,7 @@ void flecs_emit_propagate_id(
             continue;
         }
 
-        ecs_entity_t *entities = ecs_table_entities(table);
+        const ecs_entity_t *entities = ecs_table_entities(table);
         for (e = 0; e < entity_count; e ++) {
             ecs_record_t *r = flecs_entities_get(world, entities[e]);
             ecs_assert(r != NULL, ECS_INTERNAL_ERROR, NULL);
@@ -12640,7 +12640,7 @@ void flecs_emit_propagate_invalidate_tables(
             }
 
             int32_t e, entity_count = ecs_table_count(table);
-            ecs_entity_t *entities = ecs_table_entities(table);
+            const ecs_entity_t *entities = ecs_table_entities(table);
 
             for (e = 0; e < entity_count; e ++) {
                 ecs_record_t *r = flecs_entities_get(world, entities[e]);
@@ -12661,7 +12661,7 @@ void flecs_emit_propagate_invalidate(
     int32_t offset,
     int32_t count)
 {
-    ecs_entity_t *entities = &ecs_table_entities(table)[offset];
+    const ecs_entity_t *entities = &ecs_table_entities(table)[offset];
     int32_t i;
     for (i = 0; i < count; i ++) {
         ecs_record_t *record = flecs_entities_get(world, entities[i]);
@@ -12684,7 +12684,7 @@ void flecs_propagate_entities(
     ecs_world_t *world,
     ecs_iter_t *it,
     ecs_id_record_t *idr,
-    ecs_entity_t *entities,
+    const ecs_entity_t *entities,
     int32_t count,
     ecs_entity_t src,
     ecs_event_id_record_t **iders,
@@ -12697,7 +12697,7 @@ void flecs_propagate_entities(
     ecs_entity_t old_src = it->sources[0];
     ecs_table_t *old_table = it->table;
     ecs_table_t *old_other_table = it->other_table;
-    ecs_entity_t *old_entities = it->entities;
+    const ecs_entity_t *old_entities = it->entities;
     int32_t old_count = it->count;
     int32_t old_offset = it->offset;
 
@@ -12758,7 +12758,7 @@ void flecs_override_copy(
 
     ecs_iter_action_t on_set = ti->hooks.on_set;
     if (on_set) {
-        ecs_entity_t *entities = &ecs_table_entities(table)[offset];
+        const ecs_entity_t *entities = &ecs_table_entities(table)[offset];
         flecs_invoke_hook(world, table, tr, count, offset, entities,
             ti->component, ti, EcsOnSet, on_set);
     }
@@ -13289,7 +13289,7 @@ void flecs_emit_forward(
     /* Propagate events for new reachable ids downwards */
     if (table->_->traversable_count) {
         int32_t i;
-        ecs_entity_t *entities = ecs_table_entities(table);
+        const ecs_entity_t *entities = ecs_table_entities(table);
         entities = ECS_ELEM_T(entities, ecs_entity_t, it->offset);
         for (i = 0; i < it->count; i ++) {
             ecs_record_t *r = flecs_entities_get(world, entities[i]);
@@ -14067,7 +14067,7 @@ void flecs_observer_invoke(
             observer_src = 0;
         }
 
-        ecs_entity_t *entities = it->entities;
+        const ecs_entity_t *entities = it->entities;
         int32_t i, count = it->count;
         ecs_entity_t src = it->sources[0];
         it->count = 1;
@@ -17859,7 +17859,7 @@ void flecs_fini_root_tables(
         }
 
         int32_t i, count = ecs_table_count(table);
-        ecs_entity_t *entities = ecs_table_entities(table);
+        const ecs_entity_t *entities = ecs_table_entities(table);
 
         if (fini_targets) {
             /* Only delete entities that are used as pair target. Iterate
@@ -19184,7 +19184,7 @@ void flecs_process_empty_queries(
 
             for (i = 0; i < count; i ++) {
                 ecs_query_t *query = queries[i].poly;
-                ecs_entity_t *entities = ecs_table_entities(table);
+                const ecs_entity_t *entities = ecs_table_entities(table);
                 if (!ecs_query_is_true(query)) {
                     ecs_add_id(world, entities[i], EcsEmpty);
                 }
@@ -36275,7 +36275,7 @@ void flecs_table_invoke_hook(
     ecs_iter_action_t callback,
     ecs_entity_t event,
     ecs_column_t *column,
-    ecs_entity_t *entities,
+    const ecs_entity_t *entities,
     int32_t row,
     int32_t count)
 {
@@ -36389,7 +36389,7 @@ void flecs_table_dtor_all(
     int32_t count,
     bool is_delete)
 {
-    ecs_entity_t *entities = ecs_table_entities(table);
+    const ecs_entity_t *entities = ecs_table_entities(table);
     int32_t column_count = table->column_count;
     int32_t i, c, end = row + count;
 
@@ -36530,7 +36530,7 @@ void flecs_table_fini_data(
     table->flags &= ~EcsTableHasTraversable;
 }
 
-ecs_entity_t* ecs_table_entities(
+const ecs_entity_t* ecs_table_entities(
     const ecs_table_t *table)
 {
     return table->data.entities;
@@ -37097,7 +37097,7 @@ void flecs_table_delete(
     ecs_assert(row <= count, ECS_INTERNAL_ERROR, NULL);
 
     /* Move last entity id to row */
-    ecs_entity_t *entities = ecs_table_entities(table);
+    ecs_entity_t *entities = table->data.entities;
     ecs_entity_t entity_to_move = entities[count];
     ecs_entity_t entity_to_delete = entities[row];
     entities[row] = entity_to_move;
@@ -37443,7 +37443,7 @@ void flecs_table_swap(
     /* If the table is monitored indicate that there has been a change */
     flecs_table_mark_table_dirty(world, table, 0);    
 
-    ecs_entity_t *entities = ecs_table_entities(table);
+    ecs_entity_t *entities = table->data.entities;
     ecs_entity_t e1 = entities[row_1];
     ecs_entity_t e2 = entities[row_2];
 
@@ -37705,7 +37705,7 @@ void flecs_table_merge(
     flecs_table_check_sanity(world, src_table);
     flecs_table_check_sanity(world, dst_table);
 
-    ecs_entity_t *src_entities = ecs_table_entities(src_table);
+    const ecs_entity_t *src_entities = ecs_table_entities(src_table);
     int32_t src_count = ecs_table_count(src_table);
     int32_t dst_count = ecs_table_count(dst_table);
 
@@ -39647,7 +39647,7 @@ typedef struct ecs_json_ser_ctx_t {
 } ecs_json_ser_ctx_t;
 
 typedef struct ecs_json_this_data_t {
-    ecs_entity_t *ids;
+    const ecs_entity_t *ids;
     const EcsIdentifier *names;
     const EcsDocDescription *label;
     const EcsDocDescription *brief;
@@ -42215,7 +42215,7 @@ int flecs_json_serialize_matches(
                 ecs_table_t *table = tr->hdr.table;
                 EcsPoly *queries = ecs_table_get_column(table, tr->column, 0);
 
-                ecs_entity_t *entities = ecs_table_entities(table);
+                const ecs_entity_t *entities = ecs_table_entities(table);
                 int32_t i, count = ecs_table_count(table);
                 for (i = 0; i < count; i ++) {
                     ecs_query_t *q = queries[i].poly;
@@ -42269,7 +42269,7 @@ int flecs_json_serialize_refs_idr(
         const ecs_table_record_t *tr;
         while ((tr = flecs_table_cache_next(&it, ecs_table_record_t))) {
             ecs_table_t *table = tr->hdr.table;
-            ecs_entity_t *entities = ecs_table_entities(table);
+            const ecs_entity_t *entities = ecs_table_entities(table);
             int32_t i, count = ecs_table_count(table);
             for (i = 0; i < count; i ++) {
                 ecs_entity_t e = entities[i];
@@ -58285,7 +58285,9 @@ void ecs_script_vars_from_iter(
             var = ecs_script_vars_declare(vars, "this");
             var->value.type = ecs_id(ecs_entity_t);
         }
-        var->value.ptr = &it->entities[offset];
+
+        /* Safe, variable value will never be written */
+        var->value.ptr = ECS_CONST_CAST(ecs_entity_t*, &it->entities[offset]);
     }
 
     /* Set variables for fields */
@@ -58323,14 +58325,14 @@ void ecs_script_vars_from_iter(
     {
         int32_t i, var_count = it->variable_count;
         for (i = 1 /* skip this variable */ ; i < var_count; i ++) {
-            ecs_entity_t *e_ptr = NULL;
+            const ecs_entity_t *e_ptr = NULL;
             ecs_var_t *query_var = &it->variables[i];
             if (query_var->entity) {
                 e_ptr = &query_var->entity;
             } else {
                 ecs_table_range_t *range = &query_var->range;
                 if (range->count == 1) {
-                    ecs_entity_t *entities = 
+                    const ecs_entity_t *entities = 
                         ecs_table_entities(range->table);
                     e_ptr = &entities[range->offset];
                 }
@@ -58348,7 +58350,9 @@ void ecs_script_vars_from_iter(
                 ecs_check(var->value.type == ecs_id(ecs_entity_t), 
                     ECS_INVALID_PARAMETER, NULL);
             }
-            var->value.ptr = e_ptr;
+
+            /* Safe, variable value will never be written */
+            var->value.ptr = ECS_CONST_CAST(ecs_entity_t*, e_ptr);
         }
     }
 
@@ -66607,7 +66611,7 @@ void flecs_query_cache_sort_table(
         return;
     }
 
-    ecs_entity_t *entities = ecs_table_entities(table);
+    ecs_entity_t *entities = table->data.entities;
 
     void *ptr = NULL;
     int32_t size = 0;
@@ -66731,7 +66735,7 @@ void flecs_query_cache_build_sorted_table_range(
         }
 
         helper[to_sort].match = cur;
-        helper[to_sort].entities = ecs_table_entities(table);
+        helper[to_sort].entities = table->data.entities;
         helper[to_sort].row = 0;
         helper[to_sort].count = ecs_table_count(table);
         to_sort ++;      
@@ -67836,7 +67840,7 @@ bool flecs_query_up_select(
             } else {
                 int32_t row;
                 ecs_entity_t entity = 0;
-                ecs_entity_t *entities = ecs_table_entities(table);
+                const ecs_entity_t *entities = ecs_table_entities(table);
 
                 for (row = op_ctx->row; row < op_ctx->end; row ++) {
                     entity = entities[row];
@@ -68507,7 +68511,7 @@ bool flecs_query_each(
     }
 
     ecs_assert(row < ecs_table_count(table), ECS_INTERNAL_ERROR, NULL);
-    ecs_entity_t *entities = ecs_table_entities(table);
+    const ecs_entity_t *entities = ecs_table_entities(table);
     flecs_query_var_set_entity(op, op->src.var, entities[row], ctx);
 
     return true;
@@ -69687,7 +69691,7 @@ bool flecs_query_member_cmp(
 
     int32_t offset = (int32_t)op->first.entity;
     int32_t size = (int32_t)(op->first.entity >> 32);
-    ecs_entity_t *entities = ecs_table_entities(table);
+    const ecs_entity_t *entities = ecs_table_entities(table);
     ecs_entity_t e = 0;
     ecs_entity_t *val;
 
@@ -70418,7 +70422,7 @@ bool flecs_query_trav_fixed_src_reflexive(
 {
     ecs_table_t *table = range->table;
     ecs_assert(table != NULL, ECS_INTERNAL_ERROR, NULL);
-    ecs_entity_t *entities = ecs_table_entities(table);
+    const ecs_entity_t *entities = ecs_table_entities(table);
     int32_t count = range->count;
     if (!count) {
         count = ecs_table_count(table);
@@ -71227,7 +71231,7 @@ ecs_entity_t flecs_query_var_get_entity(
 
     ecs_assert(var->range.count == 1, ECS_INTERNAL_ERROR, NULL);
     ecs_table_t *table = var->range.table;
-    ecs_entity_t *entities = ecs_table_entities(table);
+    const ecs_entity_t *entities = ecs_table_entities(table);
     var->entity = entities[var->range.offset];
     return var->entity;
 }
@@ -71515,7 +71519,7 @@ void flecs_query_build_down_cache(
             }
 
             int32_t i, count = ecs_table_count(table);
-            ecs_entity_t *entities = ecs_table_entities(table);
+            const ecs_entity_t *entities = ecs_table_entities(table);
             for (i = 0; i < count; i ++) {
                 ecs_record_t *r = flecs_entities_get(world, entities[i]);
                 if (r->row & EcsEntityIsTraversable) {
@@ -71694,7 +71698,7 @@ ecs_trav_down_t* flecs_trav_table_down(
 
     ecs_assert(idr_with != NULL, ECS_INTERNAL_ERROR, NULL);
 
-    ecs_entity_t *entities = ecs_table_entities(table);
+    const ecs_entity_t *entities = ecs_table_entities(table);
     int32_t i, count = ecs_table_count(table);
     for (i = 0; i < count; i ++) {
         ecs_entity_t entity = entities[i];
@@ -71750,7 +71754,7 @@ void flecs_trav_entity_down_isa(
                 continue;
             }
 
-            ecs_entity_t *entities = ecs_table_entities(table);
+            const ecs_entity_t *entities = ecs_table_entities(table);
             int32_t i, count = ecs_table_count(table);
             for (i = 0; i < count; i ++) {
                 ecs_entity_t e = entities[i];

--- a/flecs.c
+++ b/flecs.c
@@ -424,9 +424,7 @@ typedef struct ecs_table__t {
 /** Table column */
 typedef struct ecs_column_t {
     ecs_vec_t data;                  /* Vector with component data */
-    ecs_id_t id;                     /* Component id */
     ecs_type_info_t *ti;             /* Component type info */
-    ecs_size_t size;                 /* Component size */
 } ecs_column_t;
 
 /** Table data */
@@ -626,6 +624,10 @@ int32_t flecs_table_get_toggle_column(
 ecs_bitset_t* flecs_table_get_toggle(
     ecs_table_t *table,
     ecs_id_t id);
+
+ecs_id_t flecs_column_id(
+    ecs_table_t *table,
+    int32_t column_index);
 
 #endif
 
@@ -4940,7 +4942,7 @@ flecs_component_ptr_t flecs_table_get_component(
     ecs_column_t *column = &table->data.columns[column_index];
     return (flecs_component_ptr_t){
         .ti = column->ti,
-        .ptr = ecs_vec_get(&column->data, column->size, row)
+        .ptr = ecs_vec_get(&column->data, column->ti->size, row)
     };
 error:
     return (flecs_component_ptr_t){0};
@@ -5895,7 +5897,7 @@ const ecs_entity_t* flecs_bulk_new(
             int32_t index = tr->column;
             ecs_column_t *column = &table->data.columns[index];
             ecs_type_info_t *ti = column->ti;
-            int32_t size = column->size;
+            int32_t size = ti->size;
             ecs_assert(size != 0, ECS_INTERNAL_ERROR, NULL);
             void *ptr = ecs_vec_get(&column->data, size, row);
 
@@ -5912,8 +5914,9 @@ const ecs_entity_t* flecs_bulk_new(
 
         int32_t j, storage_count = table->column_count;
         for (j = 0; j < storage_count; j ++) {
+            ecs_id_t id = flecs_column_id(table, j);
             ecs_type_t set_type = {
-                .array = &table->data.columns[j].id,
+                .array = &id,
                 .count = 1
             };
 
@@ -7747,8 +7750,9 @@ ecs_entity_t ecs_clone(
             row, src_table, ECS_RECORD_TO_ROW(src_r->row), true);
         int32_t i, count = dst_table->column_count;
         for (i = 0; i < count; i ++) {
+            ecs_id_t id = flecs_column_id(dst_table, i);
             ecs_type_t type = {
-                .array = &dst_table->data.columns[i].id,
+                .array = &id,
                 .count = 1
             };
             flecs_notify_on_set(world, dst_table, row, 1, &type, true);
@@ -10973,8 +10977,12 @@ void* ecs_field_w_size(
         (it->query && (it->query->flags & EcsQueryMatchEmptyTables)),
             ECS_INTERNAL_ERROR, NULL);
 
+    if (!size) {
+        size = column->ti->size;
+    }
+
     void *data = ecs_vec_first(&column->data);
-    return ECS_ELEM(data, column->size, row);
+    return ECS_ELEM(data, (ecs_size_t)size, row);
 error:
     return NULL;
 }
@@ -35713,8 +35721,6 @@ void flecs_table_init_columns(
         tr->column = flecs_ito(int16_t, cur);
 
         columns[cur].ti = ECS_CONST_CAST(ecs_type_info_t*, ti);
-        columns[cur].id = ids[i];
-        columns[cur].size = ti->size;
 
         if (ECS_IS_PAIR(ids[i])) {
             ecs_table_record_t *wc_tr = flecs_id_record_get_table(
@@ -36227,8 +36233,8 @@ void flecs_table_invoke_hook(
     ecs_assert(type_index >= 0, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(type_index < table->type.count, ECS_INTERNAL_ERROR, NULL);
     const ecs_table_record_t *tr = &table->_->records[type_index];
-    flecs_invoke_hook(world, table, tr, count, row, entities, column->id, 
-        column->ti, event, callback);
+    flecs_invoke_hook(world, table, tr, count, row, entities, 
+        table->type.array[type_index], column->ti, event, callback);
 }
 
 /* Construct components */
@@ -36242,7 +36248,7 @@ void flecs_table_invoke_ctor(
     ecs_assert(ti != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_xtor_t ctor = ti->hooks.ctor;
     if (ctor) {
-        void *ptr = ecs_vec_get(&column->data, column->size, row);
+        void *ptr = ecs_vec_get(&column->data, ti->size, row);
         ctor(ptr, count, ti);
     }
 }
@@ -36258,7 +36264,7 @@ void flecs_table_invoke_dtor(
     ecs_assert(ti != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_xtor_t dtor = ti->hooks.dtor;
     if (dtor) {
-        void *ptr = ecs_vec_get(&column->data, column->size, row);
+        void *ptr = ecs_vec_get(&column->data, ti->size, row);
         dtor(ptr, count, ti);
     }
 }
@@ -36435,7 +36441,7 @@ void flecs_table_fini_data(
             ecs_assert(columns[c].data.count == data->entities.count,
                 ECS_INTERNAL_ERROR, NULL);
             ecs_vec_fini(&world->allocator,
-                &columns[c].data, columns[c].size);
+                &columns[c].data, columns[c].ti->size);
         }
         flecs_wfree_n(world, ecs_column_t, column_count, columns);
         data->columns = NULL;
@@ -36752,7 +36758,7 @@ void flecs_table_grow_column(
     ecs_assert(column != NULL, ECS_INTERNAL_ERROR, NULL);
 
     ecs_type_info_t *ti = column->ti;
-    int32_t size = column->size;
+    int32_t size = ti->size;
     int32_t count = column->data.count;
     int32_t src_size = column->data.size;
     int32_t dst_count = count + to_add;
@@ -36882,7 +36888,7 @@ void flecs_table_fast_append(
     int32_t i;
     for (i = 0; i < count; i ++) {
         ecs_column_t *column = &columns[i];
-        ecs_vec_append(&world->allocator, &column->data, column->size);
+        ecs_vec_append(&world->allocator, &column->data, column->ti->size);
     }
 }
 
@@ -36994,7 +37000,7 @@ void flecs_table_fast_delete(
     int i;
     for (i = 0; i < column_count; i ++) {
         ecs_column_t *column = &columns[i];
-        ecs_vec_remove(&column->data, column->size, index);
+        ecs_vec_remove(&column->data, column->ti->size, index);
     }
 }
 
@@ -37081,7 +37087,7 @@ void flecs_table_delete(
             for (i = 0; i < column_count; i ++) {
                 ecs_column_t *column = &columns[i];
                 ecs_type_info_t *ti = column->ti;
-                ecs_size_t size = column->size;
+                ecs_size_t size = ti->size;
                 void *dst = ecs_vec_get(&column->data, size, index);
                 void *src = ecs_vec_last(&column->data, size);
 
@@ -37142,11 +37148,11 @@ void flecs_table_fast_move(
     for (; (i_new < dst_column_count) && (i_old < src_column_count);) {
         ecs_column_t *dst_column = &dst_columns[i_new];
         ecs_column_t *src_column = &src_columns[i_old];
-        ecs_id_t dst_id = dst_column->id;
-        ecs_id_t src_id = src_column->id;
+        ecs_id_t dst_id = flecs_column_id(dst_table, i_new);
+        ecs_id_t src_id = flecs_column_id(src_table, i_old);
 
         if (dst_id == src_id) {
-            int32_t size = dst_column->size;
+            int32_t size = dst_column->ti->size;
             void *dst = ecs_vec_get(&dst_column->data, size, dst_index);
             void *src = ecs_vec_get(&src_column->data, size, src_index);
             ecs_os_memcpy(dst, src, size);
@@ -37209,16 +37215,16 @@ void flecs_table_move(
     for (; (i_new < dst_column_count) && (i_old < src_column_count); ) {
         ecs_column_t *dst_column = &dst_columns[i_new];
         ecs_column_t *src_column = &src_columns[i_old];
-        ecs_id_t dst_id = dst_column->id;
-        ecs_id_t src_id = src_column->id;
+        ecs_id_t dst_id = flecs_column_id(dst_table, i_new);
+        ecs_id_t src_id = flecs_column_id(src_table, i_old);
 
         if (dst_id == src_id) {
-            int32_t size = dst_column->size;
+            ecs_type_info_t *ti = dst_column->ti;
+            int32_t size = ti->size;
 
             ecs_assert(size != 0, ECS_INTERNAL_ERROR, NULL);
             void *dst = ecs_vec_get(&dst_column->data, size, dst_index);
             void *src = ecs_vec_get(&src_column->data, size, src_index);
-            ecs_type_info_t *ti = dst_column->ti;
 
             if (same_entity) {
                 ecs_move_t move = ti->hooks.move_ctor;
@@ -37329,7 +37335,7 @@ bool flecs_table_shrink(
     int32_t i, count = table->column_count;
     for (i = 0; i < count; i ++) {
         ecs_column_t *column = &data->columns[i];
-        ecs_vec_reclaim(&world->allocator, &column->data, column->size);
+        ecs_vec_reclaim(&world->allocator, &column->data, column->ti->size);
     }
 
     return has_payload;
@@ -37416,14 +37422,14 @@ void flecs_table_swap(
      * and allocate a temporary buffer for swapping */
     int32_t i, temp_buffer_size = ECS_SIZEOF(uint64_t), column_count = table->column_count;
     for (i = 0; i < column_count; i++) {
-        temp_buffer_size = ECS_MAX(temp_buffer_size, columns[i].size);
+        temp_buffer_size = ECS_MAX(temp_buffer_size, columns[i].ti->size);
     }
 
     void* tmp = ecs_os_alloca(temp_buffer_size);
 
     /* Swap columns */
     for (i = 0; i < column_count; i ++) {
-        int32_t size = columns[i].size;
+        int32_t size = columns[i].ti->size;
         ecs_column_t *column = &columns[i];
         void *ptr = column->data.array;
         const ecs_type_info_t *ti = column->ti;
@@ -37493,7 +37499,7 @@ void flecs_table_merge_column(
     ecs_column_t *src,
     int32_t column_size)
 {
-    ecs_size_t size = dst->size;
+    ecs_size_t size = dst->ti->size;
     int32_t dst_count = dst->data.count;
 
     if (!dst_count) {
@@ -37559,8 +37565,8 @@ void flecs_table_merge_data(
     for (; (i_new < dst_column_count) && (i_old < src_column_count); ) {
         ecs_column_t *dst_column = &dst_columns[i_new];
         ecs_column_t *src_column = &src_columns[i_old];
-        ecs_id_t dst_id = dst_column->id;
-        ecs_id_t src_id = src_column->id;
+        ecs_id_t dst_id = flecs_column_id(dst_table, i_new);
+        ecs_id_t src_id = flecs_column_id(src_table, i_old);
     
         if (dst_id == src_id) {
             flecs_table_merge_column(world, dst_column, src_column, column_size);
@@ -37569,7 +37575,7 @@ void flecs_table_merge_data(
             i_old ++;
         } else if (dst_id < src_id) {
             /* New column, make sure vector is large enough. */
-            ecs_size_t size = dst_column->size;
+            ecs_size_t size = dst_column->ti->size;
             ecs_vec_set_size(a, &dst_column->data, size, column_size);
             ecs_vec_set_count(a, &dst_column->data, size, src_count + dst_count);
             flecs_table_invoke_ctor(dst_column, dst_count, src_count);
@@ -37577,7 +37583,7 @@ void flecs_table_merge_data(
         } else if (dst_id > src_id) {
             /* Old column does not occur in new table, destruct */
             flecs_table_invoke_dtor(src_column, 0, src_count);
-            ecs_vec_fini(a, &src_column->data, src_column->size);
+            ecs_vec_fini(a, &src_column->data, src_column->ti->size);
             i_old ++;
         }
     }
@@ -37587,7 +37593,7 @@ void flecs_table_merge_data(
     /* Initialize remaining columns */
     for (; i_new < dst_column_count; i_new ++) {
         ecs_column_t *column = &dst_columns[i_new];
-        int32_t size = column->size;
+        int32_t size = column->ti->size;
         ecs_assert(size != 0, ECS_INTERNAL_ERROR, NULL);
         ecs_vec_set_size(a, &column->data, size, column_size);
         ecs_vec_set_count(a, &column->data, size, src_count + dst_count);
@@ -37598,7 +37604,7 @@ void flecs_table_merge_data(
     for (; i_old < src_column_count; i_old ++) {
         ecs_column_t *column = &src_columns[i_old];
         flecs_table_invoke_dtor(column, 0, src_count);
-        ecs_vec_fini(a, &column->data, column->size);
+        ecs_vec_fini(a, &column->data, column->ti->size);
     }    
 
     /* Mark entity column as dirty */
@@ -37706,6 +37712,13 @@ ecs_bitset_t* flecs_table_get_toggle(
     return &table->_->bs_columns[toggle_column];
 }
 
+ecs_id_t flecs_column_id(
+    ecs_table_t *table,
+    int32_t column_index)
+{
+    int32_t type_index = table->column_map[table->type.count + column_index];
+    return table->type.array[type_index];
+}
 
 /* -- Public API -- */
 
@@ -37834,7 +37847,7 @@ void* ecs_table_get_column(
     ecs_column_t *column = &table->data.columns[index];
     void *result = column->data.array;
     if (offset) {
-        result = ECS_ELEM(result, column->size, offset);
+        result = ECS_ELEM(result, column->ti->size, offset);
     }
 
     return result;
@@ -37872,7 +37885,7 @@ size_t ecs_table_get_column_size(
     ecs_check(column < table->column_count, ECS_INVALID_PARAMETER, NULL);
     ecs_check(table->column_map != NULL, ECS_INVALID_PARAMETER, NULL);
 
-    return flecs_ito(size_t, table->data.columns[column].size);
+    return flecs_ito(size_t, table->data.columns[column].ti->size);
 error:
     return 0;
 }
@@ -37943,7 +37956,7 @@ void* ecs_record_get_by_column(
 
     ecs_check(index < table->column_count, ECS_INVALID_PARAMETER, NULL);
     ecs_column_t *column = &table->data.columns[index];
-    ecs_size_t size = column->size;
+    ecs_size_t size = column->ti->size;
 
     ecs_check(!flecs_utosize(c_size) || flecs_utosize(c_size) == size, 
         ECS_INVALID_PARAMETER, NULL);
@@ -42880,9 +42893,10 @@ bool flecs_json_serialize_table_type_info(
 
     for (i = 0; i < column_count; i ++) {
         ecs_column_t *column = &columns[i];
+        ecs_id_t id = flecs_column_id(table, i);
 
         if (!desc || !desc->serialize_builtin) {
-            if (flecs_json_is_builtin(column->id)) {
+            if (flecs_json_is_builtin(id)) {
                 continue;
             }
         }
@@ -42892,7 +42906,7 @@ bool flecs_json_serialize_table_type_info(
 
         flecs_json_next(buf);
         ecs_strbuf_appendlit(buf, "\"");
-        flecs_json_id_member(buf, world, column->id, desc->serialize_full_paths);
+        flecs_json_id_member(buf, world, id, desc->serialize_full_paths);
         ecs_strbuf_appendlit(buf, "\":");
 
         ecs_type_info_to_json_buf(world, ti->component, buf);
@@ -43098,8 +43112,8 @@ int flecs_json_serialize_table_components(
         int32_t column_index = table->column_map ? table->column_map[i] : -1;
         if (column_index != -1) {
             ecs_column_t *column = &table->data.columns[column_index];
-            ptr = ecs_vec_get(&column->data, column->size, row);
             ti = column->ti;
+            ptr = ecs_vec_get(&column->data, ti->size, row);
         } else {
             const ecs_table_record_t *tr = &table->_->records[i];
             ecs_id_record_t *idr = (ecs_id_record_t*)tr->hdr.cache;

--- a/flecs.h
+++ b/flecs.h
@@ -8790,16 +8790,35 @@ size_t ecs_table_get_column_size(
     const ecs_table_t *table,
     int32_t index);
 
-/** Returns the number of records in the table.
- * This operation returns the number of records that have been populated through
- * the regular (entity) API as well as the number of records that have been
- * inserted using the direct access API.
+/** Returns the number of entities in the table.
+ * This operation returns the number of entities in the table.
  *
  * @param table The table.
- * @return The number of records in a table.
+ * @return The number of entities in the table.
  */
 FLECS_API
 int32_t ecs_table_count(
+    const ecs_table_t *table);
+
+/** Returns allocated size of table.
+ * This operation returns the number of elements allocated in the table 
+ * per column.
+ * 
+ * @param table The table.
+ * @return The number of allocated elements in the table.
+ */
+FLECS_API
+int32_t ecs_table_size(
+    const ecs_table_t *table);
+
+/** Returns array with entity ids for table.
+ * The size of the returned array is the result of ecs_table_count().
+ * 
+ * @param table The table.
+ * @return Array with entity ids for table.
+ */
+FLECS_API
+ecs_entity_t* ecs_table_entities(
     const ecs_table_t *table);
 
 /** Test if table has id.

--- a/flecs.h
+++ b/flecs.h
@@ -4194,7 +4194,7 @@ struct ecs_iter_t {
     ecs_world_t *real_world;      /**< Actual world. Never points to a stage. */
 
     /* Matched data */
-    ecs_entity_t *entities;       /**< Entity identifiers */
+    const ecs_entity_t *entities; /**< Entity identifiers */
     const ecs_size_t *sizes;      /**< Component sizes */
     ecs_table_t *table;           /**< Current table */
     ecs_table_t *other_table;     /**< Prev or next table when adding/removing */
@@ -8818,7 +8818,7 @@ int32_t ecs_table_size(
  * @return Array with entity ids for table.
  */
 FLECS_API
-ecs_entity_t* ecs_table_entities(
+const ecs_entity_t* ecs_table_entities(
     const ecs_table_t *table);
 
 /** Test if table has id.

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -1053,7 +1053,7 @@ struct ecs_iter_t {
     ecs_world_t *real_world;      /**< Actual world. Never points to a stage. */
 
     /* Matched data */
-    ecs_entity_t *entities;       /**< Entity identifiers */
+    const ecs_entity_t *entities; /**< Entity identifiers */
     const ecs_size_t *sizes;      /**< Component sizes */
     ecs_table_t *table;           /**< Current table */
     ecs_table_t *other_table;     /**< Prev or next table when adding/removing */
@@ -5656,7 +5656,7 @@ int32_t ecs_table_size(
  * @return Array with entity ids for table.
  */
 FLECS_API
-ecs_entity_t* ecs_table_entities(
+const ecs_entity_t* ecs_table_entities(
     const ecs_table_t *table);
 
 /** Test if table has id.

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -5628,16 +5628,35 @@ size_t ecs_table_get_column_size(
     const ecs_table_t *table,
     int32_t index);
 
-/** Returns the number of records in the table.
- * This operation returns the number of records that have been populated through
- * the regular (entity) API as well as the number of records that have been
- * inserted using the direct access API.
+/** Returns the number of entities in the table.
+ * This operation returns the number of entities in the table.
  *
  * @param table The table.
- * @return The number of records in a table.
+ * @return The number of entities in the table.
  */
 FLECS_API
 int32_t ecs_table_count(
+    const ecs_table_t *table);
+
+/** Returns allocated size of table.
+ * This operation returns the number of elements allocated in the table 
+ * per column.
+ * 
+ * @param table The table.
+ * @return The number of allocated elements in the table.
+ */
+FLECS_API
+int32_t ecs_table_size(
+    const ecs_table_t *table);
+
+/** Returns array with entity ids for table.
+ * The size of the returned array is the result of ecs_table_count().
+ * 
+ * @param table The table.
+ * @return Array with entity ids for table.
+ */
+FLECS_API
+ecs_entity_t* ecs_table_entities(
     const ecs_table_t *table);
 
 /** Test if table has id.

--- a/src/addons/json/json.h
+++ b/src/addons/json/json.h
@@ -44,7 +44,7 @@ typedef struct ecs_json_ser_ctx_t {
 } ecs_json_ser_ctx_t;
 
 typedef struct ecs_json_this_data_t {
-    ecs_entity_t *ids;
+    const ecs_entity_t *ids;
     const EcsIdentifier *names;
     const EcsDocDescription *label;
     const EcsDocDescription *brief;

--- a/src/addons/json/serialize_entity.c
+++ b/src/addons/json/serialize_entity.c
@@ -50,7 +50,7 @@ int ecs_entity_to_json_buf(
         .table = r->table,
         .offset = row,
         .count = 1,
-        .entities = &flecs_table_entities_array(r->table)[row],
+        .entities = &ecs_table_entities(r->table)[row],
         .field_count = 0
     };
 

--- a/src/addons/json/serialize_iter_result.c
+++ b/src/addons/json/serialize_iter_result.c
@@ -75,8 +75,8 @@ int flecs_json_serialize_matches(
                 ecs_table_t *table = tr->hdr.table;
                 EcsPoly *queries = ecs_table_get_column(table, tr->column, 0);
 
+                ecs_entity_t *entities = ecs_table_entities(table);
                 int32_t i, count = ecs_table_count(table);
-                ecs_entity_t *entities = ecs_vec_first(&table->data.entities);
                 for (i = 0; i < count; i ++) {
                     ecs_query_t *q = queries[i].poly;
                     if (!q) {
@@ -129,8 +129,8 @@ int flecs_json_serialize_refs_idr(
         const ecs_table_record_t *tr;
         while ((tr = flecs_table_cache_next(&it, ecs_table_record_t))) {
             ecs_table_t *table = tr->hdr.table;
+            ecs_entity_t *entities = ecs_table_entities(table);
             int32_t i, count = ecs_table_count(table);
-            ecs_entity_t *entities = ecs_vec_first(&table->data.entities);
             for (i = 0; i < count; i ++) {
                 ecs_entity_t e = entities[i];
                 flecs_json_next(buf);
@@ -423,7 +423,7 @@ int flecs_json_serialize_iter_result(
     } else {
         ecs_table_t *table = it->table;
         if (table) {
-            this_data.ids = &flecs_table_entities_array(table)[it->offset];
+            this_data.ids = &ecs_table_entities(table)[it->offset];
 
             /* Get path to parent once for entire table */
             if (table->flags & EcsTableHasChildOf) {

--- a/src/addons/json/serialize_iter_result.c
+++ b/src/addons/json/serialize_iter_result.c
@@ -75,7 +75,7 @@ int flecs_json_serialize_matches(
                 ecs_table_t *table = tr->hdr.table;
                 EcsPoly *queries = ecs_table_get_column(table, tr->column, 0);
 
-                ecs_entity_t *entities = ecs_table_entities(table);
+                const ecs_entity_t *entities = ecs_table_entities(table);
                 int32_t i, count = ecs_table_count(table);
                 for (i = 0; i < count; i ++) {
                     ecs_query_t *q = queries[i].poly;
@@ -129,7 +129,7 @@ int flecs_json_serialize_refs_idr(
         const ecs_table_record_t *tr;
         while ((tr = flecs_table_cache_next(&it, ecs_table_record_t))) {
             ecs_table_t *table = tr->hdr.table;
-            ecs_entity_t *entities = ecs_table_entities(table);
+            const ecs_entity_t *entities = ecs_table_entities(table);
             int32_t i, count = ecs_table_count(table);
             for (i = 0; i < count; i ++) {
                 ecs_entity_t e = entities[i];

--- a/src/addons/json/serialize_iter_result_table.c
+++ b/src/addons/json/serialize_iter_result_table.c
@@ -43,9 +43,10 @@ bool flecs_json_serialize_table_type_info(
 
     for (i = 0; i < column_count; i ++) {
         ecs_column_t *column = &columns[i];
+        ecs_id_t id = flecs_column_id(table, i);
 
         if (!desc || !desc->serialize_builtin) {
-            if (flecs_json_is_builtin(column->id)) {
+            if (flecs_json_is_builtin(id)) {
                 continue;
             }
         }
@@ -55,7 +56,7 @@ bool flecs_json_serialize_table_type_info(
 
         flecs_json_next(buf);
         ecs_strbuf_appendlit(buf, "\"");
-        flecs_json_id_member(buf, world, column->id, desc->serialize_full_paths);
+        flecs_json_id_member(buf, world, id, desc->serialize_full_paths);
         ecs_strbuf_appendlit(buf, "\":");
 
         ecs_type_info_to_json_buf(world, ti->component, buf);
@@ -261,8 +262,8 @@ int flecs_json_serialize_table_components(
         int32_t column_index = table->column_map ? table->column_map[i] : -1;
         if (column_index != -1) {
             ecs_column_t *column = &table->data.columns[column_index];
-            ptr = ecs_vec_get(&column->data, column->size, row);
             ti = column->ti;
+            ptr = ecs_vec_get(&column->data, ti->size, row);
         } else {
             const ecs_table_record_t *tr = &table->_->records[i];
             ecs_id_record_t *idr = (ecs_id_record_t*)tr->hdr.cache;

--- a/src/addons/json/serialize_iter_result_table.c
+++ b/src/addons/json/serialize_iter_result_table.c
@@ -213,7 +213,7 @@ bool flecs_json_serialize_table_pairs(
         
         if (second == EcsUnion) {
             ecs_assert(row < ecs_table_count(table), ECS_INTERNAL_ERROR, NULL);
-            ecs_entity_t e = flecs_table_entities_array(table)[row];
+            ecs_entity_t e = ecs_table_entities(table)[row];
             second = ecs_get_target(world, e, first, 0);
         }
 
@@ -263,14 +263,14 @@ int flecs_json_serialize_table_components(
         if (column_index != -1) {
             ecs_column_t *column = &table->data.columns[column_index];
             ti = column->ti;
-            ptr = ecs_vec_get(&column->data, ti->size, row);
+            ptr = ECS_ELEM(column->data, ti->size, row);
         } else {
             const ecs_table_record_t *tr = &table->_->records[i];
             ecs_id_record_t *idr = (ecs_id_record_t*)tr->hdr.cache;
             if (!(idr->flags & EcsIdIsSparse)) {
                 continue;
             }
-            ecs_entity_t e = flecs_table_entities_array(table)[row];
+            ecs_entity_t e = ecs_table_entities(table)[row];
             ptr = flecs_sparse_get_any(idr->sparse, 0, e);
             ti = idr->type_info;
         }

--- a/src/addons/rest.c
+++ b/src/addons/rest.c
@@ -1083,16 +1083,17 @@ void flecs_rest_reply_table_append_memory(
     const ecs_table_t *table)
 {
     int32_t used = 0, allocated = 0;
+    int32_t count = ecs_table_count(table), size = ecs_table_size(table);
 
-    used += table->data.entities.count * ECS_SIZEOF(ecs_entity_t);
-    allocated += table->data.entities.size * ECS_SIZEOF(ecs_entity_t);
+    used += count * ECS_SIZEOF(ecs_entity_t);
+    allocated += size * ECS_SIZEOF(ecs_entity_t);
 
     int32_t i, storage_count = table->column_count;
     ecs_column_t *columns = table->data.columns;
 
     for (i = 0; i < storage_count; i ++) {
-        used += columns[i].data.count * columns[i].ti->size;
-        allocated += columns[i].data.size * columns[i].ti->size;
+        used += count * columns[i].ti->size;
+        allocated += size * columns[i].ti->size;
     }
 
     ecs_strbuf_list_push(reply, "{", ",");

--- a/src/addons/script/vars.c
+++ b/src/addons/script/vars.c
@@ -252,7 +252,8 @@ void ecs_script_vars_from_iter(
             } else {
                 ecs_table_range_t *range = &query_var->range;
                 if (range->count == 1) {
-                    ecs_entity_t *entities = range->table->data.entities.array;
+                    ecs_entity_t *entities = 
+                        ecs_table_entities(range->table);
                     e_ptr = &entities[range->offset];
                 }
             }

--- a/src/addons/script/vars.c
+++ b/src/addons/script/vars.c
@@ -207,7 +207,9 @@ void ecs_script_vars_from_iter(
             var = ecs_script_vars_declare(vars, "this");
             var->value.type = ecs_id(ecs_entity_t);
         }
-        var->value.ptr = &it->entities[offset];
+
+        /* Safe, variable value will never be written */
+        var->value.ptr = ECS_CONST_CAST(ecs_entity_t*, &it->entities[offset]);
     }
 
     /* Set variables for fields */
@@ -245,14 +247,14 @@ void ecs_script_vars_from_iter(
     {
         int32_t i, var_count = it->variable_count;
         for (i = 1 /* skip this variable */ ; i < var_count; i ++) {
-            ecs_entity_t *e_ptr = NULL;
+            const ecs_entity_t *e_ptr = NULL;
             ecs_var_t *query_var = &it->variables[i];
             if (query_var->entity) {
                 e_ptr = &query_var->entity;
             } else {
                 ecs_table_range_t *range = &query_var->range;
                 if (range->count == 1) {
-                    ecs_entity_t *entities = 
+                    const ecs_entity_t *entities = 
                         ecs_table_entities(range->table);
                     e_ptr = &entities[range->offset];
                 }
@@ -270,7 +272,9 @@ void ecs_script_vars_from_iter(
                 ecs_check(var->value.type == ecs_id(ecs_entity_t), 
                     ECS_INVALID_PARAMETER, NULL);
             }
-            var->value.ptr = e_ptr;
+
+            /* Safe, variable value will never be written */
+            var->value.ptr = ECS_CONST_CAST(ecs_entity_t*, e_ptr);
         }
     }
 

--- a/src/each.c
+++ b/src/each.c
@@ -56,7 +56,7 @@ bool ecs_each_next(
         ecs_table_t *table = next->hdr.table;
         it->table = table;
         it->count = ecs_table_count(table);
-        it->entities = flecs_table_entities_array(table);
+        it->entities = ecs_table_entities(table);
         it->ids = &table->type.array[next->index];
         it->trs = &each_iter->trs;
         it->sources = &each_iter->sources;

--- a/src/entity.c
+++ b/src/entity.c
@@ -44,7 +44,7 @@ flecs_component_ptr_t flecs_table_get_component(
     ecs_column_t *column = &table->data.columns[column_index];
     return (flecs_component_ptr_t){
         .ti = column->ti,
-        .ptr = ecs_vec_get(&column->data, column->size, row)
+        .ptr = ecs_vec_get(&column->data, column->ti->size, row)
     };
 error:
     return (flecs_component_ptr_t){0};
@@ -999,7 +999,7 @@ const ecs_entity_t* flecs_bulk_new(
             int32_t index = tr->column;
             ecs_column_t *column = &table->data.columns[index];
             ecs_type_info_t *ti = column->ti;
-            int32_t size = column->size;
+            int32_t size = ti->size;
             ecs_assert(size != 0, ECS_INTERNAL_ERROR, NULL);
             void *ptr = ecs_vec_get(&column->data, size, row);
 
@@ -1016,8 +1016,9 @@ const ecs_entity_t* flecs_bulk_new(
 
         int32_t j, storage_count = table->column_count;
         for (j = 0; j < storage_count; j ++) {
+            ecs_id_t id = flecs_column_id(table, j);
             ecs_type_t set_type = {
-                .array = &table->data.columns[j].id,
+                .array = &id,
                 .count = 1
             };
 
@@ -2851,8 +2852,9 @@ ecs_entity_t ecs_clone(
             row, src_table, ECS_RECORD_TO_ROW(src_r->row), true);
         int32_t i, count = dst_table->column_count;
         for (i = 0; i < count; i ++) {
+            ecs_id_t id = flecs_column_id(dst_table, i);
             ecs_type_t type = {
-                .array = &dst_table->data.columns[i].id,
+                .array = &id,
                 .count = 1
             };
             flecs_notify_on_set(world, dst_table, row, 1, &type, true);

--- a/src/entity.c
+++ b/src/entity.c
@@ -390,7 +390,7 @@ void flecs_instantiate_children(
     }
 
     /* Instantiate the prefab child table for each new instance */
-    ecs_entity_t *instances = ecs_table_entities(table);
+    const ecs_entity_t *instances = ecs_table_entities(table);
     int32_t child_count = ecs_table_count(child_table);
 
     for (i = row; i < count + row; i ++) {
@@ -410,7 +410,7 @@ void flecs_instantiate_children(
         /* The instance is trying to instantiate from a base that is also
          * its parent. This would cause the hierarchy to instantiate itself
          * which would cause infinite recursion. */
-        ecs_entity_t *children = ecs_table_entities(child_table);
+        const ecs_entity_t *children = ecs_table_entities(child_table);
 
 #ifdef FLECS_DEBUG
         for (j = 0; j < child_count; j ++) {
@@ -491,7 +491,7 @@ void flecs_sparse_on_add(
             const ecs_type_info_t *ti = idr->type_info;
             ecs_xtor_t ctor = ti->hooks.ctor;
             ecs_iter_action_t on_add = ti->hooks.on_add;
-            ecs_entity_t *entities = ecs_table_entities(table);
+            const ecs_entity_t *entities = ecs_table_entities(table);
             for (j = 0; j < count; j ++) {
                 ecs_entity_t e = entities[row + j];
                 void *ptr = flecs_sparse_ensure(idr->sparse, 0, e);
@@ -529,7 +529,7 @@ void flecs_sparse_on_remove(
                 flecs_id_record_get_table(idr, table);
             ecs_xtor_t dtor = ti->hooks.dtor;
             ecs_iter_action_t on_remove = ti->hooks.on_remove;
-            ecs_entity_t *entities = ecs_table_entities(table);
+            const ecs_entity_t *entities = ecs_table_entities(table);
             for (j = 0; j < count; j ++) {
                 ecs_entity_t e = entities[row + j];
                 if (on_remove) {
@@ -561,7 +561,7 @@ void flecs_union_on_add(
             ecs_id_t wc = ecs_pair(ECS_PAIR_FIRST(id), EcsUnion);
             ecs_id_record_t *idr = flecs_id_record_get(world, wc);
             if (idr && idr->flags & EcsIdIsUnion) {
-                ecs_entity_t *entities = ecs_table_entities(table);
+                const ecs_entity_t *entities = ecs_table_entities(table);
                 for (j = 0; j < count; j ++) {
                     ecs_entity_t e = entities[row + j];
                     flecs_switch_set(
@@ -587,7 +587,7 @@ void flecs_union_on_remove(
             ecs_id_t wc = ecs_pair(ECS_PAIR_FIRST(id), EcsUnion);
             ecs_id_record_t *idr = flecs_id_record_get(world, wc);
             if (idr && idr->flags & EcsIdIsUnion) {
-                ecs_entity_t *entities = ecs_table_entities(table);
+                const ecs_entity_t *entities = ecs_table_entities(table);
                 for (j = 0; j < count; j ++) {
                     ecs_entity_t e = entities[row + j];
                     flecs_switch_reset(idr->sparse, (uint32_t)e);
@@ -706,7 +706,7 @@ void flecs_update_name_index(
     ecs_assert(names != NULL, ECS_INTERNAL_ERROR, NULL);
 
     int32_t i;
-    ecs_entity_t *entities = &ecs_table_entities(dst)[offset];
+    const ecs_entity_t *entities = &ecs_table_entities(dst)[offset];
     for (i = 0; i < count; i ++) {
         ecs_entity_t e = entities[i];
         EcsIdentifier *name = &names[i];
@@ -1153,7 +1153,7 @@ void flecs_invoke_hook(
     const ecs_table_record_t *tr,
     int32_t count,
     int32_t row,
-    ecs_entity_t *entities,
+    const ecs_entity_t *entities,
     ecs_id_t id,
     const ecs_type_info_t *ti,
     ecs_entity_t event,
@@ -1197,7 +1197,7 @@ void flecs_notify_on_set(
     bool owned)
 {
     ecs_assert(ids != NULL, ECS_INTERNAL_ERROR, NULL);
-    ecs_entity_t *entities = &ecs_table_entities(table)[row];
+    const ecs_entity_t *entities = &ecs_table_entities(table)[row];
     ecs_assert(entities != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_assert((row + count) <= ecs_table_count(table), 
         ECS_INTERNAL_ERROR, NULL);
@@ -2238,7 +2238,7 @@ void flecs_targets_mark_for_delete(
     ecs_table_t *table)
 {
     ecs_id_record_t *idr;
-    ecs_entity_t *entities = ecs_table_entities(table);
+    const ecs_entity_t *entities = ecs_table_entities(table);
     int32_t i, count = ecs_table_count(table);
     for (i = 0; i < count; i ++) {
         ecs_record_t *r = flecs_entities_get(world, entities[i]);
@@ -4031,7 +4031,7 @@ void ecs_set_version(
     ecs_record_t *r = flecs_entities_get(world, entity_with_generation);
     if (r && r->table) {
         int32_t row = ECS_RECORD_TO_ROW(r->row);
-        ecs_entity_t *entities = ecs_table_entities(r->table);
+        ecs_entity_t *entities = r->table->data.entities;
         entities[row] = entity_with_generation;
     }
 }

--- a/src/iter.c
+++ b/src/iter.c
@@ -146,8 +146,12 @@ void* ecs_field_w_size(
         (it->query && (it->query->flags & EcsQueryMatchEmptyTables)),
             ECS_INTERNAL_ERROR, NULL);
 
+    if (!size) {
+        size = column->ti->size;
+    }
+
     void *data = ecs_vec_first(&column->data);
-    return ECS_ELEM(data, column->size, row);
+    return ECS_ELEM(data, (ecs_size_t)size, row);
 error:
     return NULL;
 }

--- a/src/observable.c
+++ b/src/observable.c
@@ -298,7 +298,7 @@ void flecs_emit_propagate_id(
             continue;
         }
 
-        ecs_entity_t *entities = ecs_table_entities(table);
+        const ecs_entity_t *entities = ecs_table_entities(table);
         for (e = 0; e < entity_count; e ++) {
             ecs_record_t *r = flecs_entities_get(world, entities[e]);
             ecs_assert(r != NULL, ECS_INTERNAL_ERROR, NULL);
@@ -392,7 +392,7 @@ void flecs_emit_propagate_invalidate_tables(
             }
 
             int32_t e, entity_count = ecs_table_count(table);
-            ecs_entity_t *entities = ecs_table_entities(table);
+            const ecs_entity_t *entities = ecs_table_entities(table);
 
             for (e = 0; e < entity_count; e ++) {
                 ecs_record_t *r = flecs_entities_get(world, entities[e]);
@@ -413,7 +413,7 @@ void flecs_emit_propagate_invalidate(
     int32_t offset,
     int32_t count)
 {
-    ecs_entity_t *entities = &ecs_table_entities(table)[offset];
+    const ecs_entity_t *entities = &ecs_table_entities(table)[offset];
     int32_t i;
     for (i = 0; i < count; i ++) {
         ecs_record_t *record = flecs_entities_get(world, entities[i]);
@@ -436,7 +436,7 @@ void flecs_propagate_entities(
     ecs_world_t *world,
     ecs_iter_t *it,
     ecs_id_record_t *idr,
-    ecs_entity_t *entities,
+    const ecs_entity_t *entities,
     int32_t count,
     ecs_entity_t src,
     ecs_event_id_record_t **iders,
@@ -449,7 +449,7 @@ void flecs_propagate_entities(
     ecs_entity_t old_src = it->sources[0];
     ecs_table_t *old_table = it->table;
     ecs_table_t *old_other_table = it->other_table;
-    ecs_entity_t *old_entities = it->entities;
+    const ecs_entity_t *old_entities = it->entities;
     int32_t old_count = it->count;
     int32_t old_offset = it->offset;
 
@@ -510,7 +510,7 @@ void flecs_override_copy(
 
     ecs_iter_action_t on_set = ti->hooks.on_set;
     if (on_set) {
-        ecs_entity_t *entities = &ecs_table_entities(table)[offset];
+        const ecs_entity_t *entities = &ecs_table_entities(table)[offset];
         flecs_invoke_hook(world, table, tr, count, offset, entities,
             ti->component, ti, EcsOnSet, on_set);
     }
@@ -1041,7 +1041,7 @@ void flecs_emit_forward(
     /* Propagate events for new reachable ids downwards */
     if (table->_->traversable_count) {
         int32_t i;
-        ecs_entity_t *entities = ecs_table_entities(table);
+        const ecs_entity_t *entities = ecs_table_entities(table);
         entities = ECS_ELEM_T(entities, ecs_entity_t, it->offset);
         for (i = 0; i < it->count; i ++) {
             ecs_record_t *r = flecs_entities_get(world, entities[i]);

--- a/src/observer.c
+++ b/src/observer.c
@@ -321,7 +321,7 @@ void flecs_observer_invoke(
             observer_src = 0;
         }
 
-        ecs_entity_t *entities = it->entities;
+        const ecs_entity_t *entities = it->entities;
         int32_t i, count = it->count;
         ecs_entity_t src = it->sources[0];
         it->count = 1;

--- a/src/private_api.h
+++ b/src/private_api.h
@@ -109,7 +109,7 @@ void flecs_invoke_hook(
     const ecs_table_record_t *tr,
     int32_t count,
     int32_t row,
-    ecs_entity_t *entities,
+    const ecs_entity_t *entities,
     ecs_id_t id,
     const ecs_type_info_t *ti,
     ecs_entity_t event,

--- a/src/query/engine/cache_order_by.c
+++ b/src/query/engine/cache_order_by.c
@@ -25,7 +25,7 @@ void flecs_query_cache_sort_table(
         return;
     }
 
-    ecs_entity_t *entities = ecs_table_entities(table);
+    ecs_entity_t *entities = table->data.entities;
 
     void *ptr = NULL;
     int32_t size = 0;
@@ -149,7 +149,7 @@ void flecs_query_cache_build_sorted_table_range(
         }
 
         helper[to_sort].match = cur;
-        helper[to_sort].entities = ecs_table_entities(table);
+        helper[to_sort].entities = table->data.entities;
         helper[to_sort].row = 0;
         helper[to_sort].count = ecs_table_count(table);
         to_sort ++;      

--- a/src/query/engine/eval.c
+++ b/src/query/engine/eval.c
@@ -362,7 +362,7 @@ bool flecs_query_up_select(
             } else {
                 int32_t row;
                 ecs_entity_t entity = 0;
-                ecs_entity_t *entities = flecs_table_entities_array(table);
+                ecs_entity_t *entities = ecs_table_entities(table);
 
                 for (row = op_ctx->row; row < op_ctx->end; row ++) {
                     entity = entities[row];
@@ -1024,7 +1024,7 @@ bool flecs_query_each(
         if (end) {
             end += range.offset;
         } else {
-            end = table->data.entities.count;
+            end = ecs_table_count(table);
         }
         row = ++ op_ctx->row;
         if (op_ctx->row >= end) {
@@ -1033,7 +1033,7 @@ bool flecs_query_each(
     }
 
     ecs_assert(row < ecs_table_count(table), ECS_INTERNAL_ERROR, NULL);
-    ecs_entity_t *entities = table->data.entities.array;
+    ecs_entity_t *entities = ecs_table_entities(table);
     flecs_query_var_set_entity(op, op->src.var, entities[row], ctx);
 
     return true;

--- a/src/query/engine/eval.c
+++ b/src/query/engine/eval.c
@@ -362,7 +362,7 @@ bool flecs_query_up_select(
             } else {
                 int32_t row;
                 ecs_entity_t entity = 0;
-                ecs_entity_t *entities = ecs_table_entities(table);
+                const ecs_entity_t *entities = ecs_table_entities(table);
 
                 for (row = op_ctx->row; row < op_ctx->end; row ++) {
                     entity = entities[row];
@@ -1033,7 +1033,7 @@ bool flecs_query_each(
     }
 
     ecs_assert(row < ecs_table_count(table), ECS_INTERNAL_ERROR, NULL);
-    ecs_entity_t *entities = ecs_table_entities(table);
+    const ecs_entity_t *entities = ecs_table_entities(table);
     flecs_query_var_set_entity(op, op->src.var, entities[row], ctx);
 
     return true;

--- a/src/query/engine/eval_iter.c
+++ b/src/query/engine/eval_iter.c
@@ -193,7 +193,7 @@ bool ecs_query_next(
 trivial_search_yield:
     it->table = ctx.vars[0].range.table;
     it->count = ecs_table_count(it->table);
-    it->entities = flecs_table_entities_array(it->table);
+    it->entities = ecs_table_entities(it->table);
 
 yield:
     return true;

--- a/src/query/engine/eval_member.c
+++ b/src/query/engine/eval_member.c
@@ -64,7 +64,7 @@ bool flecs_query_member_cmp(
 
     int32_t offset = (int32_t)op->first.entity;
     int32_t size = (int32_t)(op->first.entity >> 32);
-    ecs_entity_t *entities = table->data.entities.array;
+    ecs_entity_t *entities = ecs_table_entities(table);
     ecs_entity_t e = 0;
     ecs_entity_t *val;
 

--- a/src/query/engine/eval_member.c
+++ b/src/query/engine/eval_member.c
@@ -64,7 +64,7 @@ bool flecs_query_member_cmp(
 
     int32_t offset = (int32_t)op->first.entity;
     int32_t size = (int32_t)(op->first.entity >> 32);
-    ecs_entity_t *entities = ecs_table_entities(table);
+    const ecs_entity_t *entities = ecs_table_entities(table);
     ecs_entity_t e = 0;
     ecs_entity_t *val;
 

--- a/src/query/engine/eval_pred.c
+++ b/src/query/engine/eval_pred.c
@@ -58,8 +58,7 @@ bool flecs_query_pred_eq_w_range(
         ecs_var_id_t l = src_var;
         ctx->vars[l].range = r;
         if (r.count == 1) {
-            ctx->vars[l].entity = ecs_vec_get_t(&r.table->data.entities, 
-                ecs_entity_t, r.offset)[0];
+            ctx->vars[l].entity = ecs_table_entities(r.table)[r.offset];
         }
         return true;
     } else {
@@ -231,7 +230,7 @@ bool flecs_query_pred_match(
         l = op_ctx->range;
     }
 
-    const EcsIdentifier *names = l.table->data.columns[op_ctx->name_col].data.array;
+    const EcsIdentifier *names = l.table->data.columns[op_ctx->name_col].data;
     int32_t count = l.offset + l.count, offset = -1;
     for (; op_ctx->index < count; op_ctx->index ++) {
         const char *name = names[op_ctx->index].value;

--- a/src/query/engine/eval_trav.c
+++ b/src/query/engine/eval_trav.c
@@ -15,7 +15,7 @@ bool flecs_query_trav_fixed_src_reflexive(
 {
     ecs_table_t *table = range->table;
     ecs_assert(table != NULL, ECS_INTERNAL_ERROR, NULL);
-    ecs_entity_t *entities = table->data.entities.array;
+    ecs_entity_t *entities = ecs_table_entities(table);
     int32_t count = range->count;
     if (!count) {
         count = ecs_table_count(table);
@@ -203,8 +203,7 @@ bool flecs_query_trav_yield_reflexive_src(
         return false;
     }
 
-    ecs_entity_t entity = ecs_vec_get_t(
-        &range->table->data.entities, ecs_entity_t, trav_ctx->index)[0];
+    ecs_entity_t entity = ecs_table_entities(range->table)[trav_ctx->index];
     flecs_query_set_trav_match(op, NULL, trav, entity, ctx);
 
     /* Hijack existing variable to return one result at a time */

--- a/src/query/engine/eval_trav.c
+++ b/src/query/engine/eval_trav.c
@@ -15,7 +15,7 @@ bool flecs_query_trav_fixed_src_reflexive(
 {
     ecs_table_t *table = range->table;
     ecs_assert(table != NULL, ECS_INTERNAL_ERROR, NULL);
-    ecs_entity_t *entities = ecs_table_entities(table);
+    const ecs_entity_t *entities = ecs_table_entities(table);
     int32_t count = range->count;
     if (!count) {
         count = ecs_table_count(table);

--- a/src/query/engine/eval_union.c
+++ b/src/query/engine/eval_union.c
@@ -64,7 +64,7 @@ next_row:
         return false;
     }
 
-    ecs_entity_t e = flecs_table_entities_array(range.table)
+    ecs_entity_t e = ecs_table_entities(range.table)
         [range.offset + op_ctx->row];
     ecs_entity_t tgt = flecs_switch_get(op_ctx->idr->sparse, (uint32_t)e);
     if (!tgt) {
@@ -128,7 +128,7 @@ next_row:
         return false;
     }
 
-    ecs_entity_t e = flecs_table_entities_array(range.table)
+    ecs_entity_t e = ecs_table_entities(range.table)
         [range.offset + op_ctx->row];
     ecs_entity_t e_tgt = flecs_switch_get(op_ctx->idr->sparse, (uint32_t)e);
     bool match = e_tgt == tgt;

--- a/src/query/engine/eval_utils.c
+++ b/src/query/engine/eval_utils.c
@@ -154,7 +154,7 @@ ecs_entity_t flecs_query_var_get_entity(
 
     ecs_assert(var->range.count == 1, ECS_INTERNAL_ERROR, NULL);
     ecs_table_t *table = var->range.table;
-    ecs_entity_t *entities = ecs_table_entities(table);
+    const ecs_entity_t *entities = ecs_table_entities(table);
     var->entity = entities[var->range.offset];
     return var->entity;
 }

--- a/src/query/engine/eval_utils.c
+++ b/src/query/engine/eval_utils.c
@@ -20,8 +20,7 @@ void flecs_query_set_iter_this(
         it->table = table;
         it->offset = range->offset;
         it->count = count;
-        it->entities = ECS_ELEM_T(
-            table->data.entities.array, ecs_entity_t, it->offset);
+        it->entities = &ecs_table_entities(table)[it->offset];
     } else if (count == 1) {
         it->count = 1;
         it->entities = &ctx->vars[0].entity;
@@ -155,7 +154,7 @@ ecs_entity_t flecs_query_var_get_entity(
 
     ecs_assert(var->range.count == 1, ECS_INTERNAL_ERROR, NULL);
     ecs_table_t *table = var->range.table;
-    ecs_entity_t *entities = table->data.entities.array;
+    ecs_entity_t *entities = ecs_table_entities(table);
     var->entity = entities[var->range.offset];
     return var->entity;
 }
@@ -209,7 +208,7 @@ void flecs_query_var_narrow_range(
     ecs_assert(var_id < ctx->query->var_count, ECS_INTERNAL_ERROR, NULL);
     if (ctx->query_vars[var_id].kind != EcsVarTable) {    
         ecs_assert(count == 1, ECS_INTERNAL_ERROR, NULL);
-        var->entity = flecs_table_entities_array(table)[offset];
+        var->entity = ecs_table_entities(table)[offset];
     }
 }
 

--- a/src/query/engine/trav_cache.c
+++ b/src/query/engine/trav_cache.c
@@ -35,7 +35,7 @@ void flecs_query_build_down_cache(
             }
 
             int32_t i, count = ecs_table_count(table);
-            ecs_entity_t *entities = table->data.entities.array;
+            ecs_entity_t *entities = ecs_table_entities(table);
             for (i = 0; i < count; i ++) {
                 ecs_record_t *r = flecs_entities_get(world, entities[i]);
                 if (r->row & EcsEntityIsTraversable) {

--- a/src/query/engine/trav_cache.c
+++ b/src/query/engine/trav_cache.c
@@ -35,7 +35,7 @@ void flecs_query_build_down_cache(
             }
 
             int32_t i, count = ecs_table_count(table);
-            ecs_entity_t *entities = ecs_table_entities(table);
+            const ecs_entity_t *entities = ecs_table_entities(table);
             for (i = 0; i < count; i ++) {
                 ecs_record_t *r = flecs_entities_get(world, entities[i]);
                 if (r->row & EcsEntityIsTraversable) {

--- a/src/query/engine/trav_down_cache.c
+++ b/src/query/engine/trav_down_cache.c
@@ -66,7 +66,7 @@ ecs_trav_down_t* flecs_trav_table_down(
 
     ecs_assert(idr_with != NULL, ECS_INTERNAL_ERROR, NULL);
 
-    ecs_entity_t *entities = ecs_vec_first(&table->data.entities);
+    ecs_entity_t *entities = ecs_table_entities(table);
     int32_t i, count = ecs_table_count(table);
     for (i = 0; i < count; i ++) {
         ecs_entity_t entity = entities[i];
@@ -122,7 +122,7 @@ void flecs_trav_entity_down_isa(
                 continue;
             }
 
-            ecs_entity_t *entities = ecs_vec_first(&table->data.entities);
+            ecs_entity_t *entities = ecs_table_entities(table);
             int32_t i, count = ecs_table_count(table);
             for (i = 0; i < count; i ++) {
                 ecs_entity_t e = entities[i];

--- a/src/query/engine/trav_down_cache.c
+++ b/src/query/engine/trav_down_cache.c
@@ -66,7 +66,7 @@ ecs_trav_down_t* flecs_trav_table_down(
 
     ecs_assert(idr_with != NULL, ECS_INTERNAL_ERROR, NULL);
 
-    ecs_entity_t *entities = ecs_table_entities(table);
+    const ecs_entity_t *entities = ecs_table_entities(table);
     int32_t i, count = ecs_table_count(table);
     for (i = 0; i < count; i ++) {
         ecs_entity_t entity = entities[i];
@@ -122,7 +122,7 @@ void flecs_trav_entity_down_isa(
                 continue;
             }
 
-            ecs_entity_t *entities = ecs_table_entities(table);
+            const ecs_entity_t *entities = ecs_table_entities(table);
             int32_t i, count = ecs_table_count(table);
             for (i = 0; i < count; i ++) {
                 ecs_entity_t e = entities[i];

--- a/src/query/engine/trivial_iter.c
+++ b/src/query/engine/trivial_iter.c
@@ -161,7 +161,7 @@ next:
 
         it->table = table;
         it->count = ecs_table_count(table);
-        it->entities = flecs_table_entities_array(table);
+        it->entities = ecs_table_entities(table);
         it->trs[0] = tr;
     }
 
@@ -205,7 +205,7 @@ bool flecs_query_trivial_test(
             it->trs[term->field_index] = tr;
         }
 
-        it->entities = flecs_table_entities_array(table);
+        it->entities = ecs_table_entities(table);
         if (it->entities) {
             it->entities = &it->entities[it->offset];
         }

--- a/src/stage.c
+++ b/src/stage.c
@@ -372,8 +372,8 @@ void* flecs_defer_set(
             if (tr) {
                 if (tr->column != -1) {
                     /* Entity has the component */
-                    ecs_vec_t *column = &table->data.columns[tr->column].data;
-                    existing = ecs_vec_get(column, size, 
+                    existing = table->data.columns[tr->column].data;
+                    existing = ECS_ELEM(existing, size, 
                         ECS_RECORD_TO_ROW(r->row));
                 } else {
                     ecs_assert(idr->flags & EcsIdIsSparse, 

--- a/src/storage/table.c
+++ b/src/storage/table.c
@@ -650,7 +650,7 @@ void flecs_table_invoke_hook(
     ecs_iter_action_t callback,
     ecs_entity_t event,
     ecs_column_t *column,
-    ecs_entity_t *entities,
+    const ecs_entity_t *entities,
     int32_t row,
     int32_t count)
 {
@@ -764,7 +764,7 @@ void flecs_table_dtor_all(
     int32_t count,
     bool is_delete)
 {
-    ecs_entity_t *entities = ecs_table_entities(table);
+    const ecs_entity_t *entities = ecs_table_entities(table);
     int32_t column_count = table->column_count;
     int32_t i, c, end = row + count;
 
@@ -905,7 +905,7 @@ void flecs_table_fini_data(
     table->flags &= ~EcsTableHasTraversable;
 }
 
-ecs_entity_t* ecs_table_entities(
+const ecs_entity_t* ecs_table_entities(
     const ecs_table_t *table)
 {
     return table->data.entities;
@@ -1472,7 +1472,7 @@ void flecs_table_delete(
     ecs_assert(row <= count, ECS_INTERNAL_ERROR, NULL);
 
     /* Move last entity id to row */
-    ecs_entity_t *entities = ecs_table_entities(table);
+    ecs_entity_t *entities = table->data.entities;
     ecs_entity_t entity_to_move = entities[count];
     ecs_entity_t entity_to_delete = entities[row];
     entities[row] = entity_to_move;
@@ -1818,7 +1818,7 @@ void flecs_table_swap(
     /* If the table is monitored indicate that there has been a change */
     flecs_table_mark_table_dirty(world, table, 0);    
 
-    ecs_entity_t *entities = ecs_table_entities(table);
+    ecs_entity_t *entities = table->data.entities;
     ecs_entity_t e1 = entities[row_1];
     ecs_entity_t e2 = entities[row_2];
 
@@ -2080,7 +2080,7 @@ void flecs_table_merge(
     flecs_table_check_sanity(world, src_table);
     flecs_table_check_sanity(world, dst_table);
 
-    ecs_entity_t *src_entities = ecs_table_entities(src_table);
+    const ecs_entity_t *src_entities = ecs_table_entities(src_table);
     int32_t src_count = ecs_table_count(src_table);
     int32_t dst_count = ecs_table_count(dst_table);
 

--- a/src/storage/table.h
+++ b/src/storage/table.h
@@ -8,6 +8,50 @@
 
 #include "table_graph.h"
 
+#ifdef FLECS_SANITIZE
+#define ecs_vec_from_column(arg_column, table, arg_elem_size) {\
+    .array = (arg_column)->data,\
+    .count = table->data.count,\
+    .size = table->data.size,\
+    .elem_size = arg_elem_size\
+}
+
+#define ecs_vec_from_column_ext(arg_column, arg_count, arg_size, arg_elem_size) {\
+    .array = (arg_column)->data,\
+    .count = arg_count,\
+    .size = arg_size,\
+    .elem_size = arg_elem_size\
+}
+
+#define ecs_vec_from_entities(table) {\
+    .array = table->data.entities,\
+    .count = table->data.count,\
+    .size = table->data.size,\
+    .elem_size = ECS_SIZEOF(ecs_entity_t)\
+}
+#else
+#define ecs_vec_from_column(arg_column, table, arg_elem_size) {\
+    .array = (arg_column)->data,\
+    .count = table->data.count,\
+    .size = table->data.size,\
+}
+
+#define ecs_vec_from_column_ext(arg_column, arg_count, arg_size, arg_elem_size) {\
+    .array = (arg_column)->data,\
+    .count = arg_count,\
+    .size = arg_size,\
+}
+
+#define ecs_vec_from_entities(table) {\
+    .array = table->data.entities,\
+    .count = table->data.count,\
+    .size = table->data.size,\
+}
+#endif
+
+#define ecs_vec_from_column_t(arg_column, table, T)\
+    ecs_vec_from_column(arg_column, table, ECS_SIZEOF(T))
+
 /* Table event type for notifying tables of world events */
 typedef enum ecs_table_eventkind_t {
     EcsTableTriggersForId,
@@ -47,14 +91,16 @@ typedef struct ecs_table__t {
 
 /** Table column */
 typedef struct ecs_column_t {
-    ecs_vec_t data;                  /* Vector with component data */
+    void *data;                      /* Array with component data */
     ecs_type_info_t *ti;             /* Component type info */
 } ecs_column_t;
 
 /** Table data */
 struct ecs_data_t {
-    ecs_vec_t entities;              /* Entity ids */
+    ecs_entity_t *entities;          /* Entity ids */
     ecs_column_t *columns;           /* Component data */
+    int32_t count;
+    int32_t size;
 };
 
 /** A table is the Flecs equivalent of an archetype. Tables store all entities
@@ -120,10 +166,6 @@ void flecs_table_clear_entities_silent(
     ecs_world_t *world,
     ecs_table_t *table);
 
-/* Return number of entities in data */
-int32_t flecs_table_data_count(
-    const ecs_data_t *data);
-
 /* Add a new entry to the table for the specified entity */
 int32_t flecs_table_append(
     ecs_world_t *world,
@@ -159,16 +201,8 @@ void flecs_table_move(
 int32_t flecs_table_appendn(
     ecs_world_t *world,
     ecs_table_t *table,
-    ecs_data_t *data,
     int32_t count,
     const ecs_entity_t *ids);
-
-/* Set table to a fixed size. Useful for preallocating memory in advance. */
-void flecs_table_set_size(
-    ecs_world_t *world,
-    ecs_table_t *table,
-    ecs_data_t *data,
-    int32_t count);
 
 /* Shrink table to contents */
 bool flecs_table_shrink(
@@ -229,12 +263,6 @@ void flecs_table_delete_entities(
 void flecs_table_traversable_add(
     ecs_table_t *table,
     int32_t value);
-
-const ecs_vec_t* flecs_table_entities(
-    const ecs_table_t *table);
-
-ecs_entity_t* flecs_table_entities_array(
-    const ecs_table_t *table);
 
 void flecs_table_emit(
     ecs_world_t *world,

--- a/src/storage/table.h
+++ b/src/storage/table.h
@@ -48,9 +48,7 @@ typedef struct ecs_table__t {
 /** Table column */
 typedef struct ecs_column_t {
     ecs_vec_t data;                  /* Vector with component data */
-    ecs_id_t id;                     /* Component id */
     ecs_type_info_t *ti;             /* Component type info */
-    ecs_size_t size;                 /* Component size */
 } ecs_column_t;
 
 /** Table data */
@@ -250,5 +248,9 @@ int32_t flecs_table_get_toggle_column(
 ecs_bitset_t* flecs_table_get_toggle(
     ecs_table_t *table,
     ecs_id_t id);
+
+ecs_id_t flecs_column_id(
+    ecs_table_t *table,
+    int32_t column_index);
 
 #endif

--- a/src/world.c
+++ b/src/world.c
@@ -638,7 +638,7 @@ void flecs_fini_root_tables(
         }
 
         int32_t i, count = ecs_table_count(table);
-        ecs_entity_t *entities = ecs_table_entities(table);
+        const ecs_entity_t *entities = ecs_table_entities(table);
 
         if (fini_targets) {
             /* Only delete entities that are used as pair target. Iterate
@@ -1963,7 +1963,7 @@ void flecs_process_empty_queries(
 
             for (i = 0; i < count; i ++) {
                 ecs_query_t *query = queries[i].poly;
-                ecs_entity_t *entities = ecs_table_entities(table);
+                const ecs_entity_t *entities = ecs_table_entities(table);
                 if (!ecs_query_is_true(query)) {
                     ecs_add_id(world, entities[i], EcsEmpty);
                 }

--- a/src/world.c
+++ b/src/world.c
@@ -637,8 +637,8 @@ void flecs_fini_root_tables(
             continue; /* Query out modules */
         }
 
-        int32_t i, count = table->data.entities.count;
-        ecs_entity_t *entities = table->data.entities.array;
+        int32_t i, count = ecs_table_count(table);
+        ecs_entity_t *entities = ecs_table_entities(table);
 
         if (fini_targets) {
             /* Only delete entities that are used as pair target. Iterate
@@ -646,6 +646,7 @@ void flecs_fini_root_tables(
             for (i = count - 1; i >= 0; i --) {
                 ecs_record_t *r = flecs_entities_get(world, entities[i]);
                 ecs_assert(r != NULL, ECS_INTERNAL_ERROR, NULL);
+                ecs_assert(r->table == table, ECS_INTERNAL_ERROR, NULL);
                 if (ECS_RECORD_TO_ROW_FLAGS(r->row) & EcsEntityIsTarget) {
                     ecs_delete(world, entities[i]);
                 }
@@ -657,6 +658,7 @@ void flecs_fini_root_tables(
             for (i = count - 1; i >= 0; i --) {
                 ecs_record_t *r = flecs_entities_get(world, entities[i]);
                 ecs_assert(r != NULL, ECS_INTERNAL_ERROR, NULL);
+                ecs_assert(r->table == table, ECS_INTERNAL_ERROR, NULL);
                 if (!ECS_RECORD_TO_ROW_FLAGS(r->row)) {
                     ecs_delete(world, entities[i]);
                 }
@@ -1961,7 +1963,7 @@ void flecs_process_empty_queries(
 
             for (i = 0; i < count; i ++) {
                 ecs_query_t *query = queries[i].poly;
-                ecs_entity_t *entities = table->data.entities.array;
+                ecs_entity_t *entities = ecs_table_entities(table);
                 if (!ecs_query_is_true(query)) {
                     ecs_add_id(world, entities[i], EcsEmpty);
                 }

--- a/test/core/project.json
+++ b/test/core/project.json
@@ -891,7 +891,13 @@
                 "add_on_delete_from_prefab",
                 "add_on_delete_from_disabled",
                 "delete_on_delete_from_prefab",
-                "delete_on_delete_from_disabled"
+                "delete_on_delete_from_disabled",
+                "remove_all_1",
+                "remove_all_2",
+                "remove_all_3",
+                "delete_with_1",
+                "delete_with_2",
+                "delete_with_3"
             ]
         }, {
             "id": "Set",

--- a/test/core/src/OnDelete.c
+++ b/test/core/src/OnDelete.c
@@ -3196,3 +3196,141 @@ void OnDelete_delete_on_delete_from_disabled(void) {
 
     ecs_fini(world);
 }
+
+void OnDelete_remove_all_1(void) {
+    ecs_world_t *world = ecs_init();
+
+    ECS_COMPONENT(world, Position);
+
+    ecs_entity_t e1 = ecs_entity(world, { .name = "e1" });
+    ecs_set(world, e1, Position, {10, 20});
+
+    ecs_remove_all(world, ecs_id(Position));
+
+    test_assert(ecs_is_alive(world, e1));
+
+    test_assert(!ecs_has(world, e1, Position));
+
+    test_assert(ecs_lookup(world, "e1") == e1);
+
+    test_int(0, ecs_count(world, Position));
+
+    ecs_fini(world);
+}
+
+void OnDelete_remove_all_2(void) {
+    ecs_world_t *world = ecs_init();
+
+    ECS_COMPONENT(world, Position);
+
+    ecs_entity_t e1 = ecs_entity(world, { .name = "e1" });
+    ecs_entity_t e2 = ecs_entity(world, { .name = "e2" });
+    ecs_set(world, e1, Position, {10, 20});
+    ecs_set(world, e2, Position, {30, 40});
+
+    ecs_remove_all(world, ecs_id(Position));
+
+    test_assert(ecs_is_alive(world, e1));
+    test_assert(ecs_is_alive(world, e2));
+
+    test_assert(!ecs_has(world, e1, Position));
+    test_assert(!ecs_has(world, e2, Position));
+
+    test_assert(ecs_lookup(world, "e1") == e1);
+    test_assert(ecs_lookup(world, "e2") == e2);
+
+    test_int(0, ecs_count(world, Position));
+
+    ecs_fini(world);
+}
+
+void OnDelete_remove_all_3(void) {
+    ecs_world_t *world = ecs_init();
+
+    ECS_COMPONENT(world, Position);
+
+    ecs_entity_t e1 = ecs_entity(world, { .name = "e1" });
+    ecs_entity_t e2 = ecs_entity(world, { .name = "e2" });
+    ecs_entity_t e3 = ecs_entity(world, { .name = "e3" });
+    ecs_set(world, e1, Position, {10, 20});
+    ecs_set(world, e2, Position, {30, 40});
+    ecs_set(world, e3, Position, {50, 60});
+
+    ecs_remove_all(world, ecs_id(Position));
+
+    test_assert(ecs_is_alive(world, e1));
+    test_assert(ecs_is_alive(world, e2));
+    test_assert(ecs_is_alive(world, e3));
+
+    test_assert(!ecs_has(world, e1, Position));
+    test_assert(!ecs_has(world, e2, Position));
+    test_assert(!ecs_has(world, e3, Position));
+
+    test_assert(ecs_lookup(world, "e1") == e1);
+    test_assert(ecs_lookup(world, "e2") == e2);
+    test_assert(ecs_lookup(world, "e3") == e3);
+
+    test_int(0, ecs_count(world, Position));
+
+    ecs_fini(world);
+}
+
+void OnDelete_delete_with_1(void) {
+    ecs_world_t *world = ecs_init();
+
+    ECS_COMPONENT(world, Position);
+
+    ecs_entity_t e1 = ecs_entity(world, { .name = "e1" });
+    ecs_set(world, e1, Position, {10, 20});
+
+    ecs_delete_with(world, ecs_id(Position));
+
+    test_assert(!ecs_is_alive(world, e1));
+
+    test_int(0, ecs_count(world, Position));
+
+    ecs_fini(world);
+}
+
+void OnDelete_delete_with_2(void) {
+    ecs_world_t *world = ecs_init();
+
+    ECS_COMPONENT(world, Position);
+
+    ecs_entity_t e1 = ecs_entity(world, { .name = "e1" });
+    ecs_entity_t e2 = ecs_entity(world, { .name = "e2" });
+    ecs_set(world, e1, Position, {10, 20});
+    ecs_set(world, e2, Position, {30, 40});
+
+    ecs_delete_with(world, ecs_id(Position));
+
+    test_assert(!ecs_is_alive(world, e1));
+    test_assert(!ecs_is_alive(world, e2));
+
+    test_int(0, ecs_count(world, Position));
+
+    ecs_fini(world);
+}
+
+void OnDelete_delete_with_3(void) {
+    ecs_world_t *world = ecs_init();
+
+    ECS_COMPONENT(world, Position);
+
+    ecs_entity_t e1 = ecs_entity(world, { .name = "e1" });
+    ecs_entity_t e2 = ecs_entity(world, { .name = "e2" });
+    ecs_entity_t e3 = ecs_entity(world, { .name = "e3" });
+    ecs_set(world, e1, Position, {10, 20});
+    ecs_set(world, e2, Position, {30, 40});
+    ecs_set(world, e3, Position, {50, 60});
+
+    ecs_delete_with(world, ecs_id(Position));
+
+    test_assert(!ecs_is_alive(world, e1));
+    test_assert(!ecs_is_alive(world, e2));
+    test_assert(!ecs_is_alive(world, e3));
+
+    test_int(0, ecs_count(world, Position));
+
+    ecs_fini(world);
+}

--- a/test/core/src/main.c
+++ b/test/core/src/main.c
@@ -848,6 +848,12 @@ void OnDelete_add_on_delete_from_prefab(void);
 void OnDelete_add_on_delete_from_disabled(void);
 void OnDelete_delete_on_delete_from_prefab(void);
 void OnDelete_delete_on_delete_from_disabled(void);
+void OnDelete_remove_all_1(void);
+void OnDelete_remove_all_2(void);
+void OnDelete_remove_all_3(void);
+void OnDelete_delete_with_1(void);
+void OnDelete_delete_with_2(void);
+void OnDelete_delete_with_3(void);
 
 // Testsuite 'Set'
 void Set_set_empty(void);
@@ -5368,6 +5374,30 @@ bake_test_case OnDelete_testcases[] = {
     {
         "delete_on_delete_from_disabled",
         OnDelete_delete_on_delete_from_disabled
+    },
+    {
+        "remove_all_1",
+        OnDelete_remove_all_1
+    },
+    {
+        "remove_all_2",
+        OnDelete_remove_all_2
+    },
+    {
+        "remove_all_3",
+        OnDelete_remove_all_3
+    },
+    {
+        "delete_with_1",
+        OnDelete_delete_with_1
+    },
+    {
+        "delete_with_2",
+        OnDelete_delete_with_2
+    },
+    {
+        "delete_with_3",
+        OnDelete_delete_with_3
     }
 };
 
@@ -10452,7 +10482,7 @@ static bake_test_suite suites[] = {
         "OnDelete",
         NULL,
         NULL,
-        118,
+        124,
         OnDelete_testcases
     },
     {


### PR DESCRIPTION
This PR replaces the `ecs_vec_t`'s in the `ecs_table_t::columns` array with `void*` pointers, and stores a single `count` and (allocated) `size` for all columns. The PR also removes the `id` member which contained a copy of the component id for the column, and adds a new `ecs_table_entities` function.