### PR TITLE
Expose C/C++ functions to parse component id expressions

### DIFF
--- a/distr/flecs.h
+++ b/distr/flecs.h
@@ -7517,7 +7517,7 @@ FLECS_API
 const char* ecs_id_flag_str(
     ecs_id_t id_flags);
 
-/** Convert id to string.
+/** Convert (component) id to string.
  * This operation interprets the structure of an id and converts it to a string.
  *
  * @param world The world.
@@ -7529,7 +7529,7 @@ char* ecs_id_str(
     const ecs_world_t *world,
     ecs_id_t id);
 
-/** Write id string to buffer.
+/** Write (component) id string to buffer.
  * Same as ecs_id_str() but writes result to ecs_strbuf_t.
  *
  * @param world The world.
@@ -7541,6 +7541,18 @@ void ecs_id_str_buf(
     const ecs_world_t *world,
     ecs_id_t id,
     ecs_strbuf_t *buf);
+
+/** Convert string to a (component) id.
+ * This operation is the reverse of ecs_id_str(). The FLECS_SCRIPT addon
+ * is required for this operation to work.
+ *
+ * @param world The world.
+ * @param expr The string to convert to an id.
+ */
+FLECS_API
+ecs_id_t ecs_id_from_str(
+    const ecs_world_t *world,
+    const char *expr);
 
 /** @} */
 
@@ -17909,6 +17921,10 @@ struct id {
     explicit id(flecs::world_t *world, flecs::id_t first, flecs::id_t second)
         : world_(world)
         , id_(ecs_pair(first, second)) { }
+
+    explicit id(flecs::world_t *world, const char *expr)
+        : world_(world)
+        , id_(ecs_id_from_str(world, expr)) { }
 
     explicit id(flecs::id_t first, flecs::id_t second)
         : world_(nullptr)

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -4310,7 +4310,7 @@ FLECS_API
 const char* ecs_id_flag_str(
     ecs_id_t id_flags);
 
-/** Convert id to string.
+/** Convert (component) id to string.
  * This operation interprets the structure of an id and converts it to a string.
  *
  * @param world The world.
@@ -4322,7 +4322,7 @@ char* ecs_id_str(
     const ecs_world_t *world,
     ecs_id_t id);
 
-/** Write id string to buffer.
+/** Write (component) id string to buffer.
  * Same as ecs_id_str() but writes result to ecs_strbuf_t.
  *
  * @param world The world.
@@ -4334,6 +4334,18 @@ void ecs_id_str_buf(
     const ecs_world_t *world,
     ecs_id_t id,
     ecs_strbuf_t *buf);
+
+/** Convert string to a (component) id.
+ * This operation is the reverse of ecs_id_str(). The FLECS_SCRIPT addon
+ * is required for this operation to work.
+ *
+ * @param world The world.
+ * @param expr The string to convert to an id.
+ */
+FLECS_API
+ecs_id_t ecs_id_from_str(
+    const ecs_world_t *world,
+    const char *expr);
 
 /** @} */
 

--- a/include/flecs/addons/cpp/mixins/id/decl.hpp
+++ b/include/flecs/addons/cpp/mixins/id/decl.hpp
@@ -41,6 +41,10 @@ struct id {
         : world_(world)
         , id_(ecs_pair(first, second)) { }
 
+    explicit id(flecs::world_t *world, const char *expr)
+        : world_(world)
+        , id_(ecs_id_from_str(world, expr)) { }
+
     explicit id(flecs::id_t first, flecs::id_t second)
         : world_(nullptr)
         , id_(ecs_pair(first, second)) { }

--- a/src/addons/script/query_parser.c
+++ b/src/addons/script/query_parser.c
@@ -666,12 +666,6 @@ const char* flecs_id_parse(
         return NULL;
     }
 
-    if (!ecs_id_is_valid(world, term.id)) {
-        ecs_parser_error(name, expr, (result - expr), 
-            "invalid term for add expression");
-        return NULL;
-    }
-
     if (term.oper != EcsAnd) {
         ecs_parser_error(name, expr, (result - expr), 
             "invalid operator for add expression");

--- a/src/entity.c
+++ b/src/entity.c
@@ -1616,6 +1616,15 @@ int flecs_traverse_from_expr(
             if (!id) {
                 break;
             }
+
+            if (!ecs_id_is_valid(world, id)) {
+                char *idstr = ecs_id_str(world, id);
+                ecs_parser_error(name, expr, (ptr - expr), 
+                    "id %s is invalid for add expression", idstr);
+                ecs_os_free(idstr);
+                goto error;
+            }
+
             ecs_vec_append_t(&world->allocator, ids, ecs_id_t)[0] = id;
         }
 

--- a/src/id.c
+++ b/src/id.c
@@ -5,6 +5,10 @@
 
 #include "private_api.h"
 
+#ifdef FLECS_SCRIPT
+#include "addons/script/script.h"
+#endif
+
 bool ecs_id_match(
     ecs_id_t id,
     ecs_id_t pattern)
@@ -129,4 +133,27 @@ ecs_flags32_t ecs_id_get_flags(
     } else {
         return 0;
     }
+}
+
+ecs_id_t ecs_id_from_str(
+    const ecs_world_t *world,
+    const char *expr)
+{
+#ifdef FLECS_SCRIPT
+    ecs_id_t result;
+
+    /* Temporarily disable parser logging */
+    int prev_level = ecs_log_set_level(-3);
+    if (!flecs_id_parse(world, NULL, expr, &result)) {
+        /* Invalid expression */
+        ecs_log_set_level(prev_level);
+        return 0;
+    }
+    ecs_log_set_level(prev_level);
+    return result;
+#else
+    (void)world;
+    (void)expr;
+    ecs_abort(ECS_UNSUPPORTED, "ecs_id_from_str requires FLECS_SCRIPT addon");
+#endif
 }

--- a/test/core/project.json
+++ b/test/core/project.json
@@ -50,7 +50,17 @@
                 "pair_id_toggle_is_tag",
                 "make_pair",
                 "make_pair_of_pair",
-                "make_pair_of_pair_tgt"
+                "make_pair_of_pair_tgt",
+                "0_entity",
+                "entity_from_str",
+                "unresolved_entity_from_str",
+                "scoped_entity_from_str",
+                "template_entity_from_str",
+                "pair_from_str",
+                "unresolved_pair_from_str",
+                "wildcard_pair_from_str",
+                "any_pair_from_str",
+                "invalid_pair"
             ]
         }, {
             "id": "Entity",

--- a/test/core/src/Id.c
+++ b/test/core/src/Id.c
@@ -267,3 +267,118 @@ void Id_make_pair_of_pair_tgt(void) {
     test_expect_abort();
     ecs_make_pair(r, id);
 }
+
+void Id_0_entity(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ecs_id_t id = ecs_id_from_str(world, "#0");
+    test_assert(id == 0);
+
+    ecs_fini(world);
+}
+
+void Id_entity_from_str(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, Foo);
+
+    ecs_id_t id = ecs_id_from_str(world, "Foo");
+    test_assert(id != 0);
+    test_assert(id == Foo);
+
+    ecs_fini(world);
+}
+
+void Id_unresolved_entity_from_str(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ecs_id_t id = ecs_id_from_str(world, "Foo");
+    test_assert(id == 0);
+
+    ecs_fini(world);
+}
+
+void Id_scoped_entity_from_str(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ecs_entity_t parent = ecs_entity(world, {.name = "Parent"});
+    ecs_entity_t child = ecs_entity(world, {.name = "Child", .parent = parent});
+
+    ecs_id_t id = ecs_id_from_str(world, "Parent.Child");
+    test_assert(id != 0);
+    test_assert(id == child);
+
+    ecs_fini(world);
+}
+
+void Id_template_entity_from_str(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ecs_entity_t foo = ecs_entity(world, {.name = "Foo<Bar>"});
+
+    ecs_id_t id = ecs_id_from_str(world, "Foo<Bar>");
+    test_assert(id != 0);
+    test_assert(id == foo);
+
+    ecs_fini(world);
+}
+
+void Id_pair_from_str(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, Rel);
+    ECS_TAG(world, Tgt);
+
+    ecs_id_t id = ecs_id_from_str(world, "(Rel, Tgt)");
+    test_assert(id != 0);
+    test_assert(id == ecs_pair(Rel, Tgt));
+
+    ecs_fini(world);
+}
+
+void Id_unresolved_pair_from_str(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, Rel);
+
+    ecs_id_t id = ecs_id_from_str(world, "(Rel, Tgt)");
+    test_assert(id == 0);
+
+    ecs_fini(world);
+}
+
+void Id_wildcard_pair_from_str(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, Rel);
+
+    ecs_id_t id = ecs_id_from_str(world, "(Rel, *)");
+    test_assert(id != 0);
+    test_assert(id == ecs_pair(Rel, EcsWildcard));
+
+    ecs_fini(world);
+}
+
+void Id_any_pair_from_str(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, Rel);
+
+    ecs_id_t id = ecs_id_from_str(world, "(Rel, _)");
+    test_assert(id != 0);
+    test_assert(id == ecs_pair(Rel, EcsAny));
+
+    ecs_fini(world);
+}
+
+void Id_invalid_pair(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, Rel);
+    ECS_TAG(world, Tgt);
+
+    ecs_id_t id = ecs_id_from_str(world, "(Rel, Tgt");
+    test_assert(id == 0);
+
+    ecs_fini(world);
+}

--- a/test/core/src/main.c
+++ b/test/core/src/main.c
@@ -46,6 +46,16 @@ void Id_pair_id_toggle_is_tag(void);
 void Id_make_pair(void);
 void Id_make_pair_of_pair(void);
 void Id_make_pair_of_pair_tgt(void);
+void Id_0_entity(void);
+void Id_entity_from_str(void);
+void Id_unresolved_entity_from_str(void);
+void Id_scoped_entity_from_str(void);
+void Id_template_entity_from_str(void);
+void Id_pair_from_str(void);
+void Id_unresolved_pair_from_str(void);
+void Id_wildcard_pair_from_str(void);
+void Id_any_pair_from_str(void);
+void Id_invalid_pair(void);
 
 // Testsuite 'Entity'
 void Entity_init_id(void);
@@ -2381,6 +2391,46 @@ bake_test_case Id_testcases[] = {
     {
         "make_pair_of_pair_tgt",
         Id_make_pair_of_pair_tgt
+    },
+    {
+        "0_entity",
+        Id_0_entity
+    },
+    {
+        "entity_from_str",
+        Id_entity_from_str
+    },
+    {
+        "unresolved_entity_from_str",
+        Id_unresolved_entity_from_str
+    },
+    {
+        "scoped_entity_from_str",
+        Id_scoped_entity_from_str
+    },
+    {
+        "template_entity_from_str",
+        Id_template_entity_from_str
+    },
+    {
+        "pair_from_str",
+        Id_pair_from_str
+    },
+    {
+        "unresolved_pair_from_str",
+        Id_unresolved_pair_from_str
+    },
+    {
+        "wildcard_pair_from_str",
+        Id_wildcard_pair_from_str
+    },
+    {
+        "any_pair_from_str",
+        Id_any_pair_from_str
+    },
+    {
+        "invalid_pair",
+        Id_invalid_pair
     }
 };
 
@@ -10849,7 +10899,7 @@ static bake_test_suite suites[] = {
         "Id",
         NULL,
         NULL,
-        37,
+        47,
         Id_testcases
     },
     {

--- a/test/cpp/project.json
+++ b/test/cpp/project.json
@@ -435,7 +435,17 @@
                 "alias_entity",
                 "alias_entity_by_name",
                 "alias_entity_by_scoped_name",
-                "alias_entity_empty"
+                "alias_entity_empty",
+                "id_from_str_0_entity",
+                "id_from_str_entity_from_str",
+                "id_from_str_unresolved_entity_from_str",
+                "id_from_str_scoped_entity_from_str",
+                "id_from_str_template_entity_from_str",
+                "id_from_str_pair_from_str",
+                "id_from_str_unresolved_pair_from_str",
+                "id_from_str_wildcard_pair_from_str",
+                "id_from_str_any_pair_from_str",
+                "id_from_str_invalid_pair"
             ]
         }, {
             "id": "System",

--- a/test/cpp/src/Paths.cpp
+++ b/test/cpp/src/Paths.cpp
@@ -233,3 +233,97 @@ void Paths_alias_entity_empty(void) {
     test_assert(e.id() != 0);
 }
 
+
+void Paths_id_from_str_0_entity(void) {
+    flecs::world ecs;
+
+    flecs::id id = ecs.id("#0");
+    test_assert(id == 0);
+}
+
+void Paths_id_from_str_entity_from_str(void) {
+    flecs::world ecs;
+
+    flecs::entity foo = ecs.entity("foo");
+
+    flecs::id id = ecs.id("foo");
+    test_assert(id != 0);
+    test_assert(id == foo);
+}
+
+void Paths_id_from_str_unresolved_entity_from_str(void) {
+    flecs::world ecs;
+
+    flecs::id id = ecs.id("foo");
+    test_assert(id == 0);
+}
+
+void Paths_id_from_str_scoped_entity_from_str(void) {
+    flecs::world ecs;
+
+    flecs::entity foo = ecs.entity("foo::bar");
+
+    flecs::id id = ecs.id("foo.bar");
+    test_assert(id != 0);
+    test_assert(id == foo);
+}
+
+void Paths_id_from_str_template_entity_from_str(void) {
+    flecs::world ecs;
+
+    flecs::entity foo = ecs.entity("foo<bar>");
+
+    flecs::id id = ecs.id("foo<bar>");
+    test_assert(id != 0);
+    test_assert(id == foo);
+}
+
+void Paths_id_from_str_pair_from_str(void) {
+    flecs::world ecs;
+
+    flecs::entity rel = ecs.entity("Rel");
+    flecs::entity tgt = ecs.entity("Tgt");
+
+    flecs::id id = ecs.id("(Rel, Tgt)");
+    test_assert(id != 0);
+    test_assert(id == ecs.pair(rel, tgt));
+}
+
+void Paths_id_from_str_unresolved_pair_from_str(void) {
+    flecs::world ecs;
+
+    flecs::entity rel = ecs.entity("Rel");
+
+    flecs::id id = ecs.id("(Rel, Tgt)");
+    test_assert(id == 0);
+}
+
+void Paths_id_from_str_wildcard_pair_from_str(void) {
+    flecs::world ecs;
+
+    flecs::entity rel = ecs.entity("Rel");
+
+    flecs::id id = ecs.id("(Rel, *)");
+    test_assert(id != 0);
+    test_assert(id == ecs.pair(rel, flecs::Wildcard));
+}
+
+void Paths_id_from_str_any_pair_from_str(void) {
+    flecs::world ecs;
+
+    flecs::entity rel = ecs.entity("Rel");
+
+    flecs::id id = ecs.id("(Rel, _)");
+    test_assert(id != 0);
+    test_assert(id == ecs.pair(rel, flecs::Any));
+}
+
+void Paths_id_from_str_invalid_pair(void) {
+    flecs::world ecs;
+
+    flecs::entity rel = ecs.entity("Rel");
+    flecs::entity tgt = ecs.entity("Tgt");
+
+    flecs::id id = ecs.id("(Rel, Tgt");
+    test_assert(id == 0);
+}

--- a/test/cpp/src/main.cpp
+++ b/test/cpp/src/main.cpp
@@ -420,6 +420,16 @@ void Paths_alias_entity(void);
 void Paths_alias_entity_by_name(void);
 void Paths_alias_entity_by_scoped_name(void);
 void Paths_alias_entity_empty(void);
+void Paths_id_from_str_0_entity(void);
+void Paths_id_from_str_entity_from_str(void);
+void Paths_id_from_str_unresolved_entity_from_str(void);
+void Paths_id_from_str_scoped_entity_from_str(void);
+void Paths_id_from_str_template_entity_from_str(void);
+void Paths_id_from_str_pair_from_str(void);
+void Paths_id_from_str_unresolved_pair_from_str(void);
+void Paths_id_from_str_wildcard_pair_from_str(void);
+void Paths_id_from_str_any_pair_from_str(void);
+void Paths_id_from_str_invalid_pair(void);
 
 // Testsuite 'System'
 void System_iter(void);
@@ -2978,6 +2988,46 @@ bake_test_case Paths_testcases[] = {
     {
         "alias_entity_empty",
         Paths_alias_entity_empty
+    },
+    {
+        "id_from_str_0_entity",
+        Paths_id_from_str_0_entity
+    },
+    {
+        "id_from_str_entity_from_str",
+        Paths_id_from_str_entity_from_str
+    },
+    {
+        "id_from_str_unresolved_entity_from_str",
+        Paths_id_from_str_unresolved_entity_from_str
+    },
+    {
+        "id_from_str_scoped_entity_from_str",
+        Paths_id_from_str_scoped_entity_from_str
+    },
+    {
+        "id_from_str_template_entity_from_str",
+        Paths_id_from_str_template_entity_from_str
+    },
+    {
+        "id_from_str_pair_from_str",
+        Paths_id_from_str_pair_from_str
+    },
+    {
+        "id_from_str_unresolved_pair_from_str",
+        Paths_id_from_str_unresolved_pair_from_str
+    },
+    {
+        "id_from_str_wildcard_pair_from_str",
+        Paths_id_from_str_wildcard_pair_from_str
+    },
+    {
+        "id_from_str_any_pair_from_str",
+        Paths_id_from_str_any_pair_from_str
+    },
+    {
+        "id_from_str_invalid_pair",
+        Paths_id_from_str_invalid_pair
     }
 };
 
@@ -6680,7 +6730,7 @@ static bake_test_suite suites[] = {
         "Paths",
         NULL,
         NULL,
-        15,
+        25,
         Paths_testcases
     },
     {


### PR DESCRIPTION
Summary: This diff adds an `ecs_id_from_str` function that parses a (component) id expression into an id, and adds a `flecs::id::id(flecs::world_t*, const char*)` constructor.

Differential Revision: D63060151
