### PR TITLE
Improvements for script & explorer

### DIFF
--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -28057,7 +28057,7 @@ bool flecs_rest_script(
 
         /* Refetch in case it moved around */
         s = ecs_get(world, script, EcsScript);
-        
+
         if (!s || !s->error) {
             ecs_strbuf_append(&reply->body, 
                 "\"error\": \"error parsing script\"");
@@ -29072,6 +29072,14 @@ ecs_http_server_t* ecs_rest_server_init(
     srv_ctx->srv = srv;
     srv_ctx->rc = 1;
     srv_ctx->srv = srv;
+
+    /* Set build info on world so clients know which version they're using */
+    ecs_id_t build_info = ecs_lookup(world, "flecs.core.BuildInfo");
+    if (build_info) {
+        const ecs_build_info_t *bi = ecs_get_build_info();
+        ecs_set_id(world, EcsWorld, build_info, sizeof(ecs_build_info_t), bi);
+    }
+
     return srv;
 }
 
@@ -54125,7 +54133,7 @@ void flecs_meta_import_core_definitions(
 
     ecs_struct(world, {
         .entity = ecs_entity(world, { 
-            .name = "flecs.core.build_info_t",
+            .name = "flecs.core.BuildInfo",
             .root_sep = ""
         }),
         .members = {
@@ -70097,7 +70105,7 @@ void FlecsWorldSummaryImport(
     ECS_COMPONENT_DEFINE(world, EcsWorldSummary);
 
 #if defined(FLECS_META) && defined(FLECS_UNITS) 
-    ecs_entity_t build_info = ecs_lookup(world, "flecs.core.build_info_t");
+    ecs_entity_t build_info = ecs_lookup(world, "flecs.core.BuildInfo");
     ecs_struct(world, {
         .entity = ecs_id(EcsWorldSummary),
         .members = {

--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -28022,7 +28022,8 @@ bool flecs_rest_script(
     const EcsScript *s = ecs_get(world, script, EcsScript);
 
     if (s && s->filename && save_file) {
-        FILE *f = fopen(s->filename, "w");
+        FILE *f;
+        ecs_os_fopen(&f, s->filename, "w");
         fwrite(code, strlen(code), 1, f);
         fclose(f);
     }

--- a/distr/flecs.h
+++ b/distr/flecs.h
@@ -14942,6 +14942,7 @@ typedef struct ecs_script_runtime_t ecs_script_runtime_t;
  * This component is added to the entities of managed scripts and templates.
  */
 typedef struct EcsScript {
+    char *filename;
     char *code;
     char *error; /* Set if script evaluation had errors */
     ecs_script_t *script;

--- a/distr/flecs.h
+++ b/distr/flecs.h
@@ -11581,6 +11581,11 @@ bool ecs_log_enable_timedelta(
 FLECS_API
 int ecs_log_last_error(void);
 
+FLECS_API
+void ecs_log_start_capture(bool capture_try);
+
+FLECS_API
+char* ecs_log_stop_capture(void);
 
 ////////////////////////////////////////////////////////////////////////////////
 //// Error codes
@@ -14937,6 +14942,8 @@ typedef struct ecs_script_runtime_t ecs_script_runtime_t;
  * This component is added to the entities of managed scripts and templates.
  */
 typedef struct EcsScript {
+    char *code;
+    char *error; /* Set if script evaluation had errors */
     ecs_script_t *script;
     ecs_script_template_t *template_; /* Only set for template scripts */
 } EcsScript;
@@ -14999,6 +15006,11 @@ typedef struct ecs_script_eval_desc_t {
     ecs_script_runtime_t *runtime; /**< Reusable runtime (optional) */
 } ecs_script_eval_desc_t;
 
+/** Used to capture error output from script evaluation. */
+typedef struct ecs_script_eval_result_t {
+    char *error;
+} ecs_script_eval_result_t;
+
 /** Parse script.
  * This operation parses a script and returns a script object upon success. To
  * run the script, call ecs_script_eval().
@@ -15007,10 +15019,15 @@ typedef struct ecs_script_eval_desc_t {
  * provided in the vars member of the desc object that defines all variables 
  * with the correct types.
  * 
+ * When the result parameter is not NULL, the script will capture errors and 
+ * return them in the output struct. If result.error is set, it must be freed
+ * by the application.
+ * 
  * @param world The world.
  * @param name Name of the script (typically a file/module name).
  * @param code The script code.
  * @param desc Parameters for script runtime.
+ * @param result Output of script evaluation.
  * @return Script object if success, NULL if failed.
 */
 FLECS_API
@@ -15018,7 +15035,8 @@ ecs_script_t* ecs_script_parse(
     ecs_world_t *world,
     const char *name,
     const char *code,
-    const ecs_script_eval_desc_t *desc);
+    const ecs_script_eval_desc_t *desc,
+    ecs_script_eval_result_t *result);
 
 /** Evaluate script.
  * This operation evaluates (runs) a parsed script.
@@ -15027,6 +15045,10 @@ ecs_script_t* ecs_script_parse(
  * a different ecs_script_vars_t object to ecs_script_eval(), as long as the
  * object has all referenced variables and they are of the same type.
  * 
+ * When the result parameter is not NULL, the script will capture errors and 
+ * return them in the output struct. If result.error is set, it must be freed
+ * by the application.
+ * 
  * @param script The script.
  * @param desc Parameters for script runtime.
  * @return Zero if success, non-zero if failed.
@@ -15034,7 +15056,8 @@ ecs_script_t* ecs_script_parse(
 FLECS_API
 int ecs_script_eval(
     const ecs_script_t *script,
-    const ecs_script_eval_desc_t *desc);
+    const ecs_script_eval_desc_t *desc,
+    ecs_script_eval_result_t *result);
 
 /** Free script.
  * This operation frees a script object.
@@ -15068,7 +15091,8 @@ FLECS_API
 int ecs_script_run(
     ecs_world_t *world,
     const char *name,
-    const char *code);
+    const char *code,
+    ecs_script_eval_result_t *result);
 
 /** Parse script file.
  * This parses a script file and instantiates the entities in the world. This
@@ -23620,7 +23644,7 @@ void randomize_timers() const;
  * @see ecs_script_run
  */
 int script_run(const char *name, const char *str) const {
-    return ecs_script_run(world_, name, str);
+    return ecs_script_run(world_, name, str, nullptr);
 }
 
 /** Run script from file.

--- a/examples/c/script/functions/src/main.c
+++ b/examples/c/script/functions/src/main.c
@@ -64,7 +64,7 @@ int main(int argc, char *argv[]) {
         .callback = sum
     });
 
-    if (ecs_script_run(world, "My script", code)) {
+    if (ecs_script_run(world, "My script", code, NULL)) {
         printf("script failed to run\n");
         return -1;
     }

--- a/examples/c/script/script_run/src/main.c
+++ b/examples/c/script/script_run/src/main.c
@@ -20,7 +20,7 @@ const char *script =
 int main(int argc, char *argv[]) {
     ecs_world_t *world = ecs_init_w_args(argc, argv);
 
-    if (ecs_script_run(world, "My script", script)) {
+    if (ecs_script_run(world, "My script", script, NULL)) {
         printf("script failed to run\n");
     }
 

--- a/examples/c/script/script_w_vars/src/main.c
+++ b/examples/c/script/script_w_vars/src/main.c
@@ -36,7 +36,7 @@ int main(int argc, char *argv[]) {
     ecs_script_eval_desc_t desc = { .vars = vars };
 
     // Parse the script
-    ecs_script_t *script = ecs_script_parse(world, "My script", code, &desc);
+    ecs_script_t *script = ecs_script_parse(world, "My script", code, &desc, NULL);
     if (!script) {
         printf("script failed to parse\n");
         return -1;
@@ -45,7 +45,7 @@ int main(int argc, char *argv[]) {
     // Assign values to variables and evaluate
     *(int32_t*)x->value.ptr = 1;
     *(int32_t*)y->value.ptr = 2;
-    if (ecs_script_eval(script, &desc) != 0) {
+    if (ecs_script_eval(script, &desc, NULL) != 0) {
         printf("script failed to run\n");
         return -1;
     }
@@ -59,7 +59,7 @@ int main(int argc, char *argv[]) {
     // Change values for variables and reevaluate
     *(int32_t*)x->value.ptr = 2;
     *(int32_t*)y->value.ptr = 3;
-    if (ecs_script_eval(script, &desc) != 0) {
+    if (ecs_script_eval(script, &desc, NULL) != 0) {
         printf("script failed to run\n");
         return -1;
     }

--- a/include/flecs/addons/cpp/mixins/script/mixin.inl
+++ b/include/flecs/addons/cpp/mixins/script/mixin.inl
@@ -15,7 +15,7 @@
  * @see ecs_script_run
  */
 int script_run(const char *name, const char *str) const {
-    return ecs_script_run(world_, name, str);
+    return ecs_script_run(world_, name, str, nullptr);
 }
 
 /** Run script from file.

--- a/include/flecs/addons/log.h
+++ b/include/flecs/addons/log.h
@@ -530,6 +530,11 @@ bool ecs_log_enable_timedelta(
 FLECS_API
 int ecs_log_last_error(void);
 
+FLECS_API
+void ecs_log_start_capture(bool capture_try);
+
+FLECS_API
+char* ecs_log_stop_capture(void);
 
 ////////////////////////////////////////////////////////////////////////////////
 //// Error codes

--- a/include/flecs/addons/script.h
+++ b/include/flecs/addons/script.h
@@ -91,6 +91,8 @@ typedef struct ecs_script_runtime_t ecs_script_runtime_t;
  * This component is added to the entities of managed scripts and templates.
  */
 typedef struct EcsScript {
+    char *code;
+    char *error; /* Set if script evaluation had errors */
     ecs_script_t *script;
     ecs_script_template_t *template_; /* Only set for template scripts */
 } EcsScript;
@@ -153,6 +155,11 @@ typedef struct ecs_script_eval_desc_t {
     ecs_script_runtime_t *runtime; /**< Reusable runtime (optional) */
 } ecs_script_eval_desc_t;
 
+/** Used to capture error output from script evaluation. */
+typedef struct ecs_script_eval_result_t {
+    char *error;
+} ecs_script_eval_result_t;
+
 /** Parse script.
  * This operation parses a script and returns a script object upon success. To
  * run the script, call ecs_script_eval().
@@ -161,10 +168,15 @@ typedef struct ecs_script_eval_desc_t {
  * provided in the vars member of the desc object that defines all variables 
  * with the correct types.
  * 
+ * When the result parameter is not NULL, the script will capture errors and 
+ * return them in the output struct. If result.error is set, it must be freed
+ * by the application.
+ * 
  * @param world The world.
  * @param name Name of the script (typically a file/module name).
  * @param code The script code.
  * @param desc Parameters for script runtime.
+ * @param result Output of script evaluation.
  * @return Script object if success, NULL if failed.
 */
 FLECS_API
@@ -172,7 +184,8 @@ ecs_script_t* ecs_script_parse(
     ecs_world_t *world,
     const char *name,
     const char *code,
-    const ecs_script_eval_desc_t *desc);
+    const ecs_script_eval_desc_t *desc,
+    ecs_script_eval_result_t *result);
 
 /** Evaluate script.
  * This operation evaluates (runs) a parsed script.
@@ -181,6 +194,10 @@ ecs_script_t* ecs_script_parse(
  * a different ecs_script_vars_t object to ecs_script_eval(), as long as the
  * object has all referenced variables and they are of the same type.
  * 
+ * When the result parameter is not NULL, the script will capture errors and 
+ * return them in the output struct. If result.error is set, it must be freed
+ * by the application.
+ * 
  * @param script The script.
  * @param desc Parameters for script runtime.
  * @return Zero if success, non-zero if failed.
@@ -188,7 +205,8 @@ ecs_script_t* ecs_script_parse(
 FLECS_API
 int ecs_script_eval(
     const ecs_script_t *script,
-    const ecs_script_eval_desc_t *desc);
+    const ecs_script_eval_desc_t *desc,
+    ecs_script_eval_result_t *result);
 
 /** Free script.
  * This operation frees a script object.
@@ -222,7 +240,8 @@ FLECS_API
 int ecs_script_run(
     ecs_world_t *world,
     const char *name,
-    const char *code);
+    const char *code,
+    ecs_script_eval_result_t *result);
 
 /** Parse script file.
  * This parses a script file and instantiates the entities in the world. This

--- a/include/flecs/addons/script.h
+++ b/include/flecs/addons/script.h
@@ -91,6 +91,7 @@ typedef struct ecs_script_runtime_t ecs_script_runtime_t;
  * This component is added to the entities of managed scripts and templates.
  */
 typedef struct EcsScript {
+    char *filename;
     char *code;
     char *error; /* Set if script evaluation had errors */
     ecs_script_t *script;

--- a/src/addons/log.c
+++ b/src/addons/log.c
@@ -7,6 +7,82 @@
 
 #ifdef FLECS_LOG
 
+static char *flecs_log_last_err = NULL;
+static ecs_os_api_log_t flecs_log_prev_log = NULL;
+static ecs_os_api_log_t flecs_log_prev_fatal_log = NULL;
+static bool flecs_log_prev_color = false;
+static int flecs_log_prev_level = 0;
+
+static
+void flecs_set_prev_log(
+    ecs_os_api_log_t prev_log,
+    bool try)
+{
+    flecs_log_prev_log = try ? NULL : prev_log;
+    flecs_log_prev_fatal_log = prev_log;
+}
+
+static 
+void flecs_log_capture_log(
+    int32_t level, 
+    const char *file,
+    int32_t line, 
+    const char *msg)
+{
+    (void)file; (void)line;
+
+    if (level <= -4) {
+        /* Make sure to always log fatal errors */
+        if (flecs_log_prev_fatal_log) {
+            ecs_log_enable_colors(true);
+            flecs_log_prev_fatal_log(level, file, line, msg);
+            ecs_log_enable_colors(false);
+            return;
+        } else {
+            fprintf(stderr, "%s:%d: %s", file, line, msg);
+        }
+    }
+
+#ifdef FLECS_DEBUG
+    /* In debug mode, log unexpected errors to the console */
+    if (level < 0) {
+        /* Also log to previous log function in debug mode */
+        if (flecs_log_prev_log) {
+            ecs_log_enable_colors(true);
+            flecs_log_prev_log(level, file, line, msg);
+            ecs_log_enable_colors(false);
+        }
+    }
+#endif
+
+    if (!flecs_log_last_err && level <= -3) {
+        flecs_log_last_err = ecs_os_strdup(msg);
+    }
+}
+
+static
+char* flecs_log_get_captured_log(void) {
+    char *result = flecs_log_last_err;
+    flecs_log_last_err = NULL;
+    return result;
+}
+
+void ecs_log_start_capture(bool try) {
+    flecs_log_prev_color = ecs_log_enable_colors(false);
+    flecs_log_prev_log = ecs_os_api.log_;
+    flecs_log_prev_level = ecs_os_api.log_level_;
+    flecs_set_prev_log(ecs_os_api.log_, try);
+    ecs_os_api.log_ = flecs_log_capture_log;
+    ecs_os_api.log_level_ = -1; /* Ignore debug tracing, log warnings/errors */
+}
+
+char* ecs_log_stop_capture(void) {
+    ecs_os_api.log_ = flecs_log_prev_fatal_log;
+    ecs_os_api.log_level_ = flecs_log_prev_level;
+    ecs_log_enable_colors(flecs_log_prev_color);
+    return flecs_log_get_captured_log();
+}
+
 void flecs_colorize_buf(
     char *msg,
     bool enable_colors,
@@ -580,6 +656,14 @@ void ecs_assert_log_(
     (void)file;
     (void)line;
     (void)fmt;
+}
+
+void ecs_log_start_capture(bool try) {
+    (void)try;
+}
+
+char* ecs_log_stop_capture(void) {
+    return NULL;
 }
 
 #endif

--- a/src/addons/meta/definitions.c
+++ b/src/addons/meta/definitions.c
@@ -123,7 +123,7 @@ void flecs_meta_import_core_definitions(
 
     ecs_struct(world, {
         .entity = ecs_entity(world, { 
-            .name = "flecs.core.build_info_t",
+            .name = "flecs.core.BuildInfo",
             .root_sep = ""
         }),
         .members = {

--- a/src/addons/rest.c
+++ b/src/addons/rest.c
@@ -554,7 +554,8 @@ bool flecs_rest_script(
     const EcsScript *s = ecs_get(world, script, EcsScript);
 
     if (s && s->filename && save_file) {
-        FILE *f = fopen(s->filename, "w");
+        FILE *f;
+        ecs_os_fopen(&f, s->filename, "w");
         fwrite(code, strlen(code), 1, f);
         fclose(f);
     }

--- a/src/addons/rest.c
+++ b/src/addons/rest.c
@@ -589,7 +589,7 @@ bool flecs_rest_script(
 
         /* Refetch in case it moved around */
         s = ecs_get(world, script, EcsScript);
-        
+
         if (!s || !s->error) {
             ecs_strbuf_append(&reply->body, 
                 "\"error\": \"error parsing script\"");
@@ -1604,6 +1604,14 @@ ecs_http_server_t* ecs_rest_server_init(
     srv_ctx->srv = srv;
     srv_ctx->rc = 1;
     srv_ctx->srv = srv;
+
+    /* Set build info on world so clients know which version they're using */
+    ecs_id_t build_info = ecs_lookup(world, "flecs.core.BuildInfo");
+    if (build_info) {
+        const ecs_build_info_t *bi = ecs_get_build_info();
+        ecs_set_id(world, EcsWorld, build_info, sizeof(ecs_build_info_t), bi);
+    }
+
     return srv;
 }
 

--- a/src/addons/script/parser.c
+++ b/src/addons/script/parser.c
@@ -942,12 +942,17 @@ ecs_script_t* ecs_script_parse(
     ecs_world_t *world,
     const char *name,
     const char *code,
-    const ecs_script_eval_desc_t *desc) 
+    const ecs_script_eval_desc_t *desc,
+    ecs_script_eval_result_t *result) 
 {
     (void)desc; /* Will be used in future to expand type checking features */
 
     if (!code) {
         code = "";
+    }
+
+    if (result) {
+        ecs_log_start_capture(true);
     }
 
     ecs_script_t *script = flecs_script_new(world);
@@ -993,8 +998,16 @@ ecs_script_t* ecs_script_parse(
 
     impl->token_remaining = parser.token_cur;
 
+    if (result) {
+        ecs_log_stop_capture();
+    }
+
     return script;
 error:
+    if (result) {
+        result->error = ecs_log_stop_capture();
+    }
+
     ecs_script_free(script);
     return NULL;
 }

--- a/src/addons/script/script.c
+++ b/src/addons/script/script.c
@@ -22,8 +22,12 @@ ECS_MOVE(EcsScript, dst, src, {
         }
         ecs_script_free(dst->script);
     }
+    dst->code = src->code;
+    dst->error = src->error;
     dst->script = src->script;
     dst->template_ = src->template_;
+    src->code = NULL;
+    src->error = NULL;
     src->script = NULL;
     src->template_ = NULL;
 })
@@ -37,6 +41,8 @@ ECS_DTOR(EcsScript, ptr, {
     if (ptr->script) {
         ecs_script_free(ptr->script);
     }
+    ecs_os_free(ptr->code);
+    ecs_os_free(ptr->error);
 })
 
 static
@@ -98,16 +104,17 @@ void ecs_script_clear(
 int ecs_script_run(
     ecs_world_t *world,
     const char *name,
-    const char *code)
+    const char *code,
+    ecs_script_eval_result_t *result)
 {
-    ecs_script_t *script = ecs_script_parse(world, name, code, NULL);
+    ecs_script_t *script = ecs_script_parse(world, name, code, NULL, result);
     if (!script) {
         goto error;
     }
 
     ecs_entity_t prev_scope = ecs_set_scope(world, 0);
 
-    if (ecs_script_eval(script, NULL)) {
+    if (ecs_script_eval(script, NULL, result)) {
         goto error_free;
     }
 
@@ -130,7 +137,7 @@ int ecs_script_run_file(
         return -1;
     }
 
-    int result = ecs_script_run(world, filename, script);
+    int result = ecs_script_run(world, filename, script, NULL);
     ecs_os_free(script);
     return result;
 }
@@ -138,6 +145,7 @@ int ecs_script_run_file(
 void ecs_script_free(
     ecs_script_t *script)
 {
+    ecs_check(script != NULL, ECS_INVALID_PARAMETER, NULL);
     ecs_script_impl_t *impl = flecs_script_impl(script);
     ecs_check(impl->refcount > 0, ECS_INVALID_OPERATION, NULL);
     if (!--impl->refcount) {
@@ -174,12 +182,26 @@ int ecs_script_update(
         return -1;
     }
 
+    if (s->code) {
+        ecs_os_free(s->code);
+    }
+
+    s->code = ecs_os_strdup(code);
+
+    if (s->error) {
+        ecs_os_free(s->error);
+        s->error = NULL;
+    }
+
     if (s->script) {
         ecs_script_free(s->script);
     }
 
-    s->script = ecs_script_parse(world, name, code, NULL);
-    if (!s->script) {
+    ecs_script_eval_result_t eval_result = {NULL};
+
+    s->script = ecs_script_parse(world, name, code, NULL, &eval_result);
+    if (s->script == NULL) {
+        s->error = eval_result.error;
         return -1;
     }
 
@@ -197,7 +219,8 @@ int ecs_script_update(
 
     ecs_entity_t prev = ecs_set_with(world, flecs_script_tag(e, instance));
 
-    if (ecs_script_eval(s->script, NULL)) {
+    if (ecs_script_eval(s->script, NULL, &eval_result)) {
+        s->error = eval_result.error;
         ecs_script_free(s->script);
         s->script = NULL;
         ecs_delete_with(world, ecs_pair_t(EcsScript, e));
@@ -311,22 +334,18 @@ int EcsScript_serialize(
     const void *ptr) 
 {
     const EcsScript *data = ptr;
-    if (data->script) {
-        ser->member(ser, "name");
-        ser->value(ser, ecs_id(ecs_string_t), &data->script->name);
-        ser->member(ser, "code");
-        ser->value(ser, ecs_id(ecs_string_t), &data->script->code);
+    ser->member(ser, "code");
+    ser->value(ser, ecs_id(ecs_string_t), &data->code);
+    ser->member(ser, "error");
+    ser->value(ser, ecs_id(ecs_string_t), &data->error);
 
+    if (data->script) {
         char *ast = ecs_script_ast_to_str(data->script, true);
         ser->member(ser, "ast");
         ser->value(ser, ecs_id(ecs_string_t), &ast);
         ecs_os_free(ast);
     } else {
         char *nullString = NULL;
-        ser->member(ser, "name");
-        ser->value(ser, ecs_id(ecs_string_t), &nullString);
-        ser->member(ser, "code");
-        ser->value(ser, ecs_id(ecs_string_t), &nullString);
         ser->member(ser, "ast");
         ser->value(ser, ecs_id(ecs_string_t), &nullString);
     }
@@ -356,18 +375,18 @@ void FlecsScriptImport(
 
     ECS_COMPONENT(world, ecs_script_t);
 
-    ecs_struct(world, {
-        .entity = ecs_id(ecs_script_t),
+    ecs_entity_t opaque_view = ecs_struct(world, {
+        .entity = ecs_entity(world, { .name = "ecs_script_view_t"}),
         .members = {
-            { .name = "name", .type = ecs_id(ecs_string_t) },
             { .name = "code", .type = ecs_id(ecs_string_t) },
+            { .name = "error", .type = ecs_id(ecs_string_t) },
             { .name = "ast", .type = ecs_id(ecs_string_t) }
         }
     });
 
     ecs_opaque(world, {
         .entity = ecs_id(EcsScript),
-        .type.as_type = ecs_id(ecs_script_t),
+        .type.as_type = opaque_view,
         .type.serialize = EcsScript_serialize
     });
 

--- a/src/addons/script/visit.c
+++ b/src/addons/script/visit.c
@@ -120,6 +120,10 @@ int ecs_script_visit_(
     ecs_visit_action_t visit,
     ecs_script_impl_t *script)
 {
+    if (!script->root) {
+        return -1;
+    }
+
     visitor->script = script;
     visitor->visit = visit;
     visitor->depth = 0;

--- a/src/addons/script/visit_eval.c
+++ b/src/addons/script/visit_eval.c
@@ -1522,7 +1522,8 @@ void flecs_script_eval_visit_fini(
 
 int ecs_script_eval(
     const ecs_script_t *script,
-    const ecs_script_eval_desc_t *desc)
+    const ecs_script_eval_desc_t *desc,
+    ecs_script_eval_result_t *result)
 {
     ecs_script_eval_visitor_t v;
     ecs_script_impl_t *impl = flecs_script_impl(
@@ -1538,11 +1539,19 @@ int ecs_script_eval(
         priv_desc.runtime = flecs_script_runtime_get(script->world);
     }
 
+    if (result) {
+        ecs_log_start_capture(false);
+    }
+
     flecs_script_eval_visit_init(impl, &v, &priv_desc);
-    int result = ecs_script_visit(impl, &v, flecs_script_eval_node);
+    int r = ecs_script_visit(impl, &v, flecs_script_eval_node);
     flecs_script_eval_visit_fini(&v, &priv_desc);
 
-    return result;
+    if (result) {
+        result->error = ecs_log_stop_capture();
+    }
+
+    return r;
 }
 
 #endif

--- a/src/addons/script/visit_free.c
+++ b/src/addons/script/visit_free.c
@@ -178,8 +178,13 @@ int flecs_script_visit_free(
     ecs_script_t *script)
 {
     ecs_check(script != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_script_impl_t *impl = flecs_script_impl(script);
+    if (!impl->expr && !impl->root) {
+        return 0;
+    }
+
     ecs_script_visit_t v = {
-        .script = flecs_script_impl(script)
+        .script = impl
     };
 
     if (ecs_script_visit(

--- a/src/addons/script/visit_to_str.c
+++ b/src/addons/script/visit_to_str.c
@@ -453,6 +453,11 @@ char* ecs_script_ast_to_str(
 {
     ecs_check(script != NULL, ECS_INVALID_PARAMETER, NULL);
     ecs_strbuf_t buf = ECS_STRBUF_INIT;
+    ecs_script_impl_t *impl = flecs_script_impl(script);
+
+    if (!impl->expr && !impl->root) {
+        return NULL;
+    }
 
     if (flecs_script_impl(script)->expr) {
         flecs_expr_to_str_buf(

--- a/src/addons/stats/world_summary.c
+++ b/src/addons/stats/world_summary.c
@@ -71,7 +71,7 @@ void FlecsWorldSummaryImport(
     ECS_COMPONENT_DEFINE(world, EcsWorldSummary);
 
 #if defined(FLECS_META) && defined(FLECS_UNITS) 
-    ecs_entity_t build_info = ecs_lookup(world, "flecs.core.build_info_t");
+    ecs_entity_t build_info = ecs_lookup(world, "flecs.core.BuildInfo");
     ecs_struct(world, {
         .entity = ecs_id(EcsWorldSummary),
         .members = {

--- a/test/addons/src/Rest.c
+++ b/test/addons/src/Rest.c
@@ -519,6 +519,7 @@ void Rest_script_update(void) {
         char *reply_str = ecs_strbuf_get(&reply.body);
         test_str(reply_str, "{}");
         test_assert(ecs_lookup(world, "e") != 0);
+        ecs_os_free(reply_str);
     }
 
     ecs_rest_server_fini(srv);
@@ -546,6 +547,7 @@ void Rest_script_update_w_body(void) {
         test_int(reply.code, 200);
         char *reply_str = ecs_strbuf_get(&reply.body);
         test_str(reply_str, "{}");
+        ecs_os_free(reply_str);
     }
 
     ecs_rest_server_fini(srv);
@@ -680,6 +682,7 @@ void Rest_request_small_buffer_plus_one(void) {
         test_int(reply.code, 200);
         char *reply_str = ecs_strbuf_get(&reply.body);
         test_str(reply_str, "{}");
+        ecs_os_free(reply_str);
     }
 
     ecs_rest_server_fini(srv);

--- a/test/addons/src/Rest.c
+++ b/test/addons/src/Rest.c
@@ -18,14 +18,14 @@ void Rest_get(void) {
 
     ecs_http_reply_t reply = ECS_HTTP_REPLY_INIT;
     test_int(0, ecs_http_server_request(srv, "GET",
-        "/entity/flecs/core/World?label=true", NULL, &reply));
+        "/entity/flecs/core?label=true", NULL, &reply));
     test_int(reply.code, 200);
     
     char *reply_str = ecs_strbuf_get(&reply.body);
     test_assert(reply_str != NULL);
     test_str(reply_str,
-            "{\"parent\":\"flecs.core\", \"name\":\"World\", "
-                "\"components\":{\"(flecs.core.Identifier,flecs.core.Symbol)\":{\"value\":\"flecs.core.World\"}, \"(flecs.doc.Description,flecs.doc.Brief)\":{\"value\":\"Entity associated with world\"}}}");
+            "{\"parent\":\"flecs\", \"name\":\"core\", \"tags\":[\"flecs.core.Module\"], "
+                "\"components\":{\"(flecs.doc.Description,flecs.doc.Brief)\":{\"value\":\"Module with builtin components\"}}}");
     ecs_os_free(reply_str);
 
     ecs_rest_server_fini(srv);
@@ -45,28 +45,28 @@ void Rest_get_cached(void) {
     {
         ecs_http_reply_t reply = ECS_HTTP_REPLY_INIT;
         test_int(0, ecs_http_server_request(srv, "GET",
-            "/entity/flecs/core/World", NULL, &reply));
+            "/entity/flecs/core", NULL, &reply));
         test_int(reply.code, 200);
         
         char *reply_str = ecs_strbuf_get(&reply.body);
         test_assert(reply_str != NULL);
         test_str(reply_str,
-            "{\"parent\":\"flecs.core\", \"name\":\"World\", "
-                "\"components\":{\"(flecs.core.Identifier,flecs.core.Symbol)\":{\"value\":\"flecs.core.World\"}, \"(flecs.doc.Description,flecs.doc.Brief)\":{\"value\":\"Entity associated with world\"}}}");
+            "{\"parent\":\"flecs\", \"name\":\"core\", \"tags\":[\"flecs.core.Module\"], "
+                "\"components\":{\"(flecs.doc.Description,flecs.doc.Brief)\":{\"value\":\"Module with builtin components\"}}}");
         ecs_os_free(reply_str);
     }
 
     {
         ecs_http_reply_t reply = ECS_HTTP_REPLY_INIT;
         test_int(0, ecs_http_server_request(srv, "GET",
-            "/entity/flecs/core/World", NULL, &reply));
+            "/entity/flecs/core", NULL, &reply));
         test_int(reply.code, 200);
         
         char *reply_str = ecs_strbuf_get(&reply.body);
         test_assert(reply_str != NULL);
         test_str(reply_str,
-            "{\"parent\":\"flecs.core\", \"name\":\"World\", "
-                "\"components\":{\"(flecs.core.Identifier,flecs.core.Symbol)\":{\"value\":\"flecs.core.World\"}, \"(flecs.doc.Description,flecs.doc.Brief)\":{\"value\":\"Entity associated with world\"}}}");
+            "{\"parent\":\"flecs\", \"name\":\"core\", \"tags\":[\"flecs.core.Module\"], "
+                "\"components\":{\"(flecs.doc.Description,flecs.doc.Brief)\":{\"value\":\"Module with builtin components\"}}}");
         ecs_os_free(reply_str);
     }
 
@@ -517,7 +517,7 @@ void Rest_script_update(void) {
             NULL, &reply));
         test_int(reply.code, 200);
         char *reply_str = ecs_strbuf_get(&reply.body);
-        test_assert(reply_str == NULL);
+        test_str(reply_str, "{}");
         test_assert(ecs_lookup(world, "e") != 0);
     }
 
@@ -545,7 +545,7 @@ void Rest_script_update_w_body(void) {
             "/script/main.flecs", "e {}", &reply));
         test_int(reply.code, 200);
         char *reply_str = ecs_strbuf_get(&reply.body);
-        test_assert(reply_str == NULL);
+        test_str(reply_str, "{}");
     }
 
     ecs_rest_server_fini(srv);
@@ -679,7 +679,7 @@ void Rest_request_small_buffer_plus_one(void) {
             payload, &reply));
         test_int(reply.code, 200);
         char *reply_str = ecs_strbuf_get(&reply.body);
-        test_assert(reply_str == NULL);
+        test_str(reply_str, "{}");
     }
 
     ecs_rest_server_fini(srv);

--- a/test/custom_builds/c/plecs/src/main.c
+++ b/test/custom_builds/c/plecs/src/main.c
@@ -3,7 +3,7 @@
 int main(int argc, char *argv[]) {
     ecs_world_t *world = ecs_init_w_args(argc, argv);
 
-    int ret = ecs_script_run(world, NULL, "Foo {}");
+    int ret = ecs_script_run(world, NULL, "Foo {}", NULL);
     assert(ret == 0);
     (void)ret;
 

--- a/test/script/project.json
+++ b/test/script/project.json
@@ -503,7 +503,13 @@
                 "reload_script_w_component_w_error",
                 "reload_script_w_component_w_error_again",
                 "initializer_w_int_to_struct",
-                "script_initializer_w_int_to_struct"
+                "script_initializer_w_int_to_struct",
+                "capture_error",
+                "unresolved_component_error_w_script_run",
+                "unresolved_component_error_w_script_init",
+                "unresolved_component_error_w_script_init_existing",
+                "unresolved_component_error_w_script_eval",
+                "unresolved_component_error_w_script_eval_multiple_times"
             ]
         }, {
             "id": "Expr",

--- a/test/script/src/Error.c
+++ b/test/script/src/Error.c
@@ -13,7 +13,7 @@ void Error_multi_line_comment_after_newline_before_newline_scope_open(void) {
     LINE "Foo{}";
 
     ecs_log_set_level(-4); /* Newline after multiline comment is not ignored */
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -26,7 +26,7 @@ void Error_missing_end_of_scope(void) {
     HEAD "Parent {"
     LINE " Child {}";
 
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     test_assert(ecs_get_scope(world) == 0);
     test_assert(ecs_get_with(world) == 0);
@@ -57,7 +57,7 @@ void Error_with_n_tags_2_levels_invalid_tag(void) {
     LINE "HelloC {}";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -69,7 +69,7 @@ void Error_assignment_to_non_component(void) {
     HEAD "Foo { Position: {x: 10, y: 20} }";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -83,7 +83,7 @@ void Error_struct_w_member_w_assignment_to_nothing(void) {
     LINE "}";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -97,7 +97,7 @@ void Error_struct_w_member_w_assignment_to_empty_scope(void) {
     LINE "}";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -110,7 +110,7 @@ void Error_invalid_nested_assignment(void) {
     LINE "Bar { Hello }";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -122,7 +122,7 @@ void Error_invalid_partial_pair_assignment(void) {
     HEAD "Foo { (Hello, }";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -134,7 +134,7 @@ void Error_empty_assignment(void) {
     HEAD "Foo {";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -146,7 +146,7 @@ void Error_empty_assignment_before_end_of_scope(void) {
     HEAD "{Foo {}";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -161,7 +161,7 @@ void Error_default_type_with_tag(void) {
     LINE "}";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -179,7 +179,7 @@ void Error_invalid_oneof(void) {
     LINE "}"
     LINE "e { (Color, Foo) }";
 
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_entity_t color = ecs_lookup(world, "Color");
     ecs_entity_t foo = ecs_lookup(world, "Foo");
@@ -212,7 +212,7 @@ void Error_unterminated_multiline_string(void) {
     LINE "}}";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -231,7 +231,7 @@ void Error_invalid_assign_multiline_string(void) {
     HEAD "Foo { String: {value: `foo`} }";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -244,7 +244,7 @@ void Error_const_var_redeclare(void) {
     LINE "const var_x = 20";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -266,7 +266,7 @@ void Error_typed_const_w_composite_type_invalid_assignment(void) {
     LINE "";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -292,7 +292,7 @@ void Error_unterminated_multi_line_comment_in_value(void) {
     LINE "  y: 20\n"
     LINE "}}";
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -311,7 +311,7 @@ void Error_pair_w_rel_var_invalid_type(void) {
     LINE "\n";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -330,7 +330,7 @@ void Error_pair_w_tgt_var_invalid_type(void) {
     LINE "\n";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -345,7 +345,7 @@ void Error_with_value_not_a_component(void) {
     LINE "\n";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -370,7 +370,7 @@ void Error_tag_in_with_scope(void) {
     LINE "\n";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -391,7 +391,7 @@ void Error_tag_in_with_scope_2(void) {
     ;
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -413,7 +413,7 @@ void Error_pair_tag_in_with_scope_2(void) {
     ;
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -438,7 +438,7 @@ void Error_component_in_with_scope(void) {
     LINE "\n";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -482,7 +482,7 @@ void Error_component_in_with_scope_2(void) {
     ;
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -514,7 +514,7 @@ void Error_component_in_with_scope_3(void) {
     ;
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -548,7 +548,7 @@ void Error_component_in_with_scope_4(void) {
     ;
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -583,7 +583,7 @@ void Error_component_in_with_scope_5(void) {
     ;
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -619,7 +619,7 @@ void Error_component_in_with_in_template(void) {
     ;
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -655,7 +655,7 @@ void Error_component_in_with_scope_nested(void) {
     LINE "\n";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -681,7 +681,7 @@ void Error_component_in_with_scope_after_entity(void) {
     LINE "";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -707,7 +707,7 @@ void Error_component_in_with_var_scope(void) {
     LINE "";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -743,7 +743,7 @@ void Error_assign_after_with_in_scope(void) {
     LINE "}\n";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "foo");
     test_assert(foo != 0);
@@ -781,7 +781,7 @@ void Error_not_an_array_component(void) {
     LINE "foo { Position: [10, 20] }\n";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -801,7 +801,7 @@ void Error_array_component_w_curly_brackets(void) {
     LINE "foo { Position: {10, 20} }\n";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -819,7 +819,7 @@ void Error_unknown_identifier(void) {
     LINE "Foo { Comp: {A} }";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -837,7 +837,7 @@ void Error_unknown_identifier_for_int_field(void) {
     LINE "Foo { Comp: {A} }";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -849,7 +849,7 @@ void Error_prefab_w_slot_no_parent(void) {
     HEAD "slot Base {}";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -863,7 +863,7 @@ void Error_tag_not_found(void) {
     LINE "}";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -877,7 +877,7 @@ void Error_component_not_found(void) {
     LINE "}";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -893,7 +893,7 @@ void Error_pair_first_not_found(void) {
     LINE "}";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -909,7 +909,7 @@ void Error_pair_second_not_found(void) {
     LINE "}";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -923,7 +923,7 @@ void Error_kind_not_found(void) {
     HEAD "Foo Bar";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -937,7 +937,7 @@ void Error_base_not_found(void) {
     HEAD "Foo : Bar";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -974,7 +974,7 @@ void Error_member_expr_without_value_end_of_scope(void) {
     });
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, "Position(x:)") != 0);
+    test_assert(ecs_script_run(world, NULL, "Position(x:)", NULL) != 0);
 
     ecs_fini(world);
 }
@@ -993,7 +993,7 @@ void Error_member_expr_without_value_comma(void) {
     });
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, "Position(x:,0)") != 0);
+    test_assert(ecs_script_run(world, NULL, "Position(x:,0)", NULL) != 0);
 
     ecs_fini(world);
 }
@@ -1012,7 +1012,7 @@ void Error_member_expr_without_value_newline(void) {
     });
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, "Position(x:\n)") != 0);
+    test_assert(ecs_script_run(world, NULL, "Position(x:\n)", NULL) != 0);
 
     ecs_fini(world);
 }
@@ -1031,7 +1031,7 @@ void Error_2_member_expr_without_value(void) {
     });
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, "Position(x:y:)") != 0);
+    test_assert(ecs_script_run(world, NULL, "Position(x:y:)", NULL) != 0);
 
     ecs_fini(world);
 }
@@ -1050,7 +1050,7 @@ void Error_expr_junk_after_number(void) {
     });
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, "Position(0abc)") != 0);
+    test_assert(ecs_script_run(world, NULL, "Position(0abc)", NULL) != 0);
 
     ecs_fini(world);
 }
@@ -1069,7 +1069,7 @@ void Error_expr_junk_after_unary_minus(void) {
     });
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, "Position(-abc)") != 0);
+    test_assert(ecs_script_run(world, NULL, "Position(-abc)", NULL) != 0);
 
     ecs_fini(world);
 }
@@ -1088,7 +1088,7 @@ void Error_expr_comma_after_nothing(void) {
     });
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, "Position(,)") != 0);
+    test_assert(ecs_script_run(world, NULL, "Position(,)", NULL) != 0);
 
     ecs_fini(world);
 }
@@ -1107,7 +1107,7 @@ void Error_expr_digit_with_two_dots(void) {
     });
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, "Position(10.10.10)") != 0);
+    test_assert(ecs_script_run(world, NULL, "Position(10.10.10)", NULL) != 0);
 
     ecs_fini(world);
 }
@@ -1120,7 +1120,7 @@ void Error_template_empty(void) {
     LINE "}";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t tree = ecs_lookup(world, "Tree");
     test_assert(tree != 0);
@@ -1138,7 +1138,7 @@ void Error_template_unresolved_tag(void) {
     LINE "Tree ent()";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -1157,7 +1157,7 @@ void Error_template_unresolved_component(void) {
     LINE "}";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -1173,7 +1173,7 @@ void Error_template_unresolved_pair_relationship(void) {
     LINE "Tree ent()";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -1189,7 +1189,7 @@ void Error_template_unresolved_pair_target(void) {
     LINE "Tree ent()";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -1205,7 +1205,7 @@ void Error_template_unresolved_with_tag(void) {
     LINE "Tree ent()";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -1225,7 +1225,7 @@ void Error_template_unresolved_with_component(void) {
     LINE "}";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -1242,7 +1242,7 @@ void Error_template_unresolved_with_pair_relationship(void) {
     LINE "Tree ent()";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -1259,7 +1259,7 @@ void Error_template_unresolved_with_pair_target(void) {
     LINE "Tree ent()";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -1276,7 +1276,7 @@ void Error_template_unresolved_tag_in_child(void) {
     LINE "Tree ent()";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -1300,7 +1300,7 @@ void Error_template_prop_no_type(void) {
     LINE "}";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -1327,7 +1327,7 @@ void Error_template_w_composite_prop_invalid_assignment(void) {
     LINE "t { Tree: {pos: {20, 30}} }";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -1345,7 +1345,7 @@ void Error_template_redeclare_prop_as_const(void) {
     LINE "\n";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -1363,7 +1363,7 @@ void Error_template_redeclare_prop_as_prop(void) {
     LINE "\n";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -1381,7 +1381,7 @@ void Error_template_redeclare_const_as_const(void) {
     LINE "\n";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -1401,7 +1401,7 @@ void Error_run_template_after_error(void) {
     LINE "  Fo"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     {
         ecs_entity_t tree = ecs_lookup(world, "Tree");
@@ -1412,7 +1412,7 @@ void Error_run_template_after_error(void) {
     }
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr_err) != 0);
+    test_assert(ecs_script_run(world, NULL, expr_err, NULL) != 0);
     ecs_log_set_level(-1);
 
     /* Because script is not managed, entiites created by script aren't deleted */
@@ -1425,7 +1425,7 @@ void Error_run_template_after_error(void) {
         test_assert(foo != 0);
     }
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     {
         ecs_entity_t tree = ecs_lookup(world, "Tree");
@@ -1499,7 +1499,7 @@ void Error_template_in_template(void) {
     LINE "}";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -1620,7 +1620,7 @@ void Error_template_w_invalid_var_in_expr(void) {
     LINE "}";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -1669,7 +1669,135 @@ void Error_script_initializer_w_int_to_struct(void) {
     LINE "}";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
+
+    ecs_fini(world);
+}
+
+void Error_capture_error(void) {
+    ecs_world_t *world = ecs_init();
+
+    const char *expr =
+    HEAD "Parent {"
+    LINE " Child {}";
+
+    ecs_script_eval_result_t result = {0};
+    ecs_script_t *script = ecs_script_parse(world, "foo", expr, NULL, &result);
+    test_assert(script == NULL);
+    test_assert(result.error != NULL);
+    ecs_os_free(result.error);
+
+    ecs_fini(world);
+}
+
+void Error_unresolved_component_error_w_script_run(void) {
+    ecs_world_t *world = ecs_init();
+
+    const char *expr =
+    HEAD "e {"
+    LINE " Foo: {}"
+    LINE "}";
+
+    ecs_log_set_level(-4);
+
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
+
+    ecs_fini(world);
+}
+
+void Error_unresolved_component_error_w_script_init(void) {
+    ecs_world_t *world = ecs_init();
+
+    const char *expr =
+    HEAD "e {"
+    LINE " Foo: {}"
+    LINE "}";
+
+    ecs_entity_t s = ecs_script(world, {
+        .code = expr
+    });
+
+    test_assert(s == 0);
+
+    ecs_fini(world);
+}
+
+void Error_unresolved_component_error_w_script_init_existing(void) {
+    ecs_world_t *world = ecs_init();
+
+    const char *expr =
+    HEAD "e {"
+    LINE " Foo: {}"
+    LINE "}";
+
+    ecs_entity_t s = ecs_script(world, {
+        .code = ""
+    });
+
+    test_assert(s != 0);
+
+    ecs_entity_t r = ecs_script(world, {
+        .entity = s,
+        .code = expr
+    });
+
+    test_assert(r == 0);
+
+    const EcsScript *script = ecs_get(world, s, EcsScript);
+    test_assert(script != NULL);
+    test_assert(script->script == NULL);
+    test_assert(script->error != NULL);
+
+    ecs_fini(world);
+}
+
+void Error_unresolved_component_error_w_script_eval(void) {
+    ecs_world_t *world = ecs_init();
+
+    const char *expr =
+    HEAD "e {"
+    LINE " Foo: {}"
+    LINE "}";
+
+    ecs_script_eval_result_t result = {0};
+    ecs_script_t *script = ecs_script_parse(world, "foo", expr, NULL, &result);
+
+    test_assert(script != NULL);
+    test_assert(result.error == NULL);
+
+    int r = ecs_script_eval(script, NULL, &result);
+    test_assert(r != 0);
+    test_assert(result.error != NULL);
+    ecs_os_free(result.error);
+
+    ecs_script_free(script);
+
+    ecs_fini(world);
+}
+
+void Error_unresolved_component_error_w_script_eval_multiple_times(void) {
+    ecs_world_t *world = ecs_init();
+
+    const char *expr =
+    HEAD "e {"
+    LINE " Foo: {}"
+    LINE "}";
+
+    ecs_script_eval_result_t result = {0};
+    ecs_script_t *script = ecs_script_parse(world, "foo", expr, NULL, &result);
+    test_assert(script != NULL);
+    test_assert(result.error == NULL);
+
+    int r = ecs_script_eval(script, NULL, &result);
+    test_assert(r != 0);
+    test_assert(result.error != NULL);
+
+    r = ecs_script_eval(script, NULL, &result);
+    test_assert(r != 0);
+    test_assert(result.error != NULL);
+
+    ecs_os_free(result.error);
+    ecs_script_free(script);
 
     ecs_fini(world);
 }

--- a/test/script/src/Error.c
+++ b/test/script/src/Error.c
@@ -1792,6 +1792,8 @@ void Error_unresolved_component_error_w_script_eval_multiple_times(void) {
     test_assert(r != 0);
     test_assert(result.error != NULL);
 
+    ecs_os_free(result.error);
+
     r = ecs_script_eval(script, NULL, &result);
     test_assert(r != 0);
     test_assert(result.error != NULL);

--- a/test/script/src/Eval.c
+++ b/test/script/src/Eval.c
@@ -3,7 +3,7 @@
 void Eval_null(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, NULL) == 0);
+    test_assert(ecs_script_run(world, NULL, NULL, NULL) == 0);
 
     ecs_fini(world);
 }
@@ -11,7 +11,7 @@ void Eval_null(void) {
 void Eval_empty(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, "") == 0);
+    test_assert(ecs_script_run(world, NULL, "", NULL) == 0);
 
     ecs_fini(world);
 }
@@ -19,7 +19,7 @@ void Eval_empty(void) {
 void Eval_space(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, " ") == 0);
+    test_assert(ecs_script_run(world, NULL, " ", NULL) == 0);
 
     ecs_fini(world);
 }
@@ -27,7 +27,7 @@ void Eval_space(void) {
 void Eval_space_newline(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, " \n \n") == 0);
+    test_assert(ecs_script_run(world, NULL, " \n \n", NULL) == 0);
 
     ecs_fini(world);
 }
@@ -35,7 +35,7 @@ void Eval_space_newline(void) {
 void Eval_two_empty_newlines(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, "\n\n") == 0);
+    test_assert(ecs_script_run(world, NULL, "\n\n", NULL) == 0);
 
     ecs_fini(world);
 }
@@ -43,7 +43,7 @@ void Eval_two_empty_newlines(void) {
 void Eval_three_empty_newlines(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, "\n\n\n") == 0);
+    test_assert(ecs_script_run(world, NULL, "\n\n\n", NULL) == 0);
 
     ecs_fini(world);
 }
@@ -51,7 +51,7 @@ void Eval_three_empty_newlines(void) {
 void Eval_newline_trailing_space(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, "\n ") == 0);
+    test_assert(ecs_script_run(world, NULL, "\n ", NULL) == 0);
 
     ecs_fini(world);
 }
@@ -59,7 +59,7 @@ void Eval_newline_trailing_space(void) {
 void Eval_newline_trailing_spaces(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, "\n   ") == 0);
+    test_assert(ecs_script_run(world, NULL, "\n   ", NULL) == 0);
 
     ecs_fini(world);
 }
@@ -67,7 +67,7 @@ void Eval_newline_trailing_spaces(void) {
 void Eval_multiple_trailing_newlines(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, "Foo{}\n\n\n") == 0);
+    test_assert(ecs_script_run(world, NULL, "Foo{}\n\n\n", NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -80,7 +80,7 @@ void Eval_multiple_trailing_newlines(void) {
 void Eval_space_crlf(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, " \r\n \r\n") == 0);
+    test_assert(ecs_script_run(world, NULL, " \r\n \r\n", NULL) == 0);
 
     ecs_fini(world);
 }
@@ -88,7 +88,7 @@ void Eval_space_crlf(void) {
 void Eval_two_empty_crlfs(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, "\r\n\r\n") == 0);
+    test_assert(ecs_script_run(world, NULL, "\r\n\r\n", NULL) == 0);
 
     ecs_fini(world);
 }
@@ -96,7 +96,7 @@ void Eval_two_empty_crlfs(void) {
 void Eval_three_empty_crlfs(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, "\r\n\r\n\r\n") == 0);
+    test_assert(ecs_script_run(world, NULL, "\r\n\r\n\r\n", NULL) == 0);
 
     ecs_fini(world);
 }
@@ -104,7 +104,7 @@ void Eval_three_empty_crlfs(void) {
 void Eval_crlf_trailing_space(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, "\r\n ") == 0);
+    test_assert(ecs_script_run(world, NULL, "\r\n ", NULL) == 0);
 
     ecs_fini(world);
 }
@@ -112,7 +112,7 @@ void Eval_crlf_trailing_space(void) {
 void Eval_crlf_trailing_spaces(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, "\r\n   ") == 0);
+    test_assert(ecs_script_run(world, NULL, "\r\n   ", NULL) == 0);
 
     ecs_fini(world);
 }
@@ -120,7 +120,7 @@ void Eval_crlf_trailing_spaces(void) {
 void Eval_multiple_trailing_crlfs(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, "Foo{}\r\n\r\n\r\n") == 0);
+    test_assert(ecs_script_run(world, NULL, "Foo{}\r\n\r\n\r\n", NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -133,7 +133,7 @@ void Eval_multiple_trailing_crlfs(void) {
 void Eval_entity(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, "Foo{}") == 0);
+    test_assert(ecs_script_run(world, NULL, "Foo{}", NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -146,7 +146,7 @@ void Eval_entity(void) {
 void Eval_entity_newline(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, "Foo{}\n") == 0);
+    test_assert(ecs_script_run(world, NULL, "Foo{}\n", NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -159,7 +159,7 @@ void Eval_entity_newline(void) {
 void Eval_entity_crlf(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, "Foo{}\r\n") == 0);
+    test_assert(ecs_script_run(world, NULL, "Foo{}\r\n", NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -172,7 +172,7 @@ void Eval_entity_crlf(void) {
 void Eval_entity_w_core_name(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, "World{}") == 0);
+    test_assert(ecs_script_run(world, NULL, "World{}", NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup_child(world, 0, "World");
     test_assert(foo != 0);
@@ -186,7 +186,7 @@ void Eval_entity_w_core_name(void) {
 void Eval_2_entities(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, "Foo{}\nBar{}\n") == 0);
+    test_assert(ecs_script_run(world, NULL, "Foo{}\nBar{}\n", NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "Foo");
     test_assert(e != 0);
@@ -198,7 +198,7 @@ void Eval_2_entities(void) {
 void Eval_2_entities_crlf(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, "Foo{}\r\nBar{}\r\n") == 0);
+    test_assert(ecs_script_run(world, NULL, "Foo{}\r\nBar{}\r\n", NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "Foo");
     test_assert(e != 0);
@@ -210,7 +210,7 @@ void Eval_2_entities_crlf(void) {
 void Eval_line_comment(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, "// Foo{}\n") == 0);
+    test_assert(ecs_script_run(world, NULL, "// Foo{}\n", NULL) == 0);
 
     test_assert(ecs_lookup(world, "Foo") == 0);
 
@@ -220,7 +220,7 @@ void Eval_line_comment(void) {
 void Eval_line_comment_before_stmt(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, "// Hello\nFoo {}\n") == 0);
+    test_assert(ecs_script_run(world, NULL, "// Hello\nFoo {}\n", NULL) == 0);
 
     test_assert(ecs_lookup(world, "Hello") == 0);
     test_assert(ecs_lookup(world, "Foo") != 0);
@@ -231,7 +231,7 @@ void Eval_line_comment_before_stmt(void) {
 void Eval_line_comment_after_stmt(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, "Foo{}\n// Hello\n") == 0);
+    test_assert(ecs_script_run(world, NULL, "Foo{}\n// Hello\n", NULL) == 0);
 
     test_assert(ecs_lookup(world, "Hello") == 0);
     test_assert(ecs_lookup(world, "Foo") != 0);
@@ -242,7 +242,7 @@ void Eval_line_comment_after_stmt(void) {
 void Eval_line_comment_between_stmt(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, "Foo{}\n// Hello\nBar{}\n") == 0);
+    test_assert(ecs_script_run(world, NULL, "Foo{}\n// Hello\nBar{}\n", NULL) == 0);
 
     test_assert(ecs_lookup(world, "Hello") == 0);
     test_assert(ecs_lookup(world, "Foo") != 0);
@@ -254,7 +254,7 @@ void Eval_line_comment_between_stmt(void) {
 void Eval_multiple_line_comment(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, "// Hello\n// World\nFoo{}") == 0);
+    test_assert(ecs_script_run(world, NULL, "// Hello\n// World\nFoo{}", NULL) == 0);
 
     test_assert(ecs_lookup(world, "Hello") == 0);
     test_assert(ecs_lookup_child(world, 0, "World") == 0);
@@ -266,7 +266,7 @@ void Eval_multiple_line_comment(void) {
 void Eval_multiple_line_comment_w_newlines(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, "// Hello\n\n// World\n\nFoo{}") == 0);
+    test_assert(ecs_script_run(world, NULL, "// Hello\n\n// World\n\nFoo{}", NULL) == 0);
 
     test_assert(ecs_lookup(world, "Hello") == 0);
     test_assert(ecs_lookup_child(world, 0, "World") == 0);
@@ -278,7 +278,7 @@ void Eval_multiple_line_comment_w_newlines(void) {
 void Eval_line_comment_after_stmt_same_line(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, "Foo{} // Hello\nBar{}\n") == 0);
+    test_assert(ecs_script_run(world, NULL, "Foo{} // Hello\nBar{}\n", NULL) == 0);
 
     test_assert(ecs_lookup(world, "Hello") == 0);
     test_assert(ecs_lookup(world, "Foo") != 0);
@@ -297,7 +297,7 @@ void Eval_line_comment_before_scope_open(void) {
     LINE "}"
     LINE "Foo{}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     test_assert(ecs_lookup(world, "Child") == 0);
 
@@ -326,7 +326,7 @@ void Eval_line_comment_after_newline_before_scope_open(void) {
     LINE "}"
     LINE "Foo{}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     test_assert(ecs_lookup(world, "Child") == 0);
 
@@ -356,7 +356,7 @@ void Eval_line_comment_after_newline_before_newline_scope_open(void) {
     LINE "}"
     LINE "Foo{}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     test_assert(ecs_lookup(world, "Child") == 0);
 
@@ -377,7 +377,7 @@ void Eval_line_comment_after_newline_before_newline_scope_open(void) {
 void Eval_multi_line_comment(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, "/* Foo{} */") == 0);
+    test_assert(ecs_script_run(world, NULL, "/* Foo{} */", NULL) == 0);
 
     test_assert(ecs_lookup(world, "Foo") == 0);
 
@@ -387,7 +387,7 @@ void Eval_multi_line_comment(void) {
 void Eval_multi_line_comment_before_stmt(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, "/* Hello */\nFoo {}") == 0);
+    test_assert(ecs_script_run(world, NULL, "/* Hello */\nFoo {}", NULL) == 0);
 
     test_assert(ecs_lookup(world, "Hello") == 0);
     test_assert(ecs_lookup(world, "Foo") != 0);
@@ -398,7 +398,7 @@ void Eval_multi_line_comment_before_stmt(void) {
 void Eval_multi_line_comment_after_stmt(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, "Foo{}\n/* Hello */") == 0);
+    test_assert(ecs_script_run(world, NULL, "Foo{}\n/* Hello */", NULL) == 0);
 
     test_assert(ecs_lookup(world, "Hello") == 0);
     test_assert(ecs_lookup(world, "Foo") != 0);
@@ -409,7 +409,7 @@ void Eval_multi_line_comment_after_stmt(void) {
 void Eval_multi_line_comment_between_stmt(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, "Foo{}\n /* Hello */ Bar{}\n") == 0);
+    test_assert(ecs_script_run(world, NULL, "Foo{}\n /* Hello */ Bar{}\n", NULL) == 0);
 
     test_assert(ecs_lookup(world, "Hello") == 0);
     test_assert(ecs_lookup(world, "Foo") != 0);
@@ -421,7 +421,7 @@ void Eval_multi_line_comment_between_stmt(void) {
 void Eval_multiple_multi_line_comment(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, "/* Hello *//* World*/ Foo{}") == 0);
+    test_assert(ecs_script_run(world, NULL, "/* Hello *//* World*/ Foo{}", NULL) == 0);
 
     test_assert(ecs_lookup(world, "Hello") == 0);
     test_assert(ecs_lookup_child(world, 0, "World") == 0);
@@ -433,7 +433,7 @@ void Eval_multiple_multi_line_comment(void) {
 void Eval_multiple_multi_line_comment_w_newlines(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, "/* Hello */\n/* World */ Foo{}") == 0);
+    test_assert(ecs_script_run(world, NULL, "/* Hello */\n/* World */ Foo{}", NULL) == 0);
 
     test_assert(ecs_lookup(world, "Hello") == 0);
     test_assert(ecs_lookup_child(world, 0, "World") == 0);
@@ -445,7 +445,7 @@ void Eval_multiple_multi_line_comment_w_newlines(void) {
 void Eval_multi_line_comment_after_stmt_same_line(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, "Foo{} /* Hello */\nBar{}\n") == 0);
+    test_assert(ecs_script_run(world, NULL, "Foo{} /* Hello */\nBar{}\n", NULL) == 0);
 
     test_assert(ecs_lookup(world, "Hello") == 0);
     test_assert(ecs_lookup(world, "Foo") != 0);
@@ -464,7 +464,7 @@ void Eval_multi_line_comment_before_scope_open(void) {
     LINE "}"
     LINE "Foo{}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     test_assert(ecs_lookup(world, "Child") == 0);
 
@@ -493,7 +493,7 @@ void Eval_multi_line_comment_after_newline_before_scope_open(void) {
     LINE "}"
     LINE "Foo{}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     test_assert(ecs_lookup(world, "Child") == 0);
 
@@ -523,7 +523,7 @@ void Eval_multi_line_comment_multiple_lines(void) {
     LINE ""
     LINE "Bar {}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     test_assert(ecs_lookup(world, "Foo") != 0);
     test_assert(ecs_lookup(world, "Bar") != 0);
@@ -544,7 +544,7 @@ void Eval_hierarchy_1_child(void) {
     LINE " Child {}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     test_assert(ecs_lookup(world, "Child") == 0);
 
@@ -568,7 +568,7 @@ void Eval_hierarchy_2_children(void) {
     LINE " ChildB{}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     test_assert(ecs_lookup(world, "ChildA") == 0);
     test_assert(ecs_lookup(world, "ChildB") == 0);
@@ -593,7 +593,7 @@ void Eval_hierarchy_1_child_same_line(void) {
     const char *expr =
     HEAD "Parent { Child{} }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     test_assert(ecs_lookup(world, "Child") == 0);
 
@@ -614,7 +614,7 @@ void Eval_hierarchy_2_children_same_line(void) {
     const char *expr =
     HEAD "Parent { ChildA, ChildB, }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     test_assert(ecs_lookup(world, "ChildA") == 0);
     test_assert(ecs_lookup(world, "ChildB") == 0);
@@ -639,7 +639,7 @@ void Eval_hierarchy_2_children_same_line_no_trailing_comma(void) {
     const char *expr =
     HEAD "Parent { ChildA, ChildB }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     test_assert(ecs_lookup(world, "ChildA") == 0);
     test_assert(ecs_lookup(world, "ChildB") == 0);
@@ -667,7 +667,7 @@ void Eval_entity_after_hierarchy(void) {
     LINE "}"
     LINE "Foo{}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     test_assert(ecs_lookup(world, "Child") == 0);
 
@@ -696,7 +696,7 @@ void Eval_newline_before_scope_open(void) {
     LINE "}"
     LINE "Foo{}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     test_assert(ecs_lookup(world, "Child") == 0);
 
@@ -721,7 +721,7 @@ void Eval_newline_w_whitespace_before_scope_open(void) {
     LINE "}"
     LINE "Foo{}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     test_assert(ecs_lookup(world, "Child") == 0);
 
@@ -747,7 +747,7 @@ void Eval_2_newline_before_scope_open(void) {
     LINE "}"
     LINE "Foo{}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     test_assert(ecs_lookup(world, "Child") == 0);
 
@@ -773,7 +773,7 @@ void Eval_2_newline_w_whitespace_before_scope_open(void) {
     LINE "}"
     LINE "Foo{}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     test_assert(ecs_lookup(world, "Child") == 0);
 
@@ -798,7 +798,7 @@ void Eval_hierarchy_2_levels(void) {
     LINE " }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     test_assert(ecs_lookup(world, "Child") == 0);
     test_assert(ecs_lookup(world, "GrandChild") == 0);
@@ -830,7 +830,7 @@ void Eval_hierarchy_2_levels_2_subtrees(void) {
     LINE " }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     test_assert(ecs_lookup(world, "ChildA") == 0);
     test_assert(ecs_lookup(world, "ChildB") == 0);
@@ -868,7 +868,7 @@ void Eval_create_in_scope(void) {
     const char *expr =
     HEAD "Parent { Child{} }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     test_assert(ecs_get_scope(world) == Root);
 
@@ -898,7 +898,7 @@ void Eval_hierarchy_w_pred_subj(void) {
     LINE " Child{}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     test_assert(ecs_lookup(world, "Child") == 0);
 
@@ -924,7 +924,7 @@ void Eval_hierarchy_custom_relation(void) {
     LINE " Child{}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -958,7 +958,7 @@ void Eval_hierarchy_custom_relation_2_levels(void) {
     LINE "  }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -1008,7 +1008,7 @@ void Eval_entity_after_hierarchy_custom_relation(void) {
     LINE "}"
     LINE "Hello{}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -1047,7 +1047,7 @@ void Eval_entity_after_hierarchy_custom_relation_2_levels(void) {
     LINE "}"
     LINE "TestB{}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -1110,7 +1110,7 @@ void Eval_hierarchy_custom_relation_apply_to_object(void) {
     LINE " }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t rel = ecs_lookup(world, "Rel");
     ecs_entity_t obj_a = ecs_lookup(world, "ObjA");
@@ -1141,7 +1141,7 @@ void Eval_hierarchy_custom_relation_apply_to_object_2_levels(void) {
     LINE " }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t rel = ecs_lookup(world, "Rel");
     ecs_entity_t obj_a = ecs_lookup(world, "ObjA");
@@ -1175,7 +1175,7 @@ void Eval_with_tag(void) {
     LINE "  Foo{}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t tag = ecs_lookup(world, "Tag");
@@ -1199,7 +1199,7 @@ void Eval_with_tag_2_entities(void) {
     LINE "  Bar{}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -1223,7 +1223,7 @@ void Eval_with_tag_same_line(void) {
     const char *expr =
     HEAD "with Tag { Foo{} }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t tag = ecs_lookup(world, "Tag");
@@ -1244,7 +1244,7 @@ void Eval_with_tag_2_entities_same_line(void) {
     const char *expr =
     HEAD "with Tag { Foo, Bar, }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -1268,7 +1268,7 @@ void Eval_with_tag_2_entities_same_line_no_trailing_comma(void) {
     const char *expr =
     HEAD "with Tag { Foo, Bar }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -1297,7 +1297,7 @@ void Eval_with_tag_2_levels(void) {
     LINE " }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t tag_a = ecs_lookup(world, "TagA");
@@ -1332,7 +1332,7 @@ void Eval_with_tag_2_levels_2_subtrees(void) {
     LINE " }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t tag_a = ecs_lookup(world, "TagA");
@@ -1375,7 +1375,7 @@ void Eval_with_n_tags(void) {
     LINE " Bar {}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -1421,7 +1421,7 @@ void Eval_with_n_tags_2_levels(void) {
     LINE "}"
     LINE "HelloC {}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t tag_a = ecs_lookup(world, "TagA");
     ecs_entity_t tag_b = ecs_lookup(world, "TagB");
@@ -1514,7 +1514,7 @@ void Eval_with_after_scope(void) {
     LINE "  E4 { }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e1 = ecs_lookup(world, "E1");
     ecs_entity_t e2 = ecs_lookup(world, "E2");
@@ -1550,7 +1550,7 @@ void Eval_with_after_with(void) {
     LINE "  E4 { }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e1 = ecs_lookup(world, "E1");
     ecs_entity_t e2 = ecs_lookup(world, "E2");
@@ -1587,7 +1587,7 @@ void Eval_scope_inside_with_inside_scope(void) {
     LINE "  }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t sun = ecs_lookup(world, "Sun");
     ecs_entity_t planet = ecs_lookup(world, "Planet");
@@ -1626,7 +1626,7 @@ void Eval_with_tag_core_name(void) {
     LINE "  Hello {}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t hello = ecs_lookup(world, "Hello");
     test_assert(hello != 0);
@@ -1648,7 +1648,7 @@ void Eval_with_inside_scope(void) {
     LINE "  Europe {}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t earth = ecs_lookup(world, "Earth");
     ecs_entity_t continent = ecs_lookup(world, "Continent");
@@ -1674,7 +1674,7 @@ void Eval_inherit(void) {
     const char *expr =
     HEAD "Foo : Bar";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -1695,7 +1695,7 @@ void Eval_inherit_newline(void) {
     const char *expr =
     HEAD "Foo : Bar\n";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -1716,7 +1716,7 @@ void Eval_inherit_w_colon(void) {
     const char *expr =
     HEAD "Foo : Bar {}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -1737,7 +1737,7 @@ void Eval_inherit_w_colon_w_scope(void) {
     const char *expr =
     HEAD "Foo : Bar { Child{} }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -1767,7 +1767,7 @@ void Eval_assign_component_w_value(void) {
     const char *expr =
     HEAD "Foo = Position: {10, 20}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     ecs_entity_t foo = ecs_lookup(world, "Foo");
 
     test_assert(foo != 0);
@@ -1793,7 +1793,7 @@ void Eval_assign_tag_in_assign_scope(void) {
     LINE "  Bar"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -1812,7 +1812,7 @@ void Eval_assign_tag_in_assign_scope_same_line(void) {
     const char *expr =
     HEAD "Foo { Bar }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -1831,7 +1831,7 @@ void Eval_assign_tag_in_assign_scope_core_name(void) {
     LINE "  World"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t hello = ecs_lookup(world, "Hello");
     test_assert(hello != 0);
@@ -1856,7 +1856,7 @@ void Eval_assign_component_value_in_assign_scope(void) {
     LINE "  Position: {10, 20}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     ecs_entity_t foo = ecs_lookup(world, "Foo");
 
     test_assert(foo != 0);
@@ -1897,7 +1897,7 @@ void Eval_assign_2_component_values_in_assign_scope(void) {
     LINE " Velocity:{1, 2}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     ecs_entity_t foo = ecs_lookup(world, "Foo");
 
     test_assert(foo != 0);
@@ -1935,7 +1935,7 @@ void Eval_type_and_assign_in_plecs(void) {
     LINE "  Position: {10, 20}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     ecs_entity_t ecs_id(Position) = ecs_lookup(world, "Position");
     ecs_entity_t foo = ecs_lookup(world, "Foo");
 
@@ -1967,7 +1967,7 @@ void Eval_type_and_assign_in_plecs_w_2_members(void) {
     LINE "  Position: {x: 10, y: 20}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     ecs_entity_t ecs_id(Position) = ecs_lookup(world, "Position");
     ecs_entity_t foo = ecs_lookup(world, "Foo");
 
@@ -2006,7 +2006,7 @@ void Eval_type_and_assign_in_plecs_w_3_members(void) {
     LINE "  Position: {x: 10, y: 20, z: 30}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     ecs_entity_t ecs_id(Position3D) = ecs_lookup(world, "Position");
     ecs_entity_t foo = ecs_lookup(world, "Foo");
 
@@ -2052,7 +2052,7 @@ void Eval_type_and_assign_in_plecs_w_enum(void) {
     LINE "  SomeType: {value: Blue}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     ecs_entity_t ecs_id(SomeType) = ecs_lookup(world, "SomeType");
     ecs_entity_t foo = ecs_lookup(world, "Foo");
 
@@ -2096,7 +2096,7 @@ void Eval_type_and_assign_in_plecs_w_enum_using_meta(void) {
     LINE
     LINE "Foo { SomeType: {value: Blue} }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     ecs_entity_t ecs_id(SomeType) = ecs_lookup(world, "SomeType");
     ecs_entity_t foo = ecs_lookup(world, "Foo");
 
@@ -2139,7 +2139,7 @@ void Eval_type_and_assign_in_plecs_w_enum_primitive_using_meta(void) {
     LINE ""
     LINE "Foo { Color: {Blue} }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     ecs_entity_t ecs_id(Color) = ecs_lookup(world, "Color");
     ecs_entity_t foo = ecs_lookup(world, "Foo");
 
@@ -2191,7 +2191,7 @@ void Eval_type_and_assign_in_plecs_w_enum_primitive_and_struct(void) {
     LINE "  Color: {Green}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     ecs_entity_t ecs_id(Position) = ecs_lookup(world, "Position");
     ecs_entity_t ecs_id(Color) = ecs_lookup(world, "Color");
     ecs_entity_t foo = ecs_lookup(world, "Foo");
@@ -2258,7 +2258,7 @@ void Eval_type_and_assign_in_plecs_nested_member(void) {
     LINE
     LINE "l { Line: {start: {x: 10, y: 20}, stop: {x: 30, y: 40}} }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     ecs_entity_t ecs_id(Line) = ecs_lookup(world, "Line");
     ecs_entity_t l = ecs_lookup(world, "l");
 
@@ -2311,7 +2311,7 @@ void Eval_dot_assign_nested_member(void) {
     LINE
     LINE "l { Line: {start.x: 10, start.y: 20, stop.x: 30, stop.y: 40} }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     ecs_entity_t ecs_id(Line) = ecs_lookup(world, "Line");
     ecs_entity_t l = ecs_lookup(world, "l");
 
@@ -2363,7 +2363,7 @@ void Eval_dot_assign_binary_expr(void) {
     LINE
     LINE "l { Line: {start.x: 2 + 8, start.y: 5 + 15, stop.x: 10 + 20, stop.y: 15 + 25} }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     ecs_entity_t ecs_id(Line) = ecs_lookup(world, "Line");
     ecs_entity_t l = ecs_lookup(world, "l");
 
@@ -2399,7 +2399,7 @@ void Eval_open_scope_no_parent(void) {
     LINE "}"
     LINE "Hello {}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Foo.Bar");
     ecs_entity_t zoo = ecs_lookup(world, "Zoo");
@@ -2428,7 +2428,7 @@ void Eval_create_subject_in_root_scope_w_resolvable_id(void) {
     const char *expr =
     HEAD "Tag {}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     ecs_entity_t tag = ecs_lookup_child(world, 0, "Tag");
     test_assert(tag != 0);
     test_assert(tag != EcsPairIsTag);
@@ -2444,7 +2444,7 @@ void Eval_create_subject_in_scope_w_resolvable_id(void) {
     LINE "  Tag {}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
 
@@ -2471,7 +2471,7 @@ void Eval_create_subject_in_scope_w_resolvable_id_using(void) {
     LINE
     LINE "Hello Bar {}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Foo.Bar");
     ecs_entity_t root_bar = ecs_lookup(world, "Bar");
@@ -2502,7 +2502,7 @@ void Eval_using_scope(void) {
     LINE "Bar Hello {}"
     LINE "Foo.Bar World {}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Foo.Bar");
     ecs_entity_t not_bar = ecs_lookup(world, "Bar");
@@ -2538,7 +2538,7 @@ void Eval_using_nested_scope(void) {
     LINE "Zoo Hello {}"
     LINE "Foo.Bar.Zoo World {}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Foo.Bar");
     ecs_entity_t zoo = ecs_lookup(world, "Foo.Bar.Zoo");
@@ -2581,7 +2581,7 @@ void Eval_using_nested_in_scope(void) {
     LINE "}"
     LINE "Zoo World {}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Foo.Bar");
     ecs_entity_t zoo = ecs_lookup(world, "Foo.Bar.Zoo");
@@ -2626,7 +2626,7 @@ void Eval_using_with_scope(void) {
     LINE ""
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     ecs_entity_t scope = ecs_lookup(world, "Scope");
     ecs_entity_t foo = ecs_lookup(world, "Scope.Foo");
     ecs_entity_t bar = ecs_lookup(world, "Scope.Bar");
@@ -2663,7 +2663,7 @@ void Eval_using_w_entity_ref_in_value_2_members(void) {
     LINE ""
     LINE "Foo { Position: {x: 10, y: 20} }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     ecs_entity_t ecs_id(Position) = ecs_lookup(world, "Position");
     ecs_entity_t foo = ecs_lookup(world, "Foo");
 
@@ -2702,7 +2702,7 @@ void Eval_using_w_entity_ref_in_value_3_members(void) {
     LINE
     LINE "Foo { Position: {x: 10, y: 20, z: 30} }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     ecs_entity_t ecs_id(Position3D) = ecs_lookup(world, "Position");
     ecs_entity_t foo = ecs_lookup(world, "Foo");
 
@@ -2725,7 +2725,7 @@ void Eval_using_w_entity_ref_in_value_3_members(void) {
 void Eval_script_w_only_using(void) {
     ecs_world_t *world = ecs_init();
 
-    test_assert(ecs_script_run(world, NULL, "using flecs") == 0);
+    test_assert(ecs_script_run(world, NULL, "using flecs", NULL) == 0);
 
     ecs_fini(world);
 }
@@ -2748,7 +2748,7 @@ void Eval_2_using_scope(void) {
     LINE "Hello E1 {}"
     LINE "TheWorld E2 {}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t hello = ecs_lookup(world, "Foo.Hello");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -2808,7 +2808,7 @@ void Eval_2_using_in_different_scope(void) {
     LINE "TheWorld RootChild {}"
     LINE;
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t hello = ecs_lookup(world, "Foo.Hello");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -2870,7 +2870,7 @@ void Eval_scope_after_assign(void) {
     LINE "  Bar {}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Foo.Bar");
@@ -2902,7 +2902,7 @@ void Eval_assign_after_inherit(void) {
     HEAD "Foo : Position {}"
     LINE "Bar { Position: {10, 20} }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -2933,7 +2933,7 @@ void Eval_multiple_tags_single_line(void) {
     const char *expr =
     HEAD "Foo { Hello; Bar }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -2960,7 +2960,7 @@ void Eval_multiple_pairs_single_line(void) {
     const char *expr =
     HEAD "Foo { (Rel, Hello); (Rel, Bar) }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -3002,7 +3002,7 @@ void Eval_multiple_assignments_single_line(void) {
     const char *expr =
     HEAD "Foo { Position: {10, 20}; Velocity: {1, 2} }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -3048,7 +3048,7 @@ void Eval_multiple_vars_single_line(void) {
     LINE "const vel = Velocity: {1, 2}"
     LINE "Foo { $pos; $vel }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -3081,7 +3081,7 @@ void Eval_2_stmts_in_scope_w_no_parent(void) {
     LINE "Foo { Tag }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -3120,7 +3120,7 @@ void Eval_empty_scope_after_using(void) {
     LINE "  Foo { Tag }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert( foo == 0);
@@ -3144,7 +3144,7 @@ void Eval_assign_tag_to_parent(void) {
     LINE "  Child {}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -3179,7 +3179,7 @@ void Eval_assign_component_to_parent(void) {
     LINE "  Child {}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t child = ecs_lookup(world, "Foo.Child");
@@ -3211,7 +3211,7 @@ void Eval_assign_to_parent_pair_w_new_entities_in_scope(void) {
     LINE "  (Rel, Obj)"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t rel = ecs_lookup(world, "Rel");
@@ -3237,7 +3237,7 @@ void Eval_assign_to_parent_pair_w_existing_entities_in_scope(void) {
     LINE "  (Rel, Obj)"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t rel = ecs_lookup(world, "Rel");
@@ -3265,7 +3265,7 @@ void Eval_default_child_component(void) {
     LINE "  ChildB"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -3313,7 +3313,7 @@ void Eval_default_child_component_w_assign(void) {
     LINE "  ChildB = 10, 20"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     
@@ -3353,7 +3353,7 @@ void Eval_struct_type_w_default_child_component(void) {
     LINE "}"
     LINE "Foo { Position: {x: 10, y: 20} }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t ecs_id(Position) = ecs_lookup(world, "Position");
@@ -3412,7 +3412,7 @@ void Eval_struct_type_w_default_child_component_nested_member(void) {
     LINE
     LINE "Foo { Line: {start: {10, 20}, stop: {30, 40}} }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t ecs_id(Line) = ecs_lookup(world, "Line");
@@ -3448,7 +3448,7 @@ void Eval_enum_type_w_default_child_component(void) {
     LINE
     LINE "Foo { Color: {Green} }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t ecs_id(Color) = ecs_lookup(world, "Color");
@@ -3482,7 +3482,7 @@ void Eval_default_type_from_with(void) {
     LINE "  e2 = 30, 40"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e1 = ecs_lookup(world, "e1");
     ecs_entity_t e2 = ecs_lookup(world, "e2");
@@ -3532,7 +3532,7 @@ void Eval_default_type_from_nested_with(void) {
     LINE "  e4 = 3, 4"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e1 = ecs_lookup(world, "e1");
     ecs_entity_t e2 = ecs_lookup(world, "e2");
@@ -3597,7 +3597,7 @@ void Eval_default_type_from_with_in_entity_scope_w_default_type(void) {
     LINE "  e4 = 2, 3"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e1 = ecs_lookup(world, "Bar.e1");
     ecs_entity_t e2 = ecs_lookup(world, "Bar.e2");
@@ -3665,7 +3665,7 @@ void Eval_default_type_from_entity_scope_in_with(void) {
     LINE "}"
     LINE "e3 = Velocity: {1, 2}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e1 = ecs_lookup(world, "e1");
     ecs_entity_t e2 = ecs_lookup(world, "e2");
@@ -3710,7 +3710,7 @@ void Eval_scope_w_1_subj_and_2_pairs(void) {
     LINE " Foo { (RelB, Bar) }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t parent = ecs_lookup(world, "Parent");
     ecs_entity_t rel_a = ecs_lookup(world, "RelA");
@@ -3739,7 +3739,7 @@ void Eval_inherit_from_multiple(void) {
     const char *expr =
     HEAD "Inst : Foo, Bar {}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t inst = ecs_lookup(world, "Inst");
     ecs_entity_t foo = ecs_lookup(world, "Foo");
@@ -3770,7 +3770,7 @@ void Eval_assign_pair_component(void) {
     LINE
     LINE "Foo { (Position, Bar): {x: 10, y: 20} }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -3809,7 +3809,7 @@ void Eval_assign_pair_component_in_scope(void) {
     LINE "  (Position, Bar): {x: 20, y: 30}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t parent = ecs_lookup(world, "Parent");
     ecs_entity_t foo = ecs_lookup(world, "Foo");
@@ -3937,7 +3937,7 @@ void Eval_assign_pair_component_w_newline(void) {
     LINE "  (Position, Bar): {\nx: 20,\n y: 30\n}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t parent = ecs_lookup(world, "Parent");
     ecs_entity_t foo = ecs_lookup(world, "Foo");
@@ -3985,7 +3985,7 @@ void Eval_assign_pair_component_w_newline_and_spaces(void) {
     LINE "  (Position, Bar): {  \nx: 20,\n y: 30  \n}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t parent = ecs_lookup(world, "Parent");
     ecs_entity_t foo = ecs_lookup(world, "Foo");
@@ -4033,7 +4033,7 @@ void Eval_assign_pair_component_w_empty(void) {
     LINE "  (Position, Bar): {}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t parent = ecs_lookup(world, "Parent");
     ecs_entity_t foo = ecs_lookup(world, "Foo");
@@ -4081,7 +4081,7 @@ void Eval_assign_pair_component_w_newline_empty(void) {
     LINE "  (Position, Bar): {\n}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t parent = ecs_lookup(world, "Parent");
     ecs_entity_t foo = ecs_lookup(world, "Foo");
@@ -4129,7 +4129,7 @@ void Eval_assign_pair_component_w_newline_and_spaces_empty(void) {
     LINE "  (Position, Bar): {\n }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t parent = ecs_lookup(world, "Parent");
     ecs_entity_t foo = ecs_lookup(world, "Foo");
@@ -4175,7 +4175,7 @@ void Eval_assign_pair_component_after_component(void) {
     LINE "  (Position, Bar): {x: 20, y: 30}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t parent = ecs_lookup(world, "Parent");
     ecs_entity_t foo = ecs_lookup(world, "Foo");
@@ -4221,7 +4221,7 @@ void Eval_assign_pair_component_after_int_component(void) {
     LINE "  (Position, Bar): {x: 20, y: 30}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t parent = ecs_lookup(world, "Parent");
     ecs_entity_t foo = ecs_lookup(world, "Foo");
@@ -4269,7 +4269,7 @@ void Eval_assign_pair_component_after_entity_component(void) {
     LINE "  (Position, Bar): {x: 20, y: 30}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t parent = ecs_lookup(world, "Parent");
     ecs_entity_t foo = ecs_lookup(world, "Foo");
@@ -4312,7 +4312,7 @@ void Eval_set_entity_names(void) {
     LINE "foo down {}"
     LINE "foo up {}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t self = ecs_lookup(world, "self");
     ecs_entity_t down = ecs_lookup(world, "down");
@@ -4347,7 +4347,7 @@ void Eval_oneof(void) {
     LINE "}"
     LINE "e { (Color, Green) }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t color = ecs_lookup(world, "Color");
     ecs_entity_t green = ecs_lookup(world, "Color.Green");
@@ -4376,7 +4376,7 @@ void Eval_brief_annotation(void) {
     LINE "@brief Another description"
     LINE "Baz {}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -4404,7 +4404,7 @@ void Eval_name_annotation(void) {
     LINE "@name Another name"
     LINE "Baz {}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -4432,7 +4432,7 @@ void Eval_link_annotation(void) {
     LINE "@link Another link"
     LINE "Baz {}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -4460,7 +4460,7 @@ void Eval_color_annotation(void) {
     LINE "@color rgb(10, 20, 30, 1.0)"
     LINE "Baz {}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -4492,7 +4492,7 @@ void Eval_multiple_annotations(void) {
     LINE "@name Another name"
     LINE "Baz {}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -4520,7 +4520,7 @@ void Eval_annotation_w_trailing_space(void) {
     HEAD "@brief   A description  "
     LINE "Foo {}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -4551,7 +4551,7 @@ void Eval_multiline_string(void) {
     LINE "Special characters }\\{\"\"'',"
     LINE "`}}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -4579,7 +4579,7 @@ void Eval_annotate_declaration(void) {
     HEAD "@brief A brief description"
     LINE "Foo Bar";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -4604,7 +4604,7 @@ void Eval_declaration_w_underscore_name(void) {
     const char *expr =
     HEAD "Foo _Bar";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -4626,7 +4626,7 @@ void Eval_anonymous_entity(void) {
     const char *expr =
     HEAD "_ { Foo }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -4652,7 +4652,7 @@ void Eval_anonymous_entity_in_scope(void) {
     LINE "  _ { Foo }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -4679,7 +4679,7 @@ void Eval_anonymous_declaration(void) {
     const char *expr =
     HEAD "Foo _";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -4712,7 +4712,7 @@ void Eval_const_var_int(void) {
     LINE ""
     LINE "e { Position: {$var_x, $var_y} }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e");
     test_assert(e != 0);
@@ -4744,7 +4744,7 @@ void Eval_const_var_int_deprecated_notation(void) {
     LINE "e { Position: {$var_x, $var_y} }";
 
     ecs_log_set_level(-3);
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     ecs_log_set_level(-1);
 
     ecs_entity_t e = ecs_lookup(world, "e");
@@ -4776,7 +4776,7 @@ void Eval_const_var_float(void) {
     LINE ""
     LINE "e { Position: {$var_x, $var_y} }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e");
     test_assert(e != 0);
@@ -4812,7 +4812,7 @@ void Eval_const_var_bool(void) {
     LINE ""
     LINE "e { Bools: {$var_x, $var_y} }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e");
     test_assert(e != 0);
@@ -4843,7 +4843,7 @@ void Eval_const_var_string(void) {
     LINE ""
     LINE "e { Position: {$var_x, $var_y} }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e");
     test_assert(e != 0);
@@ -4882,7 +4882,7 @@ void Eval_const_var_struct(void) {
     LINE ""
     LINE "e { Line: {start: $var_start, stop: $var_stop} }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e");
     test_assert(e != 0);
@@ -4922,7 +4922,7 @@ void Eval_const_var_scoped(void) {
     LINE "  c { Position: {$var_x, $var_y} }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t a = ecs_lookup(world, "a");
     test_assert(a != 0);
@@ -4970,7 +4970,7 @@ void Eval_assign_component_from_var(void) {
     LINE "a { $var_pos }"
     LINE "";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t var = ecs_lookup(world, "var_pos");
     test_assert(var == 0);
@@ -5004,7 +5004,7 @@ void Eval_assign_component_from_var_in_scope(void) {
     LINE "}"
     LINE "";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t var = ecs_lookup(world, "var_pos");
     test_assert(var == 0);
@@ -5037,7 +5037,7 @@ void Eval_scope_w_component_after_const_var(void) {
     LINE "  Position: {x: 10, y: $var}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -5068,7 +5068,7 @@ void Eval_component_after_const_add_expr(void) {
     LINE "  Position: {x: 10, y: $var}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -5099,7 +5099,7 @@ void Eval_component_after_const_sub_expr(void) {
     LINE "  Position: {x: 10, y: $var}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -5130,7 +5130,7 @@ void Eval_component_after_const_mul_expr(void) {
     LINE "  Position: {x: 10, y: $var}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -5161,7 +5161,7 @@ void Eval_component_after_const_div_expr(void) {
     LINE "  Position: {x: 10, y: $var}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -5194,7 +5194,7 @@ void Eval_component_after_const_paren_expr(void) {
     LINE "  Position: {$val, $val * 2}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e");
     test_assert(e != 0);
@@ -5220,7 +5220,7 @@ void Eval_parse_with(void) {
     ECS_TAG(world, Tag);
 
     ecs_set_with(world, Tag);
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     ecs_set_with(world, 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
@@ -5253,7 +5253,7 @@ void Eval_parse_with_w_with(void) {
     LINE "}";
 
     ecs_set_with(world, TagA);
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     ecs_set_with(world, 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
@@ -5292,7 +5292,7 @@ void Eval_parse_with_w_tag(void) {
     LINE "}";
 
     ecs_set_with(world, TagA);
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     ecs_set_with(world, 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
@@ -5335,7 +5335,7 @@ void Eval_parse_with_value(void) {
     LINE "  Bar {}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -5388,7 +5388,7 @@ void Eval_parse_with_2_values(void) {
     LINE "  Bar {}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -5455,7 +5455,7 @@ void Eval_parse_with_2_nested_values(void) {
     LINE "  }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -5512,7 +5512,7 @@ void Eval_parse_with_var(void) {
     LINE "  Bar {}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -5566,7 +5566,7 @@ void Eval_parse_with_2_vars(void) {
     LINE "  Bar {}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -5635,7 +5635,7 @@ void Eval_parse_with_2_nested_vars(void) {
     LINE "  }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -5694,7 +5694,7 @@ void Eval_parse_with_var_in_scope(void) {
     LINE "  }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t parent = ecs_lookup(world, "Parent");
     ecs_entity_t foo = ecs_lookup(world, "Parent.Foo");
@@ -5736,7 +5736,7 @@ void Eval_assign_const_w_expr(void) {
     LINE "const var: 5 + 1"
     LINE "e { Position: {x: $var, y: $var * 2} }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e");
     test_assert(e != 0);
@@ -5765,7 +5765,7 @@ void Eval_const_w_type(void) {
     LINE "const var = flecs.meta.i32: 5 / 2"
     LINE "e { Position: {x: $var, y: $var * 3} }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e");
     test_assert(e != 0);
@@ -5795,7 +5795,7 @@ void Eval_typed_const_w_composite_type(void) {
     LINE "a { $var_pos }"
     LINE "";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t var = ecs_lookup(world, "var_pos");
     test_assert(var == 0);
@@ -5828,7 +5828,7 @@ void Eval_assign_var_to_typed_const_w_composite_type(void) {
     LINE "a { $var_pos_b }"
     LINE "";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t var = ecs_lookup(world, "var_pos");
     test_assert(var == 0);
@@ -5878,7 +5878,7 @@ void Eval_using_wildcard(void) {
     LINE "using foo.*\n"
     LINE "e { Position: {10, 20} }\n"
     LINE "e { Velocity: {1, 2} }\n";
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t pos = ecs_lookup(world, "foo.p1.Position");
     test_assert(pos == ecs_id(Position));
@@ -5925,7 +5925,7 @@ void Eval_single_line_comment_in_value(void) {
     LINE "  //foo\n"
     LINE "  y: 20\n"
     LINE "}}";
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e");
     test_assert(e != 0);
@@ -5959,7 +5959,7 @@ void Eval_single_line_comment_in_value_after_scope(void) {
     LINE "  x: 10\n"
     LINE "  y: 20\n"
     LINE "}}";
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e");
     test_assert(e != 0);
@@ -5995,7 +5995,7 @@ void Eval_multi_line_comment_in_value(void) {
     LINE "   */\n"
     LINE "  y: 20\n"
     LINE "}}";
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e");
     test_assert(e != 0);
@@ -6031,7 +6031,7 @@ void Eval_multi_line_comment_in_value_after_scope(void) {
     LINE "  x: 10\n"
     LINE "  y: 20\n"
     LINE "}}";
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e");
     test_assert(e != 0);
@@ -6064,7 +6064,7 @@ void Eval_module_stmt(void) {
     LINE "Foo {}\n"
     LINE "e { Position: {10, 20} }\n"
     LINE "e { Foo }\n";
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     test_assert(ecs_get_scope(world) == 0);
 
     ecs_entity_t hello = ecs_lookup(world, "hello");
@@ -6107,7 +6107,7 @@ void Eval_nested_module_stmt(void) {
     LINE "Foo {}\n"
     LINE "e { Position: {10, 20} }\n"
     LINE "e { Foo }\n";
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t hello = ecs_lookup(world, "hello");
     test_assert(hello != 0);
@@ -6157,7 +6157,7 @@ void Eval_module_stmt_w_scope(void) {
     LINE "f { Position: {30, 40} }\n"
     LINE "f { Foo }\n"
     LINE "";
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t hello = ecs_lookup(world, "hello");
     test_assert(hello != 0);
@@ -6221,7 +6221,7 @@ void Eval_module_stmt_w_nested_scope(void) {
     LINE "f { Position: {30, 40} }\n"
     LINE "f { Foo }\n"
     LINE "";
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t hello = ecs_lookup(world, "hello");
     test_assert(hello != 0);
@@ -6269,7 +6269,7 @@ void Eval_assign_singleton_tag(void) {
 
     const char *expr =
     LINE "$ { Foo }\n";
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -6294,7 +6294,7 @@ void Eval_assign_singleton_component(void) {
 
     const char *expr =
     LINE "$ = Position: {10, 20}\n";
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     test_assert(ecs_has(world, ecs_id(Position), Position));
 
@@ -6315,7 +6315,7 @@ void Eval_assign_singleton_tag_w_scope(void) {
     LINE "$ {\n"
     LINE "  Foo\n"
     LINE "}\n";
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -6336,7 +6336,7 @@ void Eval_assign_singleton_2_tags_w_scope(void) {
     LINE "  Foo\n"
     LINE "  Bar\n"
     LINE "}\n";
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -6366,7 +6366,7 @@ void Eval_assign_singleton_component_w_scope(void) {
     LINE "$ {\n"
     LINE "  Position: {10, 20}\n"
     LINE "}\n";
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     test_assert(ecs_has(world, ecs_id(Position), Position));
 
@@ -6405,7 +6405,7 @@ void Eval_assign_singleton_2_components_w_scope(void) {
     LINE "  Position: {10, 20}\n"
     LINE "  Velocity: {1, 2}\n"
     LINE "}\n";
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     const Position *p = ecs_get(world, ecs_id(Position), Position);
     test_assert(p != NULL);
@@ -6433,7 +6433,7 @@ void Eval_with_pair_in_scope(void) {
     LINE "  }\n"
     LINE "}\n";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t parent = ecs_lookup(world, "Parent");
     ecs_entity_t child = ecs_lookup(world, "Parent.Child");
@@ -6473,7 +6473,7 @@ void Eval_with_pair_component_in_scope(void) {
     LINE "  }\n"
     LINE "}\n";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t parent = ecs_lookup(world, "Parent");
     ecs_entity_t child = ecs_lookup(world, "Parent.Child");
@@ -6509,7 +6509,7 @@ void Eval_pair_w_rel_var(void) {
     LINE "}\n"
     LINE "\n";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t ent = ecs_lookup(world, "ent");
 
@@ -6531,7 +6531,7 @@ void Eval_pair_w_tgt_var(void) {
     LINE "}\n"
     LINE "\n";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t ent = ecs_lookup(world, "ent");
 
@@ -6553,7 +6553,7 @@ void Eval_array_component(void) {
 
     const char *expr =
     LINE "foo { Position: [10, 20] }\n";
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "foo");
     test_assert(foo != 0);
@@ -6597,7 +6597,7 @@ void Eval_on_set_w_kind_paren_no_reflection(void) {
 
     test_int(on_set_position_invoked, 0);
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e");
     test_assert(e != 0);
@@ -6634,7 +6634,7 @@ void Eval_on_set_w_kind_paren(void) {
 
     test_int(on_set_position_invoked, 0);
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e");
     test_assert(e != 0);
@@ -6671,7 +6671,7 @@ void Eval_on_set_w_kind_no_paren(void) {
 
     test_int(on_set_position_invoked, 0);
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e");
     test_assert(e != 0);
@@ -6700,7 +6700,7 @@ void Eval_on_set_w_kind_no_paren_no_reflection(void) {
 
     test_int(on_set_position_invoked, 0);
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e");
     test_assert(e != 0);
@@ -6729,7 +6729,7 @@ void Eval_on_set_w_single_assign(void) {
 
     test_int(on_set_position_invoked, 0);
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e");
     test_assert(e != 0);
@@ -6758,7 +6758,7 @@ void Eval_on_set_w_single_assign_scoped_w_value(void) {
 
     test_int(on_set_position_invoked, 0);
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e");
     test_assert(e != 0);
@@ -6787,7 +6787,7 @@ void Eval_on_set_w_single_assign_scoped_no_value(void) {
 
     test_int(on_set_position_invoked, 0);
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e");
     test_assert(e != 0);
@@ -6811,7 +6811,7 @@ void Eval_if_true(void) {
     LINE "  b{}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     test_assert(ecs_lookup(world, "a") != 0);
     test_assert(ecs_lookup(world, "b") == 0);
 
@@ -6826,7 +6826,7 @@ void Eval_if_true_no_else(void) {
     LINE "  a{}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     test_assert(ecs_lookup(world, "a") != 0);
 
     ecs_fini(world);
@@ -6842,7 +6842,7 @@ void Eval_if_false(void) {
     LINE "  b{}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     test_assert(ecs_lookup(world, "a") == 0);
     test_assert(ecs_lookup(world, "b") != 0);
 
@@ -6859,7 +6859,7 @@ void Eval_if_10(void) {
     LINE "  b{}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     test_assert(ecs_lookup(world, "a") != 0);
     test_assert(ecs_lookup(world, "b") == 0);
 
@@ -6876,7 +6876,7 @@ void Eval_if_256(void) {
     LINE "  b{}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     test_assert(ecs_lookup(world, "a") != 0);
     test_assert(ecs_lookup(world, "b") == 0);
 
@@ -6893,7 +6893,7 @@ void Eval_if_0(void) {
     LINE "  b{}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     test_assert(ecs_lookup(world, "a") == 0);
     test_assert(ecs_lookup(world, "b") != 0);
 
@@ -6911,7 +6911,7 @@ void Eval_if_true_var(void) {
     LINE "  b{}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     test_assert(ecs_lookup(world, "a") != 0);
     test_assert(ecs_lookup(world, "b") == 0);
 
@@ -6929,7 +6929,7 @@ void Eval_if_false_var(void) {
     LINE "  b{}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     test_assert(ecs_lookup(world, "a") == 0);
     test_assert(ecs_lookup(world, "b") != 0);
 
@@ -6951,7 +6951,7 @@ void Eval_if_true_in_scope(void) {
     LINE "  }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e");
     test_assert(e != 0);
@@ -6975,7 +6975,7 @@ void Eval_if_false_in_scope(void) {
     LINE "  }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e");
     test_assert(e != 0);
@@ -6995,7 +6995,7 @@ void Eval_if_lt(void) {
         LINE "  b{}"
         LINE "}";
 
-        test_assert(ecs_script_run(world, NULL, expr) == 0);
+        test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
         test_assert(ecs_lookup(world, "a") == 0);
         test_assert(ecs_lookup(world, "b") != 0);
     }
@@ -7008,7 +7008,7 @@ void Eval_if_lt(void) {
         LINE "  d{}"
         LINE "}";
 
-        test_assert(ecs_script_run(world, NULL, expr) == 0);
+        test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
         test_assert(ecs_lookup(world, "c") != 0);
         test_assert(ecs_lookup(world, "d") == 0);
     }
@@ -7028,7 +7028,7 @@ void Eval_if_lt_const(void) {
         LINE "  b{}"
         LINE "}";
 
-        test_assert(ecs_script_run(world, NULL, expr) == 0);
+        test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
         test_assert(ecs_lookup(world, "a") == 0);
         test_assert(ecs_lookup(world, "b") != 0);
     }
@@ -7042,7 +7042,7 @@ void Eval_if_lt_const(void) {
         LINE "  d{}"
         LINE "}";
 
-        test_assert(ecs_script_run(world, NULL, expr) == 0);
+        test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
         test_assert(ecs_lookup(world, "c") != 0);
         test_assert(ecs_lookup(world, "d") == 0);
     }
@@ -7061,7 +7061,7 @@ void Eval_if_else_if(void) {
     LINE "  b{}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     test_assert(ecs_lookup(world, "a") != 0);
     test_assert(ecs_lookup(world, "b") == 0);
 
@@ -7082,7 +7082,7 @@ void Eval_if_else_if_else(void) {
     LINE "}"
     ;
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     test_assert(ecs_lookup(world, "a") != 0);
     test_assert(ecs_lookup(world, "b") == 0);
     test_assert(ecs_lookup(world, "c") == 0);
@@ -7104,7 +7104,7 @@ void Eval_if_else_if_else_if(void) {
     LINE "}"
     ;
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     test_assert(ecs_lookup(world, "a") != 0);
     test_assert(ecs_lookup(world, "b") == 0);
     test_assert(ecs_lookup(world, "c") == 0);
@@ -7124,7 +7124,7 @@ void Eval_if_else_newline_if(void) {
     LINE "  b{}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     test_assert(ecs_lookup(world, "a") != 0);
     test_assert(ecs_lookup(world, "b") == 0);
 
@@ -7143,7 +7143,7 @@ void Eval_if_else_space_newline_if(void) {
     LINE "  b{}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     test_assert(ecs_lookup(world, "a") != 0);
     test_assert(ecs_lookup(world, "b") == 0);
 
@@ -7160,7 +7160,7 @@ void Eval_isa_in_module(void) {
     LINE "  (IsA, Animal)"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     test_assert(ecs_lookup_child(world, 0, "IsA") == 0);
     test_assert(ecs_lookup(world, "things.IsA") == 0);
@@ -7193,7 +7193,7 @@ void Eval_isa_hierarchy(void) {
     LINE "  }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     test_assert(ecs_lookup_child(world, 0, "IsA") == 0);
 
@@ -7244,7 +7244,7 @@ void Eval_isa_hierarchy_in_module(void) {
     LINE "  }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     test_assert(ecs_lookup_child(world, 0, "IsA") == 0);
     test_assert(ecs_lookup(world, "things.IsA") == 0);
@@ -7297,7 +7297,7 @@ void Eval_custom_isa_hierarchy_in_module(void) {
     LINE "  }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     test_assert(ecs_lookup_child(world, 0, "IsA") == 0);
 
@@ -7351,7 +7351,7 @@ void Eval_custom_isa_hierarchy_in_subtree(void) {
     LINE "  }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     test_assert(ecs_lookup_child(world, 0, "IsA") == 0);
 
@@ -7394,7 +7394,7 @@ void Eval_inherit_w_kind(void) {
     HEAD "Prefab Foo"
     LINE "Prefab Bar : Foo";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -7416,7 +7416,7 @@ void Eval_inherit_w_kind_scope(void) {
     LINE "  Child {}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -7446,7 +7446,7 @@ void Eval_inherit_w_kind_value(void) {
     HEAD "Prefab Foo"
     LINE "Position Bar : Foo (10, 20)";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -7481,7 +7481,7 @@ void Eval_inherit_w_kind_value_scope(void) {
     LINE "  Child {}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t bar = ecs_lookup(world, "Bar");
@@ -7509,7 +7509,7 @@ void Eval_multiple_inherit_w_kind(void) {
     LINE "Prefab World"
     LINE "Prefab Foo : Hello, World";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t hello = ecs_lookup(world, "Hello");
@@ -7536,7 +7536,7 @@ void Eval_multiple_inherit_w_kind_scope(void) {
     LINE "  Child {}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t hello = ecs_lookup(world, "Hello");
@@ -7565,7 +7565,7 @@ void Eval_auto_override_tag(void) {
     LINE "  auto_override | Tag"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -7592,7 +7592,7 @@ void Eval_auto_override_component(void) {
     LINE "  auto_override | Position: {10, 20}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -7619,7 +7619,7 @@ void Eval_auto_override_pair(void) {
     LINE "  auto_override | (Rel, Tgt)"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -7648,7 +7648,7 @@ void Eval_auto_override_pair_component(void) {
     LINE "  auto_override | (Position, Tgt): {10, 20}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -7674,7 +7674,7 @@ void Eval_lowercase_prefab_kind(void) {
     LINE "  Tag"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     
     test_assert(ecs_lookup(world, "prefab") == 0);
 
@@ -7706,7 +7706,7 @@ void Eval_assign_component_to_const(void) {
     LINE "  Position: {$pos.y, $pos.x}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "foo");
     test_assert(foo != 0);
@@ -7741,7 +7741,7 @@ void Eval_assign_component_member_to_const(void) {
     LINE "  Position: {$py, $px}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "foo");
     test_assert(foo != 0);
@@ -7776,7 +7776,7 @@ void Eval_prefab_w_slot(void) {
     LINE ""
     LINE "inst : Turret";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t turret = ecs_lookup(world, "Turret");
     test_assert(turret != 0);
@@ -7822,7 +7822,7 @@ void Eval_prefab_w_slot_variant(void) {
     LINE "  }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t head = ecs_lookup(world, "Turret.Head");
     ecs_entity_t variant = ecs_lookup(world, "Variant");
@@ -7859,7 +7859,7 @@ void Eval_const_w_component_expr(void) {
     LINE "  $pos"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "foo");
     test_assert(foo != 0);
@@ -7895,7 +7895,7 @@ void Eval_const_w_component_expr_in_scope(void) {
     LINE "  }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t parent = ecs_lookup(world, "parent");
     test_assert(parent != 0);
@@ -7933,7 +7933,7 @@ void Eval_const_w_component_expr_in_module(void) {
     LINE "  $pos"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t parent = ecs_lookup(world, "parent");
     test_assert(parent != 0);
@@ -7975,7 +7975,7 @@ void Eval_const_w_component_in_scope_expr_in_scope(void) {
     LINE "  }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "parent.foo");
     test_assert(foo != 0);
@@ -8013,7 +8013,7 @@ void Eval_const_w_component_in_scope_expr_in_module(void) {
     LINE "  $pos"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "parent.foo");
     test_assert(foo != 0);
@@ -8052,7 +8052,7 @@ void Eval_const_w_component_and_entity_in_scope_expr_in_scope(void) {
     LINE "  }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "parent.foo");
     test_assert(foo != 0);
@@ -8090,7 +8090,7 @@ void Eval_const_w_component_and_entity_in_scope_expr_in_module(void) {
     LINE "  $pos"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "parent.foo");
     test_assert(foo != 0);
@@ -8117,7 +8117,7 @@ void Eval_path_tag_in_scope(void) {
     LINE "  }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     test_assert(ecs_lookup(world, "parent.Hello.World") == 0);
 
@@ -8141,7 +8141,7 @@ void Eval_path_tag_in_module(void) {
     LINE "  Hello.World"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     test_assert(ecs_lookup(world, "parent.Hello.World") == 0);
 
@@ -8166,7 +8166,7 @@ void Eval_path_tag_in_nested_scope(void) {
     LINE "  }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     test_assert(ecs_lookup(world, "parent.Hello.World") == 0);
 
@@ -8190,7 +8190,7 @@ void Eval_path_tag_in_nested_module(void) {
     LINE "  Hello.World"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     test_assert(ecs_lookup(world, "Hello.parent.Hello") == 0);
     test_assert(ecs_lookup(world, "Hello.parent.Hello.World") == 0);
@@ -8858,7 +8858,7 @@ void Eval_assign_call_func(void) {
     const char *expr =
     HEAD "Foo = Position: {sqr(2), sqr(3)}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     ecs_entity_t foo = ecs_lookup(world, "Foo");
 
     test_assert(foo != 0);
@@ -8898,7 +8898,7 @@ void Eval_assign_call_scoped_func(void) {
     const char *expr =
     HEAD "Foo = Position: {parent.sqr(2), parent.sqr(3)}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     ecs_entity_t foo = ecs_lookup(world, "Foo");
 
     test_assert(foo != 0);
@@ -8939,7 +8939,7 @@ void Eval_assign_call_scoped_func_w_using(void) {
     HEAD "using parent"
     LINE "Foo = Position: {sqr(2), sqr(3)}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     ecs_entity_t foo = ecs_lookup(world, "Foo");
 
     test_assert(foo != 0);
@@ -8976,11 +8976,11 @@ void Eval_eval_w_vars(void) {
     const char *expr =
     LINE "e = Position: {$foo, $foo * 2}";
 
-    ecs_script_t *s = ecs_script_parse(world, NULL, expr, &desc);
+    ecs_script_t *s = ecs_script_parse(world, NULL, expr, &desc, NULL);
     test_assert(s != NULL);
 
     {
-        test_int(0, ecs_script_eval(s, &desc));
+        test_int(0, ecs_script_eval(s, &desc, NULL));
         ecs_entity_t e = ecs_lookup(world, "e");
         test_assert(e != 0);
         const Position *p = ecs_get(world, e, Position);
@@ -8992,7 +8992,7 @@ void Eval_eval_w_vars(void) {
     *(int32_t*)foo->value.ptr = 20;
 
     {
-        test_int(0, ecs_script_eval(s, &desc));
+        test_int(0, ecs_script_eval(s, &desc, NULL));
         ecs_entity_t e = ecs_lookup(world, "e");
         test_assert(e != 0);
         const Position *p = ecs_get(world, e, Position);
@@ -9031,10 +9031,10 @@ void Eval_eval_w_other_vars(void) {
         *(int32_t*)bar->value.ptr = 20;
         ecs_script_eval_desc_t desc = { .vars = vars };
 
-        s = ecs_script_parse(world, NULL, expr, &desc);
+        s = ecs_script_parse(world, NULL, expr, &desc, NULL);
         test_assert(s != NULL);
 
-        test_int(0, ecs_script_eval(s, &desc));
+        test_int(0, ecs_script_eval(s, &desc, NULL));
         ecs_entity_t e = ecs_lookup(world, "e");
         test_assert(e != 0);
         const Position *p = ecs_get(world, e, Position);
@@ -9053,7 +9053,7 @@ void Eval_eval_w_other_vars(void) {
         *(int32_t*)bar->value.ptr = 30;
         ecs_script_eval_desc_t desc = { .vars = vars };
 
-        test_int(0, ecs_script_eval(s, &desc));
+        test_int(0, ecs_script_eval(s, &desc, NULL));
         ecs_entity_t e = ecs_lookup(world, "e");
         test_assert(e != 0);
         const Position *p = ecs_get(world, e, Position);
@@ -9093,10 +9093,10 @@ void Eval_eval_w_vars_different_order(void) {
         *(int32_t*)bar->value.ptr = 20;
         ecs_script_eval_desc_t desc = { .vars = vars };
 
-        s = ecs_script_parse(world, NULL, expr, &desc);
+        s = ecs_script_parse(world, NULL, expr, &desc, NULL);
         test_assert(s != NULL);
 
-        test_int(0, ecs_script_eval(s, &desc));
+        test_int(0, ecs_script_eval(s, &desc, NULL));
         ecs_entity_t e = ecs_lookup(world, "e");
         test_assert(e != 0);
         const Position *p = ecs_get(world, e, Position);
@@ -9115,7 +9115,7 @@ void Eval_eval_w_vars_different_order(void) {
         *(int32_t*)foo->value.ptr = 20;
         ecs_script_eval_desc_t desc = { .vars = vars };
 
-        test_int(0, ecs_script_eval(s, &desc));
+        test_int(0, ecs_script_eval(s, &desc, NULL));
         ecs_entity_t e = ecs_lookup(world, "e");
         test_assert(e != 0);
         const Position *p = ecs_get(world, e, Position);
@@ -9170,10 +9170,10 @@ void Eval_eval_w_vars_different_order_var_component(void) {
         ((Velocity*)bar->value.ptr)->y = 2;
         ecs_script_eval_desc_t desc = { .vars = vars };
 
-        s = ecs_script_parse(world, NULL, expr, &desc);
+        s = ecs_script_parse(world, NULL, expr, &desc, NULL);
         test_assert(s != NULL);
 
-        test_int(0, ecs_script_eval(s, &desc));
+        test_int(0, ecs_script_eval(s, &desc, NULL));
         ecs_entity_t e = ecs_lookup(world, "e");
         test_assert(e != 0);
         const Position *p = ecs_get(world, e, Position);
@@ -9198,7 +9198,7 @@ void Eval_eval_w_vars_different_order_var_component(void) {
         ((Position*)foo->value.ptr)->y = 20;
         ecs_script_eval_desc_t desc = { .vars = vars };
 
-        test_int(0, ecs_script_eval(s, &desc));
+        test_int(0, ecs_script_eval(s, &desc, NULL));
         ecs_entity_t e = ecs_lookup(world, "e");
         test_assert(e != 0);
         const Position *p = ecs_get(world, e, Position);
@@ -9256,10 +9256,10 @@ void Eval_eval_w_vars_different_order_with_var(void) {
         ((Velocity*)bar->value.ptr)->y = 2;
         ecs_script_eval_desc_t desc = { .vars = vars };
 
-        s = ecs_script_parse(world, NULL, expr, &desc);
+        s = ecs_script_parse(world, NULL, expr, &desc, NULL);
         test_assert(s != NULL);
 
-        test_int(0, ecs_script_eval(s, &desc));
+        test_int(0, ecs_script_eval(s, &desc, NULL));
         ecs_entity_t e = ecs_lookup(world, "e");
         test_assert(e != 0);
         const Position *p = ecs_get(world, e, Position);
@@ -9284,7 +9284,7 @@ void Eval_eval_w_vars_different_order_with_var(void) {
         ((Position*)foo->value.ptr)->y = 20;
         ecs_script_eval_desc_t desc = { .vars = vars };
 
-        test_int(0, ecs_script_eval(s, &desc));
+        test_int(0, ecs_script_eval(s, &desc, NULL));
         ecs_entity_t e = ecs_lookup(world, "e");
         test_assert(e != 0);
         const Position *p = ecs_get(world, e, Position);
@@ -9326,10 +9326,10 @@ void Eval_eval_w_vars_different_order_pair_w_var(void) {
         *((ecs_entity_t*)bar->value.ptr) = Tgt;
         ecs_script_eval_desc_t desc = { .vars = vars };
 
-        s = ecs_script_parse(world, NULL, expr, &desc);
+        s = ecs_script_parse(world, NULL, expr, &desc, NULL);
         test_assert(s != NULL);
 
-        test_int(0, ecs_script_eval(s, &desc));
+        test_int(0, ecs_script_eval(s, &desc, NULL));
         ecs_entity_t e = ecs_lookup(world, "e");
         test_assert(e != 0);
         test_assert(ecs_has_pair(world, e, Rel, Tgt));
@@ -9344,7 +9344,7 @@ void Eval_eval_w_vars_different_order_pair_w_var(void) {
         *((ecs_entity_t*)foo->value.ptr) = Rel;
         ecs_script_eval_desc_t desc = { .vars = vars };
 
-        test_int(0, ecs_script_eval(s, &desc));
+        test_int(0, ecs_script_eval(s, &desc, NULL));
         ecs_entity_t e = ecs_lookup(world, "e");
         test_assert(e != 0);
         test_assert(ecs_has_pair(world, e, Rel, Tgt));
@@ -9378,10 +9378,10 @@ void Eval_eval_w_vars_different_order_pair_scope_w_var(void) {
         *((ecs_entity_t*)bar->value.ptr) = Tgt;
         ecs_script_eval_desc_t desc = { .vars = vars };
 
-        s = ecs_script_parse(world, NULL, expr, &desc);
+        s = ecs_script_parse(world, NULL, expr, &desc, NULL);
         test_assert(s != NULL);
 
-        test_int(0, ecs_script_eval(s, &desc));
+        test_int(0, ecs_script_eval(s, &desc, NULL));
         ecs_entity_t e = ecs_lookup(world, "e");
         test_assert(e != 0);
         test_assert(ecs_has_pair(world, e, Rel, Tgt));
@@ -9396,7 +9396,7 @@ void Eval_eval_w_vars_different_order_pair_scope_w_var(void) {
         *((ecs_entity_t*)foo->value.ptr) = Rel;
         ecs_script_eval_desc_t desc = { .vars = vars };
 
-        test_int(0, ecs_script_eval(s, &desc));
+        test_int(0, ecs_script_eval(s, &desc, NULL));
         ecs_entity_t e = ecs_lookup(world, "e");
         test_assert(e != 0);
         test_assert(ecs_has_pair(world, e, Rel, Tgt));
@@ -9425,11 +9425,11 @@ void Eval_eval_w_runtime(void) {
     const char *expr =
     LINE "e = Position: {10, 20}";
 
-    ecs_script_t *s = ecs_script_parse(world, NULL, expr, &desc);
+    ecs_script_t *s = ecs_script_parse(world, NULL, expr, &desc, NULL);
     test_assert(s != NULL);
 
     {
-        test_int(0, ecs_script_eval(s, &desc));
+        test_int(0, ecs_script_eval(s, &desc, NULL));
         ecs_entity_t e = ecs_lookup(world, "e");
         test_assert(e != 0);
         Position *p = ecs_get_mut(world, e, Position);
@@ -9441,7 +9441,7 @@ void Eval_eval_w_runtime(void) {
     }
 
     {
-        test_int(0, ecs_script_eval(s, &desc));
+        test_int(0, ecs_script_eval(s, &desc, NULL));
         ecs_entity_t e = ecs_lookup(world, "e");
         test_assert(e != 0);
         const Position *p = ecs_get(world, e, Position);
@@ -9475,7 +9475,7 @@ void Eval_component_in_entity_in_with_scope(void) {
     LINE "  }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -9500,7 +9500,7 @@ void Eval_entity_w_string_name(void) {
     const char *expr =
     HEAD "\"e\" { }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e");
     test_assert(e != 0);
@@ -9514,7 +9514,7 @@ void Eval_entity_w_interpolated_name(void) {
     const char *expr =
     HEAD "\"e_{10 + 20}\" { }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e_30");
     test_assert(e != 0);
@@ -9529,7 +9529,7 @@ void Eval_entity_w_interpolated_name_w_var(void) {
     HEAD "const i: 10"
     LINE "\"e_{$i + 20}\" { }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e_30");
     test_assert(e != 0);
@@ -9545,7 +9545,7 @@ void Eval_entity_w_string_name_w_inherit(void) {
     const char *expr =
     HEAD "\"e_{10 + 20}\" : Foo";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e_30");
     test_assert(e != 0);
@@ -9562,7 +9562,7 @@ void Eval_entity_w_string_name_w_inherit_scope(void) {
     const char *expr =
     HEAD "\"e_{10 + 20}\" : Foo { }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e_30");
     test_assert(e != 0);
@@ -9585,7 +9585,7 @@ void Eval_entity_w_string_name_w_kind(void) {
     const char *expr =
     HEAD "Position \"e_{10 + 20}\"";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e_30");
     test_assert(e != 0);
@@ -9608,7 +9608,7 @@ void Eval_entity_w_string_name_w_kind_value(void) {
     const char *expr =
     HEAD "Position \"e_{10 + 20}\"(10, 20)";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e_30");
     test_assert(e != 0);
@@ -9636,7 +9636,7 @@ void Eval_entity_w_string_name_w_kind_scope(void) {
     const char *expr =
     HEAD "Position \"e_{10 + 20}\" { }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e_30");
     test_assert(e != 0);
@@ -9659,7 +9659,7 @@ void Eval_entity_w_string_name_w_kind_value_scope(void) {
     const char *expr =
     HEAD "Position \"e_{10 + 20}\"(10, 20) { }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e_30");
     test_assert(e != 0);
@@ -9682,7 +9682,7 @@ void Eval_entity_w_interpolated_name_w_var_in_scope(void) {
     LINE "  \"e_{$i + 20}\" { }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "parent.e_30");
     test_assert(e != 0);
@@ -9708,7 +9708,7 @@ void Eval_for_range(void) {
     LINE "  }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e_0 = ecs_lookup(world, "e_0");
     ecs_entity_t e_1 = ecs_lookup(world, "e_1");
@@ -9764,7 +9764,7 @@ void Eval_for_range_vars(void) {
     LINE "  }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e_0 = ecs_lookup(world, "e_0");
     ecs_entity_t e_1 = ecs_lookup(world, "e_1");
@@ -9818,7 +9818,7 @@ void Eval_for_range_1_4(void) {
     LINE "  }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e_0 = ecs_lookup(world, "e_0");
     ecs_entity_t e_1 = ecs_lookup(world, "e_1");
@@ -9874,7 +9874,7 @@ void Eval_for_range_min_1_2(void) {
     LINE "  }"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e_min_1 = ecs_lookup(world, "e_-1");
     ecs_entity_t e_0 = ecs_lookup(world, "e_0");
@@ -9919,7 +9919,7 @@ void Eval_variable_assign_self(void) {
     ;
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -9959,7 +9959,7 @@ void Eval_func_w_entity_arg(void) {
     LINE "  (bool, False): {is_component(flecs.core.Relationship)}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e");
     test_assert(e != 0);
@@ -9999,7 +9999,7 @@ void Eval_func_w_entity_arg_w_using(void) {
     LINE "  (bool, False): {is_component(core.Relationship)}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e");
     test_assert(e != 0);
@@ -10029,7 +10029,7 @@ void Eval_method_w_entity_arg(void) {
     LINE "  (bool, False): {flecs.core.Component.has(flecs.core.Relationship)}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e");
     test_assert(e != 0);
@@ -10060,7 +10060,7 @@ void Eval_method_w_entity_arg_w_using(void) {
     LINE "  (bool, False): {core.Component.has(core.Relationship)}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e");
     test_assert(e != 0);
@@ -10095,7 +10095,7 @@ void Eval_assign_id(void) {
     const char *expr =
     HEAD "Foo = Id: {flecs.core.Component}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     ecs_entity_t foo = ecs_lookup(world, "Foo");
 
     test_assert(foo != 0);
@@ -10128,7 +10128,7 @@ void Eval_assign_id_w_using(void) {
     HEAD "using flecs"
     LINE "Foo = Id: {core.Component}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
     ecs_entity_t foo = ecs_lookup(world, "Foo");
 
     test_assert(foo != 0);
@@ -10151,7 +10151,7 @@ void Eval_const_assign_empty_initializer(void) {
     LINE;
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -10164,7 +10164,7 @@ void Eval_const_assign_empty_collection_initializer(void) {
     LINE;
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -10177,7 +10177,7 @@ void Eval_const_i32_assign_empty_initializer(void) {
     LINE;
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -10190,7 +10190,7 @@ void Eval_const_i32_assign_empty_collection_initializer(void) {
     LINE;
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -10221,12 +10221,12 @@ void Eval_component_w_match(void) {
     ecs_script_var_t *var = ecs_script_vars_define(vars, "i", ecs_i32_t);
 
     ecs_script_eval_desc_t desc = { .vars = vars };
-    ecs_script_t *s = ecs_script_parse(world, NULL, expr, &desc);
+    ecs_script_t *s = ecs_script_parse(world, NULL, expr, &desc, NULL);
     test_assert(s != NULL);
 
     {
         *(int32_t*)var->value.ptr = 1;
-        test_assert(ecs_script_eval(s, &desc) == 0);
+        test_assert(ecs_script_eval(s, &desc, NULL) == 0);
         ecs_entity_t foo = ecs_lookup(world, "Foo");
         test_assert(foo != 0);
         const Position *ptr = ecs_get(world, foo, Position);
@@ -10237,7 +10237,7 @@ void Eval_component_w_match(void) {
 
     {
         *(int32_t*)var->value.ptr = 2;
-        test_assert(ecs_script_eval(s, &desc) == 0);
+        test_assert(ecs_script_eval(s, &desc, NULL) == 0);
         ecs_entity_t foo = ecs_lookup(world, "Foo");
         test_assert(foo != 0);
         const Position *ptr = ecs_get(world, foo, Position);
@@ -10248,7 +10248,7 @@ void Eval_component_w_match(void) {
 
     {
         *(int32_t*)var->value.ptr = 3;
-        test_assert(ecs_script_eval(s, &desc) == 0);
+        test_assert(ecs_script_eval(s, &desc, NULL) == 0);
         ecs_entity_t foo = ecs_lookup(world, "Foo");
         test_assert(foo != 0);
         const Position *ptr = ecs_get(world, foo, Position);
@@ -10259,7 +10259,7 @@ void Eval_component_w_match(void) {
 
     {
         *(int32_t*)var->value.ptr = 4;
-        test_assert(ecs_script_eval(s, &desc) == 0);
+        test_assert(ecs_script_eval(s, &desc, NULL) == 0);
         ecs_entity_t foo = ecs_lookup(world, "Foo");
         test_assert(foo != 0);
         const Position *ptr = ecs_get(world, foo, Position);
@@ -10299,13 +10299,13 @@ void Eval_component_w_match_invalid(void) {
     ecs_script_var_t *var = ecs_script_vars_define(vars, "i", ecs_i32_t);
 
     ecs_script_eval_desc_t desc = { .vars = vars };
-    ecs_script_t *s = ecs_script_parse(world, NULL, expr, &desc);
+    ecs_script_t *s = ecs_script_parse(world, NULL, expr, &desc, NULL);
     test_assert(s != NULL);
 
     {
         *(int32_t*)var->value.ptr = 4;
         ecs_log_set_level(-4);
-        test_assert(ecs_script_eval(s, &desc) != 0);
+        test_assert(ecs_script_eval(s, &desc, NULL) != 0);
     }
 
     ecs_script_vars_fini(vars);
@@ -10341,13 +10341,13 @@ void Eval_pair_component_w_match(void) {
     ecs_script_var_t *var = ecs_script_vars_define(vars, "i", ecs_i32_t);
 
     ecs_script_eval_desc_t desc = { .vars = vars };
-    ecs_script_t *s = ecs_script_parse(world, NULL, expr, &desc);
+    ecs_script_t *s = ecs_script_parse(world, NULL, expr, &desc, NULL);
     test_assert(s != NULL);
 
     {
         *(int32_t*)var->value.ptr = 4;
         ecs_log_set_level(-4);
-        test_assert(ecs_script_eval(s, &desc) != 0);
+        test_assert(ecs_script_eval(s, &desc, NULL) != 0);
     }
 
     ecs_script_vars_fini(vars);
@@ -10379,13 +10379,13 @@ void Eval_component_assign_w_match(void) {
     ecs_script_var_t *var = ecs_script_vars_define(vars, "i", ecs_i32_t);
 
     ecs_script_eval_desc_t desc = { .vars = vars };
-    ecs_script_t *s = ecs_script_parse(world, NULL, expr, &desc);
+    ecs_script_t *s = ecs_script_parse(world, NULL, expr, &desc, NULL);
     test_assert(s != NULL);
 
     {
         *(int32_t*)var->value.ptr = 4;
         ecs_log_set_level(-4);
-        test_assert(ecs_script_eval(s, &desc) != 0);
+        test_assert(ecs_script_eval(s, &desc, NULL) != 0);
     }
 
     ecs_script_vars_fini(vars);
@@ -10412,12 +10412,12 @@ void Eval_const_w_match(void) {
     ecs_script_var_t *var = ecs_script_vars_define(vars, "i", ecs_i32_t);
 
     ecs_script_eval_desc_t desc = { .vars = vars };
-    ecs_script_t *s = ecs_script_parse(world, NULL, expr, &desc);
+    ecs_script_t *s = ecs_script_parse(world, NULL, expr, &desc, NULL);
     test_assert(s != NULL);
 
     {
         *(int32_t*)var->value.ptr = 1;
-        test_assert(ecs_script_eval(s, &desc) == 0);
+        test_assert(ecs_script_eval(s, &desc, NULL) == 0);
         ecs_entity_t foo = ecs_lookup(world, "Foo");
         test_assert(foo != 0);
         const int64_t *ptr = ecs_get(world, foo, ecs_i64_t);
@@ -10427,7 +10427,7 @@ void Eval_const_w_match(void) {
 
     {
         *(int32_t*)var->value.ptr = 2;
-        test_assert(ecs_script_eval(s, &desc) == 0);
+        test_assert(ecs_script_eval(s, &desc, NULL) == 0);
         ecs_entity_t foo = ecs_lookup(world, "Foo");
         test_assert(foo != 0);
         const int64_t *ptr = ecs_get(world, foo, ecs_i64_t);
@@ -10437,7 +10437,7 @@ void Eval_const_w_match(void) {
 
     {
         *(int32_t*)var->value.ptr = 3;
-        test_assert(ecs_script_eval(s, &desc) == 0);
+        test_assert(ecs_script_eval(s, &desc, NULL) == 0);
         ecs_entity_t foo = ecs_lookup(world, "Foo");
         test_assert(foo != 0);
         const int64_t *ptr = ecs_get(world, foo, ecs_i64_t);
@@ -10448,7 +10448,7 @@ void Eval_const_w_match(void) {
     {
         *(int32_t*)var->value.ptr = 4;
         ecs_log_set_level(-4);
-        test_assert(ecs_script_eval(s, &desc) != 0);
+        test_assert(ecs_script_eval(s, &desc, NULL) != 0);
         ecs_log_set_level(-1);
     }
 
@@ -10476,10 +10476,10 @@ void Eval_component_w_assign_add(void) {
     LINE "}"
     ;
 
-    ecs_script_t *s = ecs_script_parse(world, NULL, expr, NULL);
+    ecs_script_t *s = ecs_script_parse(world, NULL, expr, NULL, NULL);
     test_assert(s != NULL);
 
-    test_assert(ecs_script_eval(s, NULL) == 0);
+    test_assert(ecs_script_eval(s, NULL, NULL) == 0);
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
     const Position *ptr = ecs_get(world, foo, Position);
@@ -10510,10 +10510,10 @@ void Eval_component_w_assign_mul(void) {
     LINE "}"
     ;
 
-    ecs_script_t *s = ecs_script_parse(world, NULL, expr, NULL);
+    ecs_script_t *s = ecs_script_parse(world, NULL, expr, NULL, NULL);
     test_assert(s != NULL);
 
-    test_assert(ecs_script_eval(s, NULL) == 0);
+    test_assert(ecs_script_eval(s, NULL, NULL) == 0);
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
     const Position *ptr = ecs_get(world, foo, Position);
@@ -10568,7 +10568,7 @@ void Eval_opaque_struct_component(void) {
     LINE "}"
     ;
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e");
     test_assert(e != 0);
@@ -10607,7 +10607,7 @@ void Eval_opaque_string_component(void) {
     LINE "}"
     ;
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e");
     test_assert(e != 0);
@@ -10637,7 +10637,7 @@ void Eval_add_component_w_invalid_ctor(void) {
     ;
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -10659,7 +10659,7 @@ void Eval_add_component_pair_w_invalid_ctor(void) {
     ;
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -10680,7 +10680,7 @@ void Eval_add_component_as_tag_w_invalid_ctor(void) {
     ;
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -10702,7 +10702,7 @@ void Eval_add_component_as_tag_pair_w_invalid_ctor(void) {
     ;
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -10728,7 +10728,7 @@ void Eval_interpolated_name_w_nested_for_loop(void) {
     LINE "}"
     ;
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     {
         ecs_entity_t e = ecs_lookup(world, "e_0_0");
@@ -10808,7 +10808,7 @@ void Eval_interpolated_name_w_nested_for_loop_no_dollar_sign(void) {
     LINE "}"
     ;
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     {
         ecs_entity_t e = ecs_lookup(world, "e_0_0");
@@ -10878,7 +10878,7 @@ void Eval_interpolated_name_w_nested_for_loop_wrong_dollar_sign(void) {
     ;
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }

--- a/test/script/src/ExprAst.c
+++ b/test/script/src/ExprAst.c
@@ -291,7 +291,7 @@ void ExprAst_template_w_foldable_const(void) {
     LINE "  entity: Bar e "
     LINE "}\n";
 
-    ecs_script_t *script = ecs_script_parse(world, NULL, expr, NULL);
+    ecs_script_t *script = ecs_script_parse(world, NULL, expr, NULL, NULL);
     test_assert(script != NULL);
     {
         char *ast = ecs_script_ast_to_str(script, false);
@@ -299,7 +299,7 @@ void ExprAst_template_w_foldable_const(void) {
         ecs_os_free(ast);
     }
 
-    test_assert(ecs_script_eval(script, NULL) == 0);
+    test_assert(ecs_script_eval(script, NULL, NULL) == 0);
     {
         char *ast = ecs_script_ast_to_str(script, false);
         test_str(ast, result_after);

--- a/test/script/src/Fuzzing.c
+++ b/test/script/src/Fuzzing.c
@@ -4,7 +4,7 @@ static
 void fuzz(const char *expr) {
     ecs_world_t *world = ecs_init();
     ecs_log_set_level(-5);
-    ecs_script_run(world, "test", expr);
+    ecs_script_run(world, "test", expr, NULL);
     test_assert(true);
     ecs_fini(world);
 }

--- a/test/script/src/Template.c
+++ b/test/script/src/Template.c
@@ -6,7 +6,7 @@ void Template_template_no_scope(void) {
     const char *expr =
     LINE "template Tree";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t tree = ecs_lookup(world, "Tree");
     test_assert(tree != 0);
@@ -26,7 +26,7 @@ void Template_template_no_props(void) {
     LINE "}"
     LINE "Tree ent()";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t tree = ecs_lookup(world, "Tree");
     test_assert(tree != 0);
@@ -59,7 +59,7 @@ void Template_template_prop(void) {
     LINE "  prop height = flecs.meta.f32: 0"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t tree = ecs_lookup(world, "Tree");
     test_assert(tree != 0);
@@ -91,7 +91,7 @@ void Template_template_prop_space_colon(void) {
     LINE "  prop height = flecs.meta.f32: 0"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t tree = ecs_lookup(world, "Tree");
     test_assert(tree != 0);
@@ -124,7 +124,7 @@ void Template_template_2_props(void) {
     LINE "  prop height = flecs.meta.f32: 0"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t tree = ecs_lookup(world, "Tree");
     test_assert(tree != 0);
@@ -163,7 +163,7 @@ void Template_template_w_using(void) {
     LINE "}"
     LINE "Tree ent()";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t tree = ecs_lookup(world, "Tree");
     test_assert(tree != 0);
@@ -217,7 +217,7 @@ void Template_template_instance_w_default_values(void) {
     LINE "e { Tree }"
     LINE "";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t tree = ecs_lookup(world, "Tree");
     test_assert(tree != 0);
@@ -266,7 +266,7 @@ void Template_template_instance_w_assign_default_values(void) {
     LINE "e { Tree: {} }"
     LINE "";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t tree = ecs_lookup(world, "Tree");
     test_assert(tree != 0);
@@ -315,7 +315,7 @@ void Template_template_instance_w_overridden_values(void) {
     LINE "e { Tree: {width: 30, height: 40} }"
     LINE "";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t tree = ecs_lookup(world, "Tree");
     test_assert(tree != 0);
@@ -364,7 +364,7 @@ void Template_template_w_prop_implicit_type(void) {
     LINE "e { Tree }"
     LINE "";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t tree = ecs_lookup(world, "Tree");
     test_assert(tree != 0);
@@ -414,7 +414,7 @@ void Template_template_w_child(void) {
     LINE "e { Tree: {width: 1, height: 2} }"
     LINE "";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t tree = ecs_lookup(world, "Tree");
     test_assert(tree != 0);
@@ -624,7 +624,7 @@ void Template_template_w_child_update_after_parse(void) {
     LINE "e { Tree: {width: 3, height: 4} }"
     LINE "";
 
-    test_assert(ecs_script_run(world, NULL, expr_update) == 0);
+    test_assert(ecs_script_run(world, NULL, expr_update, NULL) == 0);
 
     ecs_entity_t tree = ecs_lookup(world, "Tree");
     test_assert(tree != 0);
@@ -685,7 +685,7 @@ void Template_template_w_nested_child(void) {
     LINE "e { Tree: {width: 1, height: 2} }"
     LINE "";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t tree = ecs_lookup(world, "Tree");
     test_assert(tree != 0);
@@ -769,7 +769,7 @@ void Template_template_w_prefab(void) {
     LINE "e { Tree: {width: 1, height: 2} }"
     LINE "";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t tree = ecs_lookup(world, "Tree");
     test_assert(tree != 0);
@@ -865,7 +865,7 @@ void Template_template_w_prefab_tree(void) {
     LINE "e { Tree: {width: 1, height: 2} }"
     LINE "";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t tree = ecs_lookup(world, "Tree");
     test_assert(tree != 0);
@@ -962,7 +962,7 @@ void Template_template_w_nested_template(void) {
     LINE "}"
     LINE "";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t tree = ecs_lookup(world, "Tree");
     test_assert(tree != 0);
@@ -999,7 +999,7 @@ void Template_template_w_nested_template(void) {
     const char *expr_instance =
     LINE "f { Forest: {10, 20} }"
     LINE "";
-    test_assert(ecs_script_run(world, NULL, expr_instance) == 0);
+    test_assert(ecs_script_run(world, NULL, expr_instance, NULL) == 0);
 
     ecs_entity_t f = ecs_lookup(world, "f");
     test_assert(f != 0);
@@ -1073,7 +1073,7 @@ void Template_instantiate_prefab_w_template(void) {
     LINE "Prefab p { Tree: {width: 10, height: 20} }"
     LINE "";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t tree = ecs_lookup(world, "Tree");
     test_assert(tree != 0);
@@ -1085,7 +1085,7 @@ void Template_instantiate_prefab_w_template(void) {
     const char *expr_instance =
     LINE "e : p"
     LINE "";
-    test_assert(ecs_script_run(world, NULL, expr_instance) == 0);
+    test_assert(ecs_script_run(world, NULL, expr_instance, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e");
     test_assert(e != 0);
@@ -1141,7 +1141,7 @@ void Template_template_w_prefab_w_template(void) {
     LINE "}"
     LINE "f { Forest: {10} }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t tree = ecs_lookup(world, "Tree");
     test_assert(tree != 0);
@@ -1201,7 +1201,7 @@ void Template_3_templates(void) {
     LINE "Park c()"
     LINE "";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t tree = ecs_lookup(world, "Tree");
     test_assert(tree != 0);
@@ -1289,7 +1289,7 @@ void Template_template_nested_w_default_var(void) {
     LINE "}"
     LINE "f { Forest: {10} }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t tree = ecs_lookup(world, "Tree");
     test_assert(tree != 0);
@@ -1366,7 +1366,7 @@ void Template_template_w_anonymous(void) {
     LINE ""
     LINE "t { Tree: {10} }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t tree = ecs_lookup(world, "Tree");
     test_assert(tree != 0);
@@ -1410,7 +1410,7 @@ void Template_template_w_anonymous_parse_again(void) {
     LINE "}"
     LINE ""
     LINE "t { Tree: {10} }";
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     {
         ecs_entity_t tree = ecs_lookup(world, "Tree");
@@ -1440,7 +1440,7 @@ void Template_template_w_anonymous_parse_again(void) {
 
     const char *expr_again =
     LINE "t { Tree: {10} }";
-    test_assert(ecs_script_run(world, NULL, expr_again) == 0);
+    test_assert(ecs_script_run(world, NULL, expr_again, NULL) == 0);
 
     {
         ecs_entity_t tree = ecs_lookup(world, "Tree");
@@ -1491,7 +1491,7 @@ void Template_template_w_composite_prop(void) {
     LINE "}"
     LINE "t { Tree: {pos: {20, 30}} }"
     LINE "";
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t tree = ecs_lookup(world, "Tree");
     test_assert(tree != 0);
@@ -1541,7 +1541,7 @@ void Template_template_with_with(void) {
     LINE "}"
     LINE "t { Tree: {count: 10} }"
     LINE "";
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t tree = ecs_lookup(world, "Tree");
     test_assert(tree != 0);
@@ -1590,11 +1590,11 @@ void Template_module_w_template(void) {
     LINE "  child { Position: {$count, $count * 2} }\n"
     LINE "}\n"
     LINE "";
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     const char *expr_inst =
     LINE "t = hello.world.Tree: {10}\n";
-    test_assert(ecs_script_run(world, NULL, expr_inst) == 0);
+    test_assert(ecs_script_run(world, NULL, expr_inst, NULL) == 0);
 
     ecs_entity_t tree = ecs_lookup(world, "hello.world.Tree");
     test_assert(tree != 0);
@@ -1647,11 +1647,11 @@ void Template_module_w_nested_template(void) {
     LINE "  t { Tree: {count:$} }"
     LINE "}"
     LINE "";
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     const char *expr_inst =
     LINE "f = hello.world.Forest: {10}\n";
-    test_assert(ecs_script_run(world, NULL, expr_inst) == 0);
+    test_assert(ecs_script_run(world, NULL, expr_inst, NULL) == 0);
 
     ecs_entity_t forest = ecs_lookup(world, "hello.world.Forest");
     test_assert(forest != 0);
@@ -1703,7 +1703,7 @@ void Template_template_w_pair_w_this_var(void) {
     LINE "ent { Foo: {} }\n"
     LINE "\n";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t ent = ecs_lookup(world, "ent");
@@ -1727,7 +1727,7 @@ void Template_template_w_pair_w_prop_var(void) {
     LINE "ent { Foo: {flecs.core} }\n"
     LINE "\n";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t ent = ecs_lookup(world, "ent");
@@ -1751,7 +1751,7 @@ void Template_template_w_pair_w_const_var(void) {
     LINE "ent { Foo: {} }\n"
     LINE "\n";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t ent = ecs_lookup(world, "ent");
@@ -1776,7 +1776,7 @@ void Template_template_w_pair_scope_w_this_var(void) {
     LINE "ent { Foo: {} }\n"
     LINE "\n";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t ent = ecs_lookup(world, "ent");
@@ -1807,7 +1807,7 @@ void Template_template_w_pair_scope_w_prop_var(void) {
     LINE "ent { Foo: {flecs.core} }\n"
     LINE "\n";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t ent = ecs_lookup(world, "ent");
@@ -1838,7 +1838,7 @@ void Template_template_w_pair_scope_w_const_var(void) {
     LINE "ent { Foo: {} }\n"
     LINE "\n";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     ecs_entity_t ent = ecs_lookup(world, "ent");
@@ -1868,7 +1868,7 @@ void Template_template_w_pair_w_unresolved_var_first(void) {
 
     ecs_log_set_level(-4);
 
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -1887,7 +1887,7 @@ void Template_template_w_pair_w_unresolved_var_second(void) {
 
     ecs_log_set_level(-4);
 
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -1908,7 +1908,7 @@ void Template_template_w_pair_scope_w_unresolved_var_first(void) {
 
     ecs_log_set_level(-4);
 
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -1929,7 +1929,7 @@ void Template_template_w_pair_scope_w_unresolved_var_second(void) {
 
     ecs_log_set_level(-4);
 
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -1942,7 +1942,7 @@ void Template_prop_without_using_meta(void) {
     LINE "  prop height = f32: 0"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t tree = ecs_lookup(world, "Tree");
     test_assert(tree != 0);
@@ -1978,7 +1978,7 @@ void Template_hoist_var(void) {
     LINE "}"
     LINE "Tree foo(height: 20)";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t tree = ecs_lookup(world, "Tree");
     test_assert(tree != 0);
@@ -2017,7 +2017,7 @@ void Template_hoist_vars_nested(void) {
     LINE "}"
     LINE "parent.Tree foo()";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t tree = ecs_lookup(world, "parent.Tree");
     test_assert(tree != 0);
@@ -2057,7 +2057,7 @@ void Template_hoist_vars_nested_w_masked(void) {
     LINE "}"
     LINE "parent.Tree foo()";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t tree = ecs_lookup(world, "parent.Tree");
     test_assert(tree != 0);
@@ -2092,7 +2092,7 @@ void Template_anonymous_template_instance(void) {
     LINE "}"
     LINE "Tree() {}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t tree = ecs_lookup(world, "Tree");
     test_assert(tree != 0);
@@ -2130,7 +2130,7 @@ void Template_anonymous_template_instance_no_scope(void) {
     LINE "}"
     LINE "Tree()";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t tree = ecs_lookup(world, "Tree");
     test_assert(tree != 0);
@@ -2169,7 +2169,7 @@ void Template_anonymous_template_instance_w_prop(void) {
     LINE "}"
     LINE "Tree() {}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t tree = ecs_lookup(world, "Tree");
     test_assert(tree != 0);
@@ -2208,7 +2208,7 @@ void Template_anonymous_template_instance_w_prop_no_scope(void) {
     LINE "}"
     LINE "Tree()";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t tree = ecs_lookup(world, "Tree");
     test_assert(tree != 0);
@@ -2239,7 +2239,7 @@ void Template_with_after_template(void) {
     LINE "}"
     LINE "withoutBar {}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t withBar = ecs_lookup(world, "withBar");
     test_assert(withBar != 0);
@@ -2267,7 +2267,7 @@ void Template_with_in_scope_after_template(void) {
     LINE "}"
     LINE "defWithoutBar {}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t withBar = ecs_lookup(world, "parent.withBar");
     test_assert(withBar != 0);
@@ -2301,7 +2301,7 @@ void Template_prefab_w_template(void) {
     LINE ""
     LINE "e : Base";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e");
     ecs_entity_t base = ecs_lookup(world, "Base");
@@ -2332,7 +2332,7 @@ void Template_template_in_scope(void) {
     LINE "}"
     LINE "parent.Foo ent";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     test_assert(ecs_lookup(world, "Foo") == 0);
     ecs_entity_t foo = ecs_lookup(world, "parent.Foo");
@@ -2374,7 +2374,7 @@ void Template_nested_templates_in_prefab(void) {
     ;
 
     // ecs_log_set_level(0);
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t frame = ecs_lookup(world, "Frame");
     test_assert(frame != 0);
@@ -2427,7 +2427,7 @@ void Template_entity_w_2_template_instances(void) {
     ;
 
     // ecs_log_set_level(0);
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -2465,7 +2465,7 @@ void Template_template_w_prefab_and_instance(void) {
     LINE "e = Foo: {}"
     ;
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -2513,7 +2513,7 @@ void Template_template_w_with_var(void) {
     LINE "e = Foo: {}"
     ;
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -2560,7 +2560,7 @@ void Template_template_w_with_prop(void) {
     LINE "}"
     ;
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -2604,7 +2604,7 @@ void Template_template_w_child_w_var(void) {
     LINE "e = Foo: {}"
     ;
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -2648,7 +2648,7 @@ void Template_template_w_child_w_prop(void) {
     LINE "e = Foo: {{10, 20}}"
     ;
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -2694,7 +2694,7 @@ void Template_fold_const(void) {
     LINE "Foo e3(16)"
     ;
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -2762,7 +2762,7 @@ void Template_bulk_create_template(void) {
     LINE "  Velocity: {$x + 5, $y + 5}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     Position p[] = {
         {10, 20},
@@ -2818,7 +2818,7 @@ void Template_template_w_expr_w_self_ref(void) {
     LINE "}"
     LINE "Foo ent()";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t tree = ecs_lookup(world, "Foo");
     test_assert(tree != 0);
@@ -2865,7 +2865,7 @@ void Template_entity_w_assign_with_nested_template(void) {
     LINE "  e = Position: {10, 20}"
     LINE "}";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -2920,7 +2920,7 @@ void Template_template_w_for(void) {
     LINE "}"
     LINE "Foo e()";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -2977,7 +2977,7 @@ void Template_template_w_component_w_undefined_identifier(void) {
 
     ecs_log_set_level(-4);
 
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -3005,7 +3005,7 @@ void Template_template_w_child_component_w_undefined_identifier(void) {
 
     ecs_log_set_level(-4);
 
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -3033,7 +3033,7 @@ void Template_template_w_anonymous_child_component_w_undefined_identifier(void) 
 
     ecs_log_set_level(-4);
 
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -3175,10 +3175,10 @@ void Template_component_w_assign_add(void) {
     LINE "}"
     ;
 
-    ecs_script_t *s = ecs_script_parse(world, NULL, expr, NULL);
+    ecs_script_t *s = ecs_script_parse(world, NULL, expr, NULL, NULL);
     test_assert(s != NULL);
 
-    test_assert(ecs_script_eval(s, NULL) == 0);
+    test_assert(ecs_script_eval(s, NULL, NULL) == 0);
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
     const Position *ptr = ecs_get(world, foo, Position);
@@ -3214,10 +3214,10 @@ void Template_component_w_assign_mul(void) {
     LINE "}"
     ;
 
-    ecs_script_t *s = ecs_script_parse(world, NULL, expr, NULL);
+    ecs_script_t *s = ecs_script_parse(world, NULL, expr, NULL, NULL);
     test_assert(s != NULL);
 
-    test_assert(ecs_script_eval(s, NULL) == 0);
+    test_assert(ecs_script_eval(s, NULL, NULL) == 0);
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
     const Position *ptr = ecs_get(world, foo, Position);
@@ -3252,7 +3252,7 @@ void Template_prop_after_const(void) {
     LINE "Tree e(30)";
 
     ecs_log_set_level(-4);
-    test_assert(ecs_script_run(world, NULL, expr) != 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) != 0);
 
     ecs_fini(world);
 }
@@ -3270,7 +3270,7 @@ void Template_const_from_prop(void) {
     LINE "}"
     LINE "Tree e(30)";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t e = ecs_lookup(world, "e");
     test_assert(e != 0);
@@ -3303,7 +3303,7 @@ void Template_redefine_nested_template_w_prefab(void) {
     LINE "e = Bar: { }"
     LINE "e = Bar: { }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -3347,7 +3347,7 @@ void Template_redefine_nested_template_w_prefab_2(void) {
     LINE "e = Bar: { }"
     LINE "e = Bar: { }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -3392,7 +3392,7 @@ void Template_redefine_nested_template_w_prefab_3(void) {
     LINE "e = Bar: { }"
     LINE "e = Bar: { }";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ecs_entity_t foo = ecs_lookup(world, "Foo");
     test_assert(foo != 0);
@@ -3434,7 +3434,7 @@ void Template_template_w_script_component(void) {
     LINE "}"
     LINE "Foo e(10, 20)";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ECS_COMPONENT(world, Position);
 
@@ -3470,7 +3470,7 @@ void Template_template_w_script_pair_component(void) {
     LINE "}"
     LINE "Foo e(10, 20)";
 
-    test_assert(ecs_script_run(world, NULL, expr) == 0);
+    test_assert(ecs_script_run(world, NULL, expr, NULL) == 0);
 
     ECS_COMPONENT(world, Position);
     ECS_TAG(world, Tgt);

--- a/test/script/src/main.c
+++ b/test/script/src/main.c
@@ -496,6 +496,12 @@ void Error_reload_script_w_component_w_error(void);
 void Error_reload_script_w_component_w_error_again(void);
 void Error_initializer_w_int_to_struct(void);
 void Error_script_initializer_w_int_to_struct(void);
+void Error_capture_error(void);
+void Error_unresolved_component_error_w_script_run(void);
+void Error_unresolved_component_error_w_script_init(void);
+void Error_unresolved_component_error_w_script_init_existing(void);
+void Error_unresolved_component_error_w_script_eval(void);
+void Error_unresolved_component_error_w_script_eval_multiple_times(void);
 
 // Testsuite 'Expr'
 void Expr_setup(void);
@@ -2919,6 +2925,30 @@ bake_test_case Error_testcases[] = {
     {
         "script_initializer_w_int_to_struct",
         Error_script_initializer_w_int_to_struct
+    },
+    {
+        "capture_error",
+        Error_capture_error
+    },
+    {
+        "unresolved_component_error_w_script_run",
+        Error_unresolved_component_error_w_script_run
+    },
+    {
+        "unresolved_component_error_w_script_init",
+        Error_unresolved_component_error_w_script_init
+    },
+    {
+        "unresolved_component_error_w_script_init_existing",
+        Error_unresolved_component_error_w_script_init_existing
+    },
+    {
+        "unresolved_component_error_w_script_eval",
+        Error_unresolved_component_error_w_script_eval
+    },
+    {
+        "unresolved_component_error_w_script_eval_multiple_times",
+        Error_unresolved_component_error_w_script_eval_multiple_times
     }
 };
 
@@ -4848,7 +4878,7 @@ static bake_test_suite suites[] = {
         "Error",
         NULL,
         NULL,
-        80,
+        86,
         Error_testcases
     },
     {


### PR DESCRIPTION
- Allow scripts to be saved from the explorer
- Always store build info (version, build configuration) on world so it is available for the explorer
- Store script code even on errors so code is never lost after reloading explorer
- Store script errors so they can be shown on explorer reload
