### PR TITLE
Add flecs::iter::other_table()

### DIFF
--- a/distr/flecs.h
+++ b/distr/flecs.h
@@ -22510,6 +22510,8 @@ public:
 
     flecs::table table() const;
 
+    flecs::table other_table() const;
+
     flecs::table_range range() const;
 
     /** Access ctx.
@@ -32401,6 +32403,10 @@ inline flecs::type iter::type() const {
 
 inline flecs::table iter::table() const {
     return flecs::table(iter_->real_world, iter_->table);
+}
+
+inline flecs::table iter::other_table() const {
+    return flecs::table(iter_->real_world, iter_->other_table);
 }
 
 inline flecs::table_range iter::range() const {

--- a/include/flecs/addons/cpp/impl/iter.hpp
+++ b/include/flecs/addons/cpp/impl/iter.hpp
@@ -54,6 +54,10 @@ inline flecs::table iter::table() const {
     return flecs::table(iter_->real_world, iter_->table);
 }
 
+inline flecs::table iter::other_table() const {
+    return flecs::table(iter_->real_world, iter_->other_table);
+}
+
 inline flecs::table_range iter::range() const {
     return flecs::table_range(iter_->real_world, iter_->table, 
         iter_->offset, iter_->count);

--- a/include/flecs/addons/cpp/iter.hpp
+++ b/include/flecs/addons/cpp/iter.hpp
@@ -117,6 +117,8 @@ public:
 
     flecs::table table() const;
 
+    flecs::table other_table() const;
+
     flecs::table_range range() const;
 
     /** Access ctx.

--- a/test/cpp/project.json
+++ b/test/cpp/project.json
@@ -918,7 +918,10 @@
                 "register_twice_w_each",
                 "register_twice_w_run",
                 "register_twice_w_run_each",
-                "register_twice_w_each_run"
+                "register_twice_w_each_run",
+                "other_table",
+                "other_table_w_pair",
+                "other_table_w_pair_wildcard"
             ]
         }, {
             "id": "ComponentLifecycle",

--- a/test/cpp/src/Observer.cpp
+++ b/test/cpp/src/Observer.cpp
@@ -1136,3 +1136,65 @@ void Observer_register_twice_w_each_run(void) {
     ecs.entity().set(Position{10, 20});
     test_int(count2, 1);
 }
+
+void Observer_other_table(void) {
+    flecs::world ecs;
+
+    int32_t count = 0;
+
+    ecs.observer<Velocity>()
+        .event(flecs::OnAdd)
+        .each([&](flecs::iter& it, size_t, Velocity&) {
+            test_assert(it.table().has<Velocity>());
+            test_assert(!it.other_table().has<Velocity>());
+            count ++;
+        });
+
+    flecs::entity e = ecs.entity().add<Position>().add<Velocity>();
+
+    test_int(count, 1);
+}
+
+void Observer_other_table_w_pair(void) {
+    flecs::world ecs;
+
+    struct Likes {};
+    struct Apples {};
+
+    int32_t count = 0;
+
+    ecs.observer()
+        .with<Likes, Apples>()
+        .event(flecs::OnAdd)
+        .each([&](flecs::iter& it, size_t) {
+            test_assert((it.table().has<Likes, Apples>()));
+            test_assert((!it.other_table().has<Likes, Apples>()));
+            count ++;
+        });
+
+    flecs::entity e = ecs.entity().add<Position>().add<Likes, Apples>();
+
+    test_int(count, 1);
+}
+
+void Observer_other_table_w_pair_wildcard(void) {
+    flecs::world ecs;
+
+    struct Likes {};
+    struct Apples {};
+
+    int32_t count = 0;
+
+    ecs.observer()
+        .with<Likes, Apples>()
+        .event(flecs::OnAdd)
+        .each([&](flecs::iter& it, size_t) {
+            test_assert((it.table().has<Likes>(flecs::Wildcard)));
+            test_assert((!it.other_table().has<Likes>(flecs::Wildcard)));
+            count ++;
+        });
+
+    flecs::entity e = ecs.entity().add<Position>().add<Likes, Apples>();
+
+    test_int(count, 1);
+}

--- a/test/cpp/src/main.cpp
+++ b/test/cpp/src/main.cpp
@@ -886,6 +886,9 @@ void Observer_register_twice_w_each(void);
 void Observer_register_twice_w_run(void);
 void Observer_register_twice_w_run_each(void);
 void Observer_register_twice_w_each_run(void);
+void Observer_other_table(void);
+void Observer_other_table_w_pair(void);
+void Observer_other_table_w_pair_wildcard(void);
 
 // Testsuite 'ComponentLifecycle'
 void ComponentLifecycle_ctor_on_add(void);
@@ -4789,6 +4792,18 @@ bake_test_case Observer_testcases[] = {
     {
         "register_twice_w_each_run",
         Observer_register_twice_w_each_run
+    },
+    {
+        "other_table",
+        Observer_other_table
+    },
+    {
+        "other_table_w_pair",
+        Observer_other_table_w_pair
+    },
+    {
+        "other_table_w_pair_wildcard",
+        Observer_other_table_w_pair_wildcard
     }
 };
 
@@ -6661,7 +6676,7 @@ static bake_test_suite suites[] = {
         "Observer",
         NULL,
         NULL,
-        46,
+        49,
         Observer_testcases
     },
     {


### PR DESCRIPTION
Summary: This diff upstreams a change that adds an `flecs::iter::other_table()` method.

Differential Revision: D62449718
