### PR TITLE
Undo double increment in query_cache_init

### DIFF
--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -70408,6 +70408,20 @@ ecs_query_cache_t* flecs_query_cache_init(
         if (!result->observer) {
             goto error;
         }
+
+        // Undo double increment from (above) query_init +  observer_init->query_init call
+        int i, count = q->term_count;
+        for (i = 0; i < count; i ++) {
+            ecs_term_t *term = &q->terms[i];
+            if (!(term->flags_ & EcsTermKeepAlive)) {
+                continue;
+            }
+
+            ecs_component_record_t *cr = flecs_components_get(q->real_world, term->id);
+            if (cr) {
+                cr->keep_alive --;
+            }
+        }
     }
 
     result->prev_match_count = -1;

--- a/src/query/cache/cache.c
+++ b/src/query/cache/cache.c
@@ -665,6 +665,20 @@ ecs_query_cache_t* flecs_query_cache_init(
         if (!result->observer) {
             goto error;
         }
+
+        // Undo double increment from (above) query_init +  observer_init->query_init call
+        int i, count = q->term_count;
+        for (i = 0; i < count; i ++) {
+            ecs_term_t *term = &q->terms[i];
+            if (!(term->flags_ & EcsTermKeepAlive)) {
+                continue;
+            }
+
+            ecs_component_record_t *cr = flecs_components_get(q->real_world, term->id);
+            if (cr) {
+                cr->keep_alive --;
+            }
+        }
     }
 
     result->prev_match_count = -1;


### PR DESCRIPTION
# Fixes Bug: Deleting module with component-matching system crashes

Reproducer:
```cpp
#include <flecs/flecs.h>
#include <iostream>

struct Velocity {};

struct VelocityModule {
    VelocityModule(flecs::world& ecs) {
        auto vel_mod = ecs.module<VelocityModule>();

        std::cout << vel_mod.id() << " Velocity Module Loaded" << std::endl;

        // ecs.entity<Velocity>(); (2)
        std::cout << ecs.component<Velocity>().id() << " Velocity Component Loaded"
                  << std::endl; // swap `component` to `entity` (1)

        auto sys = ecs.system().with<Velocity>().each([]() {});
        std::cout << sys.id() << " Velocity System " << sys.str() << std::endl;
    }
};

int main() {
    flecs::world ecs;
    ecs_log_set_level(3);
    ecs.import <VelocityModule>();

    ecs.entity<VelocityModule>().destruct();
    ecs_log_set_level(0);

    std::cout << "Velocity should be deleted..." << std::endl;

    return 0;
}
```

The above code crashes on ecs.entity<VelocityModule>().destruct() with
fatal: flecs.c: 37589: assert: (world->flags & EcsWorldQuit) || (cr->keep_alive == 0) cannot delete id that is queried for (ID_IN_USE)

The issue seems to be that cached query creation is causing a double increment on the component record, because `flecs_query_cache_init` calls `flecs_query_init`, as well as `flecs_observer_init`-which _also_ calls `flecs_query_init`. This second call is not accounted for, and therefore is never decremented causing the crash.. This is not seen by the majority of users though, as the ref-count assert check is disregarded during world cleanup.

## Solution

I went with a simple solution of immediately decrementing the ref count when the 2nd call (which would duplicate-increment) is successful. It's not the most beautiful solution, but it has a very small footprint, and only modifies the problem area. Very open to changing this if we want to fix this in a different way.