### PR TITLE
Fix query copy operations with default init queries

### DIFF
--- a/distr/flecs.h
+++ b/distr/flecs.h
@@ -30574,12 +30574,19 @@ struct query_base {
 
     query_base(const query_base& obj) {
         this->query_ = obj.query_;
-        flecs_poly_claim(this->query_);
+        if (this->query_)
+        {
+            flecs_poly_claim(this->query_);
+        }
     }
 
     query_base& operator=(const query_base& obj) {
+        this->~query_base();
         this->query_ = obj.query_;
-        flecs_poly_claim(this->query_);
+        if (this->query_)
+        {
+            flecs_poly_claim(this->query_);
+        }
         return *this; 
     }
 

--- a/include/flecs/addons/cpp/mixins/query/impl.hpp
+++ b/include/flecs/addons/cpp/mixins/query/impl.hpp
@@ -39,12 +39,19 @@ struct query_base {
 
     query_base(const query_base& obj) {
         this->query_ = obj.query_;
-        flecs_poly_claim(this->query_);
+        if (this->query_)
+        {
+            flecs_poly_claim(this->query_);
+        }
     }
 
     query_base& operator=(const query_base& obj) {
+        this->~query_base();
         this->query_ = obj.query_;
-        flecs_poly_claim(this->query_);
+        if (this->query_)
+        {
+            flecs_poly_claim(this->query_);
+        }
         return *this; 
     }
 

--- a/test/cpp/project.json
+++ b/test/cpp/project.json
@@ -711,7 +711,8 @@
                 "iter_targets_2nd_field",
                 "iter_targets_field_out_of_range",
                 "iter_targets_field_not_a_pair",
-                "iter_targets_field_not_set"
+                "iter_targets_field_not_set",
+                "copy_operators"
             ]
         }, {
             "id": "QueryBuilder",

--- a/test/cpp/src/Query.cpp
+++ b/test/cpp/src/Query.cpp
@@ -3426,3 +3426,19 @@ void Query_iter_targets_field_not_set(void) {
         it.targets(1, [&](flecs::entity tgt) { });
     });
 }
+
+void Query_copy_operators(void) {
+    flecs::world world{};
+
+    flecs::query<> q = world.query_builder()
+        .with<Position>()
+        .build();
+
+    flecs::query<> copyCtor{q};
+    flecs::query<> copyAssign{};
+    copyAssign = q;
+
+    flecs::query<> defaultInit{};
+    flecs::query<> copyCtorDefault{defaultInit};
+    copyAssign = defaultInit;
+}

--- a/test/cpp/src/main.cpp
+++ b/test/cpp/src/main.cpp
@@ -688,6 +688,7 @@ void Query_iter_targets_2nd_field(void);
 void Query_iter_targets_field_out_of_range(void);
 void Query_iter_targets_field_not_a_pair(void);
 void Query_iter_targets_field_not_set(void);
+void Query_copy_operators(void);
 
 // Testsuite 'QueryBuilder'
 void QueryBuilder_setup(void);
@@ -4108,6 +4109,10 @@ bake_test_case Query_testcases[] = {
     {
         "iter_targets_field_not_set",
         Query_iter_targets_field_not_set
+    },
+    {
+        "copy_operators",
+        Query_copy_operators
     }
 };
 
@@ -7098,7 +7103,7 @@ static bake_test_suite suites[] = {
         "Query",
         NULL,
         NULL,
-        122,
+        123,
         Query_testcases
     },
     {


### PR DESCRIPTION
Copy ctor/assign for C++ queries would abort in `flecs_poly_claim` if called with a default initialized query. This fixes that and `flecs_poly_release` not being called for the query being copied over during assignment. 