### PR TITLE
Fix typos in ComponentTraits.md and returning error code upon creating a struct with a syntax error but no members

### DIFF
--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -50393,7 +50393,8 @@ error:
 static
 const char * flecs_meta_utils_open_scope(
     const char *ptr,
-    flecs_meta_utils_parse_ctx_t *ctx)    
+    flecs_meta_utils_parse_ctx_t *ctx,
+    bool *error)
 {
     /* Skip initial whitespaces */
     ptr = flecs_parse_ws_eol(ptr);
@@ -50415,6 +50416,8 @@ const char * flecs_meta_utils_open_scope(
         goto error;
     }   
 
+    *error = false;
+
     /* Is this the end of the type definition? */
     if (*ptr == '}') {
         ptr = flecs_parse_ws_eol(ptr + 1);
@@ -50428,6 +50431,7 @@ const char * flecs_meta_utils_open_scope(
 
     return ptr;
 error:
+    *error = true;
     return NULL;
 }
 
@@ -50435,9 +50439,10 @@ static
 const char* flecs_meta_utils_parse_constant(
     const char *ptr,
     flecs_meta_utils_constant_t *token,
-    flecs_meta_utils_parse_ctx_t *ctx)
+    flecs_meta_utils_parse_ctx_t *ctx,
+    bool *error)
 {    
-    ptr = flecs_meta_utils_open_scope(ptr, ctx);
+    ptr = flecs_meta_utils_open_scope(ptr, ctx, error);
     if (!ptr) {
         return NULL;
     }
@@ -50526,9 +50531,10 @@ static
 const char* flecs_meta_utils_parse_member(
     const char *ptr,
     flecs_meta_utils_member_t *token,
-    flecs_meta_utils_parse_ctx_t *ctx)
+    flecs_meta_utils_parse_ctx_t *ctx,
+    bool *error)
 {
-    ptr = flecs_meta_utils_open_scope(ptr, ctx);
+    ptr = flecs_meta_utils_open_scope(ptr, ctx, error);
     if (!ptr) {
         return NULL;
     }
@@ -50923,7 +50929,8 @@ int flecs_meta_utils_parse_struct(
 
     ecs_entity_t old_scope = ecs_set_scope(world, t);
 
-    while ((ptr = flecs_meta_utils_parse_member(ptr, &token, &ctx)) && ptr[0]) {
+    bool error;
+    while ((ptr = flecs_meta_utils_parse_member(ptr, &token, &ctx, &error)) && ptr[0]) {
         ecs_entity_t m = ecs_entity(world, {
             .name = token.name
         });
@@ -50942,7 +50949,7 @@ int flecs_meta_utils_parse_struct(
 
     ecs_set_scope(world, old_scope);
 
-    return 0;
+    return error ? -1 : 0;
 error:
     return -1;
 }
@@ -50975,7 +50982,8 @@ int flecs_meta_utils_parse_constants(
 
     ecs_entity_t old_scope = ecs_set_scope(world, t);
 
-    while ((ptr = flecs_meta_utils_parse_constant(ptr, &token, &ctx))) {
+    bool error;
+    while ((ptr = flecs_meta_utils_parse_constant(ptr, &token, &ctx, &error))) {
         if (token.is_value_set) {
             last_value = token.value;
         } else if (is_bitmask) {
@@ -51013,7 +51021,7 @@ int flecs_meta_utils_parse_constants(
 
     ecs_set_scope(world, old_scope);
 
-    return 0;
+    return error ? -1 : 0;
 error:
     return -1;
 }

--- a/docs/ComponentTraits.md
+++ b/docs/ComponentTraits.md
@@ -369,7 +369,8 @@ ecs_observer(world, {
 });
 
 ecs_entity_t p = ecs_new_w(world, Node);
-ecs_entity_t c = ecs_new_w_pair(world, EcsChildOf, p);
+ecs_entity_t c = ecs_new_w(world, Node);
+ecs_add_pair(world, c, EcsChildOf, p);
 ```
 
 </li>
@@ -1370,7 +1371,7 @@ assert!(!inst.try_get::<&Mass>(|mass| {}));
 </div>
 
 ## Transitive trait
-Relationships can be marked as transitive. A formal-ish definition if transitivity in the context of relationships is:
+Relationships can be marked as transitive. A formal-ish definition of transitivity in the context of relationships is:
 
 ```
 If   Relationship(EntityA, EntityB) 
@@ -1447,7 +1448,7 @@ newyork.add_id((locatedin, usa));
 </ul>
 </div>
 
-If we were now to query for `(LocatedIn, USA)` we would only match `NewYork`, because we never added `(LocatedIn, USA)` to `Manhattan`. To make sure queries `Manhattan` as well we have to make the `LocatedIn` relationship transitive. We can simply do this by adding the transitive trait to the relationship entity:
+If we were now to query for `(LocatedIn, USA)` we would only match `NewYork`, because we never added `(LocatedIn, USA)` to `Manhattan`. To make sure we match `Manhattan` as well we have to make the `LocatedIn` relationship transitive. We can simply do this by adding the transitive trait to the relationship entity:
 
 <div class="flecs-snippet-tabs">
 <ul>


### PR DESCRIPTION
I noticed `ecs_meta_from_desc()` prints an error when passed the description `{` about missing the closing brace, but still returns 0 (success). This commit fixes that. Let me know about any issues with this! I'm not sure about how to add test cases for this tho.