### PR TITLE
Use __alignof__ on clang

### DIFF
--- a/distr/flecs.h
+++ b/distr/flecs.h
@@ -814,6 +814,8 @@ typedef struct ecs_allocator_t ecs_allocator_t;
 #define ECS_ALIGNOF(T) (int64_t)__alignof(T)
 #elif defined(ECS_TARGET_GNU)
 #define ECS_ALIGNOF(T) (int64_t)__alignof__(T)
+#elif defined(ECS_TARGET_CLANG)
+#define ECS_ALIGNOF(T) (int64_t)__alignof__(T)
 #else
 #define ECS_ALIGNOF(T) ((int64_t)&((struct { char c; T d; } *)0)->d)
 #endif

--- a/include/flecs/private/api_defines.h
+++ b/include/flecs/private/api_defines.h
@@ -226,6 +226,8 @@ typedef struct ecs_allocator_t ecs_allocator_t;
 #define ECS_ALIGNOF(T) (int64_t)__alignof(T)
 #elif defined(ECS_TARGET_GNU)
 #define ECS_ALIGNOF(T) (int64_t)__alignof__(T)
+#elif defined(ECS_TARGET_CLANG)
+#define ECS_ALIGNOF(T) (int64_t)__alignof__(T)
 #else
 #define ECS_ALIGNOF(T) ((int64_t)&((struct { char c; T d; } *)0)->d)
 #endif


### PR DESCRIPTION
Summary: This upstreams a change that ensures that `__alignof__` is used when compiling with clang.

Reviewed By: Jason-M-Fugate

Differential Revision: D62051794
