### PR TITLE
[docs] Add Clojure lang to quickstart guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,4 +181,4 @@ The following language bindings have been developed with Flecs! Note that these 
   - [sro5h/flecs-luajit](https://github.com/sro5h/flecs-luajit)
   - [flecs-hub/flecs-lua](https://github.com/flecs-hub/flecs-lua)
 - Clojure
-  - [vybe-flecs](https://github.com/pfeodrippe/vybe)
+  - [vybe-flecs](https://vybegame.dev/vybe-flecs)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ int main(int argc, char *argv[]) {
 
   ECS_SYSTEM(ecs, Move, EcsOnUpdate, Position, Velocity);
 
-  ecs_entity_t e = ecs_insert(ecs, 
+  ecs_entity_t e = ecs_insert(ecs,
     ecs_value(Position, {10, 20}),
     ecs_value(Velocity, {1, 2}));
 
@@ -180,3 +180,5 @@ The following language bindings have been developed with Flecs! Note that these 
 - Lua:
   - [sro5h/flecs-luajit](https://github.com/sro5h/flecs-luajit)
   - [flecs-hub/flecs-lua](https://github.com/flecs-hub/flecs-lua)
+- Clojure
+  - [vybe-flecs](https://github.com/pfeodrippe/vybe)

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -177,8 +177,8 @@ let world = World::new();
 <li><b class="tab-title">Clojure</b>
 
 ```clojure
-;; The dependency for this binding is at https://clojars.org/io.github.pfeodrippe/vybe-flecs, 
-;; code at https://github.com/pfeodrippe/vybe
+;; The dependency for this binding is at https://clojars.org/io.github.pfeodrippe/vybe-flecs,
+;; code at https://github.com/pfeodrippe/vybe, see also https://vybegame.dev/vybe-flecs
 
 ;; Require a higher-level binding and a lower-level one.
 (require '[vybe.flecs :as vf])

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -174,6 +174,22 @@ let world = World::new();
 // Do the ECS stuff
 ```
 </li>
+<li><b class="tab-title">Clojure</b>
+
+```clojure
+;; The dependency for this binding is at https://clojars.org/io.github.pfeodrippe/vybe-flecs, 
+;; code at https://github.com/pfeodrippe/vybe
+
+;; Require a higher-level binding and a lower-level one.
+(require '[vybe.flecs :as vf])
+(require '[vybe.flecs.c :as vf.c])
+(import '(org.vybe.flecs flecs))
+
+(def w (vf/make-world))
+
+;; Do the ECS stuff
+```
+</li>
 </ul>
 </div>
 
@@ -221,6 +237,19 @@ e.destruct();
 e.is_alive(); // false!
 ```
 </li>
+<li><b class="tab-title">Clojure</b>
+
+```clojure
+(merge w {:e []})
+(vf/alive? (:e w))
+;; => #{}
+
+(dissoc w :e)
+(:e w)
+;; => nil
+
+```
+</li>
 </ul>
 </div>
 
@@ -260,6 +289,14 @@ let e = world.entity_named("bob");
 println!("Entity name: {}", e.name());
 ```
 </li>
+<li><b class="tab-title">Clojure</b>
+
+```clojure
+(merge w {:bob []})
+(vf/get-name (:bob w))
+;; => "bob"
+```
+</li>
 </ul>
 </div>
 
@@ -288,6 +325,12 @@ Entity e = world.Lookup("Bob");
 
 ```rust
 let e = world.lookup("bob");
+```
+</li>
+<li><b class="tab-title">Clojure</b>
+
+```clojure
+(def e (w :bob))
 ```
 </li>
 </ul>
@@ -391,6 +434,28 @@ e.get::<&Position>(|p| {
 e.remove::<Position>();
 ```
 </li>
+<li><b class="tab-title">Clojure</b>
+
+```clojure
+(merge w {:e []})
+(def e (:e w))
+
+;; Add a component. This creates the component in the ECS storage, but does not
+;; assign it with a value.
+(conj e Velocity)
+
+;; Set the value for the Position & Velocity components. A component will be
+;; added if the entity doesn't have it yet.
+(conj e (Position [10 20]) (Velocity [1 2]))
+
+;; Get a component
+(e Position)
+;; => {Position {:x 10.0, :y 20.0}}
+
+;; Remove component
+(disj e Position)
+```
+</li>
 </ul>
 </div>
 
@@ -444,6 +509,20 @@ println!("Name: {}", pos_e.name()); // outputs 'Name: Position'
 pos_e.add::<Serializable>();
 ```
 </li>
+<li><b class="tab-title">Clojure</b>
+
+Clojure applications can use the `vf/ent` function.
+```clojure
+(def pos-e (vf/ent w Position))
+
+;; Components generated from Clojure have the name prefixed with `C_` in the Flecs internal name
+(vf/get-name pos-e)
+;; => "C_Position"
+
+;; It's possible to add components like you would for any entity
+(conj pos-e Serializable)
+```
+</li>
 </ul>
 </div>
 
@@ -487,6 +566,15 @@ let pos_e = world.entity_from::<Position>();
 pos_e.get::<&flecs::Component>(|c| {
     println!("Component size: {}", c.size);
 });
+```
+</li>
+<li><b class="tab-title">Clojure</b>
+
+```clojure
+;; We use the lower-level C Flecs API directly.
+(-> (vf.c/ecs-get-id w (vf/eid pos-e) (vf/eid w :vf/component))
+    (vp/as vf/EcsComponent))
+;; => #:vybe.flecs{EcsComponent {:size 8, :alignment 4}}
 ```
 </li>
 </ul>
@@ -589,6 +677,19 @@ e.remove_id(enemy);
 e.has_id(enemy); // false!
 ```
 </li>
+<li><b class="tab-title">Clojure</b>
+
+```clojure
+;; Add tag (it will create the tag if it doesn't already exist) to an entity
+(merge w {:e [:enemy]})
+(:enemy (w :e))
+;; => :enemy
+ 
+(disj (w :e) :enemy)
+(:enemy (w :e))
+;; => nil
+```
+</li>
 </ul>
 </div>
 
@@ -673,6 +774,22 @@ bob.remove_first::<Likes>(alice);
 bob.has_first::<Likes>(alice); // false!
 ```
 </li>
+<li><b class="tab-title">Clojure</b>
+
+```clojure
+;; Create a small graph with two entities that like each other
+;; NOTE that relationships are encoded using `[...]`
+(merge w {:bob [[:likes :alice]]
+          :alice [[:likes :bob]]})
+
+(get (w :bob) [:likes :alice])
+;; => [:likes :alice]
+
+(disj (w :bob) [:likes :alice])
+(get (w :bob) [:likes :alice])
+;; => nil
+```
+</li>
 </ul>
 </div>
 
@@ -703,6 +820,11 @@ Id id = world.Pair<Likes>(bob);
 let id = world.id_first::<Likes>(bob);
 ```
 </li>
+<li><b class="tab-title">Clojure</b>
+
+```clojure
+(vf/eid w [:likes :bob])
+```
 </ul>
 </div>
 
@@ -747,6 +869,15 @@ if id.is_pair() {
     let relationship = id.first_id();
     let target = id.second_id();
 }
+```
+</li>
+<li><b class="tab-title">Clojure</b>
+
+```clojure
+(let [id (vf/eid w [:alice :likes])]
+  [(vf/get-name (vf/pair-first w id))
+   (vf/get-name (vf/pair-second w id))])
+;; => ["alice" "likes"]
 ```
 </li>
 </ul>
@@ -806,6 +937,14 @@ bob.has_id((eats, pears)); // true!
 bob.has_id((grows, pears)); // true!
 ```
 </li>
+<li><b class="tab-title">Clojure</b>
+
+```clojure
+(merge w {:bob [[:eats :apple] [:eats :pears] [:grows :pears]]})
+(:bob w)
+;; => #{[:grows :pears] [:eats :pears] [:eats :apple]}
+```
+</li>
 </ul>
 </div>
 
@@ -837,6 +976,13 @@ Entity o = Alice.Target<Likes>(); // Returns Bob
 ```rust
 let alice = world.entity().add_first::<Likes>(bob);
 let o = alice.target::<Likes>(0); // Returns bob
+```
+</li>
+<li><b class="tab-title">Clojure</b>
+
+```clojure
+(vf/get-name (vf/target (w :alice) :likes))
+;; => "bob"
 ```
 </li>
 </ul>
@@ -888,6 +1034,21 @@ let child = world.entity().child_of_id(parent);
 
 // Deleting the parent also deletes its children
 parent.destruct();
+```
+</li>
+<li><b class="tab-title">Clojure</b>
+
+```clojure
+;; Note the nested map representing a child.
+(merge w {:parent [{:child []}]})
+(def child (w [:parent :child]))
+(vf/alive? child)
+;; => true
+
+;; Deleting the parent also deletes its children
+(dissoc w :parent)
+(vf/alive? child)
+;; => false
 ```
 </li>
 </ul>
@@ -949,6 +1110,13 @@ println!("Child path: {}", child.path().unwrap()); // output: 'parent::child'
 
 world.lookup("parent::child"); // returns child
 parent.lookup("child"); // returns child
+```
+</li>
+<li><b class="tab-title">Clojure</b>
+
+```clojure
+(vf/get-name (w [:parent :child]))
+;; => "parent.child"
 ```
 </li>
 </ul>
@@ -1020,6 +1188,18 @@ q.each(|(p, p_parent)| {
 });
 ```
 </li>
+<li><b class="tab-title">Clojure</b>
+
+```clojure
+;; The result of `with-query` will be available for you in the form of a vector.
+(vf/with-query w [pos Position
+                  pos-parent [:meta {:flags #{:up :cascade}}
+                              Position]]
+  ;; Process each entity.
+  )
+;; => [...]
+```
+</li>
 </ul>
 </div>
 
@@ -1072,6 +1252,14 @@ let e = world.entity().add::<Position>().add::<Velocity>();
 println!("Components: {}", e.archetype().to_string().unwrap()); // output: 'Position,Velocity'
 ```
 </li>
+<li><b class="tab-title">Clojure</b>
+
+```clojure
+(merge w {:some-entity [(Position) (Velocity)]})
+(:some-entity w)
+;; => #{{Position {:x 0.0, :y 0.0}}, {Velocity {:x 0.0, :y 0.0}} }
+```
+</li>
 </ul>
 </div>
 
@@ -1119,6 +1307,13 @@ e.each_component(|id| {
         // Found Position component!
     }
 });
+```
+</li>
+<li><b class="tab-title">Clojure</b>
+
+```clojure
+(for [c (:some-entity w)]
+  (vf/get-name w c))
 ```
 </li>
 </ul>
@@ -1171,6 +1366,14 @@ world.get::<&Gravity>(|g| {
 });
 ```
 </li>
+<li><b class="tab-title">Clojure</b>
+
+```clojure
+(vf/singleton! w (Position [30 40]))
+(vf/singleton w Position)
+;; => {Position {:x 30.0, :y 40.0}}
+```
+</li>
 </ul>
 </div>
 
@@ -1216,6 +1419,13 @@ grav_e.set(Gravity { x: 10, y: 20 });
 grav_e.get::<&Gravity>(|g| {
     println!("Gravity: {}, {}", g.x, g.y);
 });
+```
+</li>
+<li><b class="tab-title">Clojure</b>
+
+```clojure
+(merge w {Position [(Position [30 40])]})
+(get-in w [Position Position])
 ```
 </li>
 </ul>
@@ -1265,6 +1475,14 @@ world
     .term_at(1)
     .singleton()
     .build();
+```
+</li>
+<li><b class="tab-title">Clojure</b>
+
+```clojure
+(vf/with-query w [_ Velocity
+                  pos [:src Position Position]]
+  pos)
 ```
 </li>
 </ul>
@@ -1397,6 +1615,31 @@ q.run(|mut it| {
 });
 ```
 </li>
+<li><b class="tab-title">Clojure</b>
+    
+```clojure
+;; We create a parent and a child, with the child containing Position and Velocity
+(merge w {:parent [{:child [(Position [1 2]) (Velocity [0.1 0.2])]}]})
+
+;; Simple query, the bindings are const by default, :mut should be used to indicate 
+;; that you plan to mutate binding, otherwise an exception will be thrown
+(vf/with-query w [p [:mut Position]
+                  {:keys [x y]} Velocity]
+  (-> p
+      (update :x + x)
+      (update :y + y)))
+;; => [{Position {:x 1.1, :y 2.2}}]
+
+;; We can do more complex queries, e.g. query for all the entities
+;; that have Position and that are a child of :parent, :vf/entity
+;; is a way to retrieve the entity which we are iterating over
+(vf/with-query w [p Position
+                  _ [:vf/child-of :parent]
+                  e :vf/entity]
+  (vf/get-name e))
+;; => ["parent.child"]
+```
+</li>
 </ul>
 </div>
 
@@ -1452,6 +1695,14 @@ let q = world
     .build();
 
 // Iteration code is the same
+```
+</li>
+<li><b class="tab-title">Clojure</b>
+
+```clojure
+(vf/with-query w [_ [:vf/child-of :*]
+                  _ [:not Position]]
+  ...)
 ```
 </li>
 </ul>
@@ -1544,6 +1795,33 @@ let move_sys = world
 move_sys.run();
 ```
 </li>
+<li><b class="tab-title">Clojure</b>
+
+```clojure
+;; Use with-system function that iterates each individual entity, the return
+;; is the system entity, note that the body and bindings are just like with-query
+(vf/with-system w [:vf/name :my-system
+                   p [:mut Position]
+                   {:keys [x y]} Velocity]
+  (-> p
+      (update :x + x)
+      (update :y + y)))
+
+;; Run a system
+(vf/system-run (w :my-system))
+
+;; Or you can also define it using defsystem, it will create a function that 
+;; can be called with a world later 
+(vf/defsystem my-system w
+  [p [:mut Position]
+   {:keys [x y]} Velocity]
+  (-> p
+      (update :x + x)
+      (update :y + y)))
+
+(my-system w)
+```
+</li>
 </ul>
 </div>
 
@@ -1581,6 +1859,14 @@ moveSys.Entity.Destruct();
 println!("System: {}", move_sys.name());
 move_sys.add::<flecs::pipeline::OnUpdate>();
 move_sys.destruct();
+```
+</li>
+<li><b class="tab-title">Clojure</b>
+
+```clojure
+(vf/get-name (w :my-system))
+(conj ( :my-system) (flecs/EcsOnUpdate))
+(dissoc w :my-system)
 ```
 </li>
 </ul>
@@ -1643,6 +1929,19 @@ flecs::pipeline::PreStore;
 flecs::pipeline::OnStore;
 ```
 </li>
+<li><b class="tab-title">Clojure</b>
+
+```clojure
+(flecs/EcsOnLoad)
+(flecs/EcsPostLoad)
+(flecs/EcsPreUpdate)
+(flecs/EcsOnUpdate)
+(flecs/EcsOnValidate)
+(flecs/EcsPostUpdate)
+(flecs/EcsPreStore)
+(flecs/EcsOnStore)
+```
+</li>
 </ul>
 </div>
 
@@ -1701,6 +2000,38 @@ world
 world.progress();
 ```
 </li>
+<li><b class="tab-title">Clojure</b>
+
+```clojure
+;; Define the systems
+(vf/defsystem move w
+  [p Position
+   v Velocity
+   ;; This is the default phase.
+   :vf/phase (flecs/EcsOnUpdate)]
+  ...)
+
+(vf/defsystem transform w
+  [p Position
+   t Transform
+   :vf/phase (flecs/EcsPostUpdate)]
+  ...)
+
+(vf/defsystem render w
+  [t Transform
+   mesh Mesh
+   :vf/phase (flecs/EcsOnStore)]
+  ...)
+
+;; Add systems to the world
+(move w)
+(transform w)
+(render w)
+
+;; Run systems in default pipeline
+(vf/progress w)
+```
+</li>
 </ul>
 </div>
 
@@ -1734,6 +2065,13 @@ moveSys.Remove(Ecs.PostUpdate);
 ```rust
 move_sys.add::<flecs::pipeline::OnUpdate>();
 move_sys.remove::<flecs::pipeline::PostUpdate>();
+```
+</li>
+<li><b class="tab-title">Clojure</b>
+
+```clojure
+(conj (w :move) (flecs/EcsOnUpdate))
+(disj (w :move) (flecs/EcsPostUpdate))
 ```
 </li>
 </ul>
@@ -1803,6 +2141,29 @@ let e = world.entity(); // Doesn't invoke the observer
 e.set(Position { x: 10.0, y: 20.0 }); // Doesn't invoke the observer
 e.set(Velocity { x: 1.0, y: 2.0 }); // Invokes the observer
 e.set(Position { x: 30.0, y: 40.0 }); // Invokes the observer
+```
+</li>
+<li><b class="tab-title">Clojure</b>
+
+```clojure
+;; Similar to with-system, but you have special configuration keys like :vf/events
+(vf/with-observer w [:vf/name ::on-set-position
+                     :vf/events #{:set}
+                     p Position
+                     v Velocity]
+  ...)
+
+;; Doesn't invoke the observer
+(merge w {:e []})
+
+;; Doesn't invoke the observer
+(merge w {:e [(Position [10 20])]})
+
+;; Invokes the observer
+(merge w {:e [(Velocity [1 2])]})
+
+;; Invokes the observer
+(merge w {:e [(Position [30 40])]})
 ```
 </li>
 </ul>
@@ -1890,7 +2251,13 @@ impl Module for MyModule {
 // Import code
 world.import::<MyModule>();
 ```
+</li>
+<li><b class="tab-title">Clojure</b>
 
+```clojure
+;; No wrapper for modules as Clojure has package namespacing already, but
+;; you can use the the Flecs C Api directly if needed (vf.c/...)
+```
 </li>
 </ul>
 </div>


### PR DESCRIPTION
Adding the Clojure examples for the quickstart guide o/

Let me know if a new lang would be acceptable into the docs, Sander.

If it's undesired (because it's a niche lang or because you don't want to clutter the UI), I would totally understand, I'd just propose adding some kind of unique identifier for each example (see below) so anyone could replace/add code before the build for their own fork of the docs.

Something like
```html
.
.
.

<!--code::system-->

.
.
.

<!--code::pipeline-->

.
.
.
```

Great docs btw!
 