### PR TITLE
Fix issue in flecs::stats module when global MatchEmptyTables flag is set

### DIFF
--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -61781,6 +61781,10 @@ void MonitorStats(ecs_iter_t *it) {
 
                 cur = 0;
                 count = qit.count;
+                if (!count) {
+                    cur = -1;
+                    continue;
+                }
             } else {
                 cur ++;
             }

--- a/src/addons/stats/monitor.c
+++ b/src/addons/stats/monitor.c
@@ -78,6 +78,10 @@ void MonitorStats(ecs_iter_t *it) {
 
                 cur = 0;
                 count = qit.count;
+                if (!count) {
+                    cur = -1;
+                    continue;
+                }
             } else {
                 cur ++;
             }

--- a/test/addons/project.json
+++ b/test/addons/project.json
@@ -347,7 +347,8 @@
                 "get_entity_count",
                 "get_pipeline_stats_w_task_system",
                 "get_not_alive_entity_count",
-                "progress_stats_systems"
+                "progress_stats_systems",
+                "progress_stats_systems_w_empty_table_flag"
             ]
         }, {
             "id": "Run",

--- a/test/addons/src/Stats.c
+++ b/test/addons/src/Stats.c
@@ -259,9 +259,25 @@ void Stats_progress_stats_systems(void) {
 
     ECS_IMPORT(world, FlecsStats);
 
-    // for (int i = 0; i < 60 * 60; i ++) {
-    //     ecs_progress(world, 0.016);
-    // }
+    for (int i = 0; i < 60 * 60; i ++) {
+        ecs_progress(world, 0.016);
+    }
+
+    test_assert(true); // used to catch memory leaks
+
+    ecs_fini(world);
+}
+
+void Stats_progress_stats_systems_w_empty_table_flag(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ecs_set_default_query_flags(world, EcsQueryMatchEmptyTables);
+
+    ECS_IMPORT(world, FlecsStats);
+
+    for (int i = 0; i < 60 * 60; i ++) {
+        ecs_progress(world, 0.016);
+    }
 
     test_assert(true); // used to catch memory leaks
 

--- a/test/addons/src/main.c
+++ b/test/addons/src/main.c
@@ -320,6 +320,7 @@ void Stats_get_entity_count(void);
 void Stats_get_pipeline_stats_w_task_system(void);
 void Stats_get_not_alive_entity_count(void);
 void Stats_progress_stats_systems(void);
+void Stats_progress_stats_systems_w_empty_table_flag(void);
 
 // Testsuite 'Run'
 void Run_setup(void);
@@ -1711,6 +1712,10 @@ bake_test_case Stats_testcases[] = {
     {
         "progress_stats_systems",
         Stats_progress_stats_systems
+    },
+    {
+        "progress_stats_systems_w_empty_table_flag",
+        Stats_progress_stats_systems_w_empty_table_flag
     }
 };
 
@@ -2607,7 +2612,7 @@ static bake_test_suite suites[] = {
         "Stats",
         NULL,
         NULL,
-        12,
+        13,
         Stats_testcases
     },
     {


### PR DESCRIPTION
Summary: This diff fixes an assert that happens because the stats module does not correctly handle empty tables, which can be returned by queries if the application sets the global `EcsQueryMatchEmptyTables` flag.

Differential Revision: D63355531
