### PR TITLE
remove FLECS_API in block_allocator.c -> fixes dll import issue

### DIFF
--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -28679,7 +28679,6 @@ void flecs_bfree(
     flecs_bfree_w_dbg_info(ba, memory, NULL);
 }
 
-FLECS_API
 void flecs_bfree_w_dbg_info(
     ecs_block_allocator_t *ba, 
     void *memory,

--- a/src/datastructures/block_allocator.c
+++ b/src/datastructures/block_allocator.c
@@ -167,7 +167,6 @@ void flecs_bfree(
     flecs_bfree_w_dbg_info(ba, memory, NULL);
 }
 
-FLECS_API
 void flecs_bfree_w_dbg_info(
     ecs_block_allocator_t *ba, 
     void *memory,


### PR DESCRIPTION
fixes error: flecs.c(28687): Error C2491 : 'flecs_bfree_w_dbg_info': definition of dllimport function not allowed