### PR TITLE
Improve usability of ecs_set_entity_range function

### DIFF
--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -19040,12 +19040,16 @@ void ecs_set_entity_range(
     ecs_check(!id_end || id_end > flecs_entities_max_id(world),
         ECS_INVALID_PARAMETER, NULL);
 
+    if (id_start == 0) {
+      id_start = flecs_entities_max_id(world) + 1;
+    }
+
     uint32_t start = (uint32_t)id_start;
     uint32_t end = (uint32_t)id_end;
 
-    if (flecs_entities_max_id(world) < start) {
-        flecs_entities_max_id(world) = start - 1;
-    }
+    flecs_entities_max_id(world) = start - 1;
+    ecs_check(!id_end || id_end > flecs_entities_max_id(world),
+        ECS_INVALID_PARAMETER, NULL);
 
     world->info.min_id = start;
     world->info.max_id = end;

--- a/src/world.c
+++ b/src/world.c
@@ -1598,12 +1598,16 @@ void ecs_set_entity_range(
     ecs_check(!id_end || id_end > flecs_entities_max_id(world),
         ECS_INVALID_PARAMETER, NULL);
 
+    if (id_start == 0) {
+      id_start = flecs_entities_max_id(world) + 1;
+    }
+
     uint32_t start = (uint32_t)id_start;
     uint32_t end = (uint32_t)id_end;
 
-    if (flecs_entities_max_id(world) < start) {
-        flecs_entities_max_id(world) = start - 1;
-    }
+    flecs_entities_max_id(world) = start - 1;
+    ecs_check(!id_end || id_end > flecs_entities_max_id(world),
+        ECS_INVALID_PARAMETER, NULL);
 
     world->info.min_id = start;
     world->info.max_id = end;

--- a/test/core/project.json
+++ b/test/core/project.json
@@ -1891,6 +1891,8 @@
                 "entity_range_add_out_of_range_staged",
                 "entity_range_out_of_range_check_disabled",
                 "entity_range_check_after_delete",
+                "entity_range_offset_0",
+                "entity_range_set_limit_to_lower",
                 "dim",
                 "phases",
                 "phases_w_merging",

--- a/test/core/src/World.c
+++ b/test/core/src/World.c
@@ -261,6 +261,37 @@ void World_entity_range_add_out_of_range_staged(void) {
     ecs_fini(world);
 }
 
+void World_entity_range_offset_0(void) {
+    ecs_world_t *world = ecs_mini();
+
+    const ecs_world_info_t *info = ecs_get_world_info(world);
+    test_assert(info != NULL);
+
+    ecs_set_entity_range(world, 0, 1000);
+
+    test_uint(info->min_id, ecs_get_max_id(world) + 1);
+    test_uint(info->max_id, 1000);
+
+    ecs_fini(world);
+}
+
+void World_entity_range_set_limit_to_lower(void) {
+    ecs_world_t *world = ecs_mini();
+
+    const ecs_world_info_t *info = ecs_get_world_info(world);
+    test_assert(info != NULL);
+
+    ecs_set_entity_range(world, 0, 2000);
+
+    test_uint(info->max_id, 2000);
+
+    ecs_set_entity_range(world, 0, 1000);
+
+    test_uint(info->max_id, 1000);
+
+    ecs_fini(world);
+}
+
 void World_get_tick(void) {
     ecs_world_t *world = ecs_init();
 


### PR DESCRIPTION
Summary:
This diff upstreams two changes:
- Providing 0 for the `offset` parameter of `ecs_set_entity_range` will default to the max issued entity id
- Setting the `limit` parameter of `ecs_set_entity_range` to a value that is lower than a previously provided value is now allowed

Reviewed By: Jason-M-Fugate

Differential Revision: D62052785
