### PR TITLE
Fix issue with queries that match empty tables and iterate individual entities

### DIFF
--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -69582,6 +69582,9 @@ bool flecs_query_each(
     }
 
     if (!redo) {
+        if (!ecs_table_count(table)) {
+            return false;
+        }
         row = op_ctx->row = range.offset;
     } else {
         int32_t end = range.count;

--- a/src/query/engine/eval.c
+++ b/src/query/engine/eval.c
@@ -711,6 +711,9 @@ bool flecs_query_each(
     }
 
     if (!redo) {
+        if (!ecs_table_count(table)) {
+            return false;
+        }
         row = op_ctx->row = range.offset;
     } else {
         int32_t end = range.count;

--- a/test/query/project.json
+++ b/test/query/project.json
@@ -212,7 +212,7 @@
                 "inout_component_implicit_subject",
                 "inout_component_explicit_subject",
                 "inout_pair_implicit_subject",
-                "inout_pair_explicit_subject",   
+                "inout_pair_explicit_subject",
                 "out_component_implicit_subject",
                 "out_component_explicit_subject",
                 "out_pair_implicit_subject",
@@ -244,7 +244,7 @@
                 "from_or",
                 "from_not",
                 "pair_implicit_subject_optional",
-                "pair_explicit_subject_optional",                
+                "pair_explicit_subject_optional",
                 "pred_implicit_subject_w_role",
                 "pred_explicit_subject_w_role",
                 "pred_no_subject_w_role",
@@ -288,9 +288,9 @@
                 "pred_implicit_subject_superset_inclusive",
                 "pred_implicit_subject_superset_cascade",
                 "pred_implicit_subject_superset_inclusive_cascade",
-                "pred_implicit_subject_implicit_superset_cascade",         
+                "pred_implicit_subject_implicit_superset_cascade",
                 "pred_implicit_subject_implicit_superset_inclusive_cascade",
-                "pred_implicit_subject_implicit_superset_cascade_w_rel",         
+                "pred_implicit_subject_implicit_superset_cascade_w_rel",
                 "pred_implicit_subject_implicit_superset_inclusive_cascade_w_rel",
                 "pred_implicit_subject_superset_childof",
                 "pred_implicit_subject_cascade_superset_childof",
@@ -691,7 +691,8 @@
                 "written_pair_tgt_any_record",
                 "written_pair_any_any_record",
                 "pair_rel_any_record_component",
-                "pair_tgt_any_record_component"
+                "pair_tgt_any_record_component",
+                "entity_iteration_w_match_empty_tables"
             ]
         }, {
             "id": "Combinations",

--- a/test/query/src/main.c
+++ b/test/query/src/main.c
@@ -680,6 +680,7 @@ void Basic_written_pair_tgt_any_record(void);
 void Basic_written_pair_any_any_record(void);
 void Basic_pair_rel_any_record_component(void);
 void Basic_pair_tgt_any_record_component(void);
+void Basic_entity_iteration_w_match_empty_tables(void);
 
 // Testsuite 'Combinations'
 void Combinations_setup(void);
@@ -4777,6 +4778,10 @@ bake_test_case Basic_testcases[] = {
     {
         "pair_tgt_any_record_component",
         Basic_pair_tgt_any_record_component
+    },
+    {
+        "entity_iteration_w_match_empty_tables",
+        Basic_entity_iteration_w_match_empty_tables
     }
 };
 
@@ -10407,7 +10412,7 @@ static bake_test_suite suites[] = {
         "Basic",
         Basic_setup,
         NULL,
-        224,
+        225,
         Basic_testcases,
         1,
         Basic_params


### PR DESCRIPTION
Summary: This diff fixes an issue with queries that are created with the `EcsQueryMatchEmptyTables` flag, and iterate individual entities vs. entire tables.

Reviewed By: Jason-M-Fugate

Differential Revision: D63857210
