### PR TITLE
Allow more operators for trivial query caches

### DIFF
--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -70175,7 +70175,7 @@ ecs_query_cache_t* flecs_query_cache_init(
         /* Trivial caches may only contain And/Not operators. */
         int32_t t, count = q->term_count;
         for (t = 0; t < count; t ++) {
-            if (q->terms[t].oper != EcsAnd && q->terms[t].oper != EcsNot) {
+            if (q->terms[t].oper != EcsAnd && q->terms[t].oper != EcsNot && q->terms[t].oper != EcsOptional) {
                 break;
             }
         }
@@ -71755,6 +71755,7 @@ bool flecs_query_is_cache_test(
     it->trs = node->base.trs;
     it->ids = node->_ids;
     it->sources = node->_sources;
+    it->set_fields = node->base.set_fields;
 
     flecs_query_update_node_up_trs(ctx, node);
 

--- a/distr/flecs.h
+++ b/distr/flecs.h
@@ -8115,6 +8115,14 @@ FLECS_API
 bool ecs_id_is_wildcard(
     ecs_id_t id);
 
+/** Utility to check if id is an any wildcard.
+ * 
+ * @param id The id.
+ * @return True if id is an any wildcard or a pair containing an any wildcard.
+ */
+bool ecs_id_is_any(
+    ecs_id_t id);
+
 /** Utility to check if id is valid.
  * A valid id is an id that can be added to an entity. Invalid ids are:
  * - ids that contain wildcards

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -4316,6 +4316,14 @@ FLECS_API
 bool ecs_id_is_wildcard(
     ecs_id_t id);
 
+/** Utility to check if id is an any wildcard.
+ * 
+ * @param id The id.
+ * @return True if id is an any wildcard or a pair containing an any wildcard.
+ */
+bool ecs_id_is_any(
+    ecs_id_t id);
+
 /** Utility to check if id is valid.
  * A valid id is an id that can be added to an entity. Invalid ids are:
  * - ids that contain wildcards

--- a/src/id.c
+++ b/src/id.c
@@ -96,6 +96,24 @@ bool ecs_id_is_wildcard(
            (first == EcsAny) || (second == EcsAny);
 }
 
+bool ecs_id_is_any(
+    ecs_id_t id)
+{
+    if (id == EcsAny) {
+        return true;
+    }
+
+    bool is_pair = ECS_IS_PAIR(id);
+    if (!is_pair) {
+        return false;
+    }
+
+    ecs_entity_t first = ECS_PAIR_FIRST(id);
+    ecs_entity_t second = ECS_PAIR_SECOND(id);
+
+    return (first == EcsAny) || (second == EcsAny);
+}
+
 bool ecs_id_is_valid(
     const ecs_world_t *world,
     ecs_id_t id)

--- a/src/query/cache/cache.c
+++ b/src/query/cache/cache.c
@@ -604,8 +604,16 @@ ecs_query_cache_t* flecs_query_cache_init(
 
     /* Set flag for trivial caches which allows for faster iteration */
     if (impl->pub.flags & EcsQueryIsCacheable) {
-        if ((q->flags & EcsQueryIsTrivial) && (q->flags & EcsQueryMatchOnlySelf) &&
-        !(q->flags & EcsQueryMatchWildcards))
+        /* Trivial caches may only contain And/Not operators. */
+        int32_t t, count = q->term_count;
+        for (t = 0; t < count; t ++) {
+            if (q->terms[t].oper != EcsAnd && q->terms[t].oper != EcsNot) {
+                break;
+            }
+        }
+
+        if ((t == count) && (q->flags & EcsQueryMatchOnlySelf) &&
+           !(q->flags & EcsQueryMatchWildcards))
         {
             if (!const_desc->order_by && !const_desc->group_by && 
                 !const_desc->order_by_callback && 

--- a/src/query/cache/cache.c
+++ b/src/query/cache/cache.c
@@ -607,7 +607,7 @@ ecs_query_cache_t* flecs_query_cache_init(
         /* Trivial caches may only contain And/Not operators. */
         int32_t t, count = q->term_count;
         for (t = 0; t < count; t ++) {
-            if (q->terms[t].oper != EcsAnd && q->terms[t].oper != EcsNot) {
+            if (q->terms[t].oper != EcsAnd && q->terms[t].oper != EcsNot && q->terms[t].oper != EcsOptional) {
                 break;
             }
         }

--- a/src/query/cache/cache.h
+++ b/src/query/cache/cache.h
@@ -15,6 +15,7 @@ typedef struct ecs_query_triv_cache_match_t {
     const ecs_table_record_t **trs;  /* Information about where to find field in table. */
     void **ptrs;                     /* Cached column pointers for match. */
     uint32_t table_version;          /* Used to check if pointers need to be revalidated. */
+    ecs_termset_t set_fields;        /* Fields that are set (used by fields with Optional/Not). */
 } ecs_query_triv_cache_match_t;
 
 struct ecs_query_cache_match_t {
@@ -24,7 +25,6 @@ struct ecs_query_cache_match_t {
     ecs_id_t *_ids;                   /* Resolved (component) ids for current table. */
     ecs_entity_t *_sources;           /* Subjects (sources) of ids. */
     ecs_table_t **_tables;            /* Tables for fields with non-$this source. */
-    ecs_termset_t _set_fields;        /* Fields that are set. */
     ecs_termset_t _up_fields;         /* Fields that are matched through traversal. */
     int32_t *_monitor;                /* Used to monitor table for changes. */
     int32_t rematch_count;            /* Track whether table was rematched. */

--- a/src/query/cache/change_detection.c
+++ b/src/query/cache/change_detection.c
@@ -77,7 +77,7 @@ bool flecs_query_get_match_monitor(
 
         /* Don't track fields that aren't set */
         if (!is_trivial) {
-            if (!(match->_set_fields & (1llu << field))) {
+            if (!(match->base.set_fields & (1llu << field))) {
                 continue;
             }
         }
@@ -331,7 +331,7 @@ bool flecs_query_check_match_monitor(
     if (it) {
         set_fields = it->set_fields;
     } else if (!trivial_cache) {
-        set_fields = match->_set_fields;
+        set_fields = match->base.set_fields;
     } else {
         set_fields = (1llu << field_count) - 1;
     }

--- a/src/query/cache/iter.c
+++ b/src/query/cache/iter.c
@@ -19,7 +19,7 @@ void flecs_query_update_node_up_trs(
     ecs_query_cache_t *cache = impl->cache;
     ecs_assert(!flecs_query_cache_is_trivial(cache), ECS_INTERNAL_ERROR, NULL);
 
-    ecs_termset_t fields = node->_up_fields & node->_set_fields;
+    ecs_termset_t fields = node->_up_fields & node->base.set_fields;
     if (fields) {
         const ecs_query_t *q = cache->query;
         int32_t f, field_count = q->field_count;
@@ -232,6 +232,7 @@ ecs_query_cache_match_t* flecs_query_trivial_cache_next(
 
         it->entities = ecs_table_entities(table);
         it->trs = qm->trs;
+        it->set_fields = qm->set_fields;
 
         return qit->elem = (ecs_query_cache_match_t*)qm;
     }
@@ -295,7 +296,7 @@ void flecs_query_cache_init_mapped_fields(
         ecs_termset_t bit = (ecs_termset_t)(1u << i);
         ecs_termset_t field_bit = (ecs_termset_t)(1u << field_index);
 
-        ECS_TERMSET_COND(it->set_fields, field_bit, node->_set_fields & bit);
+        ECS_TERMSET_COND(it->set_fields, field_bit, node->base.set_fields & bit);
         ECS_TERMSET_COND(it->up_fields, field_bit, node->_up_fields & bit);
     }
 }
@@ -337,7 +338,7 @@ bool flecs_query_is_cache_search(
     it->trs = node->base.trs;
     it->ids = node->_ids;
     it->sources = node->_sources;
-    it->set_fields = node->_set_fields;
+    it->set_fields = node->base.set_fields;
     it->up_fields = node->_up_fields;
 
     flecs_query_update_node_up_trs(ctx, node);
@@ -416,6 +417,7 @@ bool flecs_query_is_trivial_cache_test(
         ecs_query_cache_match_t *qm = 
             flecs_query_cache_match_from_table(cache, qt);
         it->trs = qm->base.trs;
+        it->set_fields = qm->base.set_fields;
         return true;
     }
 

--- a/src/query/cache/iter.c
+++ b/src/query/cache/iter.c
@@ -388,6 +388,7 @@ bool flecs_query_is_cache_test(
     it->trs = node->base.trs;
     it->ids = node->_ids;
     it->sources = node->_sources;
+    it->set_fields = node->base.set_fields;
 
     flecs_query_update_node_up_trs(ctx, node);
 

--- a/src/query/cache/match.c
+++ b/src/query/cache/match.c
@@ -71,6 +71,7 @@ void flecs_query_cache_match_set(
     ecs_assert(field_count > 0, ECS_INTERNAL_ERROR, NULL);
 
     qm->base.table = it->table;
+    qm->base.set_fields = it->set_fields;
 
     if (!qm->base.ptrs) {
         qm->base.ptrs = flecs_balloc(&cache->allocators.pointers);
@@ -144,7 +145,6 @@ void flecs_query_cache_match_set(
             }
         }
 
-        qm->_set_fields = it->set_fields;
         qm->_up_fields = it->up_fields;
     } else {
         /* If this is a trivial cache, we shouldn't have any fields with 

--- a/src/query/validator.c
+++ b/src/query/validator.c
@@ -211,22 +211,6 @@ int flecs_term_ref_lookup(
 }
 
 static
-ecs_id_t flecs_wildcard_to_any(ecs_id_t id) {
-    ecs_id_t flags = id & EcsTermRefFlags;
-    
-    if (ECS_IS_PAIR(id)) {
-        ecs_entity_t first = ECS_PAIR_FIRST(id);
-        ecs_entity_t second = ECS_PAIR_SECOND(id);
-        if (first == EcsWildcard) id = ecs_pair(EcsAny, second);
-        if (second == EcsWildcard) id = ecs_pair(ECS_PAIR_FIRST(id), EcsAny);
-    } else if ((id & ~EcsTermRefFlags) == EcsWildcard) {
-        id = EcsAny;
-    }
-
-    return id | flags;
-}
-
-static
 int flecs_term_refs_finalize(
     const ecs_world_t *world,
     ecs_term_t *term,
@@ -303,19 +287,6 @@ int flecs_term_refs_finalize(
     /* If source is wildcard, term won't return any data */
     if ((src->id & EcsIsVariable) && ecs_id_is_wildcard(ECS_TERM_REF_ID(src))) {
         term->inout = EcsInOutNone;
-    }
-
-    /* If operator is Not, automatically convert wildcard queries to any */
-    if (term->oper == EcsNot) {
-        if (ECS_TERM_REF_ID(first) == EcsWildcard) {
-            first->id = EcsAny | ECS_TERM_REF_FLAGS(first);
-        }
-
-        if (ECS_TERM_REF_ID(second) == EcsWildcard) {
-            second->id = EcsAny | ECS_TERM_REF_FLAGS(second);
-        }
-
-        term->id = flecs_wildcard_to_any(term->id);
     }
 
     return 0;
@@ -981,7 +952,9 @@ int flecs_term_finalize(
         if (second->id & EcsIsVariable) {
             if (!ecs_id_is_wildcard(second_id) || second_id == EcsAny) {
                 trivial_term = false;
-                cacheable_term = false;
+                if (term->oper != EcsNot || second_id != EcsAny) {
+                    cacheable_term = false;
+                }
             }
         }
     }
@@ -1224,7 +1197,9 @@ int flecs_query_finalize_terms(
         term->field_index = flecs_ito(int8_t, field_count - 1);
 
         if (ecs_id_is_wildcard(term->id)) {
-            q->flags |= EcsQueryMatchWildcards;
+            if (term->oper != EcsNot || ecs_id_is_any(term->id)) {
+                q->flags |= EcsQueryMatchWildcards;
+            }
         } else if (!(term->flags_ & EcsTermIsOr)) {
             ECS_TERMSET_SET(q->static_id_fields, 1u << term->field_index);
         }

--- a/test/query/project.json
+++ b/test/query/project.json
@@ -827,7 +827,11 @@
                 "cached_w_not",
                 "cached_w_not_wildcard",
                 "cached_w_not_simple",
-                "cached_w_not_wildcard_simple"
+                "cached_w_not_wildcard_simple",
+                "cached_w_optional",
+                "cached_w_optional_wildcard",
+                "cached_w_optional_simple",
+                "cached_w_optional_wildcard_simple"
             ]
         }, {
             "id": "Variables",
@@ -935,6 +939,8 @@
                 "2_set_src_this_w_wildcard",
                 "2_set_src_this_w_not",
                 "3_set_src_this_w_not_wildcard",
+                "2_set_src_this_w_optional",
+                "3_set_src_this_w_optional_wildcard",
                 "1_src_this_var_as_entity",
                 "1_src_this_var_as_table",
                 "1_src_this_var_as_table_range",
@@ -2395,6 +2401,8 @@
                 "cached_trivial_test_w_or_operator",
                 "cached_trivial_search_w_optional_operator",
                 "cached_trivial_test_w_optional_operator",
+                "cached_trivial_search_w_optional_wildcard_operator",
+                "cached_trivial_test_w_optional_wildcard_operator",
                 "cached_trivial_search_w_wildcard",
                 "cached_trivial_test_w_wildcard"
             ]

--- a/test/query/project.json
+++ b/test/query/project.json
@@ -823,7 +823,11 @@
                 "cached_isa_tgt_w_self_second_no_expr",
                 "cached_w_not_and_uncacheable",
                 "cached_w_optional_and_uncacheable",
-                "cached_w_not_optional_and_uncacheable"
+                "cached_w_not_optional_and_uncacheable",
+                "cached_w_not",
+                "cached_w_not_wildcard",
+                "cached_w_not_simple",
+                "cached_w_not_wildcard_simple"
             ]
         }, {
             "id": "Variables",
@@ -929,6 +933,8 @@
                 "3_set_src_this_w_component_tag_uncacheable_component",
                 "3_set_src_this_w_component_component_uncacheable_component",
                 "2_set_src_this_w_wildcard",
+                "2_set_src_this_w_not",
+                "3_set_src_this_w_not_wildcard",
                 "1_src_this_var_as_entity",
                 "1_src_this_var_as_table",
                 "1_src_this_var_as_table_range",
@@ -2383,6 +2389,8 @@
                 "cached_trivial_test_w_up",
                 "cached_trivial_search_w_not_operator",
                 "cached_trivial_test_w_not_operator",
+                "cached_trivial_search_w_not_wildcard_operator",
+                "cached_trivial_test_w_not_wildcard_operator",
                 "cached_trivial_search_w_or_operator",
                 "cached_trivial_test_w_or_operator",
                 "cached_trivial_search_w_optional_operator",

--- a/test/query/src/Parser.c
+++ b/test/query/src/Parser.c
@@ -5141,7 +5141,7 @@ void Parser_neq_wildcard(void) {
     test_first(terms[0], EcsPredEq, EcsSelf|EcsIsEntity);
     test_uint(terms[0].src.id, EcsThis|EcsSelf|EcsIsVariable);
     test_str(terms[0].src.name, NULL);
-    test_uint(terms[0].second.id, EcsAny|EcsSelf|EcsIsVariable);
+    test_uint(terms[0].second.id, EcsWildcard|EcsSelf|EcsIsVariable);
     test_str(terms[0].second.name, NULL);
     test_int(terms[0].oper, EcsNot);
 
@@ -6728,11 +6728,11 @@ void Parser_not_wildcard(void) {
 
     test_int(q->term_count, 1);
     test_int(q->field_count, 1);
-    test_uint(q->terms[0].id, EcsAny);
+    test_uint(q->terms[0].id, EcsWildcard);
     test_int(q->terms[0].oper, EcsNot);
     test_int(q->terms[0].inout, EcsInOutNone);
     test_int(q->terms[0].field_index, 0);
-    test_uint(q->terms[0].first.id, EcsAny|EcsSelf|EcsIsVariable);
+    test_uint(q->terms[0].first.id, EcsWildcard|EcsSelf|EcsIsVariable);
     test_uint(q->terms[0].src.id, EcsThis|EcsSelf|EcsIsVariable);
     test_uint(q->terms[0].trav, 0);
 

--- a/test/query/src/Plan.c
+++ b/test/query/src/Plan.c
@@ -2674,3 +2674,105 @@ void Plan_cached_w_not_optional_and_uncacheable(void) {
 
     ecs_fini(world);
 }
+
+void Plan_cached_w_not(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, Foo);
+    ECS_TAG(world, Bar);
+
+    ecs_query_t *q = ecs_query(world, {
+        .expr = "Foo, !Bar",
+        .cache_kind = EcsQueryCacheAuto
+    });
+
+    test_assert(q != NULL);
+
+    ecs_log_enable_colors(false);
+
+    char *plan = ecs_query_plan(q);
+
+    test_str(NULL, plan);
+
+    ecs_query_fini(q);
+
+    ecs_fini(world);
+}
+
+void Plan_cached_w_not_wildcard(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, Foo);
+    ECS_TAG(world, Bar);
+
+    ecs_query_t *q = ecs_query(world, {
+        .expr = "Foo, !(Bar, *)",
+        .cache_kind = EcsQueryCacheAuto
+    });
+
+    test_assert(q != NULL);
+
+    ecs_log_enable_colors(false);
+
+    char *plan = ecs_query_plan(q);
+
+    test_str(NULL, plan);
+
+    ecs_query_fini(q);
+
+    ecs_fini(world);
+}
+
+void Plan_cached_w_not_simple(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, Foo);
+    ECS_TAG(world, Bar);
+
+    ecs_query_t *q = ecs_query(world, {
+        .terms = {
+            { Foo },
+            { Bar, .oper = EcsNot }
+        },
+        .cache_kind = EcsQueryCacheAuto
+    });
+
+    test_assert(q != NULL);
+
+    ecs_log_enable_colors(false);
+
+    char *plan = ecs_query_plan(q);
+
+    test_str(NULL, plan);
+
+    ecs_query_fini(q);
+
+    ecs_fini(world);
+}
+
+void Plan_cached_w_not_wildcard_simple(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, Foo);
+    ECS_TAG(world, Bar);
+
+    ecs_query_t *q = ecs_query(world, {
+        .terms = {
+            { Foo },
+            { ecs_pair(Bar, EcsWildcard), .oper = EcsNot }
+        },
+        .cache_kind = EcsQueryCacheAuto
+    });
+
+    test_assert(q != NULL);
+
+    ecs_log_enable_colors(false);
+
+    char *plan = ecs_query_plan(q);
+
+    test_str(NULL, plan);
+
+    ecs_query_fini(q);
+
+    ecs_fini(world);
+}

--- a/test/query/src/Plan.c
+++ b/test/query/src/Plan.c
@@ -2776,3 +2776,105 @@ void Plan_cached_w_not_wildcard_simple(void) {
 
     ecs_fini(world);
 }
+
+void Plan_cached_w_optional(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, Foo);
+    ECS_TAG(world, Bar);
+
+    ecs_query_t *q = ecs_query(world, {
+        .expr = "Foo, ?Bar",
+        .cache_kind = EcsQueryCacheAuto
+    });
+
+    test_assert(q != NULL);
+
+    ecs_log_enable_colors(false);
+
+    char *plan = ecs_query_plan(q);
+
+    test_str(NULL, plan);
+
+    ecs_query_fini(q);
+
+    ecs_fini(world);
+}
+
+void Plan_cached_w_optional_wildcard(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, Foo);
+    ECS_TAG(world, Bar);
+
+    ecs_query_t *q = ecs_query(world, {
+        .expr = "Foo, ?(Bar, *)",
+        .cache_kind = EcsQueryCacheAuto
+    });
+
+    test_assert(q != NULL);
+
+    ecs_log_enable_colors(false);
+
+    char *plan = ecs_query_plan(q);
+
+    test_str(NULL, plan);
+
+    ecs_query_fini(q);
+
+    ecs_fini(world);
+}
+
+void Plan_cached_w_optional_simple(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, Foo);
+    ECS_TAG(world, Bar);
+
+    ecs_query_t *q = ecs_query(world, {
+        .terms = {
+            { Foo },
+            { Bar, .oper = EcsOptional }
+        },
+        .cache_kind = EcsQueryCacheAuto
+    });
+
+    test_assert(q != NULL);
+
+    ecs_log_enable_colors(false);
+
+    char *plan = ecs_query_plan(q);
+
+    test_str(NULL, plan);
+
+    ecs_query_fini(q);
+
+    ecs_fini(world);
+}
+
+void Plan_cached_w_optional_wildcard_simple(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, Foo);
+    ECS_TAG(world, Bar);
+
+    ecs_query_t *q = ecs_query(world, {
+        .terms = {
+            { Foo },
+            { ecs_pair(Bar, EcsWildcard), .oper = EcsOptional }
+        },
+        .cache_kind = EcsQueryCacheAuto
+    });
+
+    test_assert(q != NULL);
+
+    ecs_log_enable_colors(false);
+
+    char *plan = ecs_query_plan(q);
+
+    test_str(NULL, plan);
+
+    ecs_query_fini(q);
+
+    ecs_fini(world);
+}

--- a/test/query/src/TrivialIter.c
+++ b/test/query/src/TrivialIter.c
@@ -311,7 +311,7 @@ void TrivialIter_cached_trivial_search_w_optional_operator(void) {
 
     ecs_iter_t it = ecs_query_iter(world, q);
     test_assert(it.flags & EcsIterTrivialSearch);
-    test_assert(it.flags & EcsIterCached);
+    test_assert(it.flags & EcsIterTrivialCached);
     test_assert(!(it.flags & EcsIterTrivialTest));
     ecs_iter_fini(&it);
 
@@ -328,6 +328,57 @@ void TrivialIter_cached_trivial_test_w_optional_operator(void) {
 
     ecs_query_t *q = ecs_query(world, {
         .terms = {{ Foo }, { Bar, .oper = EcsOptional }},
+        .cache_kind = EcsQueryCacheAll
+    });
+
+    test_assert(q != NULL);
+
+    ecs_entity_t e = ecs_new(world);
+
+    ecs_iter_t it = ecs_query_iter(world, q);
+    ecs_iter_set_var(&it, 0, e);
+    test_assert(it.flags & EcsIterTrivialTest);
+    test_assert(it.flags & EcsIterTrivialCached);
+    test_assert(!(it.flags & EcsIterTrivialSearch));
+    ecs_iter_fini(&it);
+
+    ecs_query_fini(q);
+
+    ecs_fini(world);
+}
+
+void TrivialIter_cached_trivial_search_w_optional_wildcard_operator(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, Foo);
+    ECS_TAG(world, Bar);
+
+    ecs_query_t *q = ecs_query(world, {
+        .terms = {{ Foo }, { ecs_pair(Bar, EcsWildcard), .oper = EcsOptional }},
+        .cache_kind = EcsQueryCacheAll
+    });
+
+    test_assert(q != NULL);
+
+    ecs_iter_t it = ecs_query_iter(world, q);
+    test_assert(it.flags & EcsIterTrivialSearch);
+    test_assert(it.flags & EcsIterCached);
+    test_assert(!(it.flags & EcsIterTrivialTest));
+    ecs_iter_fini(&it);
+
+    ecs_query_fini(q);
+
+    ecs_fini(world);
+}
+
+void TrivialIter_cached_trivial_test_w_optional_wildcard_operator(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, Foo);
+    ECS_TAG(world, Bar);
+
+    ecs_query_t *q = ecs_query(world, {
+        .terms = {{ Foo }, { ecs_pair(Bar, EcsWildcard), .oper = EcsOptional }},
         .cache_kind = EcsQueryCacheAll
     });
 

--- a/test/query/src/TrivialIter.c
+++ b/test/query/src/TrivialIter.c
@@ -158,7 +158,7 @@ void TrivialIter_cached_trivial_search_w_not_operator(void) {
 
     ecs_iter_t it = ecs_query_iter(world, q);
     test_assert(it.flags & EcsIterTrivialSearch);
-    test_assert(it.flags & EcsIterCached);
+    test_assert(it.flags & EcsIterTrivialCached);
     test_assert(!(it.flags & EcsIterTrivialTest));
     ecs_iter_fini(&it);
 
@@ -185,7 +185,58 @@ void TrivialIter_cached_trivial_test_w_not_operator(void) {
     ecs_iter_t it = ecs_query_iter(world, q);
     ecs_iter_set_var(&it, 0, e);
     test_assert(it.flags & EcsIterTrivialTest);
-    test_assert(it.flags & EcsIterCached);
+    test_assert(it.flags & EcsIterTrivialCached);
+    test_assert(!(it.flags & EcsIterTrivialSearch));
+    ecs_iter_fini(&it);
+
+    ecs_query_fini(q);
+
+    ecs_fini(world);
+}
+
+void TrivialIter_cached_trivial_search_w_not_wildcard_operator(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, Foo);
+    ECS_TAG(world, Bar);
+
+    ecs_query_t *q = ecs_query(world, {
+        .terms = {{ Foo }, { ecs_pair(Bar, EcsWildcard), .oper = EcsNot }},
+        .cache_kind = EcsQueryCacheAll
+    });
+
+    test_assert(q != NULL);
+
+    ecs_iter_t it = ecs_query_iter(world, q);
+    test_assert(it.flags & EcsIterTrivialSearch);
+    test_assert(it.flags & EcsIterTrivialCached);
+    test_assert(!(it.flags & EcsIterTrivialTest));
+    ecs_iter_fini(&it);
+
+    ecs_query_fini(q);
+
+    ecs_fini(world);
+}
+
+void TrivialIter_cached_trivial_test_w_not_wildcard_operator(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, Foo);
+    ECS_TAG(world, Bar);
+
+    ecs_query_t *q = ecs_query(world, {
+        .terms = {{ Foo }, { ecs_pair(Bar, EcsWildcard), .oper = EcsNot }},
+        .cache_kind = EcsQueryCacheAll
+    });
+
+    test_assert(q != NULL);
+
+    ecs_entity_t e = ecs_new(world);
+
+    ecs_iter_t it = ecs_query_iter(world, q);
+    ecs_iter_set_var(&it, 0, e);
+    test_assert(it.flags & EcsIterTrivialTest);
+    test_assert(it.flags & EcsIterTrivialCached);
     test_assert(!(it.flags & EcsIterTrivialSearch));
     ecs_iter_fini(&it);
 

--- a/test/query/src/Validator.c
+++ b/test/query/src/Validator.c
@@ -2703,11 +2703,11 @@ void Validator_not_wildcard(void) {
 
     test_int(q->term_count, 1);
     test_int(q->field_count, 1);
-    test_uint(q->terms[0].id, EcsAny);
+    test_uint(q->terms[0].id, EcsWildcard);
     test_int(q->terms[0].oper, EcsNot);
     test_int(q->terms[0].inout, EcsInOutNone);
     test_int(q->terms[0].field_index, 0);
-    test_uint(q->terms[0].first.id, EcsAny|EcsSelf|EcsIsVariable);
+    test_uint(q->terms[0].first.id, EcsWildcard|EcsSelf|EcsIsVariable);
     test_uint(q->terms[0].src.id, EcsThis|EcsSelf|EcsIsVariable);
 
     ecs_query_fini(q);
@@ -2726,11 +2726,11 @@ void Validator_not_first_wildcard(void) {
 
     test_int(q->term_count, 1);
     test_int(q->field_count, 1);
-    test_uint(q->terms[0].id, ecs_pair(EcsAny, ecs_id(Position)));
+    test_uint(q->terms[0].id, ecs_pair(EcsWildcard, ecs_id(Position)));
     test_int(q->terms[0].oper, EcsNot);
     test_int(q->terms[0].inout, EcsInOutNone);
     test_int(q->terms[0].field_index, 0);
-    test_uint(q->terms[0].first.id, EcsAny|EcsSelf|EcsIsVariable);
+    test_uint(q->terms[0].first.id, EcsWildcard|EcsSelf|EcsIsVariable);
     test_uint(q->terms[0].second.id, ecs_id(Position)|EcsSelf|EcsIsEntity);
     test_uint(q->terms[0].src.id, EcsThis|EcsSelf|EcsIsVariable);
 
@@ -2750,12 +2750,12 @@ void Validator_not_second_wildcard(void) {
 
     test_int(q->term_count, 1);
     test_int(q->field_count, 1);
-    test_uint(q->terms[0].id, ecs_pair(ecs_id(Position), EcsAny));
+    test_uint(q->terms[0].id, ecs_pair(ecs_id(Position), EcsWildcard));
     test_int(q->terms[0].oper, EcsNot);
     test_int(q->terms[0].inout, EcsInOutNone);
     test_int(q->terms[0].field_index, 0);
     test_uint(q->terms[0].first.id, ecs_id(Position)|EcsSelf|EcsIsEntity);
-    test_uint(q->terms[0].second.id, EcsAny|EcsSelf|EcsIsVariable);
+    test_uint(q->terms[0].second.id, EcsWildcard|EcsSelf|EcsIsVariable);
     test_uint(q->terms[0].src.id, EcsThis|EcsSelf|EcsIsVariable);
 
     ecs_query_fini(q);
@@ -2774,11 +2774,11 @@ void Validator_not_wildcard_id(void) {
 
     test_int(q->term_count, 1);
     test_int(q->field_count, 1);
-    test_uint(q->terms[0].id, EcsAny);
+    test_uint(q->terms[0].id, EcsWildcard);
     test_int(q->terms[0].oper, EcsNot);
     test_int(q->terms[0].inout, EcsInOutNone);
     test_int(q->terms[0].field_index, 0);
-    test_uint(q->terms[0].first.id, EcsAny|EcsSelf|EcsIsVariable);
+    test_uint(q->terms[0].first.id, EcsWildcard|EcsSelf|EcsIsVariable);
     test_uint(q->terms[0].src.id, EcsThis|EcsSelf|EcsIsVariable);
 
     ecs_query_fini(q);
@@ -2797,11 +2797,11 @@ void Validator_not_wildcard_first_pair(void) {
 
     test_int(q->term_count, 1);
     test_int(q->field_count, 1);
-    test_uint(q->terms[0].id, ecs_pair(EcsAny, ecs_id(Position)));
+    test_uint(q->terms[0].id, ecs_pair(EcsWildcard, ecs_id(Position)));
     test_int(q->terms[0].oper, EcsNot);
     test_int(q->terms[0].inout, EcsInOutNone);
     test_int(q->terms[0].field_index, 0);
-    test_uint(q->terms[0].first.id, EcsAny|EcsSelf|EcsIsVariable);
+    test_uint(q->terms[0].first.id, EcsWildcard|EcsSelf|EcsIsVariable);
     test_uint(q->terms[0].second.id, ecs_id(Position)|EcsSelf|EcsIsEntity);
     test_uint(q->terms[0].src.id, EcsThis|EcsSelf|EcsIsVariable);
 
@@ -2821,12 +2821,12 @@ void Validator_not_wildcard_second_pair(void) {
 
     test_int(q->term_count, 1);
     test_int(q->field_count, 1);
-    test_uint(q->terms[0].id, ecs_pair_t(Position, EcsAny));
+    test_uint(q->terms[0].id, ecs_pair_t(Position, EcsWildcard));
     test_int(q->terms[0].oper, EcsNot);
     test_int(q->terms[0].inout, EcsInOutNone);
     test_int(q->terms[0].field_index, 0);
     test_uint(q->terms[0].first.id, ecs_id(Position)|EcsSelf|EcsIsEntity);
-    test_uint(q->terms[0].second.id, EcsAny|EcsSelf|EcsIsVariable);
+    test_uint(q->terms[0].second.id, EcsWildcard|EcsSelf|EcsIsVariable);
     test_uint(q->terms[0].src.id, EcsThis|EcsSelf|EcsIsVariable);
 
     ecs_query_fini(q);

--- a/test/query/src/Variables.c
+++ b/test/query/src/Variables.c
@@ -5637,6 +5637,119 @@ void Variables_2_set_src_this_w_wildcard(void) {
     ecs_fini(ecs);
 }
 
+void Variables_2_set_src_this_w_not(void) {
+    ecs_world_t* ecs = ecs_mini();
+
+    ECS_COMPONENT(ecs, Position);
+    ECS_COMPONENT(ecs, Velocity);
+
+    ecs_query_t *q = ecs_query(ecs, {
+        .terms = {
+            { .id = ecs_id(Position) },
+            { .id = ecs_id(Velocity), .oper = EcsNot }
+        },
+        .cache_kind = cache_kind
+    });
+    test_assert(q != NULL);
+
+    /* ecs_entity_t e1 = */ ecs_insert(ecs, ecs_value(Position, {10, 20}));
+    ecs_entity_t e2 = ecs_insert(ecs, ecs_value(Position, {20, 30}));
+    /* ecs_entity_t e3 = */ ecs_insert(ecs, ecs_value(Position, {30, 40}));
+
+    ecs_iter_t it = ecs_query_iter(ecs, q);
+    ecs_iter_set_var(&it, 0, e2);
+
+    {
+        test_bool(true, ecs_query_next(&it));
+        test_int(it.count, 1);
+        test_uint(it.entities[0], e2);
+        Position *p = ecs_field(&it, Position, 0);
+        test_int(p[0].x, 20);
+        test_int(p[0].y, 30);
+        test_uint(ecs_id(Position), ecs_field_id(&it, 0));
+        test_uint(ecs_id(Velocity), ecs_field_id(&it, 1));
+        test_bool(true, ecs_field_is_set(&it, 0));
+        test_bool(false, ecs_field_is_set(&it, 1));
+
+    }
+
+    test_bool(false, ecs_query_next(&it));
+
+    ecs_query_fini(q);
+
+    ecs_fini(ecs);
+}
+
+void Variables_3_set_src_this_w_not_wildcard(void) {
+    ecs_world_t* ecs = ecs_mini();
+
+    ECS_COMPONENT(ecs, Position);
+    ECS_COMPONENT(ecs, Velocity);
+    ECS_TAG(ecs, Likes);
+    ECS_TAG(ecs, Apples);
+    ECS_TAG(ecs, Pears);
+
+    ecs_query_t *q = ecs_query(ecs, {
+        .terms = {
+            { .id = ecs_id(Position) },
+            { .id = ecs_id(Velocity), .oper = EcsNot },
+            { .id = ecs_pair(Likes, EcsWildcard) }
+        },
+        .cache_kind = cache_kind
+    });
+    test_assert(q != NULL);
+
+    ecs_entity_t e1 = ecs_insert(ecs, ecs_value(Position, {10, 20}));
+    ecs_entity_t e2 = ecs_insert(ecs, ecs_value(Position, {20, 30}));
+    ecs_entity_t e3 = ecs_insert(ecs, ecs_value(Position, {30, 40}));
+
+    ecs_add_pair(ecs, e1, Likes, Apples);
+    ecs_add_pair(ecs, e2, Likes, Apples);
+    ecs_add_pair(ecs, e3, Likes, Apples);
+
+    ecs_add_pair(ecs, e1, Likes, Pears);
+    ecs_add_pair(ecs, e2, Likes, Pears);
+    ecs_add_pair(ecs, e3, Likes, Pears);
+
+    ecs_iter_t it = ecs_query_iter(ecs, q);
+    ecs_iter_set_var(&it, 0, e2);
+
+    {
+        test_bool(true, ecs_query_next(&it));
+        test_int(it.count, 1);
+        test_uint(it.entities[0], e2);
+        Position *p = ecs_field(&it, Position, 0);
+        test_int(p[0].x, 20);
+        test_int(p[0].y, 30);
+        test_uint(ecs_id(Position), ecs_field_id(&it, 0));
+        test_uint(ecs_id(Velocity), ecs_field_id(&it, 1));
+        test_uint(ecs_pair(Likes, Apples), ecs_field_id(&it, 2));
+        test_bool(true, ecs_field_is_set(&it, 0));
+        test_bool(false, ecs_field_is_set(&it, 1));
+        test_bool(true, ecs_field_is_set(&it, 2));
+    }
+    {
+        test_bool(true, ecs_query_next(&it));
+        test_int(it.count, 1);
+        test_uint(it.entities[0], e2);
+        Position *p = ecs_field(&it, Position, 0);
+        test_int(p[0].x, 20);
+        test_int(p[0].y, 30);
+        test_uint(ecs_id(Position), ecs_field_id(&it, 0));
+        test_uint(ecs_id(Velocity), ecs_field_id(&it, 1));
+        test_uint(ecs_pair(Likes, Pears), ecs_field_id(&it, 2));
+        test_bool(true, ecs_field_is_set(&it, 0));
+        test_bool(false, ecs_field_is_set(&it, 1));
+        test_bool(true, ecs_field_is_set(&it, 2));
+    }
+
+    test_bool(false, ecs_query_next(&it));
+
+    ecs_query_fini(q);
+
+    ecs_fini(ecs);
+}
+
 void Variables_3_set_src_this_w_uncacheable_tag_tag_tag(void) {
     ecs_world_t* ecs = ecs_mini();
 

--- a/test/query/src/main.c
+++ b/test/query/src/main.c
@@ -799,6 +799,10 @@ void Plan_cached_isa_tgt_w_self_second_no_expr(void);
 void Plan_cached_w_not_and_uncacheable(void);
 void Plan_cached_w_optional_and_uncacheable(void);
 void Plan_cached_w_not_optional_and_uncacheable(void);
+void Plan_cached_w_not(void);
+void Plan_cached_w_not_wildcard(void);
+void Plan_cached_w_not_simple(void);
+void Plan_cached_w_not_wildcard_simple(void);
 
 // Testsuite 'Variables'
 void Variables_setup(void);
@@ -899,6 +903,8 @@ void Variables_3_set_src_this_w_tag_tag_uncacheable_component(void);
 void Variables_3_set_src_this_w_component_tag_uncacheable_component(void);
 void Variables_3_set_src_this_w_component_component_uncacheable_component(void);
 void Variables_2_set_src_this_w_wildcard(void);
+void Variables_2_set_src_this_w_not(void);
+void Variables_3_set_src_this_w_not_wildcard(void);
 void Variables_1_src_this_var_as_entity(void);
 void Variables_1_src_this_var_as_table(void);
 void Variables_1_src_this_var_as_table_range(void);
@@ -2284,6 +2290,8 @@ void TrivialIter_cached_trivial_search_w_up(void);
 void TrivialIter_cached_trivial_test_w_up(void);
 void TrivialIter_cached_trivial_search_w_not_operator(void);
 void TrivialIter_cached_trivial_test_w_not_operator(void);
+void TrivialIter_cached_trivial_search_w_not_wildcard_operator(void);
+void TrivialIter_cached_trivial_test_w_not_wildcard_operator(void);
 void TrivialIter_cached_trivial_search_w_or_operator(void);
 void TrivialIter_cached_trivial_test_w_or_operator(void);
 void TrivialIter_cached_trivial_search_w_optional_operator(void);
@@ -5451,6 +5459,22 @@ bake_test_case Plan_testcases[] = {
     {
         "cached_w_not_optional_and_uncacheable",
         Plan_cached_w_not_optional_and_uncacheable
+    },
+    {
+        "cached_w_not",
+        Plan_cached_w_not
+    },
+    {
+        "cached_w_not_wildcard",
+        Plan_cached_w_not_wildcard
+    },
+    {
+        "cached_w_not_simple",
+        Plan_cached_w_not_simple
+    },
+    {
+        "cached_w_not_wildcard_simple",
+        Plan_cached_w_not_wildcard_simple
     }
 };
 
@@ -5842,6 +5866,14 @@ bake_test_case Variables_testcases[] = {
     {
         "2_set_src_this_w_wildcard",
         Variables_2_set_src_this_w_wildcard
+    },
+    {
+        "2_set_src_this_w_not",
+        Variables_2_set_src_this_w_not
+    },
+    {
+        "3_set_src_this_w_not_wildcard",
+        Variables_3_set_src_this_w_not_wildcard
     },
     {
         "1_src_this_var_as_entity",
@@ -11249,6 +11281,14 @@ bake_test_case TrivialIter_testcases[] = {
         TrivialIter_cached_trivial_test_w_not_operator
     },
     {
+        "cached_trivial_search_w_not_wildcard_operator",
+        TrivialIter_cached_trivial_search_w_not_wildcard_operator
+    },
+    {
+        "cached_trivial_test_w_not_wildcard_operator",
+        TrivialIter_cached_trivial_test_w_not_wildcard_operator
+    },
+    {
         "cached_trivial_search_w_or_operator",
         TrivialIter_cached_trivial_search_w_or_operator
     },
@@ -11524,14 +11564,14 @@ static bake_test_suite suites[] = {
         "Plan",
         NULL,
         NULL,
-        79,
+        83,
         Plan_testcases
     },
     {
         "Variables",
         Variables_setup,
         NULL,
-        192,
+        194,
         Variables_testcases,
         1,
         Variables_params
@@ -11686,7 +11726,7 @@ static bake_test_suite suites[] = {
         "TrivialIter",
         NULL,
         NULL,
-        14,
+        16,
         TrivialIter_testcases
     },
     {

--- a/test/query/src/main.c
+++ b/test/query/src/main.c
@@ -803,6 +803,10 @@ void Plan_cached_w_not(void);
 void Plan_cached_w_not_wildcard(void);
 void Plan_cached_w_not_simple(void);
 void Plan_cached_w_not_wildcard_simple(void);
+void Plan_cached_w_optional(void);
+void Plan_cached_w_optional_wildcard(void);
+void Plan_cached_w_optional_simple(void);
+void Plan_cached_w_optional_wildcard_simple(void);
 
 // Testsuite 'Variables'
 void Variables_setup(void);
@@ -905,6 +909,8 @@ void Variables_3_set_src_this_w_component_component_uncacheable_component(void);
 void Variables_2_set_src_this_w_wildcard(void);
 void Variables_2_set_src_this_w_not(void);
 void Variables_3_set_src_this_w_not_wildcard(void);
+void Variables_2_set_src_this_w_optional(void);
+void Variables_3_set_src_this_w_optional_wildcard(void);
 void Variables_1_src_this_var_as_entity(void);
 void Variables_1_src_this_var_as_table(void);
 void Variables_1_src_this_var_as_table_range(void);
@@ -2296,6 +2302,8 @@ void TrivialIter_cached_trivial_search_w_or_operator(void);
 void TrivialIter_cached_trivial_test_w_or_operator(void);
 void TrivialIter_cached_trivial_search_w_optional_operator(void);
 void TrivialIter_cached_trivial_test_w_optional_operator(void);
+void TrivialIter_cached_trivial_search_w_optional_wildcard_operator(void);
+void TrivialIter_cached_trivial_test_w_optional_wildcard_operator(void);
 void TrivialIter_cached_trivial_search_w_wildcard(void);
 void TrivialIter_cached_trivial_test_w_wildcard(void);
 
@@ -5475,6 +5483,22 @@ bake_test_case Plan_testcases[] = {
     {
         "cached_w_not_wildcard_simple",
         Plan_cached_w_not_wildcard_simple
+    },
+    {
+        "cached_w_optional",
+        Plan_cached_w_optional
+    },
+    {
+        "cached_w_optional_wildcard",
+        Plan_cached_w_optional_wildcard
+    },
+    {
+        "cached_w_optional_simple",
+        Plan_cached_w_optional_simple
+    },
+    {
+        "cached_w_optional_wildcard_simple",
+        Plan_cached_w_optional_wildcard_simple
     }
 };
 
@@ -5874,6 +5898,14 @@ bake_test_case Variables_testcases[] = {
     {
         "3_set_src_this_w_not_wildcard",
         Variables_3_set_src_this_w_not_wildcard
+    },
+    {
+        "2_set_src_this_w_optional",
+        Variables_2_set_src_this_w_optional
+    },
+    {
+        "3_set_src_this_w_optional_wildcard",
+        Variables_3_set_src_this_w_optional_wildcard
     },
     {
         "1_src_this_var_as_entity",
@@ -11305,6 +11337,14 @@ bake_test_case TrivialIter_testcases[] = {
         TrivialIter_cached_trivial_test_w_optional_operator
     },
     {
+        "cached_trivial_search_w_optional_wildcard_operator",
+        TrivialIter_cached_trivial_search_w_optional_wildcard_operator
+    },
+    {
+        "cached_trivial_test_w_optional_wildcard_operator",
+        TrivialIter_cached_trivial_test_w_optional_wildcard_operator
+    },
+    {
         "cached_trivial_search_w_wildcard",
         TrivialIter_cached_trivial_search_w_wildcard
     },
@@ -11564,14 +11604,14 @@ static bake_test_suite suites[] = {
         "Plan",
         NULL,
         NULL,
-        83,
+        87,
         Plan_testcases
     },
     {
         "Variables",
         Variables_setup,
         NULL,
-        194,
+        196,
         Variables_testcases,
         1,
         Variables_params
@@ -11726,7 +11766,7 @@ static bake_test_suite suites[] = {
         "TrivialIter",
         NULL,
         NULL,
-        16,
+        18,
         TrivialIter_testcases
     },
     {


### PR DESCRIPTION
This PR:
- allows for creation of trivial caches with Not and Optional operators
- fixes an issue where `!(R, *)` terms were not cached