### PR TITLE
fix(prefabs): fix disabling prefabs with non-alive components (follow-up #1577)

### DIFF
--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -8909,10 +8909,21 @@ void ecs_enable(
         ecs_assert(type != NULL, ECS_INTERNAL_ERROR, NULL);
         ecs_id_t *ids = type->array;
         int32_t i, count = type->count;
-        for (i = 0; i < count; i ++) {
-            ecs_id_t id = ids[i];
-            if (!(ecs_id_get_flags(world, id) & EcsIdOnInstantiateDontInherit)){
-                ecs_enable(world, id, enabled);
+        if (ecs_has_id(world, entity, ecs_id(EcsComponent))) {
+            for (i = 0; i < count; i ++) {
+                ecs_id_t id = ids[i]; 
+                 // id != entity check for prefab types, where they have each other added.
+                 // without it, it would fall into infinite recursion and stack overflow
+                if (id != entity && !(ecs_id_get_flags(world, id) & EcsIdOnInstantiateDontInherit)){
+                    ecs_enable(world, id, enabled);
+                }
+            }
+        } else { 
+            for (i = 0; i < count; i ++) {
+                ecs_id_t id = ids[i];
+                if (!(ecs_id_get_flags(world, id) & EcsIdOnInstantiateDontInherit)){
+                    ecs_enable(world, id, enabled);
+                }
             }
         }
     } else {

--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -8915,16 +8915,18 @@ void ecs_enable(
 
                  // - `id != entity` check for prefab types, where they have each other added.
                  // without it, it would fall into infinite recursion and stack overflow
-                 // - `id & ECS_TOGGLE` check is to prevent enabling/disabling of toggles which fails the ecs_is_alive check
-                if (id != entity && !(ecs_id_get_flags(world, id) & EcsIdOnInstantiateDontInherit) && (id & ECS_TOGGLE) == 0){
+                 // - `ecs_is_alive` check is to prevent enabling/disabling of ids that are not alive, 
+                 // e.g. `ECS_TOGGLE | Component`, pair `(ENUM, ENUM_VARIANT)` etc.
+                if (id != entity && !(ecs_id_get_flags(world, id) & EcsIdOnInstantiateDontInherit) && ecs_is_alive(world, id)) {
                     ecs_enable(world, id, enabled);
                 }
             }
         } else { 
             for (i = 0; i < count; i ++) {
                 ecs_id_t id = ids[i];
-                 // - `id & ECS_TOGGLE` check is to prevent enabling/disabling of toggles which fails the ecs_is_alive check
-                if (!(ecs_id_get_flags(world, id) & EcsIdOnInstantiateDontInherit) && (id & ECS_TOGGLE) == 0){
+                 // - `ecs_is_alive` check is to prevent enabling/disabling of ids that are not alive, 
+                 // e.g. `ECS_TOGGLE | Component`, pair `(ENUM, ENUM_VARIANT)` etc.
+                if (!(ecs_id_get_flags(world, id) & EcsIdOnInstantiateDontInherit) && ecs_is_alive(world, id)) {
                     ecs_enable(world, id, enabled);
                 }
             }

--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -8912,16 +8912,21 @@ void ecs_enable(
         if (ecs_has_id(world, entity, ecs_id(EcsComponent))) {
             for (i = 0; i < count; i ++) {
                 ecs_id_t id = ids[i]; 
-                 // id != entity check for prefab types, where they have each other added.
+
+                 // - `id != entity` check for prefab types, where they have each other added.
                  // without it, it would fall into infinite recursion and stack overflow
-                if (id != entity && !(ecs_id_get_flags(world, id) & EcsIdOnInstantiateDontInherit)){
+                 // - `ecs_is_alive` check is to prevent enabling/disabling of non-existing entities, such
+                 // as `ECS_TOGGLE | AComponent`
+                if (id != entity && !(ecs_id_get_flags(world, id) & EcsIdOnInstantiateDontInherit) && (id & ECS_TOGGLE) == 0){
                     ecs_enable(world, id, enabled);
                 }
             }
         } else { 
             for (i = 0; i < count; i ++) {
                 ecs_id_t id = ids[i];
-                if (!(ecs_id_get_flags(world, id) & EcsIdOnInstantiateDontInherit)){
+                // - `ecs_is_alive` check is to prevent enabling/disabling of non-existing entities, such
+                // as `ECS_TOGGLE | AComponent`
+                if (!(ecs_id_get_flags(world, id) & EcsIdOnInstantiateDontInherit) && (id & ECS_TOGGLE) == 0){
                     ecs_enable(world, id, enabled);
                 }
             }

--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -8915,8 +8915,7 @@ void ecs_enable(
 
                  // - `id != entity` check for prefab types, where they have each other added.
                  // without it, it would fall into infinite recursion and stack overflow
-                 // - `ecs_is_alive` check is to prevent enabling/disabling of non-existing entities, such
-                 // as `ECS_TOGGLE | AComponent`
+                 // - `id & ECS_TOGGLE` check is to prevent enabling/disabling of toggles which fails the ecs_is_alive check
                 if (id != entity && !(ecs_id_get_flags(world, id) & EcsIdOnInstantiateDontInherit) && (id & ECS_TOGGLE) == 0){
                     ecs_enable(world, id, enabled);
                 }
@@ -8924,8 +8923,7 @@ void ecs_enable(
         } else { 
             for (i = 0; i < count; i ++) {
                 ecs_id_t id = ids[i];
-                // - `ecs_is_alive` check is to prevent enabling/disabling of non-existing entities, such
-                // as `ECS_TOGGLE | AComponent`
+                 // - `id & ECS_TOGGLE` check is to prevent enabling/disabling of toggles which fails the ecs_is_alive check
                 if (!(ecs_id_get_flags(world, id) & EcsIdOnInstantiateDontInherit) && (id & ECS_TOGGLE) == 0){
                     ecs_enable(world, id, enabled);
                 }

--- a/src/entity.c
+++ b/src/entity.c
@@ -4414,16 +4414,18 @@ void ecs_enable(
 
                  // - `id != entity` check for prefab types, where they have each other added.
                  // without it, it would fall into infinite recursion and stack overflow
-                 // - `id & ECS_TOGGLE` check is to prevent enabling/disabling of toggles which fails the ecs_is_alive check
-                if (id != entity && !(ecs_id_get_flags(world, id) & EcsIdOnInstantiateDontInherit) && (id & ECS_TOGGLE) == 0){
+                 // - `ecs_is_alive` check is to prevent enabling/disabling of ids that are not alive, 
+                 // e.g. `ECS_TOGGLE | Component`, pair `(ENUM, ENUM_VARIANT)` etc.
+                if (id != entity && !(ecs_id_get_flags(world, id) & EcsIdOnInstantiateDontInherit) && ecs_is_alive(world, id)) {
                     ecs_enable(world, id, enabled);
                 }
             }
         } else { 
             for (i = 0; i < count; i ++) {
                 ecs_id_t id = ids[i];
-                 // - `id & ECS_TOGGLE` check is to prevent enabling/disabling of toggles which fails the ecs_is_alive check
-                if (!(ecs_id_get_flags(world, id) & EcsIdOnInstantiateDontInherit) && (id & ECS_TOGGLE) == 0){
+                 // - `ecs_is_alive` check is to prevent enabling/disabling of ids that are not alive, 
+                 // e.g. `ECS_TOGGLE | Component`, pair `(ENUM, ENUM_VARIANT)` etc.
+                if (!(ecs_id_get_flags(world, id) & EcsIdOnInstantiateDontInherit) && ecs_is_alive(world, id)) {
                     ecs_enable(world, id, enabled);
                 }
             }

--- a/src/entity.c
+++ b/src/entity.c
@@ -4408,10 +4408,21 @@ void ecs_enable(
         ecs_assert(type != NULL, ECS_INTERNAL_ERROR, NULL);
         ecs_id_t *ids = type->array;
         int32_t i, count = type->count;
-        for (i = 0; i < count; i ++) {
-            ecs_id_t id = ids[i];
-            if (!(ecs_id_get_flags(world, id) & EcsIdOnInstantiateDontInherit)){
-                ecs_enable(world, id, enabled);
+        if (ecs_has_id(world, entity, ecs_id(EcsComponent))) {
+            for (i = 0; i < count; i ++) {
+                ecs_id_t id = ids[i]; 
+                 // id != entity check for prefab types, where they have each other added.
+                 // without it, it would fall into infinite recursion and stack overflow
+                if (id != entity && !(ecs_id_get_flags(world, id) & EcsIdOnInstantiateDontInherit)){
+                    ecs_enable(world, id, enabled);
+                }
+            }
+        } else { 
+            for (i = 0; i < count; i ++) {
+                ecs_id_t id = ids[i];
+                if (!(ecs_id_get_flags(world, id) & EcsIdOnInstantiateDontInherit)){
+                    ecs_enable(world, id, enabled);
+                }
             }
         }
     } else {

--- a/src/entity.c
+++ b/src/entity.c
@@ -4411,16 +4411,19 @@ void ecs_enable(
         if (ecs_has_id(world, entity, ecs_id(EcsComponent))) {
             for (i = 0; i < count; i ++) {
                 ecs_id_t id = ids[i]; 
-                 // id != entity check for prefab types, where they have each other added.
+
+                 // - `id != entity` check for prefab types, where they have each other added.
                  // without it, it would fall into infinite recursion and stack overflow
-                if (id != entity && !(ecs_id_get_flags(world, id) & EcsIdOnInstantiateDontInherit)){
+                 // - `id & ECS_TOGGLE` check is to prevent enabling/disabling of toggles which fails the ecs_is_alive check
+                if (id != entity && !(ecs_id_get_flags(world, id) & EcsIdOnInstantiateDontInherit) && (id & ECS_TOGGLE) == 0){
                     ecs_enable(world, id, enabled);
                 }
             }
         } else { 
             for (i = 0; i < count; i ++) {
                 ecs_id_t id = ids[i];
-                if (!(ecs_id_get_flags(world, id) & EcsIdOnInstantiateDontInherit)){
+                 // - `id & ECS_TOGGLE` check is to prevent enabling/disabling of toggles which fails the ecs_is_alive check
+                if (!(ecs_id_get_flags(world, id) & EcsIdOnInstantiateDontInherit) && (id & ECS_TOGGLE) == 0){
                     ecs_enable(world, id, enabled);
                 }
             }

--- a/test/core/project.json
+++ b/test/core/project.json
@@ -1986,6 +1986,7 @@
                 "hierarchy_w_recycled_id",
                 "disable_ids",
                 "disable_nested_ids",
+                "type_disable_self",
                 "prefab_w_children_w_isa_auto_override",
                 "prefab_child_w_override",
                 "prefab_child_w_override_and_higher_component",

--- a/test/core/project.json
+++ b/test/core/project.json
@@ -1987,6 +1987,7 @@
                 "disable_ids",
                 "disable_nested_ids",
                 "type_disable_self",
+                "disable_w_not_alive_id",
                 "prefab_w_children_w_isa_auto_override",
                 "prefab_child_w_override",
                 "prefab_child_w_override_and_higher_component",

--- a/test/core/src/Prefab.c
+++ b/test/core/src/Prefab.c
@@ -5285,4 +5285,6 @@ void Prefab_type_disable_self(void) {
 
     //satisfy the test suite so it doesn't report empty, it's purely a stack overflow test
     test_assert(true);
+
+    ecs_fini(world);
 }

--- a/test/core/src/Prefab.c
+++ b/test/core/src/Prefab.c
@@ -5288,3 +5288,25 @@ void Prefab_type_disable_self(void) {
 
     ecs_fini(world);
 }
+
+void Prefab_disable_w_not_alive_id(void) {
+    // test that disabling prefabs with not alive ids doesn't crash, attempts to disable a non-alive ids.
+    ecs_world_t *world = ecs_mini();
+
+    ECS_ENTITY(world, Tag, CanToggle);
+
+    ecs_entity_t e = ecs_new(world);
+
+    ecs_add_id(world, e, EcsPrefab);
+    
+    ecs_add_id(world, e, ECS_TOGGLE | Tag);
+
+    ecs_enable_id(world,e,Tag,false);
+
+    ecs_enable(world, e, false);
+
+    //satisfy the test suite so it doesn't report empty.
+    test_assert(true);
+
+    ecs_fini(world);
+}

--- a/test/core/src/Prefab.c
+++ b/test/core/src/Prefab.c
@@ -5268,3 +5268,21 @@ void Prefab_instantiate_w_union_while_defer_suspended(void) {
 
     ecs_fini(world);
 }
+
+void Prefab_type_disable_self(void) {
+    // test that no stack overflow, segfault occurs when disabling a type that has itself
+    
+    ecs_world_t *world = ecs_mini();
+
+    ECS_COMPONENT(world, Position);
+
+    ecs_add_id(world, ecs_id(Position), EcsPrefab);
+
+    //mimics `C++ .prefab<T>()`
+    ecs_add_id(world, ecs_id(Position), ecs_id(Position));
+
+    ecs_enable(world, ecs_id(Position), false);
+
+    //satisfy the test suite so it doesn't report empty, it's purely a stack overflow test
+    test_assert(true);
+}

--- a/test/core/src/main.c
+++ b/test/core/src/main.c
@@ -1913,6 +1913,7 @@ void Prefab_override_exclusive_2_lvls(void);
 void Prefab_hierarchy_w_recycled_id(void);
 void Prefab_disable_ids(void);
 void Prefab_disable_nested_ids(void);
+void Prefab_type_disable_self(void);
 void Prefab_prefab_w_children_w_isa_auto_override(void);
 void Prefab_prefab_child_w_override(void);
 void Prefab_prefab_child_w_override_and_higher_component(void);
@@ -9783,6 +9784,10 @@ bake_test_case Prefab_testcases[] = {
         Prefab_disable_nested_ids
     },
     {
+        "type_disable_self",
+        Prefab_type_disable_self
+    },
+    {
         "prefab_w_children_w_isa_auto_override",
         Prefab_prefab_w_children_w_isa_auto_override
     },
@@ -11777,7 +11782,7 @@ static bake_test_suite suites[] = {
         "Prefab",
         Prefab_setup,
         NULL,
-        157,
+        158,
         Prefab_testcases
     },
     {

--- a/test/core/src/main.c
+++ b/test/core/src/main.c
@@ -1914,6 +1914,7 @@ void Prefab_hierarchy_w_recycled_id(void);
 void Prefab_disable_ids(void);
 void Prefab_disable_nested_ids(void);
 void Prefab_type_disable_self(void);
+void Prefab_disable_w_not_alive_id(void);
 void Prefab_prefab_w_children_w_isa_auto_override(void);
 void Prefab_prefab_child_w_override(void);
 void Prefab_prefab_child_w_override_and_higher_component(void);
@@ -9788,6 +9789,10 @@ bake_test_case Prefab_testcases[] = {
         Prefab_type_disable_self
     },
     {
+        "disable_w_not_alive_id",
+        Prefab_disable_w_not_alive_id
+    },
+    {
         "prefab_w_children_w_isa_auto_override",
         Prefab_prefab_w_children_w_isa_auto_override
     },
@@ -11782,7 +11787,7 @@ static bake_test_suite suites[] = {
         "Prefab",
         Prefab_setup,
         NULL,
-        158,
+        159,
         Prefab_testcases
     },
     {

--- a/test/cpp/src/Enum.cpp
+++ b/test/cpp/src/Enum.cpp
@@ -1590,7 +1590,7 @@ void Enum_enum_w_one_constant_index_of(void) {
     test_int(one_type.index_by_value(0), 0);
 }
 
-void Enum_runtime_type_constant_u8_template() {
+void Enum_runtime_type_constant_u8_template(void) {
     flecs::world ecs;
 
     auto comp = ecs.component("TestEnumConstant");

--- a/test/cpp/src/main.cpp
+++ b/test/cpp/src/main.cpp
@@ -18,6 +18,7 @@ void Entity_new_named(void);
 void Entity_new_named_from_scope(void);
 void Entity_new_nested_named_from_scope(void);
 void Entity_new_nested_named_from_nested_scope(void);
+void Entity_new_named_from_scope_with_custom_separator(void);
 void Entity_new_add(void);
 void Entity_new_add_2(void);
 void Entity_new_set(void);
@@ -376,6 +377,7 @@ void Enum_prefixed_enum_reflection(void);
 void Enum_constant_with_num_reflection(void);
 void Enum_get_constant_id(void);
 void Enum_add_enum_constant(void);
+void Enum_add_enum_constant_explicit(void);
 void Enum_add_enum_class_constant(void);
 void Enum_replace_enum_constants(void);
 void Enum_has_enum(void);
@@ -415,6 +417,7 @@ void Enum_enum_u8(void);
 void Enum_enum_u16(void);
 void Enum_enum_u32(void);
 void Enum_enum_u64(void);
+void Enum_runtime_type_constant_u8_template(void);
 
 // Testsuite 'Union'
 void Union_add_case(void);
@@ -1470,6 +1473,10 @@ bake_test_case Entity_testcases[] = {
     {
         "new_nested_named_from_nested_scope",
         Entity_new_nested_named_from_nested_scope
+    },
+    {
+        "new_named_from_scope_with_custom_separator",
+        Entity_new_named_from_scope_with_custom_separator
     },
     {
         "new_add",
@@ -2894,6 +2901,10 @@ bake_test_case Enum_testcases[] = {
         Enum_add_enum_constant
     },
     {
+        "add_enum_constant_explicit",
+        Enum_add_enum_constant_explicit
+    },
+    {
         "add_enum_class_constant",
         Enum_add_enum_class_constant
     },
@@ -3048,6 +3059,10 @@ bake_test_case Enum_testcases[] = {
     {
         "enum_u64",
         Enum_enum_u64
+    },
+    {
+        "runtime_type_constant_u8_template",
+        Enum_runtime_type_constant_u8_template
     }
 };
 
@@ -7052,7 +7067,7 @@ static bake_test_suite suites[] = {
         "Entity",
         NULL,
         NULL,
-        279,
+        280,
         Entity_testcases
     },
     {
@@ -7066,7 +7081,7 @@ static bake_test_suite suites[] = {
         "Enum",
         NULL,
         NULL,
-        49,
+        51,
         Enum_testcases
     },
     {


### PR DESCRIPTION
PR #1577 should be merged first as it's based on it. Ran into a new issue where toggle-able components caused `ecs_is_alive` asserts when disabling a prefab. this also happens with pairs of (Enum, EnumVariant), etc