### PR TITLE
fix copy/move-assign operators of World class not freeing existing world

### DIFF
--- a/distr/flecs.h
+++ b/distr/flecs.h
@@ -20468,6 +20468,7 @@ struct world {
     }
 
     world& operator=(const world& obj) noexcept {
+        release();
         this->world_ = obj.world_;
         flecs_poly_claim(this->world_);
         return *this;
@@ -20479,12 +20480,15 @@ struct world {
     }
 
     world& operator=(world&& obj) noexcept {
+        release();
         world_ = obj.world_;
         obj.world_ = nullptr;
         return *this;
     }
 
-    ~world() {
+    /* Releases the underlying world object. If this is the last handle, the world
+       will be finalized. */
+    void release() {
         if (world_) {
             if (!flecs_poly_release(world_)) {
                 if (ecs_stage_get_id(world_) == -1) {
@@ -20497,7 +20501,12 @@ struct world {
                     ecs_fini(world_);
                 }
             }
-        }
+            world_ = nullptr;
+        }        
+    }
+
+    ~world() {
+        release();
     }
 
     /* Implicit conversion to world_t* */

--- a/include/flecs/addons/cpp/world.hpp
+++ b/include/flecs/addons/cpp/world.hpp
@@ -168,6 +168,7 @@ struct world {
     }
 
     world& operator=(const world& obj) noexcept {
+        release();
         this->world_ = obj.world_;
         flecs_poly_claim(this->world_);
         return *this;
@@ -179,12 +180,15 @@ struct world {
     }
 
     world& operator=(world&& obj) noexcept {
+        release();
         world_ = obj.world_;
         obj.world_ = nullptr;
         return *this;
     }
 
-    ~world() {
+    /* Releases the underlying world object. If this is the last handle, the world
+       will be finalized. */
+    void release() {
         if (world_) {
             if (!flecs_poly_release(world_)) {
                 if (ecs_stage_get_id(world_) == -1) {
@@ -197,7 +201,12 @@ struct world {
                     ecs_fini(world_);
                 }
             }
-        }
+            world_ = nullptr;
+        }        
+    }
+
+    ~world() {
+        release();
     }
 
     /* Implicit conversion to world_t* */

--- a/test/cpp/project.json
+++ b/test/cpp/project.json
@@ -1201,7 +1201,8 @@
                 "get_mut_R_T",
                 "world_mini",
                 "copy_world",
-                "fini_reentrancy"
+                "fini_reentrancy",
+                "fini_copy_move_assign"
             ]
         }, {
             "id": "Singleton",

--- a/test/cpp/src/main.cpp
+++ b/test/cpp/src/main.cpp
@@ -1157,6 +1157,7 @@ void World_get_mut_R_T(void);
 void World_world_mini(void);
 void World_copy_world(void);
 void World_fini_reentrancy(void);
+void World_fini_copy_move_assign(void);
 
 // Testsuite 'Singleton'
 void Singleton_set_get_singleton(void);
@@ -5832,6 +5833,10 @@ bake_test_case World_testcases[] = {
     {
         "fini_reentrancy",
         World_fini_reentrancy
+    },
+    {
+        "fini_copy_move_assign",
+        World_fini_copy_move_assign
     }
 };
 
@@ -6648,7 +6653,7 @@ static bake_test_suite suites[] = {
         "World",
         NULL,
         NULL,
-        115,
+        116,
         World_testcases
     },
     {


### PR DESCRIPTION
Fixed bug when overwriting a flecs::World instance with another, either via copy-assign or move-assign. The existing world is not freed, causing a memory leak:

```cpp

flecs::world world1;
flecs::world world2;

world1 = world2;  // leaks, since underlying world_t* in world1 
                  // is not fini'ed before world2's ptr takes over.
                  // same happens if move-assign is used.
```

The PR fixes this issue and adds a test to watch over that.