### PR TITLE
Add 2 sparse queries tests showcasing memory bug to fix (singleton sparse + same term)

### DIFF
--- a/test/cpp/project.json
+++ b/test/cpp/project.json
@@ -836,7 +836,9 @@
                 "named_scoped_rule",
                 "is_valid",
                 "unresolved_by_name",
-                "scope"
+                "scope",
+                "sparse_term_and_term_with_ref",
+                "sparse_multiple_term_and_term_with_ref"
             ]
         }, {
             "id": "SystemBuilder",

--- a/test/cpp/src/main.cpp
+++ b/test/cpp/src/main.cpp
@@ -808,6 +808,8 @@ void QueryBuilder_named_scoped_rule(void);
 void QueryBuilder_is_valid(void);
 void QueryBuilder_unresolved_by_name(void);
 void QueryBuilder_scope(void);
+void QueryBuilder_sparse_term_and_term_with_ref(void);
+void QueryBuilder_sparse_multiple_term_and_term_with_ref(void);
 
 // Testsuite 'SystemBuilder'
 void SystemBuilder_builder_assign_same_type(void);
@@ -4473,6 +4475,14 @@ bake_test_case QueryBuilder_testcases[] = {
     {
         "scope",
         QueryBuilder_scope
+    },
+    {
+        "sparse_term_and_term_with_ref",
+        QueryBuilder_sparse_term_and_term_with_ref
+    },
+    {
+        "sparse_multiple_term_and_term_with_ref",
+        QueryBuilder_sparse_multiple_term_and_term_with_ref
     }
 };
 
@@ -6575,7 +6585,7 @@ static bake_test_suite suites[] = {
         "QueryBuilder",
         QueryBuilder_setup,
         NULL,
-        164,
+        166,
         QueryBuilder_testcases,
         1,
         QueryBuilder_params


### PR DESCRIPTION
This PR adds 2 test cases, one simple test case, and one more "overloaded" test case to test for other anomalies. 
The test cases are quarantined so CI passes with the intention for you to un-quarantine them upon resolving the bug.

I ran into this bug when converting the Rust code base to v401. This bug currently blocks me from converting / merging to v401.

in short, this bug matches the entity position as singleton on first attempt.

```
    world.component<Position>().add(flecs::Sparse);
    
    world.set<Position>({100, 200});
    
    auto entity = flecs::entity(world)
        .set<Position>({10, 20});
        
q.each([](Position& p, Position& p2) {
        std::cout << "Position: {" << p.x << ", " << p.y << "}" << std::endl;
        std::cout << "Position singleton: {" << p2.x << ", " << p2.y << "}" << std::endl;
});
```

prints

> Position: {100, 200}
> Position singleton: {100, 200}
> Position: {10, 20}
> Position singleton: {100, 200}