### PR TITLE
Fix warnings in enum.hpp high bit calculation

### DIFF
--- a/distr/flecs.h
+++ b/distr/flecs.h
@@ -17971,8 +17971,10 @@ struct enum_reflection {
     static constexpr U each_enum(Args... args) {
         return each_mask_range<Value, high_bit>(each_enum_range<0, Value>(0, args...), args...);
     }
-
-    static const U high_bit = static_cast<U>(1) << (sizeof(U) * 8 - 1);
+    /* to avoid warnings with bit manipulation, calculate the high bit with an
+       unsigned type of the same size: */
+    using UU = typename std::make_unsigned<U>::type;
+    static const U high_bit = static_cast<U>(static_cast<UU>(1) << (sizeof(UU) * 8 - 1));
 };
 
 /** Enumeration type data */

--- a/include/flecs/addons/cpp/utils/enum.hpp
+++ b/include/flecs/addons/cpp/utils/enum.hpp
@@ -260,8 +260,10 @@ struct enum_reflection {
     static constexpr U each_enum(Args... args) {
         return each_mask_range<Value, high_bit>(each_enum_range<0, Value>(0, args...), args...);
     }
-
-    static const U high_bit = static_cast<U>(1) << (sizeof(U) * 8 - 1);
+    /* to avoid warnings with bit manipulation, calculate the high bit with an
+       unsigned type of the same size: */
+    using UU = typename std::make_unsigned<U>::type;
+    static const U high_bit = static_cast<U>(static_cast<UU>(1) << (sizeof(UU) * 8 - 1));
 };
 
 /** Enumeration type data */


### PR DESCRIPTION
This PR fixes compilation warnings, at least in GCC, due to sign mismatch calculating `high_bit` in `enum.hpp` 

After #696 was merged, a warning appeared when compiling `enum.hpp`:
```
/flecs/private/../addons/cpp/utils/enum.hpp:264:49: warning: overflow in conversion from ‘int’ to ‘flecs::_::enum_reflection<Ei8, flecs::_::enum_data_impl<Ei8>::reflection_count>::U’ {aka ‘signed char’} changes value from ‘128’ to ‘-128’ [-Woverflow]
  264 |     static const U high_bit = static_cast<U>(1) << (sizeof(U) * 8 - 1);
```

Inspite of the warning, the code works. The PR fixes this issue by calculating the high bit with an unsigned version, then casting back to the underlying enum type. This tells the compiler we really mean what we are doing.

