### PR TITLE
Fix entity index page allocator memory leak

### DIFF
--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -35399,13 +35399,11 @@ void flecs_entity_index_fini(
     ecs_entity_index_t *index)
 {
     ecs_vec_fini_t(index->allocator, &index->dense, uint64_t);
-#if defined(FLECS_SANITIZE) || defined(FLECS_USE_OS_ALLOC)
     int32_t i, count = ecs_vec_count(&index->pages);
     ecs_entity_index_page_t **pages = ecs_vec_first(&index->pages);
     for (i = 0; i < count; i ++) {
         flecs_bfree(&index->page_allocator, pages[i]);
     }
-#endif
     ecs_vec_fini_t(index->allocator, &index->pages, ecs_entity_index_page_t*);
     flecs_ballocator_fini(&index->page_allocator);
 }

--- a/src/storage/entity_index.c
+++ b/src/storage/entity_index.c
@@ -39,13 +39,11 @@ void flecs_entity_index_fini(
     ecs_entity_index_t *index)
 {
     ecs_vec_fini_t(index->allocator, &index->dense, uint64_t);
-#if defined(FLECS_SANITIZE) || defined(FLECS_USE_OS_ALLOC)
     int32_t i, count = ecs_vec_count(&index->pages);
     ecs_entity_index_page_t **pages = ecs_vec_first(&index->pages);
     for (i = 0; i < count; i ++) {
         flecs_bfree(&index->page_allocator, pages[i]);
     }
-#endif
     ecs_vec_fini_t(index->allocator, &index->pages, ecs_entity_index_page_t*);
     flecs_ballocator_fini(&index->page_allocator);
 }


### PR DESCRIPTION
After #1589 (e0d6ded62bd4eb1a9747706f93d70e98bf8046b3) My address sanitizer is reporting a leak of 98304 bytes for the simple pogram:

```cpp
int main(int argc, char **argv) {
  flecs::world world;
  return 0;
}
```
with a dump as follows: 

```
=================================================================
==578871==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 98304 byte(s) in 1 object(s) allocated from:
    #0 0x7a6f30efd9c7 in malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x7a6f30d6a0f9 in ecs_os_api_malloc /home/jm/src/vworlds/apps/cppserver/build/_deps/flecs-src/src/os_api.c:302
    #2 0x7a6f30d35210 in flecs_balloc_w_dbg_info /home/jm/src/vworlds/apps/cppserver/build/_deps/flecs-src/src/datastructures/block_allocator.c:163
    #3 0x7a6f30d35330 in flecs_bcalloc_w_dbg_info /home/jm/src/vworlds/apps/cppserver/build/_deps/flecs-src/src/datastructures/block_allocator.c:210
    #4 0x7a6f30d352f9 in flecs_bcalloc /home/jm/src/vworlds/apps/cppserver/build/_deps/flecs-src/src/datastructures/block_allocator.c:196
    #5 0x7a6f30d9c2bc in flecs_entity_index_ensure_page /home/jm/src/vworlds/apps/cppserver/build/_deps/flecs-src/src/storage/entity_index.c:18
    #6 0x7a6f30d9c7ed in flecs_entity_index_ensure /home/jm/src/vworlds/apps/cppserver/build/_deps/flecs-src/src/storage/entity_index.c:123
    #7 0x7a6f30d516ad in ecs_make_alive /home/jm/src/vworlds/apps/cppserver/build/_deps/flecs-src/src/entity.c:4206
    #8 0x7a6f30d2f3fc in flecs_bootstrap /home/jm/src/vworlds/apps/cppserver/build/_deps/flecs-src/src/bootstrap.c:705
    #9 0x7a6f30db61b5 in ecs_mini /home/jm/src/vworlds/apps/cppserver/build/_deps/flecs-src/src/world.c:991
    #10 0x7a6f30db6217 in ecs_init /home/jm/src/vworlds/apps/cppserver/build/_deps/flecs-src/src/world.c:1002
    #11 0x645c90d61898 in flecs::world::world() /home/jm/src/vworlds/apps/cppserver/build/_deps/flecs-src/include/flecs/private/../addons/cpp/world.hpp:141
    #12 0x645c90d5f02d in _main::main(int, char**) /home/jm/src/vworlds/apps/cppserver/src/main.cpp:6
    #13 0x645c90d5f0be in main /home/jm/src/vworlds/apps/cppserver/src/main.cpp:12
    #14 0x7a6f3062a1c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #15 0x7a6f3062a28a in __libc_start_main_impl ../csu/libc-start.c:360
    #16 0x645c90d5eec4 in _start (/home/jm/src/vworlds/apps/cppserver/build/vworlds+0x3aec4) (BuildId: 6a7581466c7d85b7e158e89f564671e0d8d0e120)

SUMMARY: AddressSanitizer: 98304 byte(s) leaked in 1 allocation(s).
```
This is Linux gcc 13.3

I pinpointed it to `entity_index.c` where not all pages are being freed, this is due to the new block allocator behavior (`block_allocator.c`) : 

```c
    if (ba->chunks_per_block <= FLECS_MIN_CHUNKS_PER_BLOCK) {
        return ecs_os_malloc(ba->data_size);
    }
```
... whereupon allocations that satisfy the above condition are not added to the allocator list of blocks, meaning the caller is responsible to specifically freeing each allocation and can't just free the allocator as before. There is now a mix of untracked blocks from `ecs_os_malloc` and tracked blocks from `flecs_balloc_block`.

The proposed fix solves the issue, but perhaps it would be worthwile to review where the allocators are used in a way they are trusting memory to be freed at the end, when the allocator itself is freed, or whether "direct" `ecs_os_malloc` blocks should still be tracked somewhere.


