### PR TITLE
fix(prefab): prevent infinite recursion on self-referencing disabled prefabs

### DIFF
--- a/flecs.c
+++ b/flecs.c
@@ -9079,10 +9079,21 @@ void ecs_enable(
         ecs_assert(type != NULL, ECS_INTERNAL_ERROR, NULL);
         ecs_id_t *ids = type->array;
         int32_t i, count = type->count;
-        for (i = 0; i < count; i ++) {
-            ecs_id_t id = ids[i];
-            if (!(ecs_id_get_flags(world, id) & EcsIdOnInstantiateDontInherit)){
-                ecs_enable(world, id, enabled);
+        if (ecs_has_id(world, entity, ecs_id(EcsComponent))) {
+            for (i = 0; i < count; i ++) {
+                ecs_id_t id = ids[i];
+                 // id != entity check for prefab types, where they have each other added.
+                 // without it, it would fall into infinite recursion and stack overflow
+                if (id != entity && !(ecs_id_get_flags(world, id) & EcsIdOnInstantiateDontInherit)){
+                    ecs_enable(world, id, enabled);
+                }
+            }
+        } else { 
+            for (i = 0; i < count; i ++) {
+                ecs_id_t id = ids[i];
+                if (!(ecs_id_get_flags(world, id) & EcsIdOnInstantiateDontInherit)){
+                    ecs_enable(world, id, enabled);
+                }
             }
         }
     } else {

--- a/include/flecs/addons/cpp/component.hpp
+++ b/include/flecs/addons/cpp/component.hpp
@@ -175,7 +175,7 @@ struct type_impl {
             // If no world was provided the component cannot be registered
             ecs_assert(world != nullptr, ECS_COMPONENT_NOT_REGISTERED, name);
         } else {
-            ecs_assert(!id || s_id == id, ECS_INCONSISTENT_COMPONENT_ID, NULL);
+            ecs_assert(!id, ECS_INCONSISTENT_COMPONENT_ID, NULL);
         }
 
         // If no id has been registered yet for the component (indicating the

--- a/include/flecs/addons/cpp/entity_view.hpp
+++ b/include/flecs/addons/cpp/entity_view.hpp
@@ -160,7 +160,7 @@ struct entity_view : public id {
      * @param func The function invoked for each id.
      */
     template <typename Func>
-    void each(flecs::id_t pred, flecs::id_t obj, const Func& func) const;
+    void each(flecs::id_t first, flecs::id_t second, const Func& func) const;
 
     /** Iterate targets for a given relationship.
      * The function parameter must match the following signature:

--- a/include/flecs/addons/cpp/entity_view.hpp
+++ b/include/flecs/addons/cpp/entity_view.hpp
@@ -160,7 +160,7 @@ struct entity_view : public id {
      * @param func The function invoked for each id.
      */
     template <typename Func>
-    void each(flecs::id_t first, flecs::id_t second, const Func& func) const;
+    void each(flecs::id_t pred, flecs::id_t obj, const Func& func) const;
 
     /** Iterate targets for a given relationship.
      * The function parameter must match the following signature:

--- a/src/entity.c
+++ b/src/entity.c
@@ -4186,10 +4186,21 @@ void ecs_enable(
         ecs_assert(type != NULL, ECS_INTERNAL_ERROR, NULL);
         ecs_id_t *ids = type->array;
         int32_t i, count = type->count;
-        for (i = 0; i < count; i ++) {
-            ecs_id_t id = ids[i];
-            if (!(ecs_id_get_flags(world, id) & EcsIdOnInstantiateDontInherit)){
-                ecs_enable(world, id, enabled);
+        if (ecs_has_id(world, entity, ecs_id(EcsComponent))) {
+            for (i = 0; i < count; i ++) {
+                ecs_id_t id = ids[i];
+                 // id != entity check for prefab types, where they have each other added.
+                 // without it, it would fall into infinite recursion and stack overflow
+                if (id != entity && !(ecs_id_get_flags(world, id) & EcsIdOnInstantiateDontInherit)){
+                    ecs_enable(world, id, enabled);
+                }
+            }
+        } else { 
+            for (i = 0; i < count; i ++) {
+                ecs_id_t id = ids[i];
+                if (!(ecs_id_get_flags(world, id) & EcsIdOnInstantiateDontInherit)){
+                    ecs_enable(world, id, enabled);
+                }
             }
         }
     } else {

--- a/test/core/project.json
+++ b/test/core/project.json
@@ -1814,7 +1814,8 @@
                 "override_exclusive_2_lvls",
                 "hierarchy_w_recycled_id",
                 "disable_ids",
-                "disable_nested_ids"
+                "disable_nested_ids",
+                "type_disable_self"
             ]
         }, {
             "id": "World",

--- a/test/core/src/Prefab.c
+++ b/test/core/src/Prefab.c
@@ -4553,3 +4553,21 @@ void Prefab_disable_nested_ids(void) {
 
     ecs_fini(world);
 }
+
+void Prefab_type_disable_self(void) {
+    // test that no stack overflow, segfault occurs when disabling a type that has itself
+    
+    ecs_world_t *world = ecs_mini();
+
+    ECS_COMPONENT(world, Position);
+
+    ecs_add_id(world, ecs_id(Position), EcsPrefab);
+
+    //mimics `C++ .prefab<T>()`
+    ecs_add_id(world, ecs_id(Position), ecs_id(Position));
+
+    ecs_enable(world, ecs_id(Position), false);
+
+    //satisfy the test suite so it doesn't report empty, it's purely a stack overflow test
+    test_assert(true);
+}

--- a/test/core/src/main.c
+++ b/test/core/src/main.c
@@ -1741,6 +1741,7 @@ void Prefab_override_exclusive_2_lvls(void);
 void Prefab_hierarchy_w_recycled_id(void);
 void Prefab_disable_ids(void);
 void Prefab_disable_nested_ids(void);
+void Prefab_type_disable_self(void);
 
 // Testsuite 'World'
 void World_setup(void);
@@ -8849,6 +8850,10 @@ bake_test_case Prefab_testcases[] = {
     {
         "disable_nested_ids",
         Prefab_disable_nested_ids
+    },
+    {
+        "type_disable_self",
+        Prefab_type_disable_self
     }
 };
 
@@ -10557,7 +10562,7 @@ static bake_test_suite suites[] = {
         "Prefab",
         Prefab_setup,
         NULL,
-        129,
+        130,
         Prefab_testcases
     },
     {


### PR DESCRIPTION
When a prefab type was added as a component of itself and subsequently disabled, the enabling/disabling code entered an infinite recursion. This commit introduces a check to detect self-references in disabled prefabs.