### PR TITLE
Add missing addons/app.c to meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -20,6 +20,7 @@ endif
 
 flecs_src = files(
     'src/addons/alerts.c',
+    'src/addons/app.c',
     'src/addons/doc.c',
     'src/addons/flecs_cpp.c',
     'src/addons/http.c',


### PR DESCRIPTION
The App addon was missing from the meson build.