### PR TITLE
Reduce memory consumption

### DIFF
--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -28771,6 +28771,26 @@ void* flecs_balloc_w_dbg_info(
 
     if (!ba) return NULL;
 
+    static int64_t *alloc_map = NULL;
+    static int64_t alloc_count = 1000 * 1000 * 17;
+
+    if (!alloc_map) alloc_map = ecs_os_calloc_n(int64_t, 100 * 1000 * 1000);
+    alloc_map[ba->data_size] ++;
+    alloc_count --;
+
+    if (alloc_count == 0) {
+        printf("---\n");
+        int64_t total_size = 0;
+        for (int i = 0; i < 100 * 1000 * 1000; i ++) {
+            if (alloc_map[i]) {
+                printf("%d, %lld, %lld\n", i, alloc_map[i], i * alloc_map[i]);
+                total_size += alloc_map[i] * i;
+            }
+        }
+        printf("TOTAL %lld\n", total_size);
+        alloc_count = 100;
+    }
+
 #ifdef FLECS_USE_OS_ALLOC
     result = ecs_os_malloc(ba->data_size);
 #else

--- a/distr/flecs.h
+++ b/distr/flecs.h
@@ -232,13 +232,13 @@
 /** @def FLECS_LOW_FOOTPRINT
  * Set a number of constants to values that decrease memory footprint, at the
  * cost of decreased performance. */
-#define FLECS_LOW_FOOTPRINT
+// #define FLECS_LOW_FOOTPRINT
 #ifdef FLECS_LOW_FOOTPRINT
-// #define FLECS_HI_COMPONENT_ID (8)
-// #define FLECS_HI_ID_RECORD_ID (16)
-// #define FLECS_SPARSE_PAGE_BITS (4)
-// #define FLECS_ENTITY_PAGE_BITS (6)
-// #define FLECS_USE_OS_ALLOC
+#define FLECS_HI_COMPONENT_ID (8)
+#define FLECS_HI_ID_RECORD_ID (16)
+#define FLECS_SPARSE_PAGE_BITS (4)
+#define FLECS_ENTITY_PAGE_BITS (6)
+#define FLECS_USE_OS_ALLOC
 #endif
 
 /** @def FLECS_HI_COMPONENT_ID
@@ -1769,10 +1769,10 @@ typedef struct ecs_bucket_t {
 } ecs_bucket_t;
 
 struct ecs_map_t {
-    uint8_t bucket_shift;
     ecs_bucket_t *buckets;
     int32_t bucket_count;
-    int32_t count;
+    unsigned count : 26;
+    unsigned bucket_shift : 6;
     struct ecs_allocator_t *allocator;
 };
 

--- a/distr/flecs.h
+++ b/distr/flecs.h
@@ -232,13 +232,13 @@
 /** @def FLECS_LOW_FOOTPRINT
  * Set a number of constants to values that decrease memory footprint, at the
  * cost of decreased performance. */
-// #define FLECS_LOW_FOOTPRINT
+#define FLECS_LOW_FOOTPRINT
 #ifdef FLECS_LOW_FOOTPRINT
-#define FLECS_HI_COMPONENT_ID (16)
-#define FLECS_HI_ID_RECORD_ID (16)
-#define FLECS_SPARSE_PAGE_BITS (4)
-#define FLECS_ENTITY_PAGE_BITS (6)
-#define FLECS_USE_OS_ALLOC
+// #define FLECS_HI_COMPONENT_ID (8)
+// #define FLECS_HI_ID_RECORD_ID (16)
+// #define FLECS_SPARSE_PAGE_BITS (4)
+// #define FLECS_ENTITY_PAGE_BITS (6)
+// #define FLECS_USE_OS_ALLOC
 #endif
 
 /** @def FLECS_HI_COMPONENT_ID
@@ -1770,11 +1770,9 @@ typedef struct ecs_bucket_t {
 
 struct ecs_map_t {
     uint8_t bucket_shift;
-    bool shared_allocator;
     ecs_bucket_t *buckets;
     int32_t bucket_count;
     int32_t count;
-    struct ecs_block_allocator_t *entry_allocator;
     struct ecs_allocator_t *allocator;
 };
 

--- a/distr/flecs.h
+++ b/distr/flecs.h
@@ -234,7 +234,7 @@
  * cost of decreased performance. */
 // #define FLECS_LOW_FOOTPRINT
 #ifdef FLECS_LOW_FOOTPRINT
-#define FLECS_HI_COMPONENT_ID (8)
+#define FLECS_HI_COMPONENT_ID (16)
 #define FLECS_HI_ID_RECORD_ID (16)
 #define FLECS_SPARSE_PAGE_BITS (4)
 #define FLECS_ENTITY_PAGE_BITS (6)

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -230,13 +230,13 @@
 /** @def FLECS_LOW_FOOTPRINT
  * Set a number of constants to values that decrease memory footprint, at the
  * cost of decreased performance. */
-// #define FLECS_LOW_FOOTPRINT
+#define FLECS_LOW_FOOTPRINT
 #ifdef FLECS_LOW_FOOTPRINT
-#define FLECS_HI_COMPONENT_ID (16)
-#define FLECS_HI_ID_RECORD_ID (16)
-#define FLECS_SPARSE_PAGE_BITS (4)
-#define FLECS_ENTITY_PAGE_BITS (6)
-#define FLECS_USE_OS_ALLOC
+// #define FLECS_HI_COMPONENT_ID (8)
+// #define FLECS_HI_ID_RECORD_ID (16)
+// #define FLECS_SPARSE_PAGE_BITS (4)
+// #define FLECS_ENTITY_PAGE_BITS (6)
+// #define FLECS_USE_OS_ALLOC
 #endif
 
 /** @def FLECS_HI_COMPONENT_ID

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -230,13 +230,13 @@
 /** @def FLECS_LOW_FOOTPRINT
  * Set a number of constants to values that decrease memory footprint, at the
  * cost of decreased performance. */
-#define FLECS_LOW_FOOTPRINT
+// #define FLECS_LOW_FOOTPRINT
 #ifdef FLECS_LOW_FOOTPRINT
-// #define FLECS_HI_COMPONENT_ID (8)
-// #define FLECS_HI_ID_RECORD_ID (16)
-// #define FLECS_SPARSE_PAGE_BITS (4)
-// #define FLECS_ENTITY_PAGE_BITS (6)
-// #define FLECS_USE_OS_ALLOC
+#define FLECS_HI_COMPONENT_ID (8)
+#define FLECS_HI_ID_RECORD_ID (16)
+#define FLECS_SPARSE_PAGE_BITS (4)
+#define FLECS_ENTITY_PAGE_BITS (6)
+#define FLECS_USE_OS_ALLOC
 #endif
 
 /** @def FLECS_HI_COMPONENT_ID

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -232,7 +232,7 @@
  * cost of decreased performance. */
 // #define FLECS_LOW_FOOTPRINT
 #ifdef FLECS_LOW_FOOTPRINT
-#define FLECS_HI_COMPONENT_ID (8)
+#define FLECS_HI_COMPONENT_ID (16)
 #define FLECS_HI_ID_RECORD_ID (16)
 #define FLECS_SPARSE_PAGE_BITS (4)
 #define FLECS_ENTITY_PAGE_BITS (6)

--- a/include/flecs/datastructures/map.h
+++ b/include/flecs/datastructures/map.h
@@ -29,11 +29,9 @@ typedef struct ecs_bucket_t {
 
 struct ecs_map_t {
     uint8_t bucket_shift;
-    bool shared_allocator;
     ecs_bucket_t *buckets;
     int32_t bucket_count;
     int32_t count;
-    struct ecs_block_allocator_t *entry_allocator;
     struct ecs_allocator_t *allocator;
 };
 

--- a/include/flecs/datastructures/map.h
+++ b/include/flecs/datastructures/map.h
@@ -28,10 +28,10 @@ typedef struct ecs_bucket_t {
 } ecs_bucket_t;
 
 struct ecs_map_t {
-    uint8_t bucket_shift;
     ecs_bucket_t *buckets;
     int32_t bucket_count;
-    int32_t count;
+    unsigned count : 26;
+    unsigned bucket_shift : 6;
     struct ecs_allocator_t *allocator;
 };
 

--- a/src/addons/json/serialize_iter_result.c
+++ b/src/addons/json/serialize_iter_result.c
@@ -159,7 +159,7 @@ int flecs_json_serialize_refs(
     if (idr) {
         if (relationship == EcsWildcard) {
             ecs_id_record_t *cur = idr;
-            while ((cur = cur->second.next)) {
+            while ((cur = flecs_id_record_second_next(cur))) {
                 flecs_json_serialize_refs_idr(world, buf, cur);
             }
         } else {

--- a/src/addons/metrics.c
+++ b/src/addons/metrics.c
@@ -403,7 +403,7 @@ static void UpdateCountTargets(ecs_iter_t *it) {
     for (i = 0; i < count; i ++) {
         ecs_count_targets_metric_ctx_t *ctx = m[i].ctx;
         ecs_id_record_t *cur = ctx->idr;
-        while ((cur = cur->first.next)) {
+        while ((cur = flecs_id_record_first_next(cur))) {
             ecs_id_t id = cur->id;
             ecs_entity_t *mi = ecs_map_ensure(&ctx->targets, id);
             if (!mi[0]) {

--- a/src/bootstrap.c
+++ b/src/bootstrap.c
@@ -253,7 +253,7 @@ void flecs_register_id_flag_for_relation(
             idr = flecs_id_record_ensure(world, ecs_pair(e, EcsWildcard));
             do {
                 changed |= flecs_set_id_flag(world, idr, flag);
-            } while ((idr = idr->first.next));
+            } while ((idr = flecs_id_record_first_next(idr)));
             if (entity_flag) flecs_add_flag(world, e, entity_flag);
         } else if (event == EcsOnRemove) {
             ecs_id_record_t *idr = flecs_id_record_get(world, e);
@@ -262,7 +262,7 @@ void flecs_register_id_flag_for_relation(
             if (idr) {
                 do {
                     changed |= flecs_unset_id_flag(idr, not_flag);
-                } while ((idr = idr->first.next));
+                } while ((idr = flecs_id_record_first_next(idr)));
             }
         }
 
@@ -310,7 +310,7 @@ void flecs_register_tag(ecs_iter_t *it) {
                     flecs_assert_relation_unused(world, e, EcsPairIsTag);
                 }
                 idr->type_info = NULL;
-            } while ((idr = idr->first.next));
+            } while ((idr = flecs_id_record_first_next(idr)));
         }
     }
 }

--- a/src/datastructures/block_allocator.c
+++ b/src/datastructures/block_allocator.c
@@ -17,6 +17,14 @@ int64_t ecs_block_allocator_free_count = 0;
 
 #ifndef FLECS_USE_OS_ALLOC
 
+/* Bypass block allocator if chunks per block is lower than the configured 
+ * value. This prevents holding on to large memory chunks when they're freed,
+ * which can add up especially in scenarios where an array is reallocated 
+ * several times to a large size. 
+ * A value of 1 seems to yield the best results. Higher values only impact lower
+ * allocation sizes, which are more likely to be reused. */
+#define FLECS_MIN_CHUNKS_PER_BLOCK 1
+
 static
 ecs_block_allocator_chunk_header_t* flecs_balloc_block(
     ecs_block_allocator_t *allocator)
@@ -150,6 +158,10 @@ void* flecs_balloc_w_dbg_info(
 
     if (!ba) return NULL;
 
+    if (ba->chunks_per_block <= FLECS_MIN_CHUNKS_PER_BLOCK) {
+        return ecs_os_malloc(ba->data_size);
+    }
+
     if (!ba->head) {
         ba->head = flecs_balloc_block(ba);
         ecs_assert(ba->head != NULL, ECS_INTERNAL_ERROR, NULL);
@@ -224,7 +236,13 @@ void flecs_bfree_w_dbg_info(
         ecs_assert(memory == NULL, ECS_INTERNAL_ERROR, NULL);
         return;
     }
+
     if (memory == NULL) {
+        return;
+    }
+
+    if (ba->chunks_per_block <= FLECS_MIN_CHUNKS_PER_BLOCK) {
+        ecs_os_free(memory);
         return;
     }
 

--- a/src/datastructures/block_allocator.c
+++ b/src/datastructures/block_allocator.c
@@ -152,11 +152,12 @@ void* flecs_balloc_w_dbg_info(
 {
     (void)type_name;
     void *result;
+
+    if (!ba) return NULL;
+
 #ifdef FLECS_USE_OS_ALLOC
     result = ecs_os_malloc(ba->data_size);
 #else
-
-    if (!ba) return NULL;
 
     if (ba->chunks_per_block <= FLECS_MIN_CHUNKS_PER_BLOCK) {
         return ecs_os_malloc(ba->data_size);

--- a/src/datastructures/block_allocator.c
+++ b/src/datastructures/block_allocator.c
@@ -155,26 +155,6 @@ void* flecs_balloc_w_dbg_info(
 
     if (!ba) return NULL;
 
-    static int64_t *alloc_map = NULL;
-    static int64_t alloc_count = 1000 * 1000 * 17;
-
-    if (!alloc_map) alloc_map = ecs_os_calloc_n(int64_t, 100 * 1000 * 1000);
-    alloc_map[ba->data_size] ++;
-    alloc_count --;
-
-    if (alloc_count == 0) {
-        printf("---\n");
-        int64_t total_size = 0;
-        for (int i = 0; i < 100 * 1000 * 1000; i ++) {
-            if (alloc_map[i]) {
-                printf("%d, %lld, %lld\n", i, alloc_map[i], i * alloc_map[i]);
-                total_size += alloc_map[i] * i;
-            }
-        }
-        printf("TOTAL %lld\n", total_size);
-        alloc_count = 100;
-    }
-
 #ifdef FLECS_USE_OS_ALLOC
     result = ecs_os_malloc(ba->data_size);
 #else

--- a/src/datastructures/block_allocator.c
+++ b/src/datastructures/block_allocator.c
@@ -155,6 +155,26 @@ void* flecs_balloc_w_dbg_info(
 
     if (!ba) return NULL;
 
+    static int64_t *alloc_map = NULL;
+    static int64_t alloc_count = 1000 * 1000 * 17;
+
+    if (!alloc_map) alloc_map = ecs_os_calloc_n(int64_t, 100 * 1000 * 1000);
+    alloc_map[ba->data_size] ++;
+    alloc_count --;
+
+    if (alloc_count == 0) {
+        printf("---\n");
+        int64_t total_size = 0;
+        for (int i = 0; i < 100 * 1000 * 1000; i ++) {
+            if (alloc_map[i]) {
+                printf("%d, %lld, %lld\n", i, alloc_map[i], i * alloc_map[i]);
+                total_size += alloc_map[i] * i;
+            }
+        }
+        printf("TOTAL %lld\n", total_size);
+        alloc_count = 100;
+    }
+
 #ifdef FLECS_USE_OS_ALLOC
     result = ecs_os_malloc(ba->data_size);
 #else

--- a/src/datastructures/map.c
+++ b/src/datastructures/map.c
@@ -40,7 +40,7 @@ int32_t flecs_map_get_bucket_count(
 
 /* Get bucket shift amount for a given bucket count */
 static
-uint8_t flecs_map_get_bucket_shift (
+uint8_t flecs_map_get_bucket_shift(
     int32_t bucket_count)
 {
     return (uint8_t)(64u - flecs_log2((uint32_t)bucket_count));
@@ -63,7 +63,7 @@ ecs_bucket_t* flecs_map_get_bucket(
     ecs_map_key_t key)
 {
     ecs_assert(map != NULL, ECS_INVALID_PARAMETER, NULL);
-    int32_t bucket_id = flecs_map_get_bucket_index(map->bucket_shift, key);
+    int32_t bucket_id = flecs_map_get_bucket_index((uint16_t)map->bucket_shift, key);
     ecs_assert(bucket_id < map->bucket_count, ECS_INTERNAL_ERROR, NULL);
     return &map->buckets[bucket_id];
 }
@@ -153,7 +153,7 @@ void flecs_map_rehash(
 
     map->buckets = ECS_MAP_CALLOC_N(map->allocator, ecs_bucket_t, count);
     map->bucket_count = count;
-    map->bucket_shift = flecs_map_get_bucket_shift(count);
+    map->bucket_shift = flecs_map_get_bucket_shift(count) & 0x3fu;
 
     /* Remap old bucket entries to new buckets */
     for (b = buckets; b < end; b++) {
@@ -161,7 +161,7 @@ void flecs_map_rehash(
         for (entry = b->first; entry;) {
             ecs_bucket_entry_t* next = entry->next;
             int32_t bucket_index = flecs_map_get_bucket_index(
-                map->bucket_shift, entry->key);
+                (uint16_t)map->bucket_shift, entry->key);
             ecs_bucket_t *bucket = &map->buckets[bucket_index];
             entry->next = bucket->first;
             bucket->first = entry;

--- a/src/datastructures/map.c
+++ b/src/datastructures/map.c
@@ -11,6 +11,10 @@
  * (element_count * ECS_LOAD_FACTOR) > bucket_count, bucket count is increased. */
 #define ECS_LOAD_FACTOR (12)
 #define ECS_BUCKET_END(b, c) ECS_ELEM_T(b, ecs_bucket_t, c)
+#define ECS_MAP_ALLOC(a, T) a ? flecs_alloc_t(a, T) : ecs_os_malloc_t(T)
+#define ECS_MAP_CALLOC_N(a, T, n) a ? flecs_calloc_n(a, T, n) : ecs_os_calloc_n(T, n)
+#define ECS_MAP_FREE(a, T, ptr) a ? flecs_free_t(a, T, ptr) : ecs_os_free(ptr)
+#define ECS_MAP_FREE_N(a, T, n, ptr) a ? flecs_free_n(a, T, n, ptr) : ecs_os_free(ptr)
 
 static
 uint8_t flecs_log2(uint32_t v) {
@@ -67,11 +71,11 @@ ecs_bucket_t* flecs_map_get_bucket(
 /* Add element to bucket */
 static
 ecs_map_val_t* flecs_map_bucket_add(
-    ecs_block_allocator_t *allocator,
+    ecs_allocator_t *a,
     ecs_bucket_t *bucket,
     ecs_map_key_t key)
 {
-    ecs_bucket_entry_t *new_entry = flecs_balloc(allocator);
+    ecs_bucket_entry_t *new_entry = ECS_MAP_ALLOC(a, ecs_bucket_entry_t);
     new_entry->key = key;
     new_entry->next = bucket->first;
     bucket->first = new_entry;
@@ -94,7 +98,7 @@ ecs_map_val_t flecs_map_bucket_remove(
                 next_holder = &(*next_holder)->next;
             }
             *next_holder = entry->next;
-            flecs_bfree(map->entry_allocator, entry);
+            ECS_MAP_FREE(map->allocator, ecs_bucket_entry_t, entry);
             map->count --;
             return value;
         }
@@ -106,13 +110,13 @@ ecs_map_val_t flecs_map_bucket_remove(
 /* Free contents of bucket */
 static
 void flecs_map_bucket_clear(
-    ecs_block_allocator_t *allocator,
+    ecs_allocator_t *allocator,
     ecs_bucket_t *bucket)
 {
     ecs_bucket_entry_t *entry = bucket->first;
     while(entry) {
         ecs_bucket_entry_t *next = entry->next;
-        flecs_bfree(allocator, entry);
+        ECS_MAP_FREE(allocator, ecs_bucket_entry_t, entry);
         entry = next;
     }
 }
@@ -147,11 +151,7 @@ void flecs_map_rehash(
     int32_t old_count = map->bucket_count;
     ecs_bucket_t *buckets = map->buckets, *b, *end = ECS_BUCKET_END(buckets, old_count);
 
-    if (map->allocator) {
-        map->buckets = flecs_calloc_n(map->allocator, ecs_bucket_t, count);
-    } else {
-        map->buckets = ecs_os_calloc_n(ecs_bucket_t, count);
-    }
+    map->buckets = ECS_MAP_CALLOC_N(map->allocator, ecs_bucket_t, count);
     map->bucket_count = count;
     map->bucket_shift = flecs_map_get_bucket_shift(count);
 
@@ -169,11 +169,7 @@ void flecs_map_rehash(
         }
     }
 
-    if (map->allocator) {
-        flecs_free_n(map->allocator, ecs_bucket_t, old_count, buckets);
-    } else {
-        ecs_os_free(buckets);
-    }
+    ECS_MAP_FREE_N(map->allocator, ecs_bucket_t, old_count, buckets);
 }
 
 void ecs_map_params_init(
@@ -181,7 +177,6 @@ void ecs_map_params_init(
     ecs_allocator_t *allocator)
 {
     params->allocator = allocator;
-    flecs_ballocator_init_t(&params->entry_allocator, ecs_bucket_entry_t);
 }
 
 void ecs_map_params_fini(
@@ -197,13 +192,6 @@ void ecs_map_init_w_params(
     ecs_os_zeromem(result);
 
     result->allocator = params->allocator;
-
-    if (params->entry_allocator.chunk_size) {
-        result->entry_allocator = &params->entry_allocator;
-        result->shared_allocator = true;
-    } else {
-        result->entry_allocator = flecs_ballocator_new_t(ecs_bucket_entry_t);
-    }
 
     flecs_map_rehash(result, 0);
 }
@@ -242,34 +230,16 @@ void ecs_map_fini(
         return;
     }
 
-    bool sanitize = false;
-#if defined(FLECS_SANITIZE) || defined(FLECS_USE_OS_ALLOC)
-    sanitize = true;
-#endif
-
-    /* Free buckets in sanitized mode, so we can replace the allocator with
-     * regular malloc/free and use asan/valgrind to find memory errors. */
     ecs_allocator_t *a = map->allocator;
-    ecs_block_allocator_t *ea = map->entry_allocator;
-    if (map->shared_allocator || sanitize) {
-        ecs_bucket_t *bucket = map->buckets, *end = &bucket[map->bucket_count];
-        while (bucket != end) {
-            flecs_map_bucket_clear(ea, bucket);
-            bucket ++;
-        }
-    }
-
-    if (ea && !map->shared_allocator) {
-        flecs_ballocator_free(ea);
-        map->entry_allocator = NULL;
-    }
-    if (a) {
-        flecs_free_n(a, ecs_bucket_t, map->bucket_count, map->buckets);
-    } else {
-        ecs_os_free(map->buckets);
+    ecs_bucket_t *bucket = map->buckets, *end = &bucket[map->bucket_count];
+    while (bucket != end) {
+        flecs_map_bucket_clear(a, bucket);
+        bucket ++;
     }
 
     map->bucket_shift = 0;
+
+    ECS_MAP_FREE_N(a, ecs_bucket_t, map->bucket_count, map->buckets);
 }
 
 ecs_map_val_t* ecs_map_get(
@@ -305,7 +275,7 @@ void ecs_map_insert(
     }
 
     ecs_bucket_t *bucket = flecs_map_get_bucket(map, key);
-    flecs_map_bucket_add(map->entry_allocator, bucket, key)[0] = value;
+    flecs_map_bucket_add(map->allocator, bucket, key)[0] = value;
 }
 
 void* ecs_map_insert_alloc(
@@ -336,7 +306,7 @@ ecs_map_val_t* ecs_map_ensure(
         bucket = flecs_map_get_bucket(map, key);
     }
 
-    ecs_map_val_t* v = flecs_map_bucket_add(map->entry_allocator, bucket, key);
+    ecs_map_val_t* v = flecs_map_bucket_add(map->allocator, bucket, key);
     *v = 0;
     return v;
 }
@@ -379,13 +349,9 @@ void ecs_map_clear(
     ecs_assert(map != NULL, ECS_INVALID_PARAMETER, NULL);
     int32_t i, count = map->bucket_count;
     for (i = 0; i < count; i ++) {
-        flecs_map_bucket_clear(map->entry_allocator, &map->buckets[i]);
+        flecs_map_bucket_clear(map->allocator, &map->buckets[i]);
     }
-    if (map->allocator) {
-        flecs_free_n(map->allocator, ecs_bucket_t, count, map->buckets);
-    } else {
-        ecs_os_free(map->buckets);
-    }
+    ECS_MAP_FREE_N(map->allocator, ecs_bucket_t, count, map->buckets);
     map->buckets = NULL;
     map->bucket_count = 0;
     map->count = 0;

--- a/src/entity.c
+++ b/src/entity.c
@@ -2604,13 +2604,13 @@ void flecs_id_mark_for_delete(
         ecs_assert(ECS_HAS_ID_FLAG(id, PAIR), ECS_INTERNAL_ERROR, NULL);
         ecs_id_record_t *cur = idr;
         if (ECS_PAIR_SECOND(id) == EcsWildcard) {
-            while ((cur = cur->first.next)) {
+            while ((cur = flecs_id_record_first_next(cur))) {
                 flecs_update_monitors_for_delete(world, cur->id);
             }
         } else {
             ecs_assert(ECS_PAIR_FIRST(id) == EcsWildcard, 
                 ECS_INTERNAL_ERROR, NULL);
-            while ((cur = cur->second.next)) {
+            while ((cur = flecs_id_record_second_next(cur))) {
                 flecs_update_monitors_for_delete(world, cur->id);
             }
         }

--- a/src/private_types.h
+++ b/src/private_types.h
@@ -101,6 +101,7 @@ typedef struct ecs_world_allocators_t {
     ecs_block_allocator_t graph_edge_lo;
     ecs_block_allocator_t graph_edge;
     ecs_block_allocator_t id_record;
+    ecs_block_allocator_t pair_id_record;
     ecs_block_allocator_t id_record_chunk;
     ecs_block_allocator_t table_diff;
     ecs_block_allocator_t sparse_chunk;

--- a/src/query/engine/eval.c
+++ b/src/query/engine/eval.c
@@ -677,7 +677,7 @@ bool flecs_query_idsright(
 
 next:
     do {
-        cur = op_ctx->cur = op_ctx->cur->first.next;
+        cur = op_ctx->cur = flecs_id_record_first_next(op_ctx->cur);
     } while (cur && !cur->cache.tables.count); /* Skip empty ids */
 
     if (!cur) {
@@ -733,7 +733,7 @@ bool flecs_query_idsleft(
     }
 
     do {
-        cur = op_ctx->cur = op_ctx->cur->second.next;
+        cur = op_ctx->cur = flecs_id_record_second_next(op_ctx->cur);
     } while (cur && !cur->cache.tables.count); /* Skip empty ids */ 
 
     if (!cur) {

--- a/src/storage/id_index.c
+++ b/src/storage/id_index.c
@@ -191,7 +191,8 @@ ecs_id_record_t* flecs_id_record_new(
 {
     ecs_id_record_t *idr, *idr_t = NULL;
     ecs_id_t hash = flecs_id_record_hash(id);
-    idr = flecs_bcalloc(&world->allocators.id_record);
+    idr = flecs_bcalloc_w_dbg_info(
+        &world->allocators.id_record, "ecs_id_record_t");
 
     if (hash >= FLECS_HI_ID_RECORD_ID) {
         ecs_map_insert_ptr(&world->id_index_hi, hash, idr);

--- a/src/storage/table.c
+++ b/src/storage/table.c
@@ -510,7 +510,8 @@ void flecs_table_init(
                     childof_idr = p_idr;
                 }
 
-                idr = p_idr->parent; /* (R, *) */
+                ecs_assert(p_idr->pair != NULL, ECS_INTERNAL_ERROR, NULL);
+                idr = p_idr->pair->parent; /* (R, *) */
                 ecs_assert(idr != NULL, ECS_INTERNAL_ERROR, NULL);
 
                 tr = ecs_vec_append_t(a, records, ecs_table_record_t);

--- a/src/storage/table.h
+++ b/src/storage/table.h
@@ -77,16 +77,16 @@ typedef struct ecs_table__t {
     uint64_t hash;                   /* Type hash */
     int32_t lock;                    /* Prevents modifications */
     int32_t traversable_count;       /* Traversable relationship targets in table */
+
     uint16_t generation;             /* Used for table cleanup */
     int16_t record_count;            /* Table record count including wildcards */
-    
-    struct ecs_table_record_t *records; /* Array with table records */
-    ecs_hashmap_t *name_index;       /* Cached pointer to name index */
 
-    ecs_bitset_t *bs_columns;        /* Bitset columns */
     int16_t bs_count;
     int16_t bs_offset;
-    int16_t ft_offset;
+    ecs_bitset_t *bs_columns;        /* Bitset columns */
+
+    struct ecs_table_record_t *records; /* Array with table records */
+    ecs_hashmap_t *name_index;       /* Cached pointer to name index */
 
 #ifdef FLECS_DEBUG_INFO
     /* Fields used for debug visualization */

--- a/src/world.c
+++ b/src/world.c
@@ -759,6 +759,7 @@ void flecs_world_allocators_init(
     flecs_ballocator_init_n(&a->graph_edge_lo, ecs_graph_edge_t, FLECS_HI_COMPONENT_ID);
     flecs_ballocator_init_t(&a->graph_edge, ecs_graph_edge_t);
     flecs_ballocator_init_t(&a->id_record, ecs_id_record_t);
+    flecs_ballocator_init_t(&a->pair_id_record, ecs_pair_id_record_t);
     flecs_ballocator_init_n(&a->id_record_chunk, ecs_id_record_t, FLECS_SPARSE_PAGE_SIZE);
     flecs_ballocator_init_t(&a->table_diff, ecs_table_diff_t);
     flecs_ballocator_init_n(&a->sparse_chunk, int32_t, FLECS_SPARSE_PAGE_SIZE);
@@ -779,6 +780,7 @@ void flecs_world_allocators_fini(
     flecs_ballocator_fini(&a->graph_edge_lo);
     flecs_ballocator_fini(&a->graph_edge);
     flecs_ballocator_fini(&a->id_record);
+    flecs_ballocator_fini(&a->pair_id_record);
     flecs_ballocator_fini(&a->id_record_chunk);
     flecs_ballocator_fini(&a->table_diff);
     flecs_ballocator_fini(&a->sparse_chunk);
@@ -1923,7 +1925,7 @@ bool flecs_type_info_init_id(
         {
             changed |= flecs_id_record_set_type_info(world, idr, NULL);
         }
-    } while ((idr = idr->first.next));
+    } while ((idr = flecs_id_record_first_next(idr)));
 
     /* All non-tag id records with component as object inherit type info,
      * if relationship doesn't have type info */
@@ -1932,7 +1934,7 @@ bool flecs_type_info_init_id(
         if (!(idr->flags & EcsIdTag) && !idr->type_info) {
             changed |= flecs_id_record_set_type_info(world, idr, ti);
         }
-    } while ((idr = idr->first.next));
+    } while ((idr = flecs_id_record_first_next(idr)));
 
     /* Type info of (*, component) should always point to component */
     ecs_assert(flecs_id_record_get(world, ecs_pair(EcsWildcard, component))->


### PR DESCRIPTION
This PR has the following changes:
- Bypass block allocator for large chunk sizes
- Reduce footprint of `ecs_map_t`
- Move pair-only fields of `ecs_id_record_t` to separate struct that's only allocated for pairs
- Remove unused field from `ecs_table__t` and reorder fields to reduce padding