### PR TITLE
Implemented ordered enum/bitmask constants #1594

### DIFF
--- a/distr/flecs.h
+++ b/distr/flecs.h
@@ -16059,6 +16059,9 @@ typedef struct EcsEnum {
 
     /** Populated from child entities with Constant component */
     ecs_map_t constants; /**< map<i32_t, ecs_enum_constant_t> */
+
+    /** Stores the constants in registration order */
+    ecs_vec_t ordered_constants; /**< vector<ecs_enum_constants_t> */
 } EcsEnum;
 
 /** Type that describes an bitmask constant */
@@ -16080,6 +16083,8 @@ typedef struct ecs_bitmask_constant_t {
 typedef struct EcsBitmask {
     /* Populated from child entities with Constant component */
     ecs_map_t constants; /**< map<u32_t, ecs_bitmask_constant_t> */
+    /** Stores the constants in registration order */
+    ecs_vec_t ordered_constants; /**< vector<ecs_bitmask_constants_t>  */
 } EcsBitmask;
 
 /** Component added to array type entities */

--- a/include/flecs/addons/meta.h
+++ b/include/flecs/addons/meta.h
@@ -287,6 +287,9 @@ typedef struct EcsEnum {
 
     /** Populated from child entities with Constant component */
     ecs_map_t constants; /**< map<i32_t, ecs_enum_constant_t> */
+
+    /** Stores the constants in registration order */
+    ecs_vec_t ordered_constants; /**< vector<ecs_enum_constants_t> */
 } EcsEnum;
 
 /** Type that describes an bitmask constant */
@@ -308,6 +311,8 @@ typedef struct ecs_bitmask_constant_t {
 typedef struct EcsBitmask {
     /* Populated from child entities with Constant component */
     ecs_map_t constants; /**< map<u32_t, ecs_bitmask_constant_t> */
+    /** Stores the constants in registration order */
+    ecs_vec_t ordered_constants; /**< vector<ecs_bitmask_constants_t>  */
 } EcsBitmask;
 
 /** Component added to array type entities */

--- a/src/addons/flecs_cpp.c
+++ b/src/addons/flecs_cpp.c
@@ -450,7 +450,12 @@ void ecs_cpp_enum_init(
 #ifdef FLECS_META
     ecs_suspend_readonly_state_t readonly_state;
     world = flecs_suspend_readonly(world, &readonly_state);
-    ecs_set(world, id, EcsEnum, { .underlying_type = underlying_type });
+    ecs_vec_t ordered_constants;
+    ecs_vec_init_t(NULL, &ordered_constants, ecs_enum_constant_t, 0);
+    ecs_set(world, id, EcsEnum, { 
+        .underlying_type = underlying_type,
+        .ordered_constants = ordered_constants
+    });
     flecs_resume_readonly(world, &readonly_state);
 #else
     /* Make sure that enums still behave the same even without meta */

--- a/src/addons/meta/api.c
+++ b/src/addons/meta/api.c
@@ -217,7 +217,13 @@ ecs_entity_t ecs_enum_init(
         ut_is_unsigned = true;
     }
 
-    ecs_set(world, t, EcsEnum, { .underlying_type = underlying });
+    ecs_vec_t ordered_constants;
+    ecs_vec_init_t(NULL, &ordered_constants, ecs_enum_constant_t, 0);
+
+    ecs_set(world, t, EcsEnum, { 
+        .underlying_type = underlying, 
+        .ordered_constants = ordered_constants
+    });
 
     ecs_entity_t old_scope = ecs_set_scope(world, t);
 
@@ -299,7 +305,12 @@ ecs_entity_t ecs_bitmask_init(
         t = ecs_new_low_id(world);
     }
 
-    ecs_add(world, t, EcsBitmask);
+    ecs_vec_t ordered_constants;
+    ecs_vec_init_t(NULL, &ordered_constants, ecs_bitmask_constant_t, 0);
+
+    ecs_set(world, t, EcsBitmask, { 
+        .ordered_constants = ordered_constants
+    });
 
     ecs_entity_t old_scope = ecs_set_scope(world, t);
 

--- a/src/addons/meta/c_utils.c
+++ b/src/addons/meta/c_utils.c
@@ -800,7 +800,12 @@ int flecs_meta_utils_parse_enum(
     ecs_entity_t t,
     const char *desc)
 {
-    ecs_set(world, t, EcsEnum, { .underlying_type = ecs_id(ecs_i32_t) });
+    ecs_vec_t ordered_constants;
+    ecs_vec_init_t(NULL, &ordered_constants, ecs_enum_constant_t, 0);
+    ecs_set(world, t, EcsEnum, { 
+        .underlying_type = ecs_id(ecs_i32_t),
+        .ordered_constants = ordered_constants
+    });
     return flecs_meta_utils_parse_constants(world, t, desc, false);
 }
 

--- a/src/addons/meta/meta.c
+++ b/src/addons/meta/meta.c
@@ -517,20 +517,46 @@ static void flecs_constants_copy(
     }
 }
 
+static void  flecs_ordered_constants_dtor(
+    ecs_vec_t* ordered_constants)
+{
+    /* shallow fini of is ok since map deallocs name c-string member */
+    ecs_vec_fini_t(NULL, ordered_constants, ecs_enum_constant_t);
+}
+
+static void flecs_ordered_constants_copy(
+    ecs_vec_t* dst,
+    const ecs_vec_t* src)
+{
+    /* shallow copy of is ok since map deep-copies name c-string member */
+    *dst = ecs_vec_copy_t(NULL, src, ecs_enum_constant_t);
+}
+
+
 static ECS_COPY(EcsEnum, dst, src, {
     flecs_constants_dtor(&dst->constants);
     flecs_constants_copy(&dst->constants, &src->constants);
+    flecs_ordered_constants_dtor(&dst->ordered_constants);
+    flecs_ordered_constants_copy(&dst->ordered_constants, &src->ordered_constants);  
+
     dst->underlying_type = src->underlying_type;
 })
 
 static ECS_MOVE(EcsEnum, dst, src, {
     flecs_constants_dtor(&dst->constants);
     dst->constants = src->constants;
-    dst->underlying_type = src->underlying_type;
     ecs_os_zeromem(&src->constants);
+    flecs_ordered_constants_dtor(&dst->ordered_constants);
+    dst->ordered_constants = src->ordered_constants;
+    ecs_os_zeromem(&src->ordered_constants);
+
+    dst->underlying_type = src->underlying_type;
 })
 
-static ECS_DTOR(EcsEnum, ptr, { flecs_constants_dtor(&ptr->constants); })
+static ECS_DTOR(EcsEnum, ptr, { 
+    flecs_constants_dtor(&ptr->constants);
+    flecs_ordered_constants_dtor(&ptr->ordered_constants);
+})
 
 
 /* EcsBitmask lifecycle */
@@ -539,15 +565,24 @@ static ECS_COPY(EcsBitmask, dst, src, {
     /* bitmask constant & enum constant have the same layout */
     flecs_constants_dtor(&dst->constants);
     flecs_constants_copy(&dst->constants, &src->constants);
+    flecs_ordered_constants_dtor(&dst->ordered_constants);
+    flecs_ordered_constants_copy(&dst->ordered_constants, &src->ordered_constants);
 })
 
 static ECS_MOVE(EcsBitmask, dst, src, {
     flecs_constants_dtor(&dst->constants);
     dst->constants = src->constants;
     ecs_os_zeromem(&src->constants);
+
+    flecs_ordered_constants_dtor(&dst->ordered_constants);
+    dst->ordered_constants = src->ordered_constants;
+    ecs_os_zeromem(&src->ordered_constants);
 })
 
-static ECS_DTOR(EcsBitmask, ptr, { flecs_constants_dtor(&ptr->constants); })
+static ECS_DTOR(EcsBitmask, ptr, { 
+    flecs_constants_dtor(&ptr->constants);
+    flecs_ordered_constants_dtor(&ptr->ordered_constants);
+})
 
 
 /* EcsUnit lifecycle */
@@ -1004,13 +1039,28 @@ int flecs_add_constant_to_enum(
         ut_is_unsigned = true;
     }
 
-    /* Remove constant from map if it was already added */
+    /* Remove constant from map and vector if it was already added */
     ecs_map_iter_t it = ecs_map_iter(&ptr->constants);
     while (ecs_map_next(&it)) {
         ecs_enum_constant_t *c = ecs_map_ptr(&it);
         if (c->constant == e) {
             ecs_os_free(ECS_CONST_CAST(char*, c->name));
             ecs_map_remove_free(&ptr->constants, ecs_map_key(&it));
+
+            ecs_enum_constant_t* constants = ecs_vec_first_t(
+                &ptr->ordered_constants, ecs_enum_constant_t);
+            int32_t i, count = ecs_vec_count(&ptr->ordered_constants);
+            for (i = 0; i < count; i++) {
+                if (constants[i].constant == e) {
+                    break;
+                }
+            }
+            if (i < count) {
+                for (int j = i; j < count - 1; j++) {
+                    constants[j] = constants[j + 1];
+                }
+                ecs_vec_remove_last(&ptr->ordered_constants);
+            }
         }
     }
 
@@ -1108,6 +1158,14 @@ int flecs_add_constant_to_enum(
     c->name = ecs_os_strdup(ecs_get_name(world, e));
     c->constant = e;
 
+    ecs_vec_init_if_t(&ptr->ordered_constants, ecs_enum_constant_t);
+    ecs_enum_constant_t* ordered_c = ecs_vec_append_t(NULL,
+        &ptr->ordered_constants, ecs_enum_constant_t);
+    ordered_c->name = c->name;
+    ordered_c->value = value;
+    ordered_c->value_unsigned = value_unsigned;
+    ordered_c->constant = c->constant;
+
     if (!value_set) {
         void *cptr = ecs_ensure_id(world, e, ecs_pair(EcsConstant, ut));
         ecs_assert(cptr != NULL, ECS_INTERNAL_ERROR, NULL);
@@ -1142,13 +1200,27 @@ int flecs_add_constant_to_bitmask(
 {
     EcsBitmask *ptr = ecs_ensure(world, type, EcsBitmask);
     
-    /* Remove constant from map if it was already added */
+    /* Remove constant from map and vector if it was already added */
     ecs_map_iter_t it = ecs_map_iter(&ptr->constants);
     while (ecs_map_next(&it)) {
         ecs_bitmask_constant_t *c = ecs_map_ptr(&it);
         if (c->constant == e) {
             ecs_os_free(ECS_CONST_CAST(char*, c->name));
             ecs_map_remove_free(&ptr->constants, ecs_map_key(&it));
+
+            ecs_bitmask_constant_t* constants = ecs_vec_first_t(&ptr->ordered_constants, ecs_bitmask_constant_t);
+            int32_t i, count = ecs_vec_count(&ptr->ordered_constants);
+            for (i = 0; i < count; i++) {
+                if (constants[i].constant == c->value) {
+                    break;
+                }
+            }
+            if (i < count) {
+                for (int j = i; j < count - 1; j++) {
+                    constants[j] = constants[j + 1];
+                }
+                ecs_vec_remove_last(&ptr->ordered_constants);
+            }
         }
     }
 
@@ -1190,6 +1262,13 @@ int flecs_add_constant_to_bitmask(
     c->name = ecs_os_strdup(ecs_get_name(world, e));
     c->value = value;
     c->constant = e;
+
+    ecs_vec_init_if_t(&ptr->ordered_constants, ecs_bitmask_constant_t);
+    ecs_bitmask_constant_t* ordered_c = ecs_vec_append_t(NULL,
+        &ptr->ordered_constants, ecs_bitmask_constant_t);
+    ordered_c->name = c->name;
+    ordered_c->value = value;
+    ordered_c->constant = c->constant;
 
     ecs_u32_t *cptr = ecs_ensure_pair_second(
         world, e, EcsConstant, ecs_u32_t);

--- a/test/meta/src/BitmaskTypes.c
+++ b/test/meta/src/BitmaskTypes.c
@@ -25,7 +25,8 @@ void meta_test_constant(
     ecs_world_t *world, 
     ecs_entity_t t, 
     const char *name,
-    int32_t value)
+    int32_t value,
+    int32_t order)
 {
     ecs_entity_t m = ecs_lookup_child(world, t, name);
     test_assert(m != 0);
@@ -59,6 +60,17 @@ void meta_test_constant(
     }
 
     test_assert(constant_found == true);
+
+    /* Ensure ordering is correct */
+    ecs_bitmask_constant_t* constants = ecs_vec_first(&bt->ordered_constants);
+    test_assert(constants != NULL);
+    int32_t i, count = ecs_vec_count(&bt->ordered_constants);
+    for (i = 0; i < count; i++) {
+        if (constants[i].value == value) {
+            test_int(i, order);
+            break;
+        }
+    }
 }
 
 void BitmaskTypes_bitmask_1_constant(void) {
@@ -71,7 +83,7 @@ void BitmaskTypes_bitmask_1_constant(void) {
     });
 
     meta_test_bitmask(world, b, 1);
-    meta_test_constant(world, b, "Lettuce", 1);
+    meta_test_constant(world, b, "Lettuce", 1, 0);
 
     ecs_fini(world);
 }
@@ -86,8 +98,8 @@ void BitmaskTypes_bitmask_2_constants(void) {
     });
 
     meta_test_bitmask(world, b, 2);
-    meta_test_constant(world, b, "Lettuce", 1);
-    meta_test_constant(world, b, "Bacon", 2);
+    meta_test_constant(world, b, "Lettuce", 1, 0);
+    meta_test_constant(world, b, "Bacon", 2, 1);
 
     ecs_fini(world);
 }
@@ -102,9 +114,9 @@ void BitmaskTypes_bitmask_3_constants(void) {
     });
 
     meta_test_bitmask(world, b, 3);
-    meta_test_constant(world, b, "Lettuce", 1);
-    meta_test_constant(world, b, "Bacon", 2);
-    meta_test_constant(world, b, "Tomato", 4);
+    meta_test_constant(world, b, "Lettuce", 1, 0);
+    meta_test_constant(world, b, "Bacon", 2, 1);
+    meta_test_constant(world, b, "Tomato", 4, 2);
 
     ecs_fini(world);
 }
@@ -119,10 +131,10 @@ void BitmaskTypes_bitmask_4_constants(void) {
     });
 
     meta_test_bitmask(world, b, 4);
-    meta_test_constant(world, b, "Lettuce", 1);
-    meta_test_constant(world, b, "Bacon", 2);
-    meta_test_constant(world, b, "Tomato", 4);
-    meta_test_constant(world, b, "Cheese", 8);
+    meta_test_constant(world, b, "Lettuce", 1, 0);
+    meta_test_constant(world, b, "Bacon", 2, 1);
+    meta_test_constant(world, b, "Tomato", 4, 2);
+    meta_test_constant(world, b, "Cheese", 8, 3);
 
     ecs_fini(world);
 }
@@ -137,10 +149,10 @@ void BitmaskTypes_bitmask_4_constants_manual_values(void) {
     });
 
     meta_test_bitmask(world, b, 4);
-    meta_test_constant(world, b, "Lettuce", 8);
-    meta_test_constant(world, b, "Bacon", 4);
-    meta_test_constant(world, b, "Tomato", 2);
-    meta_test_constant(world, b, "BLT", 16);
+    meta_test_constant(world, b, "Lettuce", 8, 0);
+    meta_test_constant(world, b, "Bacon", 4, 1);
+    meta_test_constant(world, b, "Tomato", 2, 2);
+    meta_test_constant(world, b, "BLT", 16, 3);
 
     ecs_fini(world);
 }

--- a/test/meta/src/EnumTypes.c
+++ b/test/meta/src/EnumTypes.c
@@ -25,7 +25,8 @@ void meta_test_constant(
     ecs_world_t *world, 
     ecs_entity_t t, 
     const char *name,
-    int32_t value)
+    int32_t value,
+    int32_t order)
 {
     ecs_entity_t m = ecs_lookup_child(world, t, name);
     test_assert(m != 0);
@@ -59,6 +60,16 @@ void meta_test_constant(
     }
 
     test_assert(constant_found == true);
+
+    ecs_enum_constant_t* constants = ecs_vec_first(&et->ordered_constants);
+    test_assert(constants != NULL);
+    int32_t i, count = ecs_vec_count(&et->ordered_constants);
+    for (i = 0; i < count; i++) {
+        if (constants[i].value == value) {
+            test_int(i, order);
+            break;
+        }
+    }
 }
 
 void EnumTypes_enum_1_constant(void) {
@@ -73,7 +84,7 @@ void EnumTypes_enum_1_constant(void) {
     test_assert(e != 0);
 
     meta_test_enum(world, e, 1);
-    meta_test_constant(world, e, "Red", 0);
+    meta_test_constant(world, e, "Red", 0, 0);
 
     ecs_fini(world);
 }
@@ -90,8 +101,8 @@ void EnumTypes_enum_2_constants(void) {
     test_assert(e != 0);
 
     meta_test_enum(world, e, 2);
-    meta_test_constant(world, e, "Red", 0);
-    meta_test_constant(world, e, "Blue", 1);
+    meta_test_constant(world, e, "Red", 0, 0);
+    meta_test_constant(world, e, "Blue", 1, 1);
 
     ecs_fini(world);
 }
@@ -108,9 +119,9 @@ void EnumTypes_enum_3_constants(void) {
     test_assert(e != 0);
 
     meta_test_enum(world, e, 3);
-    meta_test_constant(world, e, "Red", 0);
-    meta_test_constant(world, e, "Blue", 1);
-    meta_test_constant(world, e, "Green", 2);
+    meta_test_constant(world, e, "Red", 0, 0);
+    meta_test_constant(world, e, "Blue", 1, 1);
+    meta_test_constant(world, e, "Green", 2, 2);
 
     ecs_fini(world);
 }
@@ -127,9 +138,9 @@ void EnumTypes_enum_3_constants_manual_values(void) {
     test_assert(e != 0);
 
     meta_test_enum(world, e, 3);
-    meta_test_constant(world, e, "Red", 3);
-    meta_test_constant(world, e, "Blue", 2);
-    meta_test_constant(world, e, "Green", 1);
+    meta_test_constant(world, e, "Red", 3, 0);
+    meta_test_constant(world, e, "Blue", 2, 1);
+    meta_test_constant(world, e, "Green", 1, 2);
 
     ecs_fini(world);
 }
@@ -305,9 +316,9 @@ void EnumTypes_enum_modified_event(void) {
     test_int(enum_modified_calls, 4); 
 
     meta_test_enum(world, e, 3);
-    meta_test_constant(world, e, "Red", 0);
-    meta_test_constant(world, e, "Blue", 1);
-    meta_test_constant(world, e, "Orange", 2);
+    meta_test_constant(world, e, "Red", 0, 0);
+    meta_test_constant(world, e, "Blue", 1, 1);
+    meta_test_constant(world, e, "Orange", 2, 2);
 
     ecs_fini(world);
 }


### PR DESCRIPTION
Implemented with vector<ecs_enum_constants_t> and extended existing test to test the ordering.