### PR TITLE
Added ecs_table_clear_entities

### DIFF
--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -37034,14 +37034,12 @@ const ecs_entity_t* ecs_table_entities(
     return table->data.entities;
 }
 
-/* Cleanup, optionally run OnRemove, clear entity index, deactivate table, optionally free allocations */
+/* Cleanup, no OnRemove, delete from entity index, deactivate table, retain allocations */
 void ecs_table_clear_entities(
     ecs_world_t* world,
-    ecs_table_t* table,
-    bool notify,
-    bool deallocate)
+    ecs_table_t* table)
 {
-    flecs_table_fini_data(world, table, notify, true, true, deallocate);
+    flecs_table_fini_data(world, table, true, true, true, false);
 }
 
 /* Cleanup, no OnRemove, clear entity index, deactivate table, free allocations */

--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -37041,7 +37041,7 @@ void ecs_table_clear_entities(
     bool notify,
     bool deallocate)
 {
-    flecs_table_fini_data(world, table, notify, false, true, deallocate);
+    flecs_table_fini_data(world, table, notify, true, true, deallocate);
 }
 
 /* Cleanup, no OnRemove, clear entity index, deactivate table, free allocations */

--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -36961,7 +36961,8 @@ void flecs_table_fini_data(
     ecs_table_t *table,
     bool do_on_remove,
     bool is_delete,
-    bool deactivate)
+    bool deactivate,
+    bool deallocate)
 {
     ecs_assert(!table->_->lock, ECS_LOCKED_STORAGE, FLECS_LOCKED_STORAGE_MSG);
 
@@ -36974,36 +36975,50 @@ void flecs_table_fini_data(
         flecs_table_dtor_all(world, table, 0, count, is_delete);
     }
 
-    ecs_column_t *columns = table->data.columns;
-    if (columns) {
-        int32_t c, column_count = table->column_count;
-        for (c = 0; c < column_count; c ++) {
-            ecs_column_t *column = &columns[c];
-            ecs_vec_t v = ecs_vec_from_column(column, table, column->ti->size);
-            ecs_vec_fini(&world->allocator, &v, column->ti->size);
-            column->data = NULL;
-        }
+    if (deallocate) {
+        ecs_column_t *columns = table->data.columns;
+        if (columns) {
+            int32_t c, column_count = table->column_count;
+            for (c = 0; c < column_count; c ++) {
+                ecs_column_t *column = &columns[c];
+                ecs_vec_t v = ecs_vec_from_column(column, table, column->ti->size);
+                ecs_vec_fini(&world->allocator, &v, column->ti->size);
+                column->data = NULL;
+            }
 
-        flecs_wfree_n(world, ecs_column_t, table->column_count, columns);
-        table->data.columns = NULL;
+            flecs_wfree_n(world, ecs_column_t, table->column_count, columns);
+            table->data.columns = NULL;
+        }
     }
 
     ecs_table__t *meta = table->_;
     ecs_bitset_t *bs_columns = meta->bs_columns;
     if (bs_columns) {
         int32_t c, column_count = meta->bs_count;
-        for (c = 0; c < column_count; c ++) {
-            flecs_bitset_fini(&bs_columns[c]);
+        if (deallocate) {
+            for (c = 0; c < column_count; c ++) {
+                flecs_bitset_fini(&bs_columns[c]);
+            }
         }
-        flecs_wfree_n(world, ecs_bitset_t, column_count, bs_columns);
-        meta->bs_columns = NULL;
+        else {
+            for (c = 0; c < column_count; c++) {
+                bs_columns[c].count = 0;
+            }
+        }        
+        
+        if (deallocate) {
+            flecs_wfree_n(world, ecs_bitset_t, column_count, bs_columns);
+            meta->bs_columns = NULL;
+        }
     }
 
-    ecs_vec_t v = ecs_vec_from_entities(table);
-    ecs_vec_fini_t(&world->allocator, &v, ecs_entity_t);
-    table->data.entities = NULL;
+    if (deallocate) {
+        ecs_vec_t v = ecs_vec_from_entities(table);
+        ecs_vec_fini_t(&world->allocator, &v, ecs_entity_t);
+        table->data.entities = NULL;
+        table->data.size = 0;
+    }
     table->data.count = 0;
-    table->data.size = 0;
 
     if (deactivate && count) {
         flecs_table_set_empty(world, table);
@@ -37019,28 +37034,38 @@ const ecs_entity_t* ecs_table_entities(
     return table->data.entities;
 }
 
-/* Cleanup, no OnRemove, clear entity index, deactivate table */
+/* Cleanup, optionally run OnRemove, clear entity index, deactivate table, optionally free allocations */
+void ecs_table_clear_entities(
+    ecs_world_t* world,
+    ecs_table_t* table,
+    bool notify,
+    bool deallocate)
+{
+    flecs_table_fini_data(world, table, notify, false, true, deallocate);
+}
+
+/* Cleanup, no OnRemove, clear entity index, deactivate table, free allocations */
 void flecs_table_clear_entities_silent(
     ecs_world_t *world,
     ecs_table_t *table)
 {
-    flecs_table_fini_data(world, table, false, false, true);
+    flecs_table_fini_data(world, table, false, false, true, true);
 }
 
-/* Cleanup, run OnRemove, clear entity index, deactivate table */
+/* Cleanup, run OnRemove, clear entity index, deactivate table, free allocations */
 void flecs_table_clear_entities(
     ecs_world_t *world,
     ecs_table_t *table)
 {
-    flecs_table_fini_data(world, table, true, false, true);
+    flecs_table_fini_data(world, table, true, false, true, true);
 }
 
-/* Cleanup, run OnRemove, delete from entity index, deactivate table */
+/* Cleanup, run OnRemove, delete from entity index, deactivate table, free allocations */
 void flecs_table_delete_entities(
     ecs_world_t *world,
     ecs_table_t *table)
 {
-    flecs_table_fini_data(world, table, true, true, true);
+    flecs_table_fini_data(world, table, true, true, true, true);
 }
 
 /* Unset all components in table. This function is called before a table is 
@@ -37085,7 +37110,7 @@ void flecs_table_fini(
     world->info.empty_table_count -= (ecs_table_count(table) == 0);
 
     /* Cleanup data, no OnRemove, delete from entity index, don't deactivate */
-    flecs_table_fini_data(world, table, false, true, false);
+    flecs_table_fini_data(world, table, false, true, false, true);
     flecs_table_clear_edges(world, table);
 
     if (!is_root) {

--- a/distr/flecs.h
+++ b/distr/flecs.h
@@ -9188,21 +9188,17 @@ int32_t ecs_search_relation(
     ecs_id_t *id_out,
     struct ecs_table_record_t **tr_out);
 
-/** Remove all entities in a table. Optionally, notify all observers and 
- * deallocate table memory. Retaining table memory can be efficient when
- * planning to refill the table with operations like ecs_bulk_init
+/** Remove all entities in a table. Does not deallocate table memory. 
+ * Retaining table memory can be efficient when planning 
+ * to refill the table with operations like ecs_bulk_init
  *
  * @param world The world.
  * @param table The table to clear.
- * @param notify Call OnRemove hooks.
- * @param deallocate Deallocate unused table memory.
  */
 FLECS_API
 void ecs_table_clear_entities(
     ecs_world_t* world,
-    ecs_table_t* table,
-    bool notify,
-    bool deallocate);
+    ecs_table_t* table);
     
 /** @} */
 

--- a/distr/flecs.h
+++ b/distr/flecs.h
@@ -9188,6 +9188,22 @@ int32_t ecs_search_relation(
     ecs_id_t *id_out,
     struct ecs_table_record_t **tr_out);
 
+/** Remove all entities in a table. Optionally, notify all observers and 
+ * deallocate table memory. Retaining table memory can be efficient when
+ * planning to refill the table with operations like ecs_bulk_init
+ *
+ * @param world The world.
+ * @param table The table to clear.
+ * @param notify Call OnRemove hooks.
+ * @param deallocate Deallocate unused table memory.
+ */
+FLECS_API
+void ecs_table_clear_entities(
+    ecs_world_t* world,
+    ecs_table_t* table,
+    bool notify,
+    bool deallocate);
+    
 /** @} */
 
 /**

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -5974,6 +5974,22 @@ int32_t ecs_search_relation(
     ecs_id_t *id_out,
     struct ecs_table_record_t **tr_out);
 
+/** Remove all entities in a table. Optionally, notify all observers and 
+ * deallocate table memory. Retaining table memory can be efficient when
+ * planning to refill the table with operations like ecs_bulk_init
+ *
+ * @param world The world.
+ * @param table The table to clear.
+ * @param notify Call OnRemove hooks.
+ * @param deallocate Deallocate unused table memory.
+ */
+FLECS_API
+void ecs_table_clear_entities(
+    ecs_world_t* world,
+    ecs_table_t* table,
+    bool notify,
+    bool deallocate);
+    
 /** @} */
 
 /**

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -5974,21 +5974,17 @@ int32_t ecs_search_relation(
     ecs_id_t *id_out,
     struct ecs_table_record_t **tr_out);
 
-/** Remove all entities in a table. Optionally, notify all observers and 
- * deallocate table memory. Retaining table memory can be efficient when
- * planning to refill the table with operations like ecs_bulk_init
+/** Remove all entities in a table. Does not deallocate table memory. 
+ * Retaining table memory can be efficient when planning 
+ * to refill the table with operations like ecs_bulk_init
  *
  * @param world The world.
  * @param table The table to clear.
- * @param notify Call OnRemove hooks.
- * @param deallocate Deallocate unused table memory.
  */
 FLECS_API
 void ecs_table_clear_entities(
     ecs_world_t* world,
-    ecs_table_t* table,
-    bool notify,
-    bool deallocate);
+    ecs_table_t* table);
     
 /** @} */
 

--- a/src/storage/table.c
+++ b/src/storage/table.c
@@ -963,7 +963,7 @@ void ecs_table_clear_entities(
     bool notify,
     bool deallocate)
 {
-    flecs_table_fini_data(world, table, notify, false, true, deallocate);
+    flecs_table_fini_data(world, table, notify, true, true, deallocate);
 }
 
 /* Cleanup, no OnRemove, clear entity index, deactivate table, free allocations */

--- a/src/storage/table.c
+++ b/src/storage/table.c
@@ -883,7 +883,8 @@ void flecs_table_fini_data(
     ecs_table_t *table,
     bool do_on_remove,
     bool is_delete,
-    bool deactivate)
+    bool deactivate,
+    bool deallocate)
 {
     ecs_assert(!table->_->lock, ECS_LOCKED_STORAGE, FLECS_LOCKED_STORAGE_MSG);
 
@@ -896,36 +897,50 @@ void flecs_table_fini_data(
         flecs_table_dtor_all(world, table, 0, count, is_delete);
     }
 
-    ecs_column_t *columns = table->data.columns;
-    if (columns) {
-        int32_t c, column_count = table->column_count;
-        for (c = 0; c < column_count; c ++) {
-            ecs_column_t *column = &columns[c];
-            ecs_vec_t v = ecs_vec_from_column(column, table, column->ti->size);
-            ecs_vec_fini(&world->allocator, &v, column->ti->size);
-            column->data = NULL;
-        }
+    if (deallocate) {
+        ecs_column_t *columns = table->data.columns;
+        if (columns) {
+            int32_t c, column_count = table->column_count;
+            for (c = 0; c < column_count; c ++) {
+                ecs_column_t *column = &columns[c];
+                ecs_vec_t v = ecs_vec_from_column(column, table, column->ti->size);
+                ecs_vec_fini(&world->allocator, &v, column->ti->size);
+                column->data = NULL;
+            }
 
-        flecs_wfree_n(world, ecs_column_t, table->column_count, columns);
-        table->data.columns = NULL;
+            flecs_wfree_n(world, ecs_column_t, table->column_count, columns);
+            table->data.columns = NULL;
+        }
     }
 
     ecs_table__t *meta = table->_;
     ecs_bitset_t *bs_columns = meta->bs_columns;
     if (bs_columns) {
         int32_t c, column_count = meta->bs_count;
-        for (c = 0; c < column_count; c ++) {
-            flecs_bitset_fini(&bs_columns[c]);
+        if (deallocate) {
+            for (c = 0; c < column_count; c ++) {
+                flecs_bitset_fini(&bs_columns[c]);
+            }
         }
-        flecs_wfree_n(world, ecs_bitset_t, column_count, bs_columns);
-        meta->bs_columns = NULL;
+        else {
+            for (c = 0; c < column_count; c++) {
+                bs_columns[c].count = 0;
+            }
+        }        
+        
+        if (deallocate) {
+            flecs_wfree_n(world, ecs_bitset_t, column_count, bs_columns);
+            meta->bs_columns = NULL;
+        }
     }
 
-    ecs_vec_t v = ecs_vec_from_entities(table);
-    ecs_vec_fini_t(&world->allocator, &v, ecs_entity_t);
-    table->data.entities = NULL;
+    if (deallocate) {
+        ecs_vec_t v = ecs_vec_from_entities(table);
+        ecs_vec_fini_t(&world->allocator, &v, ecs_entity_t);
+        table->data.entities = NULL;
+        table->data.size = 0;
+    }
     table->data.count = 0;
-    table->data.size = 0;
 
     if (deactivate && count) {
         flecs_table_set_empty(world, table);
@@ -941,28 +956,38 @@ const ecs_entity_t* ecs_table_entities(
     return table->data.entities;
 }
 
-/* Cleanup, no OnRemove, clear entity index, deactivate table */
+/* Cleanup, optionally run OnRemove, clear entity index, deactivate table, optionally free allocations */
+void ecs_table_clear_entities(
+    ecs_world_t* world,
+    ecs_table_t* table,
+    bool notify,
+    bool deallocate)
+{
+    flecs_table_fini_data(world, table, notify, false, true, deallocate);
+}
+
+/* Cleanup, no OnRemove, clear entity index, deactivate table, free allocations */
 void flecs_table_clear_entities_silent(
     ecs_world_t *world,
     ecs_table_t *table)
 {
-    flecs_table_fini_data(world, table, false, false, true);
+    flecs_table_fini_data(world, table, false, false, true, true);
 }
 
-/* Cleanup, run OnRemove, clear entity index, deactivate table */
+/* Cleanup, run OnRemove, clear entity index, deactivate table, free allocations */
 void flecs_table_clear_entities(
     ecs_world_t *world,
     ecs_table_t *table)
 {
-    flecs_table_fini_data(world, table, true, false, true);
+    flecs_table_fini_data(world, table, true, false, true, true);
 }
 
-/* Cleanup, run OnRemove, delete from entity index, deactivate table */
+/* Cleanup, run OnRemove, delete from entity index, deactivate table, free allocations */
 void flecs_table_delete_entities(
     ecs_world_t *world,
     ecs_table_t *table)
 {
-    flecs_table_fini_data(world, table, true, true, true);
+    flecs_table_fini_data(world, table, true, true, true, true);
 }
 
 /* Unset all components in table. This function is called before a table is 
@@ -1007,7 +1032,7 @@ void flecs_table_fini(
     world->info.empty_table_count -= (ecs_table_count(table) == 0);
 
     /* Cleanup data, no OnRemove, delete from entity index, don't deactivate */
-    flecs_table_fini_data(world, table, false, true, false);
+    flecs_table_fini_data(world, table, false, true, false, true);
     flecs_table_clear_edges(world, table);
 
     if (!is_root) {

--- a/src/storage/table.c
+++ b/src/storage/table.c
@@ -956,14 +956,12 @@ const ecs_entity_t* ecs_table_entities(
     return table->data.entities;
 }
 
-/* Cleanup, optionally run OnRemove, clear entity index, deactivate table, optionally free allocations */
+/* Cleanup, no OnRemove, delete from entity index, deactivate table, retain allocations */
 void ecs_table_clear_entities(
     ecs_world_t* world,
-    ecs_table_t* table,
-    bool notify,
-    bool deallocate)
+    ecs_table_t* table)
 {
-    flecs_table_fini_data(world, table, notify, true, true, deallocate);
+    flecs_table_fini_data(world, table, true, true, true, false);
 }
 
 /* Cleanup, no OnRemove, clear entity index, deactivate table, free allocations */

--- a/test/core/project.json
+++ b/test/core/project.json
@@ -2296,7 +2296,13 @@
                 "has_id",
                 "has_pair",
                 "has_wildcard_pair",
-                "has_any_pair"
+                "has_any_pair",
+                "clear_table_kills_entities",
+                "clear_table_add_new",
+                "clear_table_check_size",
+                "clear_table_twice_check_size",
+                "clear_table_on_remove_hooks",
+                "clear_table_on_remove_observer"
             ]
         }, {
             "id": "Poly",

--- a/test/core/src/Table.c
+++ b/test/core/src/Table.c
@@ -618,8 +618,7 @@ void Table_has_any_pair(void) {
     ecs_fini(world);
 }
 
-static
-void Clear_table_and_verify_members_not_alive(bool notify, bool dealloc) {
+void Table_clear_table_kills_entities(void) {
     ecs_world_t *world = ecs_mini();
 
     ECS_COMPONENT(world, Position);
@@ -631,7 +630,7 @@ void Clear_table_and_verify_members_not_alive(bool notify, bool dealloc) {
 
     ecs_table_t *table = ecs_get_table(world, e1);
    
-    ecs_table_clear_entities(world, table, notify, dealloc);
+    ecs_table_clear_entities(world, table);
 
     test_assert(!ecs_is_alive(world, e1));
     test_assert(!ecs_is_alive(world, e2));
@@ -640,15 +639,7 @@ void Clear_table_and_verify_members_not_alive(bool notify, bool dealloc) {
     ecs_fini(world);
 }
 
-void Table_clear_table_kills_entities(void) {
-    Clear_table_and_verify_members_not_alive(true, true);
-    Clear_table_and_verify_members_not_alive(false, true);
-    Clear_table_and_verify_members_not_alive(true, false);
-    Clear_table_and_verify_members_not_alive(false, false);
-}
-
-static
-void Clear_table_and_verify_new_members_exist(bool notify, bool dealloc) {
+void Table_clear_table_add_new(void) {
     ecs_world_t *world = ecs_mini();
 
     ecs_entity_t ecs_id(Position) = ecs_component(world, {
@@ -664,7 +655,7 @@ void Clear_table_and_verify_new_members_exist(bool notify, bool dealloc) {
 
     ecs_table_t *table = ecs_get_table(world, e1);
    
-    ecs_table_clear_entities(world, table, notify, dealloc);
+    ecs_table_clear_entities(world, table);
 
     ecs_id(Position) = ecs_component(world, {
         .entity = ecs_new(world),
@@ -688,15 +679,7 @@ void Clear_table_and_verify_new_members_exist(bool notify, bool dealloc) {
     ecs_fini(world);
 }
 
-void Table_clear_table_add_new(void) {
-    Clear_table_and_verify_new_members_exist(true, true);
-    Clear_table_and_verify_new_members_exist(false, true);
-    Clear_table_and_verify_new_members_exist(true, false);
-    Clear_table_and_verify_new_members_exist(false, false);
-}
-
-static
-void Clear_table_and_check_size(bool notify, bool dealloc) {
+void Table_clear_table_check_size(void) {
     ecs_world_t *world = ecs_mini();
 
     ECS_COMPONENT(world, Position);
@@ -709,24 +692,16 @@ void Clear_table_and_check_size(bool notify, bool dealloc) {
     ecs_table_t *table = ecs_get_table(world, e1);
     const int32_t size = ecs_table_size(table);
 
-    ecs_table_clear_entities(world, table, notify, dealloc);
+    ecs_table_clear_entities(world, table);
 
-    const int32_t expected_size = dealloc ? 0 : size;
-    test_int(expected_size, ecs_table_size(table));
+    test_int(size, ecs_table_size(table));
     test_int(0, ecs_table_count(table));
 
     ecs_fini(world);
 }
 
-void Table_clear_table_check_size(void) {
-    Clear_table_and_check_size(true, true);
-    Clear_table_and_check_size(false, true);
-    Clear_table_and_check_size(true, false);
-    Clear_table_and_check_size(false, false);
-}
 
-static
-void Clear_table_twice_and_check_size(bool first_dealloc, bool second_dealloc) {
+void Table_clear_table_twice_check_size(void) {
     ecs_world_t *world = ecs_mini();
 
     ECS_COMPONENT(world, Position);
@@ -739,21 +714,13 @@ void Clear_table_twice_and_check_size(bool first_dealloc, bool second_dealloc) {
     ecs_table_t *table = ecs_get_table(world, e1);
     const int32_t size = ecs_table_size(table);
 
-    ecs_table_clear_entities(world, table, true, first_dealloc);
-    ecs_table_clear_entities(world, table, true, second_dealloc);
+    ecs_table_clear_entities(world, table);
+    ecs_table_clear_entities(world, table);
 
-    const int32_t expected_size = (first_dealloc || second_dealloc) ? 0 : size;
-    test_int(expected_size, ecs_table_size(table));
+    test_int(size, ecs_table_size(table));
     test_int(0, ecs_table_count(table));
  
     ecs_fini(world);
-}
-
-void Table_clear_table_twice_check_size(void) {
-    Clear_table_twice_and_check_size(true, true);
-    Clear_table_twice_and_check_size(false, true);
-    Clear_table_twice_and_check_size(true, false);
-    Clear_table_twice_and_check_size(false, false);
 }
 
 static int on_remove_position = 0;
@@ -770,8 +737,7 @@ static void ecs_on_remove(Position)(ecs_iter_t *it) {
     }
 }
 
-static
-void Verify_on_remove_hooks_table_clear(bool notify, bool dealloc) {
+void Table_clear_table_on_remove_hooks(void) {
     ecs_world_t *world = ecs_mini();
     on_remove_position = 0;
 
@@ -786,18 +752,11 @@ void Verify_on_remove_hooks_table_clear(bool notify, bool dealloc) {
     ecs_entity_t e3 = ecs_insert(world, ecs_value(Position, {10, 20}));
 
     ecs_table_t *table = ecs_get_table(world, e1);
-    ecs_table_clear_entities(world, table, notify, dealloc);
+    ecs_table_clear_entities(world, table);
       
     test_int(on_remove_position, 3);
 
     ecs_fini(world);
-}
-
-void Table_clear_table_on_remove_hooks(void) {
-    Verify_on_remove_hooks_table_clear(true, true);
-    Verify_on_remove_hooks_table_clear(false, true);
-    Verify_on_remove_hooks_table_clear(true, false);
-    Verify_on_remove_hooks_table_clear(false, false);
 }
 
 static
@@ -805,8 +764,7 @@ void Observer(ecs_iter_t *it) {
     probe_system_w_ctx(it, it->ctx);
 }
 
-static 
-void Check_on_remove_when_clearing_table(bool notify, bool dealloc) {
+void Table_clear_table_on_remove_observer(void) {
      ecs_world_t *world = ecs_mini();
 
     ECS_COMPONENT(world, Position);
@@ -828,17 +786,10 @@ void Check_on_remove_when_clearing_table(bool notify, bool dealloc) {
     test_int(ctx.invoked, 0);
 
     ecs_table_t *table = ecs_get_table(world, e1);
-    ecs_table_clear_entities(world, table, notify, dealloc);
+    ecs_table_clear_entities(world, table);
 
-    test_int(ctx.invoked, notify ? 1 : 0);
-    test_int(ctx.count, notify ? 2 : 0);
+    test_int(ctx.invoked, 1);
+    test_int(ctx.count, 2);
 
     ecs_fini(world);
-}
-
-void Table_clear_table_on_remove_observer(void) {
-    Check_on_remove_when_clearing_table(true, true);
-    Check_on_remove_when_clearing_table(false, true);
-    Check_on_remove_when_clearing_table(true, false);
-    Check_on_remove_when_clearing_table(false, false);
 }

--- a/test/core/src/Table.c
+++ b/test/core/src/Table.c
@@ -617,3 +617,228 @@ void Table_has_any_pair(void) {
 
     ecs_fini(world);
 }
+
+static
+void Clear_table_and_verify_members_not_alive(bool notify, bool dealloc) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_COMPONENT(world, Position);
+
+    ecs_entity_t e1 = ecs_new(world);
+    ecs_add(world, e1, Position);
+    ecs_entity_t e2 = ecs_new(world);
+    ecs_add(world, e2, Position);
+
+    ecs_table_t *table = ecs_get_table(world, e1);
+   
+    ecs_table_clear_entities(world, table, notify, dealloc);
+
+    test_assert(!ecs_is_alive(world, e1));
+    test_assert(!ecs_is_alive(world, e2));
+    test_int(0, ecs_table_count(table));
+
+    ecs_fini(world);
+}
+
+void Table_clear_table_kills_entities(void) {
+    Clear_table_and_verify_members_not_alive(true, true);
+    Clear_table_and_verify_members_not_alive(false, true);
+    Clear_table_and_verify_members_not_alive(true, false);
+    Clear_table_and_verify_members_not_alive(false, false);
+}
+
+static
+void Clear_table_and_verify_new_members_exist(bool notify, bool dealloc) {
+    ecs_world_t *world = ecs_mini();
+
+    ecs_entity_t ecs_id(Position) = ecs_component(world, {
+        .entity = ecs_new(world),
+        .type.size = ECS_SIZEOF(Position),
+        .type.alignment = ECS_ALIGNOF(Position)
+    });
+
+    ecs_entity_t e1 = ecs_new(world);
+    ecs_add(world, e1, Position);
+    ecs_entity_t e2 = ecs_new(world);
+    ecs_add(world, e2, Position);
+
+    ecs_table_t *table = ecs_get_table(world, e1);
+   
+    ecs_table_clear_entities(world, table, notify, dealloc);
+
+    ecs_id(Position) = ecs_component(world, {
+        .entity = ecs_new(world),
+        .type.size = ECS_SIZEOF(Position),
+        .type.alignment = ECS_ALIGNOF(Position)
+    });  
+
+    ecs_entity_t e3 = ecs_new(world);
+    ecs_add(world, e3, Position);
+    ecs_entity_t e4 = ecs_new(world);
+    ecs_add(world, e4, Position);
+    test_assert(ecs_is_alive(world, e3));
+    test_assert(ecs_is_alive(world, e4));
+ 
+    ecs_table_t *table_e3 = ecs_get_table(world, e3);
+    ecs_table_t *table_e4 = ecs_get_table(world, e4);
+
+    test_assert(table_e3 == table_e4);
+    test_int(2, ecs_table_count(table_e3));
+
+    ecs_fini(world);
+}
+
+void Table_clear_table_add_new(void) {
+    Clear_table_and_verify_new_members_exist(true, true);
+    Clear_table_and_verify_new_members_exist(false, true);
+    Clear_table_and_verify_new_members_exist(true, false);
+    Clear_table_and_verify_new_members_exist(false, false);
+}
+
+static
+void Clear_table_and_check_size(bool notify, bool dealloc) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_COMPONENT(world, Position);
+
+    ecs_entity_t e1 = ecs_new(world);
+    ecs_add(world, e1, Position);
+    ecs_entity_t e2 = ecs_new(world);
+    ecs_add(world, e2, Position);
+
+    ecs_table_t *table = ecs_get_table(world, e1);
+    const int32_t size = ecs_table_size(table);
+
+    ecs_table_clear_entities(world, table, notify, dealloc);
+
+    const int32_t expected_size = dealloc ? 0 : size;
+    test_int(expected_size, ecs_table_size(table));
+    test_int(0, ecs_table_count(table));
+
+    ecs_fini(world);
+}
+
+void Table_clear_table_check_size(void) {
+    Clear_table_and_check_size(true, true);
+    Clear_table_and_check_size(false, true);
+    Clear_table_and_check_size(true, false);
+    Clear_table_and_check_size(false, false);
+}
+
+static
+void Clear_table_twice_and_check_size(bool first_dealloc, bool second_dealloc) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_COMPONENT(world, Position);
+
+    ecs_entity_t e1 = ecs_new(world);
+    ecs_add(world, e1, Position);
+    ecs_entity_t e2 = ecs_new(world);
+    ecs_add(world, e2, Position);
+
+    ecs_table_t *table = ecs_get_table(world, e1);
+    const int32_t size = ecs_table_size(table);
+
+    ecs_table_clear_entities(world, table, true, first_dealloc);
+    ecs_table_clear_entities(world, table, true, second_dealloc);
+
+    const int32_t expected_size = (first_dealloc || second_dealloc) ? 0 : size;
+    test_int(expected_size, ecs_table_size(table));
+    test_int(0, ecs_table_count(table));
+ 
+    ecs_fini(world);
+}
+
+void Table_clear_table_twice_check_size(void) {
+    Clear_table_twice_and_check_size(true, true);
+    Clear_table_twice_and_check_size(false, true);
+    Clear_table_twice_and_check_size(true, false);
+    Clear_table_twice_and_check_size(false, false);
+}
+
+static int on_remove_position = 0;
+
+static void ecs_on_remove(Position)(ecs_iter_t *it) {
+    test_assert(it->count >= 1);
+    test_assert(it->event == EcsOnRemove);
+
+    Position *p = ecs_field(it, Position, 0);
+    for (int i = 0; i < it->count; i ++) {
+        on_remove_position ++;
+        test_int(p[i].x, 10);
+        test_int(p[i].y, 20);
+    }
+}
+
+static
+void Verify_on_remove_hooks_table_clear(bool notify, bool dealloc) {
+    ecs_world_t *world = ecs_mini();
+    on_remove_position = 0;
+
+    ECS_COMPONENT(world, Position);
+
+    ecs_set_hooks(world, Position, {
+        .on_remove = ecs_on_remove(Position)
+    });
+
+    ecs_entity_t e1 = ecs_insert(world, ecs_value(Position, {10, 20}));
+    ecs_entity_t e2 = ecs_insert(world, ecs_value(Position, {10, 20}));
+    ecs_entity_t e3 = ecs_insert(world, ecs_value(Position, {10, 20}));
+
+    ecs_table_t *table = ecs_get_table(world, e1);
+    ecs_table_clear_entities(world, table, notify, dealloc);
+      
+    test_int(on_remove_position, 3);
+
+    ecs_fini(world);
+}
+
+void Table_clear_table_on_remove_hooks(void) {
+    Verify_on_remove_hooks_table_clear(true, true);
+    Verify_on_remove_hooks_table_clear(false, true);
+    Verify_on_remove_hooks_table_clear(true, false);
+    Verify_on_remove_hooks_table_clear(false, false);
+}
+
+static
+void Observer(ecs_iter_t *it) {
+    probe_system_w_ctx(it, it->ctx);
+}
+
+static 
+void Check_on_remove_when_clearing_table(bool notify, bool dealloc) {
+     ecs_world_t *world = ecs_mini();
+
+    ECS_COMPONENT(world, Position);
+
+    Probe ctx = {0};
+    ecs_entity_t o = ecs_observer(world, {
+        .query.terms = {{EcsWildcard}},
+        .events = {EcsOnRemove},
+        .callback = Observer,
+        .ctx = &ctx
+    });
+    test_assert(o != 0);
+
+    ecs_entity_t e1 = ecs_new(world);
+    ecs_add(world, e1, Position);
+    ecs_entity_t e2 = ecs_new(world);
+    ecs_add(world, e2, Position);
+
+    test_int(ctx.invoked, 0);
+
+    ecs_table_t *table = ecs_get_table(world, e1);
+    ecs_table_clear_entities(world, table, notify, dealloc);
+
+    test_int(ctx.invoked, notify ? 1 : 0);
+    test_int(ctx.count, notify ? 2 : 0);
+
+    ecs_fini(world);
+}
+
+void Table_clear_table_on_remove_observer(void) {
+    Check_on_remove_when_clearing_table(true, true);
+    Check_on_remove_when_clearing_table(false, true);
+    Check_on_remove_when_clearing_table(true, false);
+    Check_on_remove_when_clearing_table(false, false);
+}

--- a/test/core/src/main.c
+++ b/test/core/src/main.c
@@ -2210,6 +2210,12 @@ void Table_has_id(void);
 void Table_has_pair(void);
 void Table_has_wildcard_pair(void);
 void Table_has_any_pair(void);
+void Table_clear_table_kills_entities(void);
+void Table_clear_table_add_new(void);
+void Table_clear_table_check_size(void);
+void Table_clear_table_twice_check_size(void);
+void Table_clear_table_on_remove_hooks(void);
+void Table_clear_table_on_remove_observer(void);
 
 // Testsuite 'Poly'
 void Poly_on_set_poly_observer(void);
@@ -10803,6 +10809,30 @@ bake_test_case Table_testcases[] = {
     {
         "has_any_pair",
         Table_has_any_pair
+    },
+    {
+        "clear_table_kills_entities",
+        Table_clear_table_kills_entities
+    },
+    {
+        "clear_table_add_new",
+        Table_clear_table_add_new
+    },
+    {
+        "clear_table_check_size",
+        Table_clear_table_check_size
+    },
+    {
+        "clear_table_twice_check_size",
+        Table_clear_table_twice_check_size
+    },
+    {
+        "clear_table_on_remove_hooks",
+        Table_clear_table_on_remove_hooks
+    },
+    {
+        "clear_table_on_remove_observer",
+        Table_clear_table_on_remove_observer
     }
 };
 
@@ -11251,7 +11281,7 @@ static bake_test_suite suites[] = {
         "Table",
         NULL,
         NULL,
-        24,
+        30,
         Table_testcases
     },
     {


### PR DESCRIPTION
Added ecs_table_clear_entities to allow users to clear a table's entities while optionally retaining its memory allocations. This can help reduce allocation churn when overwriting table entities using ecs_bulk_init. 

Discord Conversation: https://discord.com/channels/633826290415435777/1090412095893422101/1288146063982858242