### PR TITLE
Add flecs::ref::has

### DIFF
--- a/distr/flecs.h
+++ b/distr/flecs.h
@@ -27511,9 +27511,13 @@ struct ref {
         return get();
     }
 
-    /** implicit conversion to bool.  return true if there is a valid T* being referred to **/
-    operator bool() {       
+    bool has() {
         return !!try_get();
+    }
+
+    /** implicit conversion to bool.  return true if there is a valid T* being referred to **/
+    operator bool() {
+        return has();
     }
 
     flecs::entity entity() const;

--- a/include/flecs/addons/cpp/ref.hpp
+++ b/include/flecs/addons/cpp/ref.hpp
@@ -66,9 +66,13 @@ struct ref {
         return get();
     }
 
-    /** implicit conversion to bool.  return true if there is a valid T* being referred to **/
-    operator bool() {       
+    bool has() {
         return !!try_get();
+    }
+
+    /** implicit conversion to bool.  return true if there is a valid T* being referred to **/
+    operator bool() {
+        return has();
     }
 
     flecs::entity entity() const;

--- a/test/cpp/project.json
+++ b/test/cpp/project.json
@@ -1018,7 +1018,9 @@
                 "default_ctor",
                 "ctor_from_entity",
                 "implicit_operator_bool",
-                "try_get"
+                "try_get",
+                "has",
+                "bool_operator"
             ]
         }, {
             "id": "Module",

--- a/test/cpp/src/Refs.cpp
+++ b/test/cpp/src/Refs.cpp
@@ -190,3 +190,39 @@ void Refs_try_get(void) {
 
     test_assert(p.try_get() == nullptr);
 }
+
+void Refs_has(void) {
+    flecs::world world;
+
+    flecs::entity e = world.entity();
+
+    {
+        flecs::ref<Position> p = e.get_ref<Position>();
+        test_assert(!p.has());
+    }
+
+    e.set<Position>({10, 20});
+
+    {
+        flecs::ref<Position> p = e.get_ref<Position>();
+        test_assert(p.has());
+    }
+}
+
+void Refs_bool_operator(void) {
+    flecs::world world;
+
+    flecs::entity e = world.entity();
+
+    {
+        flecs::ref<Position> p = e.get_ref<Position>();
+        test_assert(!p);
+    }
+
+    e.set<Position>({10, 20});
+
+    {
+        flecs::ref<Position> p = e.get_ref<Position>();
+        test_assert(p);
+    }
+}

--- a/test/cpp/src/main.cpp
+++ b/test/cpp/src/main.cpp
@@ -982,6 +982,8 @@ void Refs_default_ctor(void);
 void Refs_ctor_from_entity(void);
 void Refs_implicit_operator_bool(void);
 void Refs_try_get(void);
+void Refs_has(void);
+void Refs_bool_operator(void);
 
 // Testsuite 'Module'
 void Module_import(void);
@@ -5159,6 +5161,14 @@ bake_test_case Refs_testcases[] = {
     {
         "try_get",
         Refs_try_get
+    },
+    {
+        "has",
+        Refs_has
+    },
+    {
+        "bool_operator",
+        Refs_bool_operator
     }
 };
 
@@ -6655,7 +6665,7 @@ static bake_test_suite suites[] = {
         "Refs",
         NULL,
         NULL,
-        15,
+        17,
         Refs_testcases
     },
     {


### PR DESCRIPTION
Summary: This diff upstreams a change that adds a `has` method to `flecs::ref`.

Differential Revision: D62446531
