### PR TITLE
[meta] Notify on enum modifications

### DIFF
--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -50109,6 +50109,7 @@ int flecs_add_constant_to_enum(
     cptr = ecs_ensure_id(world, e, type);
     cptr[0] = value;
 
+    ecs_modified(world, type, EcsEnum);
     return 0;
 }
 

--- a/src/addons/meta/meta.c
+++ b/src/addons/meta/meta.c
@@ -638,6 +638,7 @@ int flecs_add_constant_to_enum(
     cptr = ecs_ensure_id(world, e, type);
     cptr[0] = value;
 
+    ecs_modified(world, type, EcsEnum);
     return 0;
 }
 

--- a/test/meta/project.json
+++ b/test/meta/project.json
@@ -81,7 +81,8 @@
                 "struct_w_enum",
                 "zero_initialized",
                 "enum_relation",
-                "enum_w_short_notation"
+                "enum_w_short_notation",
+                "enum_modified_event"
             ]
         }, {
             "id": "BitmaskTypes",

--- a/test/meta/src/main.c
+++ b/test/meta/src/main.c
@@ -75,6 +75,7 @@ void EnumTypes_struct_w_enum(void);
 void EnumTypes_zero_initialized(void);
 void EnumTypes_enum_relation(void);
 void EnumTypes_enum_w_short_notation(void);
+void EnumTypes_enum_modified_event(void);
 
 // Testsuite 'BitmaskTypes'
 void BitmaskTypes_bitmask_1_constant(void);
@@ -1246,6 +1247,10 @@ bake_test_case EnumTypes_testcases[] = {
     {
         "enum_w_short_notation",
         EnumTypes_enum_w_short_notation
+    },
+    {
+        "enum_modified_event",
+        EnumTypes_enum_modified_event
     }
 };
 
@@ -4811,7 +4816,7 @@ static bake_test_suite suites[] = {
         "EnumTypes",
         NULL,
         NULL,
-        8,
+        9,
         EnumTypes_testcases
     },
     {


### PR DESCRIPTION
This PR makes sure that when an enum changes, observers on `EcsEnum` (`flecs::Enum`) are notified.

This makes the api coherent with structs, that is, when a member is added to a struct, observers watching `EcsStruct` (`flecs::Struct`) are notified.

Normally, structs/enums/etc are only modified during startup logic as they are constructed. These notifications help serialization libraries synchronize what they know about the type.