### PR TITLE
Fix issue where observers could be triggered multiple times for the same event

### DIFF
--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -14650,8 +14650,6 @@ void flecs_multi_observer_invoke(
         return;
     }
 
-    impl->last_event_id[0] = world->event_id;
-
     ecs_table_t *table = it->table;
     ecs_table_t *prev_table = it->other_table;
     int8_t pivot_term = it->term_index;
@@ -14703,6 +14701,8 @@ void flecs_multi_observer_invoke(
                 goto done;
             }
         }
+
+        impl->last_event_id[0] = it->event_cur;
 
         /* Patch data from original iterator. If the observer query has 
          * wildcards which triggered the original event, the component id that

--- a/src/observer.c
+++ b/src/observer.c
@@ -459,8 +459,6 @@ void flecs_multi_observer_invoke(
         return;
     }
 
-    impl->last_event_id[0] = world->event_id;
-
     ecs_table_t *table = it->table;
     ecs_table_t *prev_table = it->other_table;
     int8_t pivot_term = it->term_index;
@@ -512,6 +510,8 @@ void flecs_multi_observer_invoke(
                 goto done;
             }
         }
+
+        impl->last_event_id[0] = it->event_cur;
 
         /* Patch data from original iterator. If the observer query has 
          * wildcards which triggered the original event, the component id that

--- a/test/core/project.json
+++ b/test/core/project.json
@@ -1690,6 +1690,8 @@
                 "on_remove_multi_optional",
                 "on_add_multi_only_optional",
                 "on_remove_multi_only_optional",
+                "on_add_multi_observers_w_prefab_instance",
+                "on_add_overlapping_multi_observers_w_prefab_instance",
                 "cache_test_1",
                 "cache_test_2",
                 "cache_test_3",

--- a/test/core/src/main.c
+++ b/test/core/src/main.c
@@ -1629,6 +1629,8 @@ void Observer_on_add_multi_optional(void);
 void Observer_on_remove_multi_optional(void);
 void Observer_on_add_multi_only_optional(void);
 void Observer_on_remove_multi_only_optional(void);
+void Observer_on_add_multi_observers_w_prefab_instance(void);
+void Observer_on_add_overlapping_multi_observers_w_prefab_instance(void);
 void Observer_cache_test_1(void);
 void Observer_cache_test_2(void);
 void Observer_cache_test_3(void);
@@ -8644,6 +8646,14 @@ bake_test_case Observer_testcases[] = {
         Observer_on_remove_multi_only_optional
     },
     {
+        "on_add_multi_observers_w_prefab_instance",
+        Observer_on_add_multi_observers_w_prefab_instance
+    },
+    {
+        "on_add_overlapping_multi_observers_w_prefab_instance",
+        Observer_on_add_overlapping_multi_observers_w_prefab_instance
+    },
+    {
         "cache_test_1",
         Observer_cache_test_1
     },
@@ -11530,7 +11540,7 @@ static bake_test_suite suites[] = {
         "Observer",
         NULL,
         NULL,
-        229,
+        231,
         Observer_testcases
     },
     {


### PR DESCRIPTION
Summary:
This diff fixes a Flecs issue where mulit-component observers could get triggered multiple times for the same event. Two separate problems contributed to this issue:

1. Observers copied the wrong event id used to dedup events. Instead of using the event id passed by `flecs_emit`, observers used the global event id counter. In most cases these are the same, except when nested `flecs_emit` calls happen (which is rare).

2. The event id was copied at the wrong time. When a multi-component observer gets triggered, it still needs to verify if the event matches its query. Observers copied the event id before checking if the query matched, which could cause events to get skipped or delivered multiple times.

Differential Revision: D67219403
