### PR TITLE
Remove redundant query instructions

### DIFF
--- a/src/query/compiler/compiler_term.c
+++ b/src/query/compiler/compiler_term.c
@@ -1038,11 +1038,9 @@ void flecs_query_mark_last_or_op(
 
 static
 void flecs_query_set_op_kind(
-    ecs_query_t *q,
     ecs_query_op_t *op,
     ecs_term_t *term,
-    bool src_is_var,
-    bool member_term)
+    bool src_is_var)
 {
     /* Default instruction for And operators. If the source is fixed (like for
      * singletons or terms with an entity source), use With, which like And but
@@ -1095,18 +1093,6 @@ void flecs_query_set_op_kind(
             op->kind = EcsQuerySelfUp;
         } else if (term->flags_ & (EcsTermMatchAny|EcsTermMatchAnySrc)) {
             op->kind = EcsQueryAndAny;
-        }
-    }
-
-    /* If term has fixed id, insert simpler instruction that skips dealing with
-     * wildcard terms and variables */
-    if (flecs_term_is_fixed_id(q, term) && !member_term) {
-        if (op->kind == EcsQueryAnd) {
-            op->kind = EcsQueryAndId;
-        } else if (op->kind == EcsQuerySelfUp) {
-            op->kind = EcsQuerySelfUpId;
-        } else if (op->kind == EcsQueryUp) {
-            op->kind = EcsQueryUpId;
         }
     }
 }
@@ -1207,7 +1193,7 @@ int flecs_query_compile_term(
     op.field_index = flecs_ito(int8_t, term->field_index);
     op.term_index = flecs_ito(int8_t, term - q->terms);
 
-    flecs_query_set_op_kind(q, &op, term, src_is_var, member_term);
+    flecs_query_set_op_kind(&op, term, src_is_var);
 
     bool is_not = (term->oper == EcsNot) && !builtin_pred;
 

--- a/src/query/engine/eval.c
+++ b/src/query/engine/eval.c
@@ -237,21 +237,6 @@ bool flecs_query_with_id(
     return true;
 }
 
-static
-bool flecs_query_and_id(
-    const ecs_query_op_t *op,
-    bool redo,
-    const ecs_query_run_ctx_t *ctx)
-{
-    uint64_t written = ctx->written[ctx->op_index];
-    if (written & (1ull << op->src.var)) {
-        return flecs_query_with_id(op, redo, ctx);
-    } else {
-        return flecs_query_select_id(op, redo, ctx, 
-            (EcsTableNotQueryable|EcsTableIsPrefab|EcsTableIsDisabled));
-    }
-}
-
 bool flecs_query_up_select(
     const ecs_query_op_t *op,
     bool redo,
@@ -533,36 +518,6 @@ bool flecs_query_self_up(
     } else {
         return flecs_query_up_select(op, redo, ctx, 
             FlecsQueryUpSelectSelfUp, FlecsQueryUpSelectDefault);
-    }
-}
-
-static
-bool flecs_query_up_id(
-    const ecs_query_op_t *op,
-    bool redo,
-    const ecs_query_run_ctx_t *ctx)
-{
-    uint64_t written = ctx->written[ctx->op_index];
-    if (flecs_ref_is_written(op, &op->src, EcsQuerySrc, written)) {
-        return flecs_query_up_with(op, redo, ctx);
-    } else {
-        return flecs_query_up_select(op, redo, ctx, 
-            FlecsQueryUpSelectUp, FlecsQueryUpSelectId);
-    }
-}
-
-static
-bool flecs_query_self_up_id(
-    const ecs_query_op_t *op,
-    bool redo,
-    const ecs_query_run_ctx_t *ctx)
-{
-    uint64_t written = ctx->written[ctx->op_index];
-    if (flecs_ref_is_written(op, &op->src, EcsQuerySrc, written)) {
-        return flecs_query_self_up_with(op, redo, ctx, true);
-    } else {
-        return flecs_query_up_select(op, redo, ctx, 
-            FlecsQueryUpSelectSelfUp, FlecsQueryUpSelectId);
     }
 }
 
@@ -1642,16 +1597,13 @@ bool flecs_query_dispatch(
 {
     switch(op->kind) {
     case EcsQueryAnd: return flecs_query_and(op, redo, ctx);
-    case EcsQueryAndId: return flecs_query_and_id(op, redo, ctx);
     case EcsQueryAndAny: return flecs_query_and_any(op, redo, ctx);
     case EcsQueryTriv: return flecs_query_triv(op, redo, ctx);
     case EcsQueryCache: return flecs_query_cache(op, redo, ctx);
     case EcsQueryIsCache: return flecs_query_is_cache(op, redo, ctx);
     case EcsQueryOnlyAny: return flecs_query_only_any(op, redo, ctx);
     case EcsQueryUp: return flecs_query_up(op, redo, ctx);
-    case EcsQueryUpId: return flecs_query_up_id(op, redo, ctx);
     case EcsQuerySelfUp: return flecs_query_self_up(op, redo, ctx);
-    case EcsQuerySelfUpId: return flecs_query_self_up_id(op, redo, ctx);
     case EcsQueryWith: return flecs_query_with(op, redo, ctx);
     case EcsQueryTrav: return flecs_query_trav(op, redo, ctx);
     case EcsQueryAndFrom: return flecs_query_and_from(op, redo, ctx);

--- a/src/query/engine/eval_iter.c
+++ b/src/query/engine/eval_iter.c
@@ -218,8 +218,6 @@ void flecs_query_iter_fini_ctx(
             break;
         case EcsQueryUp:
         case EcsQuerySelfUp:
-        case EcsQueryUpId:
-        case EcsQuerySelfUpId: 
         case EcsQueryUnionEqUp:
         case EcsQueryUnionEqSelfUp: {
             ecs_trav_up_cache_t *cache = &ctx[i].is.up.cache;

--- a/src/query/types.h
+++ b/src/query/types.h
@@ -43,16 +43,13 @@ extern char *flecs_this_name_array;
 /* -- Instruction kinds -- */
 typedef enum {
     EcsQueryAnd,            /* And operator: find or match id against variable source */
-    EcsQueryAndId,          /* And operator for fixed id (no wildcards/variables) */
     EcsQueryAndAny,         /* And operator with support for matching Any src/id */
     EcsQueryOnlyAny,        /* Dedicated instruction for _ queries where the src is unknown */
     EcsQueryTriv,           /* Trivial search (batches multiple terms) */
     EcsQueryCache,          /* Cached search */
     EcsQueryIsCache,        /* Cached search for queries that are entirely cached */
     EcsQueryUp,             /* Up traversal */
-    EcsQueryUpId,           /* Up traversal for fixed id (like AndId) */
     EcsQuerySelfUp,         /* Self|up traversal */
-    EcsQuerySelfUpId,       /* Self|up traversal for fixed id (like AndId) */
     EcsQueryWith,           /* Match id against fixed or variable source */
     EcsQueryTrav,           /* Support for transitive/reflexive queries */
     EcsQueryAndFrom,        /* AndFrom operator */

--- a/src/query/util.c
+++ b/src/query/util.c
@@ -175,16 +175,13 @@ const char* flecs_query_op_str(
 {
     switch(kind) {
     case EcsQueryAnd:            return "and       ";
-    case EcsQueryAndId:          return "andid     ";
     case EcsQueryAndAny:         return "andany    ";
     case EcsQueryTriv:           return "triv      ";
     case EcsQueryCache:          return "cache     ";
     case EcsQueryIsCache:        return "xcache    ";
     case EcsQueryOnlyAny:        return "any       ";
     case EcsQueryUp:             return "up        ";
-    case EcsQueryUpId:           return "upid      ";
     case EcsQuerySelfUp:         return "selfup    ";
-    case EcsQuerySelfUpId:       return "selfupid  ";
     case EcsQueryWith:           return "with      ";
     case EcsQueryTrav:           return "trav      ";
     case EcsQueryAndFrom:        return "andfrom   ";

--- a/test/meta/src/SerializeQueryInfoToJson.c
+++ b/test/meta/src/SerializeQueryInfoToJson.c
@@ -740,7 +740,7 @@ void SerializeQueryInfoToJson_serialize_plan_nontrivial_query(void) {
     };
 
     char *json = ecs_iter_to_json(&it, &desc);
-    char *expect = flecs_asprintf("{\"query_plan\":\"[[0;49m 0. [[[0;37m-1[[0;49m, [[0;32m 1[[0;49m]  setids      \\n[[0;49m 1. [[[0;37m 0[[0;49m, [[0;32m 2[[0;49m]  selfupid    [[0;32m$[[0;49m[[[0;32mthis[[0;49m]           ([[0;34mPosition[[0;49m)\\n[[0;49m 2. [[[0;37m 1[[0;49m, [[0;32m 3[[0;49m]  yield       \\n\", \"results\":[]}");
+    char *expect = flecs_asprintf("{\"query_plan\":\"[[0;49m 0. [[[0;37m-1[[0;49m, [[0;32m 1[[0;49m]  setids      \\n[[0;49m 1. [[[0;37m 0[[0;49m, [[0;32m 2[[0;49m]  selfup      [[0;32m$[[0;49m[[[0;32mthis[[0;49m]           ([[0;34mPosition[[0;49m)\\n[[0;49m 2. [[[0;37m 1[[0;49m, [[0;32m 3[[0;49m]  yield       \\n\", \"results\":[]}");
     test_json(json, expect);
     ecs_os_free(json);
     ecs_os_free(expect);

--- a/test/query/src/Plan.c
+++ b/test/query/src/Plan.c
@@ -16,11 +16,11 @@ void Plan_reordered_plan_1(void) {
 
     const char *expect = 
     HEAD " 0. [-1,  1]  setids      "
-    LINE " 1. [ 0,  2]  selfupid    $[this]           (Foo)"
+    LINE " 1. [ 0,  2]  selfup      $[this]           (Foo)"
     LINE " 2. [ 1,  3]  and         $[this]           (ChildOf, $p)"
     LINE " 3. [ 2,  4]  and         $p                (ChildOf, $gp)"
     LINE " 4. [ 3,  5]  and         $gp               (ChildOf, $ggp)"
-    LINE " 5. [ 4,  6]  selfupid    $ggp              (Bar)"
+    LINE " 5. [ 4,  6]  selfup      $ggp              (Bar)"
     LINE " 6. [ 5,  7]  setvars     "
     LINE " 7. [ 6,  8]  yield       "
     LINE "";
@@ -50,14 +50,14 @@ void Plan_reordered_plan_2(void) {
 
     const char *expect = 
     HEAD " 0. [-1,  1]  setids      "
-    LINE " 1. [ 0,  2]  selfupid    $[ggp]            (Foo)"
+    LINE " 1. [ 0,  2]  selfup      $[ggp]            (Foo)"
     LINE " 2. [ 1,  3]  each        $ggp              ($[ggp])"
     LINE " 3. [ 2,  4]  and         $[gp]             (ChildOf, $ggp)"
     LINE " 4. [ 3,  5]  each        $gp               ($[gp])"
     LINE " 5. [ 4,  6]  and         $[p]              (ChildOf, $gp)"
     LINE " 6. [ 5,  7]  each        $p                ($[p])"
     LINE " 7. [ 6,  8]  and         $[this]           (ChildOf, $p)"
-    LINE " 8. [ 7,  9]  selfupid    $[this]           (Bar)"
+    LINE " 8. [ 7,  9]  selfup      $[this]           (Bar)"
     LINE " 9. [ 8, 10]  setvars     "
     LINE "10. [ 9, 11]  yield       "
     LINE "";
@@ -87,7 +87,7 @@ void Plan_reordered_plan_3(void) {
 
     const char *expect = 
     HEAD " 0. [-1,  1]  setids      "
-    LINE " 1. [ 0,  2]  andid       $[this]           (Bar)"
+    LINE " 1. [ 0,  2]  and         $[this]           (Bar)"
     LINE " 2. [ 1,  4]  option      "
     LINE " 3. [ 2,  4]   and        $[this]           (Foo)"
     LINE " 4. [ 2,  5]  end         $[this]           (Foo)"
@@ -121,12 +121,12 @@ void Plan_reordered_plan_4(void) {
 
     const char *expect = 
     HEAD " 0. [-1,  1]  setids      "
-    LINE " 1. [ 0,  2]  andid       $[this]           (Hello)"
+    LINE " 1. [ 0,  2]  and         $[this]           (Hello)"
     LINE " 2. [ 1,  4]  option      "
     LINE " 3. [ 2,  4]   and        $[this]           (Foo)"
     LINE " 4. [ 2,  5]  end         $[this]           (Foo)"
     LINE " 5. [ 4,  7]  option      "
-    LINE " 6. [ 5,  7]   andid      $[this]           (Bar)"
+    LINE " 6. [ 5,  7]   and        $[this]           (Bar)"
     LINE " 7. [ 5,  8]  end         $[this]           (Bar)"
     LINE " 8. [ 7,  9]  yield       "
     LINE "";
@@ -157,12 +157,12 @@ void Plan_reordered_plan_5(void) {
 
     const char *expect = 
     HEAD " 0. [-1,  1]  setids      "
-    LINE " 1. [ 0,  2]  andid       $[this]           (Hello)"
+    LINE " 1. [ 0,  2]  and         $[this]           (Hello)"
     LINE " 2. [ 1,  4]  option      "
     LINE " 3. [ 2,  4]   and        $[this]           (Foo)"
     LINE " 4. [ 2,  5]  end         $[this]           (Foo)"
     LINE " 5. [ 4,  7]  option      "
-    LINE " 6. [ 5,  7]   andid      $[this]           (Bar)"
+    LINE " 6. [ 5,  7]   and        $[this]           (Bar)"
     LINE " 7. [ 5,  8]  end         $[this]           (Bar)"
     LINE " 8. [ 7,  9]  yield       "
     LINE "";
@@ -199,7 +199,7 @@ void Plan_reordered_plan_6(void) {
     LINE " 3. [ 2,  4]   and        $[this]           (Foo)"
     LINE " 4. [ 2,  5]  end         $[this]           (Foo)"
     LINE " 5. [ 4,  7]  option      "
-    LINE " 6. [ 5,  7]   andid      $[this]           (Bar)"
+    LINE " 6. [ 5,  7]   and        $[this]           (Bar)"
     LINE " 7. [ 5,  8]  end         $[this]           (Bar)"
     LINE " 8. [ 7,  9]  yield       "
     LINE "";
@@ -231,7 +231,7 @@ void Plan_reordered_plan_7(void) {
 
     const char *expect = 
     HEAD " 0. [-1,  1]  setids      "
-    LINE " 1. [ 0,  2]  andid       $[this]           (Hello)"
+    LINE " 1. [ 0,  2]  and         $[this]           (Hello)"
     LINE " 2. [ 1,  4]  option      "
     LINE " 3. [ 2,  4]   and        $[this]           (Foo)"
     LINE " 4. [ 2,  5]  end         $[this]           (Foo)"
@@ -239,7 +239,7 @@ void Plan_reordered_plan_7(void) {
     LINE " 6. [ 5,  7]   and        $[this]           (Bar, $foo)"
     LINE " 7. [ 5,  8]  end         $[this]           (Bar, $foo)"
     LINE " 8. [ 7, 10]  ifvar       $foo"
-    LINE " 9. [ 8, 10]   andid      $foo              (World)"
+    LINE " 9. [ 8, 10]   and        $foo              (World)"
     LINE "10. [ 8, 11]  end         $foo              (World)"
     LINE "11. [10, 12]  setvars     "
     LINE "12. [11, 13]  yield       "
@@ -601,7 +601,7 @@ void Plan_2_trivial_plan_w_wildcard(void) {
 
     const char *expect = 
     HEAD " 0. [-1,  1]  setids      "
-    LINE " 1. [ 0,  2]  andid       $[this]           (Foo)"
+    LINE " 1. [ 0,  2]  and         $[this]           (Foo)"
     LINE " 2. [ 1,  3]  and         $[this]           (ChildOf, $*'1)"
     LINE " 3. [ 2,  4]  yield       "
     LINE "";
@@ -634,8 +634,8 @@ void Plan_this_before_fixed_src(void) {
     const char *expect = 
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
-    LINE " 2. [ 1,  3]  selfupid    e                 (Bar)"
-    LINE " 3. [ 2,  4]  selfupid    $[this]           (Foo)"
+    LINE " 2. [ 1,  3]  selfup      e                 (Bar)"
+    LINE " 3. [ 2,  4]  selfup      $[this]           (Foo)"
     LINE " 4. [ 3,  5]  yield       "
     LINE "";
     char *plan = ecs_query_plan(r);
@@ -667,8 +667,8 @@ void Plan_fixed_src_before_this(void) {
     const char *expect = 
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
-    LINE " 2. [ 1,  3]  selfupid    e                 (Bar)"
-    LINE " 3. [ 2,  4]  selfupid    $[this]           (Foo)"
+    LINE " 2. [ 1,  3]  selfup      e                 (Bar)"
+    LINE " 3. [ 2,  4]  selfup      $[this]           (Foo)"
     LINE " 4. [ 3,  5]  yield       "
     LINE "";
     char *plan = ecs_query_plan(r);
@@ -700,8 +700,8 @@ void Plan_var_before_fixed_src(void) {
     const char *expect = 
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
-    LINE " 2. [ 1,  3]  selfupid    e                 (Bar)"
-    LINE " 3. [ 2,  4]  selfupid    $[var]            (Foo)"
+    LINE " 2. [ 1,  3]  selfup      e                 (Bar)"
+    LINE " 3. [ 2,  4]  selfup      $[var]            (Foo)"
     LINE " 4. [ 3,  5]  each        $var              ($[var])"
     LINE " 5. [ 4,  6]  setvars     "
     LINE " 6. [ 5,  7]  yield       "
@@ -735,8 +735,8 @@ void Plan_fixed_src_before_var(void) {
     const char *expect = 
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
-    LINE " 2. [ 1,  3]  selfupid    e                 (Bar)"
-    LINE " 3. [ 2,  4]  selfupid    $[var]            (Foo)"
+    LINE " 2. [ 1,  3]  selfup      e                 (Bar)"
+    LINE " 3. [ 2,  4]  selfup      $[var]            (Foo)"
     LINE " 4. [ 3,  5]  each        $var              ($[var])"
     LINE " 5. [ 4,  6]  setvars     "
     LINE " 6. [ 5,  7]  yield       "
@@ -771,9 +771,9 @@ void Plan_this_before_fixed_src_w_not(void) {
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
     LINE " 2. [ 1,  4]  not         "
-    LINE " 3. [ 2,  4]   selfupid   e                 (Bar)"
+    LINE " 3. [ 2,  4]   selfup     e                 (Bar)"
     LINE " 4. [ 2,  5]  end         e                 (Bar)"
-    LINE " 5. [ 4,  6]  selfupid    $[this]           (Foo)"
+    LINE " 5. [ 4,  6]  selfup      $[this]           (Foo)"
     LINE " 6. [ 5,  7]  yield       "
     LINE "";
     char *plan = ecs_query_plan(r);
@@ -806,7 +806,7 @@ void Plan_this_before_fixed_src_w_first_var(void) {
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
     LINE " 2. [ 1,  3]  with        e                 ($this)"
-    LINE " 3. [ 2,  4]  selfupid    $this             (Foo)"
+    LINE " 3. [ 2,  4]  selfup      $this             (Foo)"
     LINE " 4. [ 3,  5]  setthis                       ($this)"
     LINE " 5. [ 4,  6]  yield       "
     LINE "";
@@ -839,7 +839,7 @@ void Plan_this_before_fixed_src_w_first_var_w_not(void) {
     const char *expect = 
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
-    LINE " 2. [ 1,  3]  selfupid    $[this]           (Foo)"
+    LINE " 2. [ 1,  3]  selfup      $[this]           (Foo)"
     LINE " 3. [ 2,  4]  each        $this             ($[this])"
     LINE " 4. [ 3,  6]  not         "
     LINE " 5. [ 4,  6]   with       e                 ($this)"
@@ -877,7 +877,7 @@ void Plan_this_before_fixed_src_w_second_var(void) {
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
     LINE " 2. [ 1,  3]  selfup      e                 (Bar, $this)"
-    LINE " 3. [ 2,  4]  selfupid    $this             (Foo)"
+    LINE " 3. [ 2,  4]  selfup      $this             (Foo)"
     LINE " 4. [ 3,  5]  setthis                       ($this)"
     LINE " 5. [ 4,  6]  yield       "
     LINE "";
@@ -910,7 +910,7 @@ void Plan_this_before_fixed_src_w_second_var_w_not(void) {
     const char *expect = 
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
-    LINE " 2. [ 1,  3]  selfupid    $[this]           (Foo)"
+    LINE " 2. [ 1,  3]  selfup      $[this]           (Foo)"
     LINE " 3. [ 2,  4]  each        $this             ($[this])"
     LINE " 4. [ 3,  6]  not         "
     LINE " 5. [ 4,  6]   selfup     e                 (Bar, $this)"
@@ -949,7 +949,7 @@ void Plan_populate_1_fixed(void) {
     const char *expect = 
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
-    LINE " 2. [ 1,  3]  selfupid    e                 (Position)"
+    LINE " 2. [ 1,  3]  selfup      e                 (Position)"
     LINE " 3. [ 2,  4]  yield       "
     LINE "";
     char *plan = ecs_query_plan(r);
@@ -983,8 +983,8 @@ void Plan_populate_2_fixed(void) {
     const char *expect = 
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
-    LINE " 2. [ 1,  3]  selfupid    e                 (Position)"
-    LINE " 3. [ 2,  4]  selfupid    e                 (Velocity)"
+    LINE " 2. [ 1,  3]  selfup      e                 (Position)"
+    LINE " 3. [ 2,  4]  selfup      e                 (Velocity)"
     LINE " 4. [ 3,  5]  yield       "
     LINE "";
     char *plan = ecs_query_plan(r);
@@ -1018,8 +1018,8 @@ void Plan_populate_1_fixed_1_this_self(void) {
     const char *expect = 
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
-    LINE " 2. [ 1,  3]  selfupid    e                 (Position)"
-    LINE " 3. [ 2,  4]  andid       $[this]           (Velocity)"
+    LINE " 2. [ 1,  3]  selfup      e                 (Position)"
+    LINE " 3. [ 2,  4]  and         $[this]           (Velocity)"
     LINE " 4. [ 3,  5]  yield       "
     LINE "";
     char *plan = ecs_query_plan(r);
@@ -1057,8 +1057,8 @@ void Plan_populate_2_fixed_2_this_self(void) {
     const char *expect = 
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
-    LINE " 2. [ 1,  3]  selfupid    e                 (Position)"
-    LINE " 3. [ 2,  4]  selfupid    e                 (Velocity)"
+    LINE " 2. [ 1,  3]  selfup      e                 (Position)"
+    LINE " 3. [ 2,  4]  selfup      e                 (Velocity)"
     LINE " 4. [ 3,  5]  triv        {2,3}"
     LINE " 5. [ 4,  6]  yield       "
     LINE "";
@@ -1097,8 +1097,8 @@ void Plan_populate_2_fixed_2_this_self_interleaved(void) {
     const char *expect = 
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
-    LINE " 2. [ 1,  3]  selfupid    e                 (Position)"
-    LINE " 3. [ 2,  4]  selfupid    e                 (Velocity)"
+    LINE " 2. [ 1,  3]  selfup      e                 (Position)"
+    LINE " 3. [ 2,  4]  selfup      e                 (Velocity)"
     LINE " 4. [ 3,  5]  triv        {1,3}"
     LINE " 5. [ 4,  6]  yield       "
     LINE "";
@@ -1137,8 +1137,8 @@ void Plan_populate_2_this_self_2_fixed(void) {
     const char *expect = 
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
-    LINE " 2. [ 1,  3]  selfupid    e                 (Position)"
-    LINE " 3. [ 2,  4]  selfupid    e                 (Velocity)"
+    LINE " 2. [ 1,  3]  selfup      e                 (Position)"
+    LINE " 3. [ 2,  4]  selfup      e                 (Velocity)"
     LINE " 4. [ 3,  5]  triv        {0,1}"
     LINE " 5. [ 4,  6]  yield       "
     LINE "";
@@ -1173,8 +1173,8 @@ void Plan_populate_1_fixed_1_this_up(void) {
     const char *expect = 
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
-    LINE " 2. [ 1,  3]  selfupid    e                 (Position)"
-    LINE " 3. [ 2,  4]  upid        $[this]           (Velocity)"
+    LINE " 2. [ 1,  3]  selfup      e                 (Position)"
+    LINE " 3. [ 2,  4]  up          $[this]           (Velocity)"
     LINE " 4. [ 3,  5]  yield       "
     LINE "";
     char *plan = ecs_query_plan(r);
@@ -1212,10 +1212,10 @@ void Plan_populate_2_fixed_2_this_up(void) {
     const char *expect = 
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
-    LINE " 2. [ 1,  3]  selfupid    e                 (Position)"
-    LINE " 3. [ 2,  4]  selfupid    e                 (Velocity)"
-    LINE " 4. [ 3,  5]  upid        $[this]           (Mass)"
-    LINE " 5. [ 4,  6]  upid        $[this]           (Rotation)"
+    LINE " 2. [ 1,  3]  selfup      e                 (Position)"
+    LINE " 3. [ 2,  4]  selfup      e                 (Velocity)"
+    LINE " 4. [ 3,  5]  up          $[this]           (Mass)"
+    LINE " 5. [ 4,  6]  up          $[this]           (Rotation)"
     LINE " 6. [ 5,  7]  yield       "
     LINE "";
     char *plan = ecs_query_plan(r);
@@ -1253,10 +1253,10 @@ void Plan_populate_2_fixed_2_this_up_interleaved(void) {
     const char *expect = 
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
-    LINE " 2. [ 1,  3]  selfupid    e                 (Position)"
-    LINE " 3. [ 2,  4]  selfupid    e                 (Velocity)"
-    LINE " 4. [ 3,  5]  upid        $[this]           (Mass)"
-    LINE " 5. [ 4,  6]  upid        $[this]           (Rotation)"
+    LINE " 2. [ 1,  3]  selfup      e                 (Position)"
+    LINE " 3. [ 2,  4]  selfup      e                 (Velocity)"
+    LINE " 4. [ 3,  5]  up          $[this]           (Mass)"
+    LINE " 5. [ 4,  6]  up          $[this]           (Rotation)"
     LINE " 6. [ 5,  7]  yield       "
     LINE "";
     char *plan = ecs_query_plan(r);
@@ -1294,10 +1294,10 @@ void Plan_populate_2_this_up_2_fixed(void) {
     const char *expect = 
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
-    LINE " 2. [ 1,  3]  selfupid    e                 (Position)"
-    LINE " 3. [ 2,  4]  selfupid    e                 (Velocity)"
-    LINE " 4. [ 3,  5]  upid        $[this]           (Mass)"
-    LINE " 5. [ 4,  6]  upid        $[this]           (Rotation)"
+    LINE " 2. [ 1,  3]  selfup      e                 (Position)"
+    LINE " 3. [ 2,  4]  selfup      e                 (Velocity)"
+    LINE " 4. [ 3,  5]  up          $[this]           (Mass)"
+    LINE " 5. [ 4,  6]  up          $[this]           (Rotation)"
     LINE " 6. [ 5,  7]  yield       "
     LINE "";
     char *plan = ecs_query_plan(r);
@@ -1332,7 +1332,7 @@ void Plan_populate_1_fixed_1_this_self_cached(void) {
     const char *expect = 
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
-    LINE " 2. [ 1,  3]  selfupid    e                 (Position)"
+    LINE " 2. [ 1,  3]  selfup      e                 (Position)"
     LINE " 3. [ 2,  4]  cache       "
     LINE " 4. [ 3,  5]  yield       "
     LINE "";
@@ -1372,8 +1372,8 @@ void Plan_populate_2_fixed_2_this_self_cached(void) {
     const char *expect = 
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
-    LINE " 2. [ 1,  3]  selfupid    e                 (Position)"
-    LINE " 3. [ 2,  4]  selfupid    e                 (Velocity)"
+    LINE " 2. [ 1,  3]  selfup      e                 (Position)"
+    LINE " 3. [ 2,  4]  selfup      e                 (Velocity)"
     LINE " 4. [ 3,  5]  cache       "
     LINE " 5. [ 4,  6]  yield       "
     LINE "";
@@ -1413,8 +1413,8 @@ void Plan_populate_2_fixed_2_this_self_interleaved_cached(void) {
     const char *expect = 
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
-    LINE " 2. [ 1,  3]  selfupid    e                 (Position)"
-    LINE " 3. [ 2,  4]  selfupid    e                 (Velocity)"
+    LINE " 2. [ 1,  3]  selfup      e                 (Position)"
+    LINE " 3. [ 2,  4]  selfup      e                 (Velocity)"
     LINE " 4. [ 3,  5]  cache       "
     LINE " 5. [ 4,  6]  yield       "
     LINE "";
@@ -1454,8 +1454,8 @@ void Plan_populate_2_this_self_2_fixed_cached(void) {
     const char *expect = 
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
-    LINE " 2. [ 1,  3]  selfupid    e                 (Position)"
-    LINE " 3. [ 2,  4]  selfupid    e                 (Velocity)"
+    LINE " 2. [ 1,  3]  selfup      e                 (Position)"
+    LINE " 3. [ 2,  4]  selfup      e                 (Velocity)"
     LINE " 4. [ 3,  5]  cache       "
     LINE " 5. [ 4,  6]  yield       "
     LINE "";
@@ -1491,7 +1491,7 @@ void Plan_populate_1_fixed_1_this_up_cached(void) {
     const char *expect = 
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
-    LINE " 2. [ 1,  3]  selfupid    e                 (Position)"
+    LINE " 2. [ 1,  3]  selfup      e                 (Position)"
     LINE " 3. [ 2,  4]  cache       "
     LINE " 4. [ 3,  5]  yield       "
     LINE "";
@@ -1531,8 +1531,8 @@ void Plan_populate_2_fixed_2_this_up_cached(void) {
     const char *expect = 
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
-    LINE " 2. [ 1,  3]  selfupid    e                 (Position)"
-    LINE " 3. [ 2,  4]  selfupid    e                 (Velocity)"
+    LINE " 2. [ 1,  3]  selfup      e                 (Position)"
+    LINE " 3. [ 2,  4]  selfup      e                 (Velocity)"
     LINE " 4. [ 3,  5]  cache       "
     LINE " 5. [ 4,  6]  yield       "
     LINE "";
@@ -1572,8 +1572,8 @@ void Plan_populate_2_fixed_2_this_up_interleaved_cached(void) {
     const char *expect = 
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
-    LINE " 2. [ 1,  3]  selfupid    e                 (Position)"
-    LINE " 3. [ 2,  4]  selfupid    e                 (Velocity)"
+    LINE " 2. [ 1,  3]  selfup      e                 (Position)"
+    LINE " 3. [ 2,  4]  selfup      e                 (Velocity)"
     LINE " 4. [ 3,  5]  cache       "
     LINE " 5. [ 4,  6]  yield       "
     LINE "";
@@ -1613,8 +1613,8 @@ void Plan_populate_2_this_up_2_fixed_cached(void) {
     const char *expect = 
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
-    LINE " 2. [ 1,  3]  selfupid    e                 (Position)"
-    LINE " 3. [ 2,  4]  selfupid    e                 (Velocity)"
+    LINE " 2. [ 1,  3]  selfup      e                 (Position)"
+    LINE " 3. [ 2,  4]  selfup      e                 (Velocity)"
     LINE " 4. [ 3,  5]  cache       "
     LINE " 5. [ 4,  6]  yield       "
     LINE "";
@@ -1650,8 +1650,8 @@ void Plan_populate_1_fixed_1_var_self(void) {
     const char *expect = 
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
-    LINE " 2. [ 1,  3]  selfupid    e                 (Position)"
-    LINE " 3. [ 2,  4]  andid       $[var]            (Velocity)"
+    LINE " 2. [ 1,  3]  selfup      e                 (Position)"
+    LINE " 3. [ 2,  4]  and         $[var]            (Velocity)"
     LINE " 4. [ 3,  5]  each        $var              ($[var])"
     LINE " 5. [ 4,  6]  setvars     "
     LINE " 6. [ 5,  7]  yield       "
@@ -1692,10 +1692,10 @@ void Plan_populate_2_fixed_2_var_self(void) {
     const char *expect = 
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
-    LINE " 2. [ 1,  3]  selfupid    e                 (Position)"
-    LINE " 3. [ 2,  4]  selfupid    e                 (Velocity)"
-    LINE " 4. [ 3,  5]  andid       $[var]            (Mass)"
-    LINE " 5. [ 4,  6]  andid       $[var]            (Rotation)"
+    LINE " 2. [ 1,  3]  selfup      e                 (Position)"
+    LINE " 3. [ 2,  4]  selfup      e                 (Velocity)"
+    LINE " 4. [ 3,  5]  and         $[var]            (Mass)"
+    LINE " 5. [ 4,  6]  and         $[var]            (Rotation)"
     LINE " 6. [ 5,  7]  each        $var              ($[var])"
     LINE " 7. [ 6,  8]  setvars     "
     LINE " 8. [ 7,  9]  yield       "
@@ -1736,10 +1736,10 @@ void Plan_populate_2_fixed_2_var_self_interleaved(void) {
     const char *expect = 
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
-    LINE " 2. [ 1,  3]  selfupid    e                 (Position)"
-    LINE " 3. [ 2,  4]  selfupid    e                 (Velocity)"
-    LINE " 4. [ 3,  5]  andid       $[var]            (Mass)"
-    LINE " 5. [ 4,  6]  andid       $[var]            (Rotation)"
+    LINE " 2. [ 1,  3]  selfup      e                 (Position)"
+    LINE " 3. [ 2,  4]  selfup      e                 (Velocity)"
+    LINE " 4. [ 3,  5]  and         $[var]            (Mass)"
+    LINE " 5. [ 4,  6]  and         $[var]            (Rotation)"
     LINE " 6. [ 5,  7]  each        $var              ($[var])"
     LINE " 7. [ 6,  8]  setvars     "
     LINE " 8. [ 7,  9]  yield       "
@@ -1780,10 +1780,10 @@ void Plan_populate_2_var_self_2_fixed(void) {
     const char *expect = 
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
-    LINE " 2. [ 1,  3]  selfupid    e                 (Position)"
-    LINE " 3. [ 2,  4]  selfupid    e                 (Velocity)"
-    LINE " 4. [ 3,  5]  andid       $[var]            (Mass)"
-    LINE " 5. [ 4,  6]  andid       $[var]            (Rotation)"
+    LINE " 2. [ 1,  3]  selfup      e                 (Position)"
+    LINE " 3. [ 2,  4]  selfup      e                 (Velocity)"
+    LINE " 4. [ 3,  5]  and         $[var]            (Mass)"
+    LINE " 5. [ 4,  6]  and         $[var]            (Rotation)"
     LINE " 6. [ 5,  7]  each        $var              ($[var])"
     LINE " 7. [ 6,  8]  setvars     "
     LINE " 8. [ 7,  9]  yield       "
@@ -1820,8 +1820,8 @@ void Plan_populate_1_fixed_1_var_up(void) {
     const char *expect = 
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
-    LINE " 2. [ 1,  3]  selfupid    e                 (Position)"
-    LINE " 3. [ 2,  4]  upid        $[var]            (Velocity)"
+    LINE " 2. [ 1,  3]  selfup      e                 (Position)"
+    LINE " 3. [ 2,  4]  up          $[var]            (Velocity)"
     LINE " 4. [ 3,  5]  each        $var              ($[var])"
     LINE " 5. [ 4,  6]  setvars     "
     LINE " 6. [ 5,  7]  yield       "
@@ -1862,10 +1862,10 @@ void Plan_populate_2_fixed_2_var_up(void) {
     const char *expect = 
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
-    LINE " 2. [ 1,  3]  selfupid    e                 (Position)"
-    LINE " 3. [ 2,  4]  selfupid    e                 (Velocity)"
-    LINE " 4. [ 3,  5]  upid        $[var]            (Mass)"
-    LINE " 5. [ 4,  6]  upid        $[var]            (Rotation)"
+    LINE " 2. [ 1,  3]  selfup      e                 (Position)"
+    LINE " 3. [ 2,  4]  selfup      e                 (Velocity)"
+    LINE " 4. [ 3,  5]  up          $[var]            (Mass)"
+    LINE " 5. [ 4,  6]  up          $[var]            (Rotation)"
     LINE " 6. [ 5,  7]  each        $var              ($[var])"
     LINE " 7. [ 6,  8]  setvars     "
     LINE " 8. [ 7,  9]  yield       "
@@ -1906,10 +1906,10 @@ void Plan_populate_2_fixed_2_var_up_interleaved(void) {
     const char *expect = 
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
-    LINE " 2. [ 1,  3]  selfupid    e                 (Position)"
-    LINE " 3. [ 2,  4]  selfupid    e                 (Velocity)"
-    LINE " 4. [ 3,  5]  upid        $[var]            (Mass)"
-    LINE " 5. [ 4,  6]  upid        $[var]            (Rotation)"
+    LINE " 2. [ 1,  3]  selfup      e                 (Position)"
+    LINE " 3. [ 2,  4]  selfup      e                 (Velocity)"
+    LINE " 4. [ 3,  5]  up          $[var]            (Mass)"
+    LINE " 5. [ 4,  6]  up          $[var]            (Rotation)"
     LINE " 6. [ 5,  7]  each        $var              ($[var])"
     LINE " 7. [ 6,  8]  setvars     "
     LINE " 8. [ 7,  9]  yield       "
@@ -1950,10 +1950,10 @@ void Plan_populate_2_var_up_2_fixed(void) {
     const char *expect = 
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
-    LINE " 2. [ 1,  3]  selfupid    e                 (Position)"
-    LINE " 3. [ 2,  4]  selfupid    e                 (Velocity)"
-    LINE " 4. [ 3,  5]  upid        $[var]            (Mass)"
-    LINE " 5. [ 4,  6]  upid        $[var]            (Rotation)"
+    LINE " 2. [ 1,  3]  selfup      e                 (Position)"
+    LINE " 3. [ 2,  4]  selfup      e                 (Velocity)"
+    LINE " 4. [ 3,  5]  up          $[var]            (Mass)"
+    LINE " 5. [ 4,  6]  up          $[var]            (Rotation)"
     LINE " 6. [ 5,  7]  each        $var              ($[var])"
     LINE " 7. [ 6,  8]  setvars     "
     LINE " 8. [ 7,  9]  yield       "
@@ -2398,7 +2398,7 @@ void Plan_0_src_w_sparse_and_component(void) {
     const char *expect = 
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
-    LINE " 2. [ 1,  3]  andid       $[this]           (Velocity)"
+    LINE " 2. [ 1,  3]  and         $[this]           (Velocity)"
     LINE " 3. [ 2,  4]  yield       "
     LINE "";
     char *plan = ecs_query_plan(q);
@@ -2430,7 +2430,7 @@ void Plan_0_src_w_toggle_and_component(void) {
     const char *expect = 
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
-    LINE " 2. [ 1,  3]  andid       $[this]           (Velocity)"
+    LINE " 2. [ 1,  3]  and         $[this]           (Velocity)"
     LINE " 3. [ 2,  4]  yield       "
     LINE "";
     char *plan = ecs_query_plan(q);
@@ -2462,7 +2462,7 @@ void Plan_0_src_w_union_and_component(void) {
     const char *expect = 
     HEAD " 0. [-1,  1]  setfix      "
     LINE " 1. [ 0,  2]  setids      "
-    LINE " 2. [ 1,  3]  andid       $[this]           (Velocity)"
+    LINE " 2. [ 1,  3]  and         $[this]           (Velocity)"
     LINE " 3. [ 2,  4]  yield       "
     LINE "";
     char *plan = ecs_query_plan(q);


### PR DESCRIPTION
This PR removes query instructions that optimize for terms that have static (non-wildcard) ids. The instructions were introduced as a performance optimization, but the `triv` instruction (which matches n trivial terms in a single call) makes these mostly redundant.