### PR TITLE
Fix possible handle leak

### DIFF
--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -12997,6 +12997,9 @@ char* flecs_load_from_file(
 
     return content;
 error:
+    if (file) {
+        fclose(file);
+    }
     ecs_os_free(content);
     return NULL;
 }

--- a/src/misc.c
+++ b/src/misc.c
@@ -252,6 +252,9 @@ char* flecs_load_from_file(
 
     return content;
 error:
+    if (file) {
+        fclose(file);
+    }
     ecs_os_free(content);
     return NULL;
 }


### PR DESCRIPTION
Calls to ```fclose()``` were missing in some cases when ```goto error``` was used.
Therefore, I added ```fclose()```.
The check ```if (file)``` is needed, because ```goto error``` is also used when file was not successfully opened.