### PR TITLE
fix leak in ecs_clone

### DIFF
--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -7940,7 +7940,9 @@ ecs_entity_t ecs_clone(
         .added_flags = dst_table->flags & EcsTableAddEdgeFlags
     };
     ecs_record_t *dst_r = flecs_entities_get(world, dst);
-    flecs_new_entity(world, dst, dst_r, dst_table, &diff, true, 0);
+    /* Note 'ctor' parameter below is set to 'false' if the value will be copied, since flecs_table_move
+       will call a copy constructor */
+    flecs_new_entity(world, dst, dst_r, dst_table, &diff, !copy_value, 0);
     int32_t row = ECS_RECORD_TO_ROW(dst_r->row);
 
     if (copy_value) {

--- a/src/entity.c
+++ b/src/entity.c
@@ -2952,7 +2952,9 @@ ecs_entity_t ecs_clone(
         .added_flags = dst_table->flags & EcsTableAddEdgeFlags
     };
     ecs_record_t *dst_r = flecs_entities_get(world, dst);
-    flecs_new_entity(world, dst, dst_r, dst_table, &diff, true, 0);
+    /* Note 'ctor' parameter below is set to 'false' if the value will be copied, since flecs_table_move
+       will call a copy constructor */
+    flecs_new_entity(world, dst, dst_r, dst_table, &diff, !copy_value, 0);
     int32_t row = ECS_RECORD_TO_ROW(dst_r->row);
 
     if (copy_value) {

--- a/test/core/project.json
+++ b/test/core/project.json
@@ -1045,6 +1045,7 @@
                 "1_component",
                 "2_component",
                 "1_component_w_value",
+                "1_component_w_lifecycle",
                 "2_component_w_value",
                 "3_component",
                 "3_component_w_value",

--- a/test/core/src/Clone.c
+++ b/test/core/src/Clone.c
@@ -263,6 +263,82 @@ void Clone_3_component_w_value(void) {
     ecs_fini(world);
 }
 
+static int ctor_position = 0;
+static
+ECS_CTOR(Position, ptr, {
+    ptr->x = 7;
+    ptr->y = 9;
+    ctor_position ++;
+})
+
+static int dtor_position = 0;
+static
+ECS_DTOR(Position, ptr, {
+    dtor_position ++;
+})
+
+static int copy_position = 0;
+static
+ECS_COPY(Position, dst, src, {
+    copy_position ++;
+    *dst = *src;
+})
+
+static int move_position = 0;
+static
+ECS_MOVE(Position, dst, src, {
+    move_position ++;
+    *dst = *src;
+})
+
+void Clone_1_component_w_lifecycle(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_COMPONENT(world, Position);
+        ecs_set_hooks(world, Position, {
+        .ctor = ecs_ctor(Position),
+        .dtor = ecs_dtor(Position),
+        .copy = ecs_copy(Position),
+        .move = ecs_move(Position)
+    });
+
+    ecs_entity_t e1 = ecs_new(world);
+    test_assert(e1 != 0);
+
+    Position * p = ecs_ensure(world, e1, Position);
+    test_int(1, ctor_position);
+    /* Check we get the special default values as per the ctor above */
+    test_int(7, p->x);
+    test_int(9, p->y);
+
+    /* Change the values to something different than default */
+    p->x = 1;
+    p->y = 2;
+
+    ecs_entity_t e2 = ecs_clone(world, 0, e1, true);
+    /* Test for leaks. Only 2 position objects should be alive */
+    test_int(2, ctor_position - dtor_position);
+    test_assert(e2 != 0);
+    test_assert(e1 != e2);
+
+    test_assert(ecs_has(world, e1, Position));
+    test_assert(ecs_has(world, e2, Position));
+
+    const Position *p_1 = ecs_get(world, e1, Position);
+    test_assert(p_1 != NULL);
+    test_int(1, p_1->x);
+    test_int(2, p_1->y);
+
+    const Position *p_2 = ecs_get(world, e2, Position);
+    test_assert(p_2 != NULL);
+    test_assert(p_1 != p_2);
+    test_int(1, p_2->x);
+    test_int(2, p_2->y);
+
+    ecs_fini(world);
+    test_int(0, ctor_position - dtor_position); /* test for leaks */
+}
+
 void Clone_tag(void) {
     ecs_world_t *world = ecs_mini();
 

--- a/test/core/src/main.c
+++ b/test/core/src/main.c
@@ -991,6 +991,7 @@ void Clone_null_w_value(void);
 void Clone_1_component(void);
 void Clone_2_component(void);
 void Clone_1_component_w_value(void);
+void Clone_1_component_w_lifecycle(void);
 void Clone_2_component_w_value(void);
 void Clone_3_component(void);
 void Clone_3_component_w_value(void);
@@ -5988,6 +5989,10 @@ bake_test_case Clone_testcases[] = {
         Clone_1_component_w_value
     },
     {
+        "1_component_w_lifecycle",
+        Clone_1_component_w_lifecycle
+    },
+    {
         "2_component_w_value",
         Clone_2_component_w_value
     },
@@ -10862,7 +10867,7 @@ static bake_test_suite suites[] = {
         "Clone",
         NULL,
         NULL,
-        15,
+        16,
         Clone_testcases
     },
     {


### PR DESCRIPTION
When working on #1330 I noticed that when copying an entity with `ecs_clone(...,true)`, a component's ctor was being called twice, the second time over already initialized memory. This causes a memory leak of components that allocate dynamic memory in the constructor.

Even if the component is trivial, the registered constructor was being called twice during a clone anyway. This PR fixes that and adds a test to make sure there are no leaks.

The bug does not affect copies created while instantiating a prefab.
