### PR TITLE
[meta] Opaque random-access serializer for vectors/arrays and structs

### DIFF
--- a/distr/flecs.h
+++ b/distr/flecs.h
@@ -19590,6 +19590,15 @@ using serialize_t = ecs_meta_serialize_t;
 template <typename T>
 using serialize = int(*)(const serializer *, const T*);
 
+/** Type safe variant of serialize_member function */
+template <typename T>
+using serialize_member = int(*)(const serializer *, const T*, const char* name);
+
+/** Type safe variant of serialize_element function */
+template <typename T>
+using serialize_element = int(*)(const serializer *, const T*, size_t element);
+
+
 /** Type safe interface for opaque types */
 template <typename T, typename ElemType = void>
 struct opaque {
@@ -19610,6 +19619,22 @@ struct opaque {
         this->desc.type.serialize =
             reinterpret_cast<decltype(
                 this->desc.type.serialize)>(func);
+        return *this;
+    }
+
+    /** Serialize member function */
+    opaque& serialize_member(flecs::serialize_member<T> func) {
+        this->desc.type.serialize_member =
+            reinterpret_cast<decltype(
+                this->desc.type.serialize_member)>(func);
+        return *this;
+    }
+
+    /** Serialize element function */
+    opaque& serialize_element(flecs::serialize_element<T> func) {
+        this->desc.type.serialize_element =
+            reinterpret_cast<decltype(
+                this->desc.type.serialize_element)>(func);
         return *this;
     }
 

--- a/distr/flecs.h
+++ b/distr/flecs.h
@@ -15999,6 +15999,19 @@ typedef int (*ecs_meta_serialize_t)(
     const ecs_serializer_t *ser,
     const void *src);                  /**< Pointer to value to serialize */
 
+
+/** Callback invoked to serialize an opaque struct member */
+typedef int (*ecs_meta_serialize_member_t)(
+    const ecs_serializer_t *ser,
+    const void *src,                   /**< Pointer to value to serialize */
+    const char* name);                 /**< Name of member to serialize */
+    
+/** Callback invoked to serialize an opaque vector/array element */
+typedef int (*ecs_meta_serialize_element_t)(
+    const ecs_serializer_t *ser,
+    const void *src,                   /**< Pointer to value to serialize */
+    size_t elem);                      /**< Element index to serialize */
+    
 /** Opaque type reflection data. 
  * An opaque type is a type with an unknown layout that can be mapped to a type
  * known to the reflection framework. See the opaque type reflection examples.
@@ -16006,6 +16019,8 @@ typedef int (*ecs_meta_serialize_t)(
 typedef struct EcsOpaque {
     ecs_entity_t as_type;              /**< Type that describes the serialized output */
     ecs_meta_serialize_t serialize;    /**< Serialize action */
+    ecs_meta_serialize_member_t serialize_member; /**< Serialize member action */
+    ecs_meta_serialize_element_t serialize_element; /**< Serialize element action */
 
     /* Deserializer interface
      * Only override the callbacks that are valid for the opaque type. If a

--- a/include/flecs/addons/cpp/mixins/meta/opaque.hpp
+++ b/include/flecs/addons/cpp/mixins/meta/opaque.hpp
@@ -27,6 +27,15 @@ using serialize_t = ecs_meta_serialize_t;
 template <typename T>
 using serialize = int(*)(const serializer *, const T*);
 
+/** Type safe variant of serialize_member function */
+template <typename T>
+using serialize_member = int(*)(const serializer *, const T*, const char* name);
+
+/** Type safe variant of serialize_element function */
+template <typename T>
+using serialize_element = int(*)(const serializer *, const T*, size_t element);
+
+
 /** Type safe interface for opaque types */
 template <typename T, typename ElemType = void>
 struct opaque {
@@ -47,6 +56,22 @@ struct opaque {
         this->desc.type.serialize =
             reinterpret_cast<decltype(
                 this->desc.type.serialize)>(func);
+        return *this;
+    }
+
+    /** Serialize member function */
+    opaque& serialize_member(flecs::serialize_member<T> func) {
+        this->desc.type.serialize_member =
+            reinterpret_cast<decltype(
+                this->desc.type.serialize_member)>(func);
+        return *this;
+    }
+
+    /** Serialize element function */
+    opaque& serialize_element(flecs::serialize_element<T> func) {
+        this->desc.type.serialize_element =
+            reinterpret_cast<decltype(
+                this->desc.type.serialize_element)>(func);
         return *this;
     }
 

--- a/include/flecs/addons/meta.h
+++ b/include/flecs/addons/meta.h
@@ -382,6 +382,19 @@ typedef int (*ecs_meta_serialize_t)(
     const ecs_serializer_t *ser,
     const void *src);                  /**< Pointer to value to serialize */
 
+
+/** Callback invoked to serialize an opaque struct member */
+typedef int (*ecs_meta_serialize_member_t)(
+    const ecs_serializer_t *ser,
+    const void *src,                   /**< Pointer to value to serialize */
+    const char* name);                 /**< Name of member to serialize */
+    
+/** Callback invoked to serialize an opaque vector/array element */
+typedef int (*ecs_meta_serialize_element_t)(
+    const ecs_serializer_t *ser,
+    const void *src,                   /**< Pointer to value to serialize */
+    size_t elem);                      /**< Element index to serialize */
+    
 /** Opaque type reflection data. 
  * An opaque type is a type with an unknown layout that can be mapped to a type
  * known to the reflection framework. See the opaque type reflection examples.
@@ -389,6 +402,8 @@ typedef int (*ecs_meta_serialize_t)(
 typedef struct EcsOpaque {
     ecs_entity_t as_type;              /**< Type that describes the serialized output */
     ecs_meta_serialize_t serialize;    /**< Serialize action */
+    ecs_meta_serialize_member_t serialize_member; /**< Serialize member action */
+    ecs_meta_serialize_element_t serialize_element; /**< Serialize element action */
 
     /* Deserializer interface
      * Only override the callbacks that are valid for the opaque type. If a

--- a/test/cpp/project.json
+++ b/test/cpp/project.json
@@ -1456,6 +1456,8 @@
                 "ser_deser_std_vector_int",
                 "ser_deser_std_vector_std_string",
                 "ser_deser_type_w_std_string_std_vector_std_string",
+                "std_vector_random_access",
+                "struct_random_access",
                 "ser_deser_flecs_entity",
                 "world_ser_deser_flecs_entity",
                 "new_world_ser_deser_flecs_entity",

--- a/test/cpp/src/main.cpp
+++ b/test/cpp/src/main.cpp
@@ -1405,6 +1405,8 @@ void Meta_ser_deser_std_string(void);
 void Meta_ser_deser_std_vector_int(void);
 void Meta_ser_deser_std_vector_std_string(void);
 void Meta_ser_deser_type_w_std_string_std_vector_std_string(void);
+void Meta_std_vector_random_access(void);
+void Meta_struct_random_access(void);
 void Meta_ser_deser_flecs_entity(void);
 void Meta_world_ser_deser_flecs_entity(void);
 void Meta_new_world_ser_deser_flecs_entity(void);
@@ -6940,6 +6942,14 @@ bake_test_case Meta_testcases[] = {
         Meta_ser_deser_type_w_std_string_std_vector_std_string
     },
     {
+        "std_vector_random_access",
+        Meta_std_vector_random_access
+    },
+    {
+        "struct_random_access",
+        Meta_struct_random_access
+    },
+    {
         "ser_deser_flecs_entity",
         Meta_ser_deser_flecs_entity
     },
@@ -7334,7 +7344,7 @@ static bake_test_suite suites[] = {
         "Meta",
         NULL,
         NULL,
-        61,
+        63,
         Meta_testcases
     },
     {


### PR DESCRIPTION
This PR introduces two new opaque handlers that allow opaque implementers to provide random access to struct members or vector/array elements.

By defining `serialize_element` or `serialize_member`, the developer implementing the opaque can provide an interface to access an element or member directly.

For example, providing access to an `std::vector` item:

```cpp
// Reusable reflection support for std::vector
template<typename Elem, typename Vector = std::vector<Elem>>
flecs::opaque<Vector, Elem> std_vector_opaque(flecs::world &world) {
  return flecs::opaque<Vector, Elem>()
      .as_type(world.vector<Elem>())
      .count([](const Vector *data) { return data->size(); })
      .resize([](Vector *data, size_t size) { data->resize(size); })
      .ensure_element([](Vector *data, size_t elem) {
        if (data->size() <= elem) {
          data->resize(elem + 1);
        }
        return &data->data()[elem];
      })
     // new serialize_element handler:
      .serialize_element([](const flecs::serializer *s, const Vector *data,
                            size_t element) -> int {
        if (element >= data->size()) {
          return 1; // element not found
        }
        return s->value((*data)[element]); // invoke callback to submit the value.
      })
      .serialize([](const flecs::serializer *s, const Vector *data) {
        for (const auto &el : *data) {
          if (s->value(el)) {
            return 1;
          }
        }
        return 0;
      });
}
```

... or, to provide direct access to a struct member, use `serialize_member`:

```cpp
    world.component<Position>()
        .opaque(world.component()
            .member(flecs::F32, "x")
            .member(flecs::F32, "y"))
        .serialize_member([](
            const flecs::serializer * ser,
            const Position* data,
            const char* member) {
                const Position *p = (const Position*) data;
                if(!strcmp(member, "x")) {
                    return ser->value(p->x);
                } else if(!strcmp(member, "y")) {
                    return ser->value(p->y);
                }
                return 1;
            });
```

