### PR TITLE
Properly set and read is_ref in delegate.hpp to fix non-$this variable source components in query iteration

### DIFF
--- a/distr/flecs.h
+++ b/distr/flecs.h
@@ -25659,6 +25659,7 @@ private:
     void populate_self(const ecs_iter_t *iter, size_t index, T, Targs... comps) {
         fields_[index].ptr = ecs_field_w_size(iter, sizeof(A), 
             static_cast<int8_t>(index));
+        fields_[index].is_ref = iter->sources[index] != 0;
         populate_self(iter, index + 1, comps ...);
     }
 
@@ -25680,7 +25681,19 @@ struct each_field { };
 // Base class
 struct each_column_base {
     each_column_base(const _::field_ptr& field, size_t row) 
-        : field_(field), row_(row) { }
+        : field_(field), row_(row) {
+
+        if (field.is_ref) {
+            // If this is a reference, set the row to 0 as a ref always is a
+            // single value, not an array. This prevents the application from
+            // having to do an if-check on whether the column is owned.
+            //
+            // This check only happens when the current table being iterated
+            // over caused the query to match a reference. The check is
+            // performed once per iterated table.
+            this->row_ = 0;
+        }
+    }
 
 protected:
     const _::field_ptr& field_;
@@ -25758,17 +25771,6 @@ template <typename T, typename = int>
 struct each_ref_field : public each_field<T> {
     each_ref_field(const flecs::iter_t *iter, _::field_ptr& field, size_t row)
         : each_field<T>(iter, field, row) {
-
-        if (field.is_ref) {
-            // If this is a reference, set the row to 0 as a ref always is a
-            // single value, not an array. This prevents the application from
-            // having to do an if-check on whether the column is owned.
-            //
-            // This check only happens when the current table being iterated
-            // over caused the query to match a reference. The check is
-            // performed once per iterated table.
-            this->row_ = 0;
-        }
 
         if (field.is_row) {
             field.ptr = ecs_field_at_w_size(iter, sizeof(T), field.index, 

--- a/include/flecs/addons/cpp/delegate.hpp
+++ b/include/flecs/addons/cpp/delegate.hpp
@@ -99,6 +99,7 @@ private:
     void populate_self(const ecs_iter_t *iter, size_t index, T, Targs... comps) {
         fields_[index].ptr = ecs_field_w_size(iter, sizeof(A), 
             static_cast<int8_t>(index));
+        fields_[index].is_ref = iter->sources[index] != 0;
         populate_self(iter, index + 1, comps ...);
     }
 
@@ -120,7 +121,19 @@ struct each_field { };
 // Base class
 struct each_column_base {
     each_column_base(const _::field_ptr& field, size_t row) 
-        : field_(field), row_(row) { }
+        : field_(field), row_(row) {
+
+        if (field.is_ref) {
+            // If this is a reference, set the row to 0 as a ref always is a
+            // single value, not an array. This prevents the application from
+            // having to do an if-check on whether the column is owned.
+            //
+            // This check only happens when the current table being iterated
+            // over caused the query to match a reference. The check is
+            // performed once per iterated table.
+            this->row_ = 0;
+        }
+    }
 
 protected:
     const _::field_ptr& field_;
@@ -198,17 +211,6 @@ template <typename T, typename = int>
 struct each_ref_field : public each_field<T> {
     each_ref_field(const flecs::iter_t *iter, _::field_ptr& field, size_t row)
         : each_field<T>(iter, field, row) {
-
-        if (field.is_ref) {
-            // If this is a reference, set the row to 0 as a ref always is a
-            // single value, not an array. This prevents the application from
-            // having to do an if-check on whether the column is owned.
-            //
-            // This check only happens when the current table being iterated
-            // over caused the query to match a reference. The check is
-            // performed once per iterated table.
-            this->row_ = 0;
-        }
 
         if (field.is_row) {
             field.ptr = ecs_field_at_w_size(iter, sizeof(T), field.index, 

--- a/test/cpp/project.json
+++ b/test/cpp/project.json
@@ -664,7 +664,9 @@
                 "run_w_iter_fini_empty",
                 "run_w_iter_fini_no_query",
                 "add_to_match_from_staged_query",
-                "add_to_match_from_staged_query_readonly_threaded"
+                "add_to_match_from_staged_query_readonly_threaded",
+                "pair_with_variable_src",
+                "pair_with_variable_src_no_row_fields"
             ]
         }, {
             "id": "QueryBuilder",

--- a/test/cpp/src/Query.cpp
+++ b/test/cpp/src/Query.cpp
@@ -3057,8 +3057,7 @@ void Query_empty_tables_each_w_iter(void) {
 void Query_pair_with_variable_src(void) {
     flecs::world world;
 
-    struct EmptyRel {};
-    struct Rel { int x; };
+    struct Rel {};
     struct ThisComp { int x; };
     struct OtherComp { int x; };
 
@@ -3069,30 +3068,15 @@ void Query_pair_with_variable_src(void) {
     auto other = flecs::entity(world)
         .set(OtherComp{0});
 
+    // Guaranty we don't lukily hit zero if we read the the wrong component
     flecs::entity(world)
         .set(OtherComp{1});
 
     for (int i = 0; i < 3; ++i)
         flecs::entity(world)
             .set(ThisComp{i})
-            .add<Rel>(other)
-            .add<EmptyRel>(other);
+            .add<Rel>(other);
 
-    {
-        auto q = world.query_builder<Rel, ThisComp, OtherComp>()
-            .term_at(0).second("$other")
-            .term_at(2).src("$other")
-            .build();
-
-        size_t isPresentBitField = 0;
-        q.each([&isPresentBitField](Rel &rel, ThisComp &thisComp, OtherComp &otherComp) {
-            isPresentBitField |= (1 << thisComp.x);
-            rel.x = thisComp.x;
-            test_int(otherComp.x, 0);
-        });
-
-        test_int(isPresentBitField, 7);
-    }
     {
         auto q = world.query_builder<Rel const, ThisComp const, OtherComp const>()
             .term_at(0).second("$other")
@@ -3102,20 +3086,44 @@ void Query_pair_with_variable_src(void) {
         size_t isPresentBitField = 0;
         q.each([&isPresentBitField](Rel const &rel, ThisComp const &thisComp, OtherComp const &otherComp) {
             isPresentBitField |= (1 << thisComp.x);
-            test_int(rel.x, thisComp.x);
             test_int(otherComp.x, 0);
         });
 
         test_int(isPresentBitField, 7);
     }
+}
+
+void Query_pair_with_variable_src_no_row_fields(void) {
+    flecs::world world;
+
+    struct Rel { int dummy; }; // make sure this isn't a tag, so that the query contains no row field
+    struct ThisComp { int x; };
+    struct OtherComp { int x; };
+
+    world.component<Rel>();
+    world.component<ThisComp>();
+    world.component<OtherComp>();
+
+    auto other = flecs::entity(world)
+        .set(OtherComp{0});
+
+    // Guaranty we don't lukily hit zero if we read the the wrong component
+    flecs::entity(world)
+        .set(OtherComp{1});
+
+    for (int i = 0; i < 3; ++i)
+        flecs::entity(world)
+            .set(ThisComp{i})
+            .add<Rel>(other);
+
     {
-        auto q = world.query_builder<EmptyRel const, ThisComp const, OtherComp const>()
+        auto q = world.query_builder<Rel const, ThisComp const, OtherComp const>()
             .term_at(0).second("$other")
             .term_at(2).src("$other")
             .build();
 
         size_t isPresentBitField = 0;
-        q.each([&isPresentBitField](EmptyRel const &, ThisComp const &thisComp, OtherComp const &otherComp) {
+        q.each([&isPresentBitField](Rel const &rel, ThisComp const &thisComp, OtherComp const &otherComp) {
             isPresentBitField |= (1 << thisComp.x);
             test_int(otherComp.x, 0);
         });

--- a/test/cpp/src/main.cpp
+++ b/test/cpp/src/main.cpp
@@ -641,6 +641,8 @@ void Query_run_w_iter_fini_empty(void);
 void Query_run_w_iter_fini_no_query(void);
 void Query_add_to_match_from_staged_query(void);
 void Query_add_to_match_from_staged_query_readonly_threaded(void);
+void Query_pair_with_variable_src(void);
+void Query_pair_with_variable_src_no_row_fields(void);
 
 // Testsuite 'QueryBuilder'
 void QueryBuilder_setup(void);
@@ -3818,6 +3820,14 @@ bake_test_case Query_testcases[] = {
     {
         "add_to_match_from_staged_query_readonly_threaded",
         Query_add_to_match_from_staged_query_readonly_threaded
+    },
+    {
+        "pair_with_variable_src",
+        Query_pair_with_variable_src
+    },
+    {
+        "pair_with_variable_src_no_row_fields",
+        Query_pair_with_variable_src_no_row_fields
     }
 };
 
@@ -6588,7 +6598,7 @@ static bake_test_suite suites[] = {
         "Query",
         NULL,
         NULL,
-        109,
+        111,
         Query_testcases
     },
     {


### PR DESCRIPTION
- set is_ref in populate_self so that it's properly set for any type of query
- always set row to 0 for components with is_ref to avoid indexing garbage

Fixes #1324