### PR TITLE
Remove unnecessary version attribute from flecs bazel module definition

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,5 +1,5 @@
 "A fast entity component system (ECS) for C & C++"
-module(name = "flecs", version = "4.0.1")
+module(name = "flecs")
 
 git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 

--- a/examples/build/bazel/README.md
+++ b/examples/build/bazel/README.md
@@ -20,3 +20,29 @@ This directory contains a complete example of this usage. To try it you can run 
 ```
 bazel run //example
 ```
+
+To keep your flecs dependency up to date with [Renovate](https://docs.renovatebot.com/) + CI, make sure to declare the version attribute of the `bazel_dep`.
+Due to a bit of laziness, Renovate doesn't discover bzlmod dependencies without the `version` attribute. 
+The actual number doesn't matter, and it will create pull requests to update the commit.
+
+```bazel
+bazel_dep(name = "flecs", version = "0.0.0")
+git_override(
+    module_name = "flecs",
+    remote = "https://github.com/SanderMertens/flecs.git",
+    commit = "02c8c2666b22ccce5706c8f16efaf813704fe31e",
+)
+```
+
+If you use a merge queue for managing CI, you can configure Renovate to automatically kick off your CI and automerge for the dependency update with the following in your `.github/renovate.json5`
+
+```json5
+{
+  "extends": ["config:base"],
+  "dependencyDashboard": true,
+
+  "automerge": true,
+  "automergeType": "pr-comment", // have Renovate leave a comment to kick off CI + merge
+  "automergeComment": "/trunk merge" // the comment to leave
+}
+```


### PR DESCRIPTION
The version attribute is not required in bazel module definitions. Currently, the only way to depend on flecs with bzlmod is through `git_override`, which overrides the version with a specific commit anyways. if flecs becomes distributed on Bazel central, this decision will need to be reevaluated, but for now, it's easier to leave it off instead of having to maintain keeping the module version up to date with the current release.

Also updated the docs with guidance on how to configure renovate to autoupdate flecs dependency.