### PR TITLE
Add FLECS_NO_ALERTS support

### DIFF
--- a/distr/flecs.h
+++ b/distr/flecs.h
@@ -10314,6 +10314,9 @@ int ecs_value_move_ctor(
 #ifdef FLECS_NO_SYSTEM
 #undef FLECS_SYSTEM
 #endif
+#ifdef FLECS_NO_ALERTS
+#undef FLECS_ALERTS
+#endif
 #ifdef FLECS_NO_PIPELINE
 #undef FLECS_PIPELINE
 #endif

--- a/include/flecs/private/addons.h
+++ b/include/flecs/private/addons.h
@@ -24,6 +24,9 @@
 #ifdef FLECS_NO_SYSTEM
 #undef FLECS_SYSTEM
 #endif
+#ifdef FLECS_NO_ALERTS
+#undef FLECS_ALERTS
+#endif
 #ifdef FLECS_NO_PIPELINE
 #undef FLECS_PIPELINE
 #endif


### PR DESCRIPTION
I was having some runtime crash with FLECS_REST and FLECS_TIMER (the last one which the alerts module uses) while compiling flecs with zig, but wasn't unable to disable FLECS_ALERTS, so I'm assuming that's missing unintentionally and I'm adding it here \o