### PR TITLE
Fix issue with testing tables for wildcard pair ids

### DIFF
--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -38215,7 +38215,6 @@ int32_t ecs_table_get_type_index(
 {
     flecs_poly_assert(world, ecs_world_t);
     ecs_check(table != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_check(ecs_id_is_valid(world, id), ECS_INVALID_PARAMETER, NULL);
 
     if (id < FLECS_HI_COMPONENT_ID) {
         int16_t res = table->component_map[id];

--- a/src/storage/table.c
+++ b/src/storage/table.c
@@ -2259,7 +2259,6 @@ int32_t ecs_table_get_type_index(
 {
     flecs_poly_assert(world, ecs_world_t);
     ecs_check(table != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_check(ecs_id_is_valid(world, id), ECS_INVALID_PARAMETER, NULL);
 
     if (id < FLECS_HI_COMPONENT_ID) {
         int16_t res = table->component_map[id];

--- a/test/core/project.json
+++ b/test/core/project.json
@@ -2239,7 +2239,11 @@
                 "get_depth",
                 "get_depth_non_acyclic",
                 "get_depth_2_paths",
-                "get_column_size"
+                "get_column_size",
+                "has_id",
+                "has_pair",
+                "has_wildcard_pair",
+                "has_any_pair"
             ]
         }, {
             "id": "Poly",

--- a/test/core/src/Table.c
+++ b/test/core/src/Table.c
@@ -542,3 +542,78 @@ void Table_get_column_size(void) {
 
     ecs_fini(world);
 }
+
+void Table_has_id(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, Tag);
+    ECS_TAG(world, Foo);
+
+    ecs_entity_t e1 = ecs_new(world);
+    ecs_add(world, e1, Foo);
+
+    ecs_table_t *table = ecs_get_table(world, e1);
+    test_assert(table != NULL);
+
+    test_assert(ecs_table_has_id(world, table, Foo));
+    test_assert(!ecs_table_has_id(world, table, Tag));
+
+    ecs_fini(world);
+}
+
+void Table_has_pair(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, Rel);
+    ECS_TAG(world, Tgt);
+    ECS_TAG(world, Tag);
+
+    ecs_entity_t e1 = ecs_new(world);
+    ecs_add_pair(world, e1, Rel, Tgt);
+
+    ecs_table_t *table = ecs_get_table(world, e1);
+    test_assert(table != NULL);
+
+    test_assert(ecs_table_has_id(world, table, ecs_pair(Rel, Tgt)));
+    test_assert(!ecs_table_has_id(world, table, Tag));
+
+    ecs_fini(world);
+}
+
+void Table_has_wildcard_pair(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, Rel);
+    ECS_TAG(world, Tgt);
+    ECS_TAG(world, Tag);
+
+    ecs_entity_t e1 = ecs_new(world);
+    ecs_add_pair(world, e1, Rel, Tgt);
+
+    ecs_table_t *table = ecs_get_table(world, e1);
+    test_assert(table != NULL);
+
+    test_assert(ecs_table_has_id(world, table, ecs_pair(Rel, EcsWildcard)));
+    test_assert(!ecs_table_has_id(world, table, Tag));
+
+    ecs_fini(world);
+}
+
+void Table_has_any_pair(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, Rel);
+    ECS_TAG(world, Tgt);
+    ECS_TAG(world, Tag);
+
+    ecs_entity_t e1 = ecs_new(world);
+    ecs_add_pair(world, e1, Rel, Tgt);
+
+    ecs_table_t *table = ecs_get_table(world, e1);
+    test_assert(table != NULL);
+
+    test_assert(ecs_table_has_id(world, table, ecs_pair(Rel, EcsAny)));
+    test_assert(!ecs_table_has_id(world, table, Tag));
+
+    ecs_fini(world);
+}

--- a/test/core/src/main.c
+++ b/test/core/src/main.c
@@ -2152,6 +2152,10 @@ void Table_get_depth(void);
 void Table_get_depth_non_acyclic(void);
 void Table_get_depth_2_paths(void);
 void Table_get_column_size(void);
+void Table_has_id(void);
+void Table_has_pair(void);
+void Table_has_wildcard_pair(void);
+void Table_has_any_pair(void);
 
 // Testsuite 'Poly'
 void Poly_on_set_poly_observer(void);
@@ -10513,6 +10517,22 @@ bake_test_case Table_testcases[] = {
     {
         "get_column_size",
         Table_get_column_size
+    },
+    {
+        "has_id",
+        Table_has_id
+    },
+    {
+        "has_pair",
+        Table_has_pair
+    },
+    {
+        "has_wildcard_pair",
+        Table_has_wildcard_pair
+    },
+    {
+        "has_any_pair",
+        Table_has_any_pair
     }
 };
 
@@ -10961,7 +10981,7 @@ static bake_test_suite suites[] = {
         "Table",
         NULL,
         NULL,
-        20,
+        24,
         Table_testcases
     },
     {


### PR DESCRIPTION
Summary: This diff upstreams a change that fixes an issue with testing a table for wildcard ids.

Differential Revision: D62449697


