### PR TITLE
ecs_set_name returns 0 in some situations since `1f4c816a2 * #1461 Fl…

### DIFF
--- a/test/core/project.json
+++ b/test/core/project.json
@@ -649,6 +649,7 @@
                 "fullpath_for_core",
                 "path_w_number",
                 "path_w_entity_id",
+                "recreated_parent_w_named_children",
                 "lookup_depth_0",
                 "lookup_depth_1",
                 "lookup_depth_2",

--- a/test/core/src/Hierarchies.c
+++ b/test/core/src/Hierarchies.c
@@ -1918,3 +1918,28 @@ void Hierarchies_defer_batch_remove_childof_w_add_name(void) {
 
     ecs_fini(world);
 }
+
+void Hierarchies_recreated_parent_w_named_children(void) {
+    ecs_world_t *world = ecs_mini();
+
+    char child_name[128] = { '\0' };
+
+    ecs_entity_t parent = ecs_set_name(world, 0, "e1");
+    sprintf(&child_name, "#%lu.e2", parent);
+    ecs_entity_t child = ecs_set_name(world, 0, child_name);
+    test_assert(parent != 0);
+    test_assert(child != 0);
+
+    // Recreate the parent and children.
+    ecs_delete(world, parent);
+    child_name[0] = '\0';
+
+    ecs_entity_t parent_new = ecs_set_name(world, 0, "e1");
+    sprintf(&child_name, "#%lu.e2", parent_new);
+    ecs_entity_t child_new = ecs_set_name(world, 0, child_name);
+    test_assert(parent_new != parent);
+    test_assert(parent_new != 0);
+    test_assert(child_new != 0);
+
+    ecs_fini(world);
+}

--- a/test/core/src/main.c
+++ b/test/core/src/main.c
@@ -618,6 +618,7 @@ void Hierarchies_path_only_escaped_two_sep_w_parent(void);
 void Hierarchies_fullpath_for_core(void);
 void Hierarchies_path_w_number(void);
 void Hierarchies_path_w_entity_id(void);
+void Hierarchies_recreated_parent_w_named_children(void);
 void Hierarchies_lookup_depth_0(void);
 void Hierarchies_lookup_depth_1(void);
 void Hierarchies_lookup_depth_2(void);
@@ -4708,6 +4709,10 @@ bake_test_case Hierarchies_testcases[] = {
     {
         "path_w_entity_id",
         Hierarchies_path_w_entity_id
+    },
+    {
+        "recreated_parent_w_named_children",
+        Hierarchies_recreated_parent_w_named_children
     },
     {
         "lookup_depth_0",
@@ -11403,7 +11408,6 @@ bake_test_case StackAlloc_testcases[] = {
     }
 };
 
-
 static bake_test_suite suites[] = {
     {
         "Id",
@@ -11500,7 +11504,7 @@ static bake_test_suite suites[] = {
         "Hierarchies",
         Hierarchies_setup,
         NULL,
-        105,
+        106,
         Hierarchies_testcases
     },
     {


### PR DESCRIPTION
…ecs script expression refactor`

Adding a test only here, not fixing anything \o

Would it be related to https://github.com/SanderMertens/flecs/pull/1461/files#diff-e3a8a20303056194087fb9a5c85ec9396d13cc3ed87af18566d1383936a933efR1756 ?