### PR TITLE
fix: bump cmake_minimum_required version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 cmake_policy(SET CMP0063 NEW)
 
 project(flecs LANGUAGES C)


### PR DESCRIPTION
Previous versions to 3.10 is deprecated and cmake gives a warning

```
CMake Deprecation Warning at Coffee/vendor/flecs/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
```