### PR TITLE
add performance tracing to pipeline phases

### DIFF
--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -25348,6 +25348,9 @@ struct ecs_pipeline_state_t {
     ecs_vec_t ops;              /* Pipeline schedule */
     ecs_vec_t systems;          /* Vector with system ids */
 
+    ecs_vec_t phase_offsets;    /* Vector of offsets into phase_names (for perf tracing) */
+    ecs_vec_t phase_names;      /* Vector with phase names (for perf tracing) */
+
     ecs_entity_t last_system;   /* Last system ran by pipeline */
     ecs_id_record_t *idr_inactive; /* Cached record for quick inactive test */
     int32_t match_count;        /* Used to track of rebuild is necessary */
@@ -52683,6 +52686,17 @@ static void flecs_pipeline_free(
         ecs_allocator_t *a = &world->allocator;
         ecs_vec_fini_t(a, &p->ops, ecs_pipeline_op_t);
         ecs_vec_fini_t(a, &p->systems, ecs_entity_t);
+
+#ifdef FLECS_PERF_TRACE
+        ecs_vec_fini_t(a, &p->phase_offsets, int32_t);
+        int32_t i, count = ecs_vec_count(&p->phase_names);
+        const char** phase_names = ecs_vec_first_t(&p->phase_names, const char*);
+        for (i = 0; i < count; i ++) {
+            ecs_os_free(ECS_CONST_CAST(char*, phase_names[i]));
+        }
+        ecs_vec_fini_t(a, &p->phase_names, const char*);
+#endif
+
         ecs_os_free(p->iters);
         ecs_query_fini(p->query);
         ecs_os_free(p);
@@ -52943,6 +52957,14 @@ bool flecs_pipeline_build(
     ecs_vec_reset_t(a, &pq->ops, ecs_pipeline_op_t);
     ecs_vec_reset_t(a, &pq->systems, ecs_entity_t);
 
+#ifdef FLECS_PERF_TRACE
+    ecs_vec_reset_t(a, &pq->phase_offsets, int32_t);
+    ecs_vec_reset_t(a, &pq->phase_names, const char*);
+    /* Local map for building up phase_offsets & phase_names */
+    ecs_map_t phase_offset_map;
+    ecs_map_init(&phase_offset_map, a);
+#endif
+
     bool multi_threaded = false;
     bool immediate = false;
     bool first = true;
@@ -52952,6 +52974,23 @@ bool flecs_pipeline_build(
         EcsPoly *poly = flecs_pipeline_term_system(&it);
         bool is_active = ecs_table_get_type_index(
             world, it.table, EcsEmpty) == -1;
+
+#ifdef FLECS_PERF_TRACE
+        ecs_entity_t phase = ecs_field_src(&it, 1);
+
+        ecs_map_val_t* phase_offset_p = ecs_map_get(&phase_offset_map, phase);
+        int32_t phase_offset = 0;
+        if (!phase_offset_p) {
+            /* New phase, record its name into the name vector */
+            phase_offset = ecs_vec_count(&pq->phase_names);
+            const char* phase_name = ecs_get_path(world, phase);
+
+            ecs_map_insert(&phase_offset_map, phase, (uint64_t)(phase_offset));
+            ecs_vec_append_t(a, &pq->phase_names, const char*)[0] = phase_name;
+        } else {
+            phase_offset = (int32_t)*phase_offset_p;
+        }
+#endif
 
         int32_t i;
         for (i = 0; i < it.count; i ++) {
@@ -53026,6 +53065,12 @@ bool flecs_pipeline_build(
             if (is_active) {
                 ecs_vec_append_t(a, &pq->systems, ecs_entity_t)[0] = 
                     it.entities[i];
+
+#ifdef FLECS_PERF_TRACE
+                /* Each system in the systems vector has a corresponding phase offset */
+                ecs_vec_append_t(a, &pq->phase_offsets, int32_t)[0] = phase_offset;
+#endif
+
                 if (!op->count) {
                     op->multi_threaded = multi_threaded;
                     op->immediate = immediate;
@@ -53041,6 +53086,10 @@ bool flecs_pipeline_build(
 
     ecs_map_fini(&ws.ids);
     ecs_map_fini(&ws.wildcard_ids);
+
+#ifdef FLECS_PERF_TRACE
+    ecs_map_fini(&phase_offset_map);
+#endif
 
     op = ecs_vec_first_t(&pq->ops, ecs_pipeline_op_t);
 
@@ -53219,7 +53268,27 @@ int32_t flecs_run_pipeline_ops(
     ecs_entity_t* systems = ecs_vec_first_t(&pq->systems, ecs_entity_t);
     int32_t ran_since_merge = i - op->offset;
 
+#ifdef FLECS_PERF_TRACE
+    int32_t* phase_offsets = ecs_vec_first_t(&pq->phase_offsets, int32_t);
+    const char** phase_names = ecs_vec_first_t(&pq->phase_names, const char*);
+#endif
+
     for (; i < count; i++) {
+#ifdef FLECS_PERF_TRACE
+        if (i > 0) {
+            int32_t phase = phase_offsets[i];
+            int32_t last_phase = phase_offsets[i - 1];
+
+            if (phase != last_phase) {
+                /* Close the span of the previous phase and open the current one.
+                 * The first/last phases are handled in flecs_run_pipeline because
+                 * this function may run multiple times during one pipeline. */
+                ecs_os_perf_trace_pop(phase_names[last_phase]);
+                ecs_os_perf_trace_push(phase_names[phase]);
+            }
+        }
+#endif
+
         ecs_entity_t system = systems[i];
         const EcsPoly* poly = ecs_get_pair(world, system, EcsPoly, EcsSystem);
         flecs_poly_assert(poly->poly, ecs_system_t);
@@ -53277,6 +53346,17 @@ void flecs_run_pipeline(
 
     // Update the pipeline before waking the workers.
     flecs_pipeline_update(world, pq, true);
+
+#ifdef FLECS_PERF_TRACE
+    int32_t* phase_offsets = ecs_vec_first_t(&pq->phase_offsets, int32_t);
+    const char** phase_names = ecs_vec_first_t(&pq->phase_names, const char*);
+
+    if (phase_offsets && phase_names) {
+        /* Open the span of the first phase in the pipeline.
+         * Intermediate phases are handled in flecs_run_pipeline_ops. */
+        ecs_os_perf_trace_push(phase_names[phase_offsets[0]]);
+    }
+#endif
 
     // If there are no operations to execute in the pipeline bail early,
     // no need to wake the workers since they have nothing to do.
@@ -53344,6 +53424,14 @@ void flecs_run_pipeline(
 
         flecs_pipeline_update(world, pq, false);
     }
+
+#ifdef FLECS_PERF_TRACE
+    if (phase_offsets && phase_names) {
+        int32_t last_phase_offset = ecs_vec_last_t(&pq->phase_offsets, int32_t)[0];
+        /* Close the span of the first phase in the pipeline */
+        ecs_os_perf_trace_pop(phase_names[last_phase_offset]);
+    }
+#endif
 }
 
 static

--- a/distr/flecs.h
+++ b/distr/flecs.h
@@ -11921,6 +11921,12 @@ typedef struct ecs_pipeline_desc_t {
      * pipeline query works.
     */
     ecs_query_desc_t query;
+
+    /** The pipeline query's phase term (optional).
+     * If non-zero, the source entity of this term will be considered a "phase"
+     * for the purposes of performance tracing.
+     */
+    int8_t query_phase_term;
 } ecs_pipeline_desc_t;
 
 /** Create a custom pipeline.

--- a/include/flecs/addons/pipeline.h
+++ b/include/flecs/addons/pipeline.h
@@ -113,6 +113,12 @@ typedef struct ecs_pipeline_desc_t {
      * pipeline query works.
     */
     ecs_query_desc_t query;
+
+    /** The pipeline query's phase term (optional).
+     * If non-zero, the source entity of this term will be considered a "phase"
+     * for the purposes of performance tracing.
+     */
+    int8_t query_phase_term;
 } ecs_pipeline_desc_t;
 
 /** Create a custom pipeline.

--- a/src/addons/pipeline/pipeline.c
+++ b/src/addons/pipeline/pipeline.c
@@ -307,19 +307,21 @@ bool flecs_pipeline_build(
             world, it.table, EcsEmpty) == -1;
 
 #ifdef FLECS_PERF_TRACE
-        ecs_entity_t phase = ecs_field_src(&it, 1);
-
-        ecs_map_val_t* phase_offset_p = ecs_map_get(&phase_offset_map, phase);
         int32_t phase_offset = 0;
-        if (!phase_offset_p) {
-            /* New phase, record its name into the name vector */
-            phase_offset = ecs_vec_count(&pq->phase_names);
-            const char* phase_name = ecs_get_path(world, phase);
+        if (pq->query_phase_term) {
+            ecs_entity_t phase = ecs_field_src(&it, pq->query_phase_term);
 
-            ecs_map_insert(&phase_offset_map, phase, (uint64_t)(phase_offset));
-            ecs_vec_append_t(a, &pq->phase_names, const char*)[0] = phase_name;
-        } else {
-            phase_offset = (int32_t)*phase_offset_p;
+            ecs_map_val_t* phase_offset_p = ecs_map_get(&phase_offset_map, phase);
+            if (!phase_offset_p) {
+                /* New phase, record its name into the name vector */
+                phase_offset = ecs_vec_count(&pq->phase_names);
+                const char* phase_name = ecs_get_path(world, phase);
+
+                ecs_map_insert(&phase_offset_map, phase, (uint64_t)(phase_offset));
+                ecs_vec_append_t(a, &pq->phase_names, const char*)[0] = phase_name;
+            } else {
+                phase_offset = (int32_t)*phase_offset_p;
+            }
         }
 #endif
 
@@ -398,8 +400,10 @@ bool flecs_pipeline_build(
                     it.entities[i];
 
 #ifdef FLECS_PERF_TRACE
-                /* Each system in the systems vector has a corresponding phase offset */
-                ecs_vec_append_t(a, &pq->phase_offsets, int32_t)[0] = phase_offset;
+                if (pq->query_phase_term) {
+                    /* Each system in the systems vector has a corresponding phase offset */
+                    ecs_vec_append_t(a, &pq->phase_offsets, int32_t)[0] = phase_offset;
+                }
 #endif
 
                 if (!op->count) {
@@ -606,16 +610,18 @@ int32_t flecs_run_pipeline_ops(
 
     for (; i < count; i++) {
 #ifdef FLECS_PERF_TRACE
-        if (i > 0) {
-            int32_t phase = phase_offsets[i];
-            int32_t last_phase = phase_offsets[i - 1];
+        if (pq->query_phase_term) {
+            if (i > 0) {
+                int32_t phase = phase_offsets[i];
+                int32_t last_phase = phase_offsets[i - 1];
 
-            if (phase != last_phase) {
-                /* Close the span of the previous phase and open the current one.
-                 * The first/last phases are handled in flecs_run_pipeline because
-                 * this function may run multiple times during one pipeline. */
-                ecs_os_perf_trace_pop(phase_names[last_phase]);
-                ecs_os_perf_trace_push(phase_names[phase]);
+                if (phase != last_phase) {
+                    /* Close the span of the previous phase and open the current one.
+                     * The first/last phases are handled in flecs_run_pipeline because
+                     * this function may run multiple times during one pipeline. */
+                    ecs_os_perf_trace_pop(phase_names[last_phase]);
+                    ecs_os_perf_trace_push(phase_names[phase]);
+                }
             }
         }
 #endif
@@ -682,7 +688,7 @@ void flecs_run_pipeline(
     int32_t* phase_offsets = ecs_vec_first_t(&pq->phase_offsets, int32_t);
     const char** phase_names = ecs_vec_first_t(&pq->phase_names, const char*);
 
-    if (phase_offsets && phase_names) {
+    if (pq->query_phase_term && phase_offsets && phase_names) {
         /* Open the span of the first phase in the pipeline.
          * Intermediate phases are handled in flecs_run_pipeline_ops. */
         ecs_os_perf_trace_push(phase_names[phase_offsets[0]]);
@@ -757,7 +763,7 @@ void flecs_run_pipeline(
     }
 
 #ifdef FLECS_PERF_TRACE
-    if (phase_offsets && phase_names) {
+    if (pq->query_phase_term && phase_offsets && phase_names) {
         int32_t last_phase_offset = ecs_vec_last_t(&pq->phase_offsets, int32_t)[0];
         /* Close the span of the first phase in the pipeline */
         ecs_os_perf_trace_pop(phase_names[last_phase_offset]);
@@ -796,7 +802,8 @@ void flecs_run_startup_systems(
                 { .id = EcsDisabled, .src.id = EcsUp, .trav = EcsChildOf, .oper = EcsNot }
             },
             .order_by_callback = flecs_entity_compare
-        }
+        },
+        .query_phase_term = 1,
     });
     ecs_log_pop_2();
 
@@ -926,6 +933,7 @@ ecs_entity_t ecs_pipeline_init(
 
     ecs_pipeline_state_t *pq = ecs_os_calloc_t(ecs_pipeline_state_t);
     pq->query = query;
+    pq->query_phase_term = desc->query_phase_term;
     pq->match_count = -1;
     pq->idr_inactive = flecs_id_record_ensure(world, EcsEmpty);
     ecs_set(world, result, EcsPipeline, { pq });
@@ -1023,7 +1031,8 @@ void FlecsPipelineImport(
                 { .id = EcsDisabled, .src.id = EcsUp, .trav = EcsChildOf, .oper = EcsNot }
             },
             .order_by_callback = flecs_entity_compare
-        }
+        },
+        .query_phase_term = 1,
     });
 
     /* Cleanup thread administration when world is destroyed */

--- a/src/addons/pipeline/pipeline.h
+++ b/src/addons/pipeline/pipeline.h
@@ -34,6 +34,8 @@ struct ecs_pipeline_state_t {
     ecs_iter_t *iters;          /* Iterator for worker(s) */
     int32_t iter_count;
 
+    int8_t query_phase_term;    /* Pipeline query phase term if != 0 (for perf tracing) */
+
     /* Members for continuing pipeline iteration after pipeline rebuild */
     ecs_pipeline_op_t *cur_op;  /* Current pipeline op */
     int32_t cur_i;              /* Index in current result */

--- a/src/addons/pipeline/pipeline.h
+++ b/src/addons/pipeline/pipeline.h
@@ -24,6 +24,9 @@ struct ecs_pipeline_state_t {
     ecs_vec_t ops;              /* Pipeline schedule */
     ecs_vec_t systems;          /* Vector with system ids */
 
+    ecs_vec_t phase_offsets;    /* Vector of offsets into phase_names (for perf tracing) */
+    ecs_vec_t phase_names;      /* Vector with phase names (for perf tracing) */
+
     ecs_entity_t last_system;   /* Last system ran by pipeline */
     ecs_id_record_t *idr_inactive; /* Cached record for quick inactive test */
     int32_t match_count;        /* Used to track of rebuild is necessary */


### PR DESCRIPTION
~~Note: I'm not sure how this will react to pipelines being modified while they are executing.~~
Tested with a basic example of pipeline modification during execution (system A toggles whether system B's entity is enabled) and it reacts appropriately.