### PR TITLE
Use correct world in term_builder_i::singleton(), Add missing enum tests

### DIFF
--- a/distr/flecs.h
+++ b/distr/flecs.h
@@ -29993,7 +29993,7 @@ struct term_builder_i : term_ref_builder_i<Base> {
         if (!ECS_IS_PAIR(sid)) {
             term_->src.id = sid;
         } else {
-            term_->src.id = ecs_pair_first(world(), sid);
+            term_->src.id = ecs_pair_first(this->world_v(), sid);
         }
         return *this;
     }

--- a/include/flecs/addons/cpp/mixins/term/builder_i.hpp
+++ b/include/flecs/addons/cpp/mixins/term/builder_i.hpp
@@ -401,7 +401,7 @@ struct term_builder_i : term_ref_builder_i<Base> {
         if (!ECS_IS_PAIR(sid)) {
             term_->src.id = sid;
         } else {
-            term_->src.id = ecs_pair_first(world(), sid);
+            term_->src.id = ecs_pair_first(this->world_v(), sid);
         }
         return *this;
     }

--- a/test/cpp/project.json
+++ b/test/cpp/project.json
@@ -896,7 +896,8 @@
                 "each_w_const_field_w_fixed_src",
                 "each_w_const_field_at_w_fixed_src",
                 "each_w_untyped_field_w_fixed_src",
-                "each_w_untyped_field_at_w_fixed_src"
+                "each_w_untyped_field_at_w_fixed_src",
+                "singleton_pair"
             ]
         }, {
             "id": "SystemBuilder",

--- a/test/cpp/src/Enum.cpp
+++ b/test/cpp/src/Enum.cpp
@@ -1590,7 +1590,7 @@ void Enum_enum_w_one_constant_index_of(void) {
     test_int(one_type.index_by_value(0), 0);
 }
 
-void Enum_runtime_type_constant_u8_template() {
+void Enum_runtime_type_constant_u8_template(void) {
     flecs::world ecs;
 
     auto comp = ecs.component("TestEnumConstant");

--- a/test/cpp/src/Observer.cpp
+++ b/test/cpp/src/Observer.cpp
@@ -960,7 +960,7 @@ void Observer_on_add_with_pair_singleton(void) {
     world.observer()
         .with<Position>(tgt).singleton()
         .event(flecs::OnSet)
-        .each([&](flecs::entity) {
+        .each([&](flecs::iter&, size_t) {
             count ++;
         });
 

--- a/test/cpp/src/QueryBuilder.cpp
+++ b/test/cpp/src/QueryBuilder.cpp
@@ -5223,3 +5223,29 @@ void QueryBuilder_each_w_untyped_field_at_w_fixed_src(void) {
 
     test_int(count, 2);
 }
+
+void QueryBuilder_singleton_pair(void) {
+    flecs::world ecs;
+
+    flecs::entity rel = ecs.component<Position>();
+    flecs::entity tgt = ecs.entity();
+
+    ecs.set<Position>(tgt, {10, 20});
+
+    int32_t count = 0;
+
+    auto q = ecs.query_builder<const Position>()
+        .term_at(0).second(tgt).singleton()
+        .cache_kind(cache_kind)
+        .build();
+
+    q.each([&](flecs::iter& it, size_t, const Position& p) {
+        test_assert(it.src(0) == rel);
+        test_assert(it.pair(0) == ecs.pair<Position>(tgt));
+        test_int(p.x, 10);
+        test_int(p.y, 20);
+        count ++;
+    });
+
+    test_int(count, 1);
+}

--- a/test/cpp/src/main.cpp
+++ b/test/cpp/src/main.cpp
@@ -18,6 +18,7 @@ void Entity_new_named(void);
 void Entity_new_named_from_scope(void);
 void Entity_new_nested_named_from_scope(void);
 void Entity_new_nested_named_from_nested_scope(void);
+void Entity_new_named_from_scope_with_custom_separator(void);
 void Entity_new_add(void);
 void Entity_new_add_2(void);
 void Entity_new_set(void);
@@ -376,6 +377,7 @@ void Enum_prefixed_enum_reflection(void);
 void Enum_constant_with_num_reflection(void);
 void Enum_get_constant_id(void);
 void Enum_add_enum_constant(void);
+void Enum_add_enum_constant_explicit(void);
 void Enum_add_enum_class_constant(void);
 void Enum_replace_enum_constants(void);
 void Enum_has_enum(void);
@@ -415,6 +417,7 @@ void Enum_enum_u8(void);
 void Enum_enum_u16(void);
 void Enum_enum_u32(void);
 void Enum_enum_u64(void);
+void Enum_runtime_type_constant_u8_template(void);
 
 // Testsuite 'Union'
 void Union_add_case(void);
@@ -865,6 +868,7 @@ void QueryBuilder_each_w_const_field_w_fixed_src(void);
 void QueryBuilder_each_w_const_field_at_w_fixed_src(void);
 void QueryBuilder_each_w_untyped_field_w_fixed_src(void);
 void QueryBuilder_each_w_untyped_field_at_w_fixed_src(void);
+void QueryBuilder_singleton_pair(void);
 
 // Testsuite 'SystemBuilder'
 void SystemBuilder_builder_assign_same_type(void);
@@ -1470,6 +1474,10 @@ bake_test_case Entity_testcases[] = {
     {
         "new_nested_named_from_nested_scope",
         Entity_new_nested_named_from_nested_scope
+    },
+    {
+        "new_named_from_scope_with_custom_separator",
+        Entity_new_named_from_scope_with_custom_separator
     },
     {
         "new_add",
@@ -2894,6 +2902,10 @@ bake_test_case Enum_testcases[] = {
         Enum_add_enum_constant
     },
     {
+        "add_enum_constant_explicit",
+        Enum_add_enum_constant_explicit
+    },
+    {
         "add_enum_class_constant",
         Enum_add_enum_class_constant
     },
@@ -3048,6 +3060,10 @@ bake_test_case Enum_testcases[] = {
     {
         "enum_u64",
         Enum_enum_u64
+    },
+    {
+        "runtime_type_constant_u8_template",
+        Enum_runtime_type_constant_u8_template
     }
 };
 
@@ -4809,6 +4825,10 @@ bake_test_case QueryBuilder_testcases[] = {
     {
         "each_w_untyped_field_at_w_fixed_src",
         QueryBuilder_each_w_untyped_field_at_w_fixed_src
+    },
+    {
+        "singleton_pair",
+        QueryBuilder_singleton_pair
     }
 };
 
@@ -7052,7 +7072,7 @@ static bake_test_suite suites[] = {
         "Entity",
         NULL,
         NULL,
-        279,
+        280,
         Entity_testcases
     },
     {
@@ -7066,7 +7086,7 @@ static bake_test_suite suites[] = {
         "Enum",
         NULL,
         NULL,
-        49,
+        51,
         Enum_testcases
     },
     {
@@ -7115,7 +7135,7 @@ static bake_test_suite suites[] = {
         "QueryBuilder",
         QueryBuilder_setup,
         NULL,
-        172,
+        173,
         QueryBuilder_testcases,
         1,
         QueryBuilder_params


### PR DESCRIPTION
When calling ``term_builder_i::singleton()``, there's a typo where the term's source id isn't being set correctly for pairs (always 0) because it is creating and passing a new world  to ``ecs_get_alive`` instead of using the world that is returned by ``world_v()``. 
https://github.com/SanderMertens/flecs/blob/98d13a6907996bfc4c9faacddfc8b102a0b9af64/include/flecs/addons/cpp/mixins/term/builder_i.hpp#L404

Bake generated some missing enum tests so I included those as well.