### PR TITLE
[chore] Fix some annoying warnings in tests

### DIFF
--- a/test/core/src/Table.c
+++ b/test/core/src/Table.c
@@ -748,8 +748,8 @@ void Table_clear_table_on_remove_hooks(void) {
     });
 
     ecs_entity_t e1 = ecs_insert(world, ecs_value(Position, {10, 20}));
-    ecs_entity_t e2 = ecs_insert(world, ecs_value(Position, {10, 20}));
-    ecs_entity_t e3 = ecs_insert(world, ecs_value(Position, {10, 20}));
+    /* e2 */ ecs_insert(world, ecs_value(Position, {10, 20}));
+    /* e3 */ ecs_insert(world, ecs_value(Position, {10, 20}));
 
     ecs_table_t *table = ecs_get_table(world, e1);
     ecs_table_clear_entities(world, table);

--- a/test/cpp/src/Paths.cpp
+++ b/test/cpp/src/Paths.cpp
@@ -292,7 +292,7 @@ void Paths_id_from_str_pair_from_str(void) {
 void Paths_id_from_str_unresolved_pair_from_str(void) {
     flecs::world ecs;
 
-    flecs::entity rel = ecs.entity("Rel");
+    ecs.entity("Rel");
 
     flecs::id id = ecs.id("(Rel, Tgt)");
     test_assert(id == 0);
@@ -321,8 +321,8 @@ void Paths_id_from_str_any_pair_from_str(void) {
 void Paths_id_from_str_invalid_pair(void) {
     flecs::world ecs;
 
-    flecs::entity rel = ecs.entity("Rel");
-    flecs::entity tgt = ecs.entity("Tgt");
+    ecs.entity("Rel");
+    ecs.entity("Tgt");
 
     flecs::id id = ecs.id("(Rel, Tgt");
     test_assert(id == 0);


### PR DESCRIPTION
This PR just removes some unused variables in a few tests that were giving out warnings during compilation.