### PR TITLE
Fix members named `_` not being created in structs

### DIFF
--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -47167,9 +47167,7 @@ ecs_entity_t ecs_struct_init(
             goto error;
         }
 
-        ecs_entity_t m = ecs_entity(world, {
-            .name = m_desc->name
-        });
+        ecs_entity_t m = ecs_new_from_path(world, t, m_desc->name);
 
         ecs_set(world, m, EcsMember, {
             .type = m_desc->type, 

--- a/src/addons/meta/api.c
+++ b/src/addons/meta/api.c
@@ -426,9 +426,7 @@ ecs_entity_t ecs_struct_init(
             goto error;
         }
 
-        ecs_entity_t m = ecs_entity(world, {
-            .name = m_desc->name
-        });
+        ecs_entity_t m = ecs_new_from_path(world, t, m_desc->name);
 
         ecs_set(world, m, EcsMember, {
             .type = m_desc->type, 


### PR DESCRIPTION
This PR fixes an issue I found with `ecs_struct_init`. When attempting to initialize a struct with a member named `_` the member would silently not be created at all. The issue was that the method used to create the members, `ecs_entity`, would return the *any* entity instead of creating a new one. Swapping that method for `ecs_new_from_path` fixes the issue.