### PR TITLE
Fix crash when sorted query with MatchEmptyTables flag only matches empty tables

### DIFF
--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -68023,6 +68023,12 @@ ecs_query_cache_t* flecs_query_cache_init(
     ecs_flags32_t query_flags = const_desc->flags | world->default_query_flags;
     desc.flags |= EcsQueryMatchEmptyTables | EcsQueryTableOnly | EcsQueryNested;
 
+    /* order_by is not compatible with matching empty tables, as it causes
+     * a query to return table slices, not entire tables. */
+    if (const_desc->order_by_callback) {
+        query_flags &= ~EcsQueryMatchEmptyTables;
+    }
+
     ecs_query_t *q = result->query = ecs_query_init(world, &desc);
     if (!q) {
         goto error;

--- a/src/query/engine/cache.c
+++ b/src/query/engine/cache.c
@@ -1238,6 +1238,12 @@ ecs_query_cache_t* flecs_query_cache_init(
     ecs_flags32_t query_flags = const_desc->flags | world->default_query_flags;
     desc.flags |= EcsQueryMatchEmptyTables | EcsQueryTableOnly | EcsQueryNested;
 
+    /* order_by is not compatible with matching empty tables, as it causes
+     * a query to return table slices, not entire tables. */
+    if (const_desc->order_by_callback) {
+        query_flags &= ~EcsQueryMatchEmptyTables;
+    }
+
     ecs_query_t *q = result->query = ecs_query_init(world, &desc);
     if (!q) {
         goto error;

--- a/test/query/project.json
+++ b/test/query/project.json
@@ -2120,7 +2120,9 @@
                 "sort_by_wildcard",
                 "sort_not_term",
                 "sort_or_term",
-                "sort_optional_term"
+                "sort_optional_term",
+                "order_empty_table",
+                "order_empty_table_only"
             ]
         }, {
             "id": "OrderByEntireTable",

--- a/test/query/src/main.c
+++ b/test/query/src/main.c
@@ -2036,6 +2036,8 @@ void OrderBy_sort_by_wildcard(void);
 void OrderBy_sort_not_term(void);
 void OrderBy_sort_or_term(void);
 void OrderBy_sort_optional_term(void);
+void OrderBy_order_empty_table(void);
+void OrderBy_order_empty_table_only(void);
 
 // Testsuite 'OrderByEntireTable'
 void OrderByEntireTable_sort_by_component(void);
@@ -10066,6 +10068,14 @@ bake_test_case OrderBy_testcases[] = {
     {
         "sort_optional_term",
         OrderBy_sort_optional_term
+    },
+    {
+        "order_empty_table",
+        OrderBy_order_empty_table
+    },
+    {
+        "order_empty_table_only",
+        OrderBy_order_empty_table_only
     }
 };
 
@@ -10584,7 +10594,7 @@ static bake_test_suite suites[] = {
         "OrderBy",
         NULL,
         NULL,
-        42,
+        44,
         OrderBy_testcases
     },
     {


### PR DESCRIPTION
Summary: This issue fixes an assert that occurs when a query that is created with `EcsQueryMatchEmptyTables` (which is the default for HSR) and has an `order_by` callback, only matches empty tables.

Reviewed By: Jason-M-Fugate

Differential Revision: D66028916
