### PR TITLE
patch ecs_set_hooks_id being too strict with read-only flags

### DIFF
--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -19033,8 +19033,9 @@ void ecs_set_hooks_id(
 {
     ecs_check(world != NULL, ECS_INVALID_PARAMETER, NULL);
 
-    ecs_check(!(h->flags & ECS_TYPE_HOOKS), ECS_INVALID_PARAMETER, 
-        "hooks flags are derived");
+    /* TODO: Refactor to enforce flags consistency: */
+    ecs_flags32_t flags = h->flags;
+    flags &= ~((ecs_flags32_t)ECS_TYPE_HOOKS);
 
     /* TODO: enable asserts once RTT API is updated */
     /*
@@ -19115,7 +19116,6 @@ void ecs_set_hooks_id(
     }
 
     /* Set default copy ctor, move ctor and merge */
-    ecs_flags32_t flags = h->flags;
     if (!h->copy_ctor) {
         if(flags & ECS_TYPE_HOOK_COPY_ILLEGAL || flags & ECS_TYPE_HOOK_CTOR_ILLEGAL) {
             flags |= ECS_TYPE_HOOK_COPY_CTOR_ILLEGAL;

--- a/src/world.c
+++ b/src/world.c
@@ -1269,8 +1269,9 @@ void ecs_set_hooks_id(
 {
     ecs_check(world != NULL, ECS_INVALID_PARAMETER, NULL);
 
-    ecs_check(!(h->flags & ECS_TYPE_HOOKS), ECS_INVALID_PARAMETER, 
-        "hooks flags are derived");
+    /* TODO: Refactor to enforce flags consistency: */
+    ecs_flags32_t flags = h->flags;
+    flags &= ~((ecs_flags32_t)ECS_TYPE_HOOKS);
 
     /* TODO: enable asserts once RTT API is updated */
     /*
@@ -1351,7 +1352,6 @@ void ecs_set_hooks_id(
     }
 
     /* Set default copy ctor, move ctor and merge */
-    ecs_flags32_t flags = h->flags;
     if (!h->copy_ctor) {
         if(flags & ECS_TYPE_HOOK_COPY_ILLEGAL || flags & ECS_TYPE_HOOK_CTOR_ILLEGAL) {
             flags |= ECS_TYPE_HOOK_COPY_CTOR_ILLEGAL;

--- a/test/cpp/project.json
+++ b/test/cpp/project.json
@@ -1049,7 +1049,8 @@
                 "register_parent_after_child_w_hooks_implicit",
                 "sparse_component",
                 "count_in_add_hook",
-                "count_in_remove_hook"
+                "count_in_remove_hook",
+                "set_multiple_hooks"
             ]
         }, {
             "id": "Refs",

--- a/test/cpp/src/ComponentLifecycle.cpp
+++ b/test/cpp/src/ComponentLifecycle.cpp
@@ -2243,3 +2243,40 @@ void ComponentLifecycle_count_in_remove_hook(void) {
 
     test_int(matched, 0);
 }
+
+/* This test checks that the hook configuration API (ecs_set_hooks_id) 
+ * is invoked in a consistent manner */
+void ComponentLifecycle_set_multiple_hooks(void) {
+    flecs::world ecs;
+
+    /* `Pod` type has various lifecycle hooks */
+    auto pod = ecs.component<Pod>();
+    
+    /* It should be possible to configure other hooks afterwards: */
+    int adds = 0;
+    int sets = 0;
+    int removes = 0;
+    pod.on_add([&](Pod&) {
+        adds++;
+    });
+
+    pod.on_set([&](Pod&) {
+        sets++;
+    });
+
+    pod.on_remove([&](Pod&) {
+        removes++;
+    });
+
+    /* Test hooks actually work: */
+
+    ecs.entity().add<Pod>();
+    test_int(adds, 1);
+
+    ecs.entity().set<Pod>(Pod());
+    test_int(adds, 2);
+    test_int(sets, 1);
+
+    ecs.release(); /* destroys world */
+    test_int(removes, 2); /* two instances of `Pod` removed */
+}

--- a/test/cpp/src/main.cpp
+++ b/test/cpp/src/main.cpp
@@ -1015,6 +1015,7 @@ void ComponentLifecycle_register_parent_after_child_w_hooks_implicit(void);
 void ComponentLifecycle_sparse_component(void);
 void ComponentLifecycle_count_in_add_hook(void);
 void ComponentLifecycle_count_in_remove_hook(void);
+void ComponentLifecycle_set_multiple_hooks(void);
 
 // Testsuite 'Refs'
 void Refs_get_ref_by_ptr(void);
@@ -5356,6 +5357,10 @@ bake_test_case ComponentLifecycle_testcases[] = {
     {
         "count_in_remove_hook",
         ComponentLifecycle_count_in_remove_hook
+    },
+    {
+        "set_multiple_hooks",
+        ComponentLifecycle_set_multiple_hooks
     }
 };
 
@@ -6948,7 +6953,7 @@ static bake_test_suite suites[] = {
         "ComponentLifecycle",
         NULL,
         NULL,
-        88,
+        89,
         ComponentLifecycle_testcases
     },
     {


### PR DESCRIPTION
This fails on master now, no test catches it:
Hopefully we can fix it by the end of today together with other changes.

```cpp
    struct Position {
        int x;
        int y;
// the following copy ctor will configure a copy_ctor hook:
        Position(const Position &other) {
            x = other.x;
            y = other.y;
        }
    };

    flecs::world ecs;

    auto pos = ecs.component<Position>();

 // later on, the user adds a `on_add` hook:
    pos.on_add([](flecs::entity e, Position &) {}); // boom
```
This is because `ecs_set_hooks_id` may be called repeatedly to set one hook at a time. On the first call, the `ECS_TYPE_HOOKS` flags get calculated, and stored.

Code all over the place expects to be able to retrieve the hooks, make some changes (perhaps add a new hook) and then resubmit the modified hooks structure, inadvertently resubmitting already derived flags.

The patch removes the check and replaces it with resetting those flags so they are recalculated from scratch, ignoring any set values.

In the meantime, I continue my work on the compare stuff with this patch considered.