### PR TITLE
Fix each_ref_field not casting to int32_t for ecs_field_at_w_size's ow parameter

### DIFF
--- a/distr/flecs.h
+++ b/distr/flecs.h
@@ -26543,7 +26543,7 @@ struct each_ref_field : public each_field<T> {
 
         if (field.is_row) {
             field.ptr = ecs_field_at_w_size(iter, sizeof(T), field.index, 
-                static_cast<int8_t>(row));
+                static_cast<int32_t>(row));
         }
     }
 };

--- a/include/flecs/addons/cpp/delegate.hpp
+++ b/include/flecs/addons/cpp/delegate.hpp
@@ -215,7 +215,7 @@ struct each_ref_field : public each_field<T> {
 
         if (field.is_row) {
             field.ptr = ecs_field_at_w_size(iter, sizeof(T), field.index, 
-                static_cast<int8_t>(row));
+                static_cast<int32_t>(row));
         }
     }
 };


### PR DESCRIPTION
This is used in the C++ API for iterating sparse component data and appears to cast to int8 instead of the intended int32.

Repro with making 2000 sparse components and iterating them in a system:
```cc
    flecs::world ecs;

    class Vec4Sparse {
    public:
        float F32[4];
    };

    ecs.component<Vec4Sparse>().add(flecs::Sparse);

    for (int i = 0; i < 2000; ++i) {
        auto e = ecs.entity().set<Vec4Sparse>({});
        std::cout << " Made entity id: " << e.id() << "\n";
    }

    ecs.system<Vec4Sparse>().each([](flecs::entity e, Vec4Sparse& p) {
        // crash happens in .each field templates
        std::cout << e.id() << "Sparse data: {" << p.F32[0] << ", " << p.F32[1] << "}\n";
    });

    ecs.progress();
```