### PR TITLE
Add missing Ref tests to project.json

### DIFF
--- a/test/cpp/project.json
+++ b/test/cpp/project.json
@@ -1098,6 +1098,8 @@
                 "ref_before_set",
                 "non_const_ref",
                 "pair_ref",
+                "pair_ref_w_pair_type",
+                "pair_ref_w_pair_type_second",
                 "pair_ref_w_entity",
                 "pair_ref_second",
                 "from_stage",

--- a/test/cpp/src/main.cpp
+++ b/test/cpp/src/main.cpp
@@ -1061,6 +1061,8 @@ void Refs_ref_after_set(void);
 void Refs_ref_before_set(void);
 void Refs_non_const_ref(void);
 void Refs_pair_ref(void);
+void Refs_pair_ref_w_pair_type(void);
+void Refs_pair_ref_w_pair_type_second(void);
 void Refs_pair_ref_w_entity(void);
 void Refs_pair_ref_second(void);
 void Refs_from_stage(void);
@@ -5581,6 +5583,14 @@ bake_test_case Refs_testcases[] = {
         Refs_pair_ref
     },
     {
+        "pair_ref_w_pair_type",
+        Refs_pair_ref_w_pair_type
+    },
+    {
+        "pair_ref_w_pair_type_second",
+        Refs_pair_ref_w_pair_type_second
+    },
+    {
         "pair_ref_w_entity",
         Refs_pair_ref_w_entity
     },
@@ -7175,7 +7185,7 @@ static bake_test_suite suites[] = {
         "Refs",
         NULL,
         NULL,
-        21,
+        23,
         Refs_testcases
     },
     {


### PR DESCRIPTION
In reviewing code, I just realized two `Refs` tests exist but are not being run because they are missing from the corresponding `project.json`.