### PR TITLE
Fix having two observers using run actions not working correctly

### DIFF
--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -15083,6 +15083,7 @@ void flecs_observer_invoke(
     if (o->run) {
         it->next = flecs_default_next_callback;
         it->callback = o->callback;
+        it->interrupted_by = 0;
         if (flecs_observer_impl(o)->flags & EcsObserverBypassQuery) {
             it->ctx = o;
         } else {

--- a/src/observer.c
+++ b/src/observer.c
@@ -288,6 +288,7 @@ void flecs_observer_invoke(
     if (o->run) {
         it->next = flecs_default_next_callback;
         it->callback = o->callback;
+        it->interrupted_by = 0;
         if (flecs_observer_impl(o)->flags & EcsObserverBypassQuery) {
             it->ctx = o;
         } else {

--- a/test/core/project.json
+++ b/test/core/project.json
@@ -1604,6 +1604,7 @@
                 "custom_run_action_w_iter_next_2_terms",
                 "custom_run_action_w_field",
                 "custom_run_action_w_2_fields",
+                "custom_run_action_twice",
                 "custom_run_w_yield_existing",
                 "custom_run_w_yield_existing_1_field",
                 "custom_run_w_yield_existing_1_field_w_callback",

--- a/test/core/src/Observer.c
+++ b/test/core/src/Observer.c
@@ -5268,6 +5268,40 @@ void Observer_custom_run_action_w_iter_next_2_terms(void) {
     ecs_fini(world);
 }
 
+void Observer_custom_run_action_twice(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, TagA);
+
+    Probe ctx = {0};
+    ecs_entity_t t1 = ecs_observer_init(world, &(ecs_observer_desc_t){
+        .query.terms = {{ TagA }},
+        .events = {EcsOnAdd},
+        .run = Run,
+        .callback = Observer,
+        .ctx = &ctx
+    });
+    test_assert(t1 != 0);
+    ecs_entity_t t2 = ecs_observer_init(world, &(ecs_observer_desc_t){
+        .query.terms = {{ TagA }},
+        .events = {EcsOnAdd},
+        .run = Run,
+        .callback = Observer,
+        .ctx = &ctx
+    });
+    test_assert(t2 != 0);
+
+    ecs_entity_t e = ecs_new_w(world, TagA);
+
+    test_int(run_invoked, 2);
+    test_int(ctx.invoked, 2);
+    test_int(ctx.count, 2);
+    test_int(ctx.e[0], e);
+    test_int(ctx.event, EcsOnAdd);
+
+    ecs_fini(world);
+}
+
 void Observer_read_in_on_remove_after_add_other_w_not(void) {
     ecs_world_t *world = ecs_mini();
 

--- a/test/core/src/main.c
+++ b/test/core/src/main.c
@@ -1543,6 +1543,7 @@ void Observer_custom_run_action_2_terms(void);
 void Observer_custom_run_action_w_iter_next_2_terms(void);
 void Observer_custom_run_action_w_field(void);
 void Observer_custom_run_action_w_2_fields(void);
+void Observer_custom_run_action_twice(void);
 void Observer_custom_run_w_yield_existing(void);
 void Observer_custom_run_w_yield_existing_1_field(void);
 void Observer_custom_run_w_yield_existing_1_field_w_callback(void);
@@ -8327,6 +8328,10 @@ bake_test_case Observer_testcases[] = {
         Observer_custom_run_action_w_2_fields
     },
     {
+        "custom_run_action_twice",
+        Observer_custom_run_action_twice
+    },
+    {
         "custom_run_w_yield_existing",
         Observer_custom_run_w_yield_existing
     },
@@ -11665,7 +11670,7 @@ static bake_test_suite suites[] = {
         "Observer",
         NULL,
         NULL,
-        236,
+        237,
         Observer_testcases
     },
     {


### PR DESCRIPTION
`flecs_default_next_callback` uses the `interrupted_by` field to decide if next should return true or false for systems using the run callback. `flecs_multi_observer_builtin_run` resets this before calling the callback but it was missing from `flecs_observer_invoke` meaning having two matching observers could cause the second one not to iterate when called.