### PR TITLE
Add Doxygen filter script for cleaning markdown documentation from test and hide statements

### DIFF
--- a/docs/cfg/Doxyfile
+++ b/docs/cfg/Doxyfile
@@ -1107,7 +1107,7 @@ INPUT_FILTER           =
 # need to set EXTENSION_MAPPING for the extension otherwise the files are not
 # properly processed by doxygen.
 
-FILTER_PATTERNS        =
+FILTER_PATTERNS        = *.md="python3 docs/scripts/doxygen_filter.py"
 
 # If the FILTER_SOURCE_FILES tag is set to YES, the input filter (if set using
 # INPUT_FILTER) will also be used to filter the input files that are used for

--- a/docs/scripts/doxygen_filter.py
+++ b/docs/scripts/doxygen_filter.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""
+Doxygen filter to clean markdown for documentation:
+- Remove 'test' from code blocks: ```cpp test -> ```cpp  
+- Remove HIDE: lines
+"""
+
+import sys
+import re
+
+# Read input file
+with open(sys.argv[1], 'r') as f:
+    content = f.read()
+
+# Process each line
+filtered_lines = []
+for line in content.split('\n'):
+    # Remove 'test' attribute from code blocks
+    if re.match(r'^```(\w+)\s+test\s*$', line):
+        language = re.match(r'^```(\w+)', line).group(1)
+        filtered_lines.append(f'```{language}')
+    # Skip HIDE: lines  
+    elif re.match(r'^\s*HIDE:', line):
+        continue
+    # Keep all other lines
+    else:
+        filtered_lines.append(line)
+
+# Output filtered content
+print('\n'.join(filtered_lines), end='')


### PR DESCRIPTION
Doxygen filter to clean markdown for documentation:
- Remove 'test' from code blocks: ```cpp test -> ```cpp  
- Remove HIDE: lines