### PR TITLE
rust docs code snippets update

### DIFF
--- a/docs/ComponentTraits.md
+++ b/docs/ComponentTraits.md
@@ -65,18 +65,19 @@ Debug.Assert(e.Enabled<Position>());
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 world
 .component::<Position>()
 .add_trait::<flecs::CanToggle>();
 
 let e = world.entity().set(Position { x: 10.0, y: 20.0 });
 
-e.disable::<Position>(); // Disable component
-assert!(!e.enabled::<Position>());
+e.disable(Position::id()); // Disable component
+assert!(!e.is_enabled(Position::id()));
 
-e.enable::<Position>(); // Enable component
-assert!(e.enabled::<Position>());
+e.enable(Position::id()); // Enable component
+assert!(e.is_enabled(Position::id()));
 ```
 
 </li>
@@ -126,13 +127,16 @@ e.Add(Ecs.ChildOf, parent); // Covered by cleanup traits
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
+HIDE: let parent = world.entity();
+HIDE: let e = world.entity();
 #[derive(Component)]
 struct MyComponent {
     e: Entity, // Not covered by cleanup traits
 }
 
-e.child_of_id(parent); // Covered by cleanup traits
+e.child_of(parent); // Covered by cleanup traits
 ```
 
 </li>
@@ -166,8 +170,12 @@ world.RemoveAll(archer);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
-world.remove_all_id(archer);
+```rust test
+HIDE: let world = World::new();
+let archer = world.entity();
+world.remove_all(archer); //entity
+world.remove_all(Archer); //type
+
 ```
 
 </li>
@@ -207,10 +215,12 @@ world.RemoveAll(Ecs.Wildcard, archer);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
-world.remove_all_id(archer);
-world.remove_all_id((archer, flecs::Wildcard::ID));
-world.remove_all_id((flecs::Wildcard::ID, archer));
+```rust test
+HIDE: let world = World::new();
+HIDE: let archer = world.entity();
+world.remove_all(archer);
+world.remove_all((archer, flecs::Wildcard));
+world.remove_all((flecs::Wildcard, archer));
 ```
 
 </li>
@@ -289,13 +299,14 @@ world.Component<Archer>().Entity.Destruct();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Remove Archer from entities when Archer is deleted
 world
     .component::<Archer>()
     .add_trait::<(flecs::OnDelete, flecs::Remove)>();
 
-let e = world.entity().add::<Archer>();
+let e = world.entity().add(Archer::id());
 ```
 </ul>
 </div>
@@ -348,13 +359,14 @@ world.Component<Archer>().Entity.Destruct();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Remove Archer from entities when Archer is deleted
 world
     .component::<Archer>()
     .add_trait::<(flecs::OnDelete, flecs::Remove)>();
 
-let e = world.entity().add::<Archer>();
+let e = world.entity().add(Archer::id());
 
 // This will remove Archer from e
 world.component::<Archer>().destruct();
@@ -415,14 +427,15 @@ p.Destruct();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Delete children when deleting parent
 world
     .component::<flecs::ChildOf>()
     .add_trait::<(flecs::OnDeleteTarget, flecs::Delete)>();
 
 let p = world.entity();
-let e = world.entity().add_first::<flecs::ChildOf>(p);
+let e = world.entity().add((flecs::ChildOf, p));
 
 // This will delete both p and e
 p.destruct();
@@ -482,15 +495,17 @@ Entity c = world.Entity().Add<Node>().ChildOf(p);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 world
-    .observer::<flecs::OnRemove, &Node>()
-    .each_entity(|e, node| {
+    .observer::<flecs::OnRemove, ()>()
+    .with(Node)
+    .each_entity(|e, _| {
 // This observer will be invoked when a Node is removed
 });
 
-let p = world.entity().add::<Node>();
-let c = world.entity().add::<Node>().child_of_id(p);
+let p = world.entity().add(Node::id());
+let c = world.entity().add(Node::id()).child_of(p);
 ```
 
 </li>
@@ -561,7 +576,8 @@ ecs.Component<Position>().Entity
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 world.component::<Position>().add_trait::<flecs::DontFragment>();
 ```
 
@@ -618,11 +634,13 @@ e.ChildOf(parentB); // replaces (ChildOf, parentA)
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
+HIDE: let e = world.entity();
 let parent_a = world.entity();
 let parent_b = world.entity();
-e.child_of_id(parent_a);
-e.child_of_id(parent_b); // replaces (ChildOf, parent_a)
+e.child_of(parent_a);
+e.child_of(parent_b); // replaces (ChildOf, parent_a)
 ```
 
 </li>
@@ -659,7 +677,8 @@ Entity marriedTo = world.Entity()
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let married_to = world.entity().add_trait::<flecs::Exclusive>();
 ```
 
@@ -707,10 +726,13 @@ Entity i = ecs.Entity()
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let e = world.entity().add_trait::<flecs::Final>();
 
-let i = world.entity().is_a_id(e); // not allowed
+HIDE: /*
+let i = world.entity().is_a(e); // not allowed
+HIDE: */
 ```
 
 </li>
@@ -776,16 +798,17 @@ q.Each([](Entity unit) {
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 world.component::<Unit>().add_trait::<flecs::Inheritable>();
 
-auto q = world.query()
-  .with::<Unit>()
+let q = world.query::<()>()
+  .with(Unit::id())
   .build();
 
-world.component<Warrior>().is_a<Unit>();
+world.component::<Warrior>().is_a(Unit::id());
 
-q.each_entity(|e|  {
+q.each_entity(|e, _|  {
     // ...
 });
 ```
@@ -861,17 +884,20 @@ Entity b = world.Entity().Add(food, fork);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Enforce that target of relationship is child of Food
 let food = world.entity().add_trait::<flecs::OneOf>();
-let apples = world.entity().child_of_id(food);
+let apples = world.entity().child_of(food);
 let fork = world.entity();
 
 // This is ok, Apples is a child of Food
-let a = world.entity().add_id((food, apples));
+let a = world.entity().add((food, apples));
 
+HIDE: /*
 // This is not ok, Fork is not a child of Food
-let b = world.entity().add_id((food, fork));
+let b = world.entity().add((food, fork));
+HIDE: */
 ```
 
 </li>
@@ -938,18 +964,21 @@ Entity b = world.Entity().Add(eats, fork);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Enforce that target of relationship is child of Food
 let food = world.entity();
-let eats = world.entity().add_first::<flecs::OneOf>(food);
-let apples = world.entity().child_of_id(food);
+let eats = world.entity().add((flecs::OneOf::id(), food));
+let apples = world.entity().child_of(food);
 let fork = world.entity();
 
 // This is ok, Apples is a child of Food
-let a = world.entity().add_id((eats, apples));
+let a = world.entity().add((eats, apples));
 
+HIDE: /*
 // This is not ok, Fork is not a child of Food
-let b = world.entity().add_id((eats, fork));
+let b = world.entity().add((eats, fork));
+HIDE: */
 ```
 
 </li>
@@ -1025,17 +1054,18 @@ Debug.Assert(inst.Owns<Mass>());
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Register component with trait. Optional, since this is the default behavior.
 world
 .component::<Mass>()
 .add_trait::<(flecs::OnInstantiate, flecs::Override)>();
 
 let base = world.entity().set(Mass { value: 100.0 });
-let inst = world.entity().is_a_id(base); // Mass is copied to inst
+let inst = world.entity().is_a(base); // Mass is copied to inst
 
-assert!(inst.owns::<Mass>());
-assert!(base.cloned::<&Mass>() != inst.cloned::<&Mass>());
+assert!(inst.owns(Mass::id()));
+assert!(base.cloned::<&Mass>() == inst.cloned::<&Mass>());
 ```
 
 </li>
@@ -1103,18 +1133,19 @@ Debug.Assert(!inst.Owns<Mass>());
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Register component with trait
 world
 .component::<Mass>()
 .add_trait::<(flecs::OnInstantiate, flecs::Inherit)>();
 
 let base = world.entity().set(Mass { value: 100.0 });
-let inst = world.entity().is_a_id(base);
+let inst = world.entity().is_a(base);
 
-assert!(inst.has::<Mass>());
-assert!(!inst.owns::<Mass>());
-assert!(base.cloned::<&Mass>() != inst.cloned::<&Mass>());
+assert!(inst.has(Mass::id()));
+assert!(!inst.owns(Mass::id()));
+assert!(base.cloned::<&Mass>() == inst.cloned::<&Mass>());
 ```
 
 </li>
@@ -1182,18 +1213,19 @@ Debug.Assert(!inst.Owns<Mass>());
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Register component with trait
 world
 .component::<Mass>()
 .add_trait::<(flecs::OnInstantiate, flecs::DontInherit)>();
 
 let base = world.entity().set(Mass { value: 100.0 });
-let inst = world.entity().is_a_id(base);
+let inst = world.entity().is_a(base);
 
-assert!(!inst.has::<Mass>());
-assert!(!inst.owns::<Mass>());
-assert!(!inst.try_get::<&Mass>(|mass| {}));
+assert!(!inst.has(Mass::id()));
+assert!(!inst.owns(Mass::id()));
+assert!(inst.try_get::<&Mass>(|mass| {}).is_none());
 ```
 
 </li>
@@ -1280,16 +1312,17 @@ parent.Children((Entity child) => {
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let parent = world.entity().add_trait::<flecs::OrderedChildren>();
 
-let child_1 = world.entity().child_of_id(parent);
-let child_2 = world.entity().child_of_id(parent);
-let child_3 = world.entity().child_of_id(parent);
+let child_1 = world.entity().child_of(parent);
+let child_2 = world.entity().child_of(parent);
+let child_3 = world.entity().child_of(parent);
 
 // Adding/removing components usually changes the order in which children are
 // iterated, but with the OrderedChildren trait order is preserved.
-child_2.set(Position{10, 20});
+child_2.set(Position { x: 10.0, y: 20.0 });
 
 parent.each_child(|child| {
     // 1st result: child_1
@@ -1376,22 +1409,17 @@ ref readonly Position p = ref e.GetSecond<Serializable, Position>();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 #[derive(Component)]
 struct Serializable; // Tag, contains no data
 
 impl flecs::FlecsTrait for Serializable {}
 
-#[derive(Component)]
-struct Position {
-    x: f32,
-    y: f32,
-}
-
 let e = world
     .entity()
     .set(Position { x: 10.0, y: 20.9 })
-    .add_trait::<(Serializable, Position)>(); // Because Serializable is a tag, the pair
+    .add((Serializable::id(), Position::id())); // Because Serializable is a tag, the pair
 // has a value of type Position
 
 // Gets value from Position component
@@ -1474,7 +1502,8 @@ ref readonly Position p = ref e.GetSecond<Serializable, Position>();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // This is currently not supported in Rust due to safety concerns.
 ```
 
@@ -1536,7 +1565,8 @@ Entity e = ecs.Entity()
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 #[derive(Component)]
 struct Likes;
 
@@ -1549,9 +1579,11 @@ world
 
 let e = world
     .entity()
-    .add::<Likes>() // Panic, 'Likes' is not used as relationship
-    .add::<(Apples, Likes)>() // Panic, 'Likes' is not used as relationship, but as target
-    .add::<(Likes, Apples)>(); // OK
+    HIDE: /*
+    .add(Likes::id()) // Panic, 'Likes' is not used as relationship
+    .add((Apples::id(), Likes::id())) // Panic, 'Likes' is not used as relationship, but as target
+    HIDE: */
+    .add((Likes::id(), Apples::id())); // OK
 ```
 
 </li>
@@ -1604,7 +1636,8 @@ world.Component<Loves>().Entity.Add(Ecs.With, world.Component<Likes>());
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 #[derive(Component)]
 struct Likes;
 
@@ -1706,10 +1739,11 @@ world.Component<TimeOfDay>().Entity.Set<TimeOfDay>(new(0));
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 world.component::<TimeOfDay>().add_trait::<flecs::Singleton>();
 
-world.set(TimeOfDay{0});
+world.set(TimeOfDay(0.0));
 ```
 
 </li>
@@ -1772,13 +1806,14 @@ auto q2 = world.query_builder<Position, Velocity, const TimeOfDay>()
 
 A singleton query can be created by specifying the same id as component and source:
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Automatically matches TimeOfDay as singleton
 let q = world.new_query::<(&Position, &Velocity, &TimeOfDay)>();
 
 // Is the same as
 let q = world.query::<(&Position, &Velocity, &TimeOfDay)>()
-  .term_at(2).set_src::<TimeOfDay>()
+  .term_at(2).set_src(TimeOfDay::id())
   .build();
 ```
 
@@ -1837,7 +1872,8 @@ ecs.Component<Position>().Entity
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 world.component::<Position>().add_trait::<flecs::Sparse>();
 ```
 
@@ -1884,11 +1920,12 @@ Bob.Add(marriedTo, alice); // Also adds (MarriedTo, Bob) to Alice
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let married_to = world.entity().add_trait::<flecs::Symmetric>();
 let bob = world.entity();
 let alice = world.entity();
-bob.add_id((married_to, alice)); // Also adds (MarriedTo, Bob) to Alice
+bob.add((married_to, alice)); // Also adds (MarriedTo, Bob) to Alice
 ```
 
 </li>
@@ -1947,7 +1984,8 @@ Entity e = ecs.Entity()
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 #[derive(Component)]
 struct Likes;
 
@@ -1958,9 +1996,11 @@ world.component::<Apples>().add_trait::<flecs::Target>();
 
 let e = world
     .entity()
-    .add::<Apples>() // Panic, 'Apples' is not used as target
-    .add::<(Apples, Likes)>() // Panic, 'Apples' is not used as target, but as relationship
-    .add::<(Likes, Apples)>(); // OK
+    HIDE: /*
+    .add(Apples::id()) // Panic, 'Apples' is not used as target
+    .add((Apples::id(), Likes::id())) // Panic, 'Apples' is not used as target, but as relationship
+    HIDE: */
+    .add((Likes::id(), Apples::id())); // OK
 ```
 
 </li>
@@ -2001,7 +2041,8 @@ world.Component<Serializable>().Entity.Add(Ecs.Trait);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 #[derive(Component)]
 struct Serializable;
 
@@ -2078,14 +2119,15 @@ NewYork.Add(locatedin, usa);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let locatedin = world.entity();
 let manhattan = world.entity();
 let newyork = world.entity();
 let usa = world.entity();
 
-manhattan.add_id((locatedin, newyork));
-newyork.add_id((locatedin, usa));
+manhattan.add((locatedin, newyork));
+newyork.add((locatedin, usa));
 ```
 
 </li>
@@ -2119,7 +2161,9 @@ locatedIn.Add(Ecs.Transitive);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
+HIDE: let locatedin = world.entity();
 locatedin.add_trait::<flecs::Transitive>();
 ```
 
@@ -2174,12 +2218,13 @@ Entity e = world.Entity().Add(power);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let responsibility = world.entity();
-let power = world.entity().add_first::<flecs::With>(responsibility);
+let power = world.entity().add((flecs::With::id(), responsibility));
 
 // Create new entity that has both Power and Responsibility
-let e = world.entity().add_id(power);
+let e = world.entity().add(power);
 ```
 
 </li>
@@ -2228,13 +2273,14 @@ Entity e = world.Entity().Add(loves, pears);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let likes = world.entity();
 let loves = world.entity().add_trait::<(flecs::With, Likes)>();
 let pears = world.entity();
 
 // Create new entity with both (Loves, Pears) and (Likes, Pears)
-let e = world.entity().add_id((loves, pears));
+let e = world.entity().add((loves, pears));
 ```
 
 </li>

--- a/docs/EntitiesComponents.md
+++ b/docs/EntitiesComponents.md
@@ -46,7 +46,8 @@ Entity myEntity world.Entity();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let my_entity = world.entity();
 ```
 </li>
@@ -85,7 +86,9 @@ myEntity.Destruct();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
+HIDE: let my_entity = world.entity();
 my_entity.destruct();
 ```
 </li>
@@ -141,14 +144,17 @@ e2.Add<Npc>(); // OK, 500v1 is alive
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let e1 = world.entity(); // Returns 500v0
 e1.destruct(); // Recycles 500
 let e2 = world.entity(); // Returns 500v1
+HIDE: /*
 // Fails, 500v0 is not alive
-e1.add::<Npc>();
+e1.add(Npc::id());
+HIDE: */
 // OK, 500v1 is alive
-e2.add::<Npc>();
+e2.add(Npc::id());
 ```
 </li>
 </ul>
@@ -187,7 +193,8 @@ e1.Destruct(); // OK: post condition is satisfied
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let e1 = world.entity();
 e1.destruct();
 e1.destruct(); // OK: post condition is satisfied
@@ -224,7 +231,9 @@ myEntity.Clear();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
+HIDE: let my_entity = world.entity();
 my_entity.clear();
 ```
 </li>
@@ -274,7 +283,8 @@ e2.IsAlive(); // True
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let e1 = world.entity();
 let e2 = world.entity();
 e1.destruct();
@@ -329,7 +339,8 @@ world.Entity(0).IsValid(); // False
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let e1 = world.entity();
 let e2 = world.entity();
 e1.destruct();
@@ -368,7 +379,8 @@ Entity e = world.MakeAlive(1000);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let e = world.make_alive(1000);
 ```
 </li>
@@ -405,9 +417,10 @@ world.SetVersion(versionedId);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
-//TODO does not exist yet
-//world.set_version(versioned_id);
+```rust test
+HIDE: let world = World::new();
+HIDE: let versioned_id = 1000;
+world.set_version(versioned_id);
 ```
 </li>
 </ul>
@@ -441,7 +454,8 @@ world.SetEntityRange(5000, 0);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 world.set_entity_range(5000, 0);
 ```
 </li>
@@ -475,7 +489,8 @@ world.SetEntityRange(5000, 10000);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 world.set_entity_range(5000, 10000);
 ```
 </li>
@@ -513,7 +528,8 @@ world.EnableRangeCheck(true);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 world.enable_range_check(true);
 ```
 </li>
@@ -568,7 +584,8 @@ Console.WriteLine(e.Name());
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let e = world.entity_named("MyEntity");
 if e == world.lookup("MyEntity") {
     // true
@@ -621,9 +638,10 @@ if (e == world.Lookup("Parent.Child")) {
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let p = world.entity_named("Parent");
-let e = world.entity_named("Child").child_of_id(p);
+let e = world.entity_named("Child").child_of(p);
 if e == world.lookup("Parent::Child") {
     // true
 }
@@ -674,9 +692,10 @@ if (e == p.Lookup("Child")) {
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let p = world.entity_named("Parent");
-let e = world.entity_named("Child").child_of_id(p);
+let e = world.entity_named("Child").child_of(p);
 if e == p.lookup("Child") {
     // true
 }
@@ -736,9 +755,10 @@ Console.WriteLine(e.Path()); // Parent.Child
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let p = world.entity_named("Parent");
-let e = world.entity_named("Child").child_of_id(p);
+let e = world.entity_named("Child").child_of(p);
 // Returns entity name, does not allocate
 println!("{}", e.name()); // Child
 // Returns entity path, does allocate
@@ -792,7 +812,8 @@ if (e1 == e2) {
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let e1 = world.entity_named("Parent::Child");
 let e2 = world.entity_named("Parent::Child");
 if e1 == e2 {
@@ -838,7 +859,8 @@ e.SetName("Bar");
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let e = world.entity_named("Foo");
 // Change name
 e.set_name("Bar");
@@ -877,7 +899,8 @@ Entity twenty = world.Entity("20");
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let ten = world.entity_named("10");
 let twenty = world.entity_named("20");
 ```
@@ -933,7 +956,8 @@ e.Disable();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let e = world.entity();
 // Enable entity
 e.enable_self();
@@ -1016,7 +1040,8 @@ p.Enable();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Three entities to disable
 let e1 = world.entity();
 let e2 = world.entity();
@@ -1024,9 +1049,9 @@ let e3 = world.entity();
 
 // Create prefab that has the three entities
 let p = world.prefab();
-p.add_id(e1);
-p.add_id(e2);
-p.add_id(e3);
+p.add(e1);
+p.add(e2);
+p.add(e3);
 
 // Disable entities
 p.disable_self();
@@ -1119,15 +1144,17 @@ p1.Enable();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: return; //TODO bug flecs upstream
+HIDE: let world = World::new();
 // Three entities to disable
 let e1 = world.entity();
 let e2 = world.entity();
 let e3 = world.entity();
 
 // Create prefab hierarchy with the three entities
-let p1 = world.prefab().add_id(e1);
-let p2 = world.prefab().is_a_id(p1).add_id(e2).add_id(e3);
+let p1 = world.prefab().add(e1);
+let p2 = world.prefab().is_a(p1).add(e2).add(e3);
 
 // Disable e1, e2, e3
 p2.disable_self();
@@ -1166,8 +1193,10 @@ e.Add(Ecs.Disabled);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
-e.add::<flecs::Disabled>();
+```rust test
+HIDE: let world = World::new();
+HIDE: let e = world.entity();
+e.add(flecs::Disabled);
 ```
 </li>
 </ul>
@@ -1322,7 +1351,8 @@ file struct Position(float x, float y) :
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 world
     .component::<Position>()
     .on_set(|entity, pos| {
@@ -1378,7 +1408,8 @@ world.component<Position>()
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 world
     .component::<Position>()
     .on_replace(|entity, prev, next| {
@@ -1442,7 +1473,8 @@ Console.WriteLine($"Size: {compData.size}, Alignment: {compData.alignment}");
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Get the entity for the Position component
 let pos = world.component::<Position>();
 // Component entities have the Component component
@@ -1489,7 +1521,8 @@ world.Component<Position>().Entity.add(Ecs.Sparse);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Register a sparse component
 world.component::<Position>().add_trait::<flecs::Sparse>();
 ```
@@ -1702,7 +1735,8 @@ public static void Main()
 
 In Rust components are automatically registered upon first usage. The following example shows how:
 
-```rust
+```rust test
+HIDE: let world = World::new();
 fn main() {
     let world = World::new();
     let e1 = world
@@ -1725,7 +1759,8 @@ Components can be registered in advance, which can be done for several reasons:
 
 To register a component in advance, do:
 
-```rust
+```rust test
+HIDE: let world = World::new();
 world.component::<Position>();
 ```
 
@@ -1733,7 +1768,8 @@ In general it is recommended to register components in advance, and to only use 
 
 A convenient way to organize component registration code is to use Flecs modules. An example:
 
-```rust
+```rust test
+HIDE: let world = World::new();
 
 use flecs_ecs::prelude::*;
 
@@ -1810,6 +1846,7 @@ TODO
 <li><b class="tab-title">Rust</b>
 
 ```rust
+HIDE: let world = World::new();
 TODO
 ```
 
@@ -1874,6 +1911,7 @@ TODO
 <li><b class="tab-title">Rust</b>
 
 ```rust
+HIDE: let world = World::new();
 TODO
 ```
 
@@ -1937,11 +1975,12 @@ pos.Destruct();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let pos = world.component::<Position>();
 
 // Create entity with Position
-let e = world.entity().add::<Position>();
+let e = world.entity().add(Position::id());
 
 // Unregister the component
 pos.destruct();
@@ -1995,12 +2034,16 @@ ref readonly TimeOfDay t = ref world.Get<TimeOfDay>();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
+
+world.component::<TimeOfDay>().add_trait::<flecs::Singleton>();
+
 // Set singleton
-world.set(TimeOfDay { value: 0.5 });
+world.set(TimeOfDay(0.5));
 
 // Get singleton
-world.get::<&TimeOfDay>(|time| println!("{}", time.value));
+world.get::<&TimeOfDay>(|time| println!("{}", time.0));
 ```
 
 </li>
@@ -2048,12 +2091,16 @@ world.Component<TimeOfDay>().Entity.Set(new TimeOfDay(0.5));
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
+
+world.component::<TimeOfDay>().add_trait::<flecs::Singleton>();
+
 // Set singleton
-world.set(TimeOfDay { value: 0.5 });
+world.set(TimeOfDay(0.5));
 
 // Equivalent to:
-world.component::<TimeOfDay>().set(TimeOfDay { value: 0.5 });
+world.component::<TimeOfDay>().set(TimeOfDay(0.5));
 ```
 
 </li>
@@ -2123,7 +2170,8 @@ e.IsEnabled<Position>(); // True
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Register toggle-able component
 world
     .component::<Position>()
@@ -2132,14 +2180,14 @@ world
 let e = world.entity().set(Position { x: 10.0, y: 20.0 });
 
 // Disable component
-e.disable::<Position>();
+e.disable(Position::id());
 
-e.enabled::<Position>(); // False
+e.is_enabled(Position::id()); // False
 
 // Enable component
-e.enable::<Position>();
+e.enable(Position::id());
 
-e.enabled::<Position>(); // True
+e.is_enabled(Position::id()); // True
 ```
 </li>
 </ul>

--- a/docs/FlecsRemoteApi.md
+++ b/docs/FlecsRemoteApi.md
@@ -63,7 +63,9 @@ while (world.Progress()) { }
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: return; //compile-only
+HIDE: let world = World::new();
 // Optional, gather statistics for explorer
 world.import::<stats::Stats>();
 
@@ -118,7 +120,9 @@ world.App()
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: return; //compile-only
+HIDE: let world = World::new();
 world
     .app()
     // Optional, gather statistics for explorer
@@ -334,7 +338,9 @@ while (world.Progress()) { }
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: return; //compile-only
+HIDE: let world = World::new();
 // Optional, gather statistics for explorer
 world.import::<stats::Stats>();
 

--- a/docs/ObserversManual.md
+++ b/docs/ObserversManual.md
@@ -65,7 +65,8 @@ world.Entity().Set(new Position(10, 20)); // Invokes observer
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Create observer that is invoked whenever Position is set
 world
     .observer::<flecs::OnSet, &Position>()
@@ -176,14 +177,15 @@ e.Add<Position>();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let e = world.entity();
 
 // OnAdd observer fires
-e.add::<Position>();
+e.add(Position::id());
 
 // OnAdd observer doesn't fire, entity already has component
-e.add::<Position>();
+e.add(Position::id());
 ```
 
 </li>
@@ -238,7 +240,8 @@ e.Set(new Position(10, 20));
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let e = world.entity();
 
 // OnAdd observer fires first, then OnSet observer fires
@@ -293,11 +296,12 @@ Entity i = world.Entity().IsA(p);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let p = world.prefab().set(Position { x: 10.0, y: 20.0 });
 
 // Produces OnSet event for Position
-let i = world.entity().is_a_id(p);
+let i = world.entity().is_a(p);
 ```
 
 </li>
@@ -364,17 +368,18 @@ i.Remove<Position>();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let p = world.prefab().set(Position { x: 10.0, y: 20.0 });
 
 // Produces OnSet event for inherited Position component
-let i = world.entity().is_a_id(p);
+let i = world.entity().is_a(p);
 
 // Override component. Produces regular OnSet event.
 i.set(Position { x: 20.0, y: 30.0 });
 
 // Reexposes inherited component, produces OnSet event
-i.remove::<Position>();
+i.remove(Position::id());
 ```
 
 </li>
@@ -421,11 +426,12 @@ Entity i = world.Entity().IsA(p);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let p = world.prefab().set(Position { x: 10.0, y: 20.0 });
 
 // Produces OnSet event for Position
-let i = world.entity().is_a_id(p);
+let i = world.entity().is_a(p);
 ```
 
 </li>
@@ -478,14 +484,15 @@ e.Remove<Position>();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let e = world.entity().set(Position { x: 10.0, y: 20.0 });
 
 // OnRemove observer fires
-e.remove::<Position>();
+e.remove(Position::id());
 
 // OnRemove observer doesn't fire, entity doesn't have the component
-e.remove::<Position>();
+e.remove(Position::id());
 ```
 
 </li>
@@ -538,12 +545,14 @@ world.Observer<Position>()
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Observer that listens for both OnAdd and OnRemove events
 world
-    .observer::<flecs::OnAdd, &Position>()
-    .add_event::<flecs::OnRemove>()
-    .each_entity(|e, p| {
+    .observer::<flecs::OnAdd, ()>()
+    .with(Position::id())
+    .add_event(flecs::OnRemove::id())
+    .each_entity(|e, _| {
 // ...
 });
 ```
@@ -604,11 +613,13 @@ world.Observer<Position>()
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 world
-    .observer::<flecs::OnAdd, &Position>()
-    .add_event::<flecs::OnRemove>()
-    .each_iter(|it, i, p| {
+    .observer::<flecs::OnAdd, ()>()
+    .with(Position::id())
+    .add_event(flecs::OnRemove::id())
+    .each_iter(|it, i, _| {
         if it.event() == flecs::OnAdd::ID {
         // ...
         } else if it.event() == flecs::OnRemove::ID {
@@ -664,7 +675,8 @@ world.Observer<Position>()
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Observer that listens for all events for Position
 world
     .observer::<flecs::Wildcard, &Position>()
@@ -730,11 +742,14 @@ world.Observer<Position, Velocity>()
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Observer that listens for entities with both Position and Velocity
 world
-    .observer::<flecs::OnAdd, (&Position, &Velocity)>()
-    .each_entity(|e, (p, v)| {
+    .observer::<flecs::OnAdd, ()>()
+    .with(Position::id())
+    .with(Velocity::id())
+    .each_entity(|e, _| {
         // ...
     });
 ```
@@ -788,14 +803,15 @@ e.Add<Velocity>();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let e = world.entity();
 
 // Does not trigger "Position, Velocity" observer
-e.add::<Position>();
+e.add(Position::id());
 
 // Entity now matches "Position, Velocity" query, triggers observer
-e.add::<Velocity>();
+e.add(Velocity::id());
 ```
 
 </li>
@@ -886,13 +902,15 @@ e.Set(new Position(20, 30));
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Observer that only triggers on Position, not on Velocity
 world
-    .observer::<flecs::OnAdd, &Position>()
-    .with::<Velocity>()
+    .observer::<flecs::OnAdd, ()>()
+    .with(Position::id())
+    .with(Velocity::id())
     .filter()
-    .each_entity(|e, p| {
+    .each_entity(|e, _| {
         // ...
     });
 
@@ -986,7 +1004,8 @@ world.Observer()
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Observer that listens for spaceships docked to planets. The observer triggers
 // only when the SpaceShip tag or DockedTo pair is added to an entity. It will
 // not trigger when Planet is added to the target of a DockedTo pair.
@@ -994,11 +1013,11 @@ world.Observer()
 // The DSL notation for this query is
 //   SpaceShip, (DockedTo, $object), Planet($object)
 world
-    .observer::<flecs::OnAdd>()
-    .with::<SpaceShip>()
-    .with_first_name::<DockedTo>("$object")
-    .with::<Planet>().set_src_name("$object")
-    .each_entity(|e| {
+    .observer::<flecs::OnAdd,()>()
+    .with(SpaceShip::id())
+    .with((DockedTo,"$object")).set_inout_none()
+    .with(Planet::id()).set_src("$object")
+    .each_entity(|e, _| {
         // ...
     });
 ```
@@ -1089,11 +1108,12 @@ e.Set(new Position(20, 30));
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // OnSet observer with both component and tag
 world
     .observer::<flecs::OnSet, &Position>()
-    .with::<Npc>() // Tag
+    .with(Npc::id()) // Tag
     .each_entity(|e, p| {
         // ...
     });
@@ -1104,7 +1124,7 @@ let e = world.entity();
 e.set(Position { x: 10.0, y: 20.0 });
 
 // Produces and OnAdd event & triggers observer
-e.add::<Npc>();
+e.add(Npc::id());
 
 // Produces an OnSet event & triggers observer
 e.set(Position { x: 20.0, y: 30.0 });
@@ -1196,12 +1216,14 @@ e.Remove<Velocity>();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Observer with a Not term
 world
-    .observer::<flecs::OnAdd, &Position>()
-    .without::<Velocity>()
-    .each_entity(|e, p| {
+    .observer::<flecs::OnAdd, ()>()
+    .with(Position::id())
+    .without(Velocity::id())
+    .each_entity(|e, _| {
         // ...
     });
 
@@ -1214,7 +1236,7 @@ e.set(Position { x: 10.0, y: 20.0 });
 e.set(Velocity { x: 1.0, y: 2.0 });
 
 // Triggers the observer, as the Velocity term was inverted to OnRemove
-e.remove::<Velocity>();
+e.remove(Velocity::id());
 ```
 
 </li>
@@ -1342,12 +1364,13 @@ e.Remove<Velocity>();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Monitor observer for Position, (ChildOf, *)
 world
-    .observer::<flecs::Monitor, (&Position)>()
-    .with::<flecs::ChildOf>(flecs::Wildcard)
-    .each_iter(|it, i, (p, v)| {
+    .observer::<flecs::Monitor, &Position>()
+    .with((flecs::ChildOf, flecs::Wildcard))
+    .each_iter(|it, i, p| {
         if it.event() == flecs::OnAdd::ID {
             // Entity started matching query
         } else if it.event() == flecs::OnRemove::ID {
@@ -1369,7 +1392,7 @@ e.child_of(p_a);
 e.child_of(p_b);
 
 // Entity no longer matches, triggers monitor with OnRemove event
-e.remove::<Position>();
+e.remove(Position::id());
 ```
 
 </li>
@@ -1460,15 +1483,18 @@ Entity e2 = world.Entity().Set(new Position(10, 20));
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Entity created before the observer
 let e1 = world.entity().set(Position { x: 10.0, y: 20.0 });
 
 // Yield existing observer
 world
-    .observer::<flecs::OnAdd, (&Position, &Velocity)>()
+    .observer::<flecs::OnAdd, ()>()
+    .with(Position::id())
+    .with(Velocity::id())
     .yield_existing()
-    .each_iter(|it, i, (p, v)| {
+    .each_iter(|it, i, _| {
         // ...
     });
 
@@ -1532,7 +1558,8 @@ world.observer<Position, Velocity>()
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // TODO
 ```
 
@@ -1615,24 +1642,22 @@ Entity e = world.Entity().Set(new TimeOfDay(0));
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Entity used for fixed source
-let game = world.entity().set(TimeOfDay { value: 0.0 });
+let game = world.entity().set(TimeOfDay(0.0));
 
 // Observer with fixed source
 world
     .observer::<flecs::OnSet, &TimeOfDay>()
     .term_at(0)
-    .set_src_id(game) // Match TimeOfDay on game
+    .set_src(game) // Match TimeOfDay on game
     .each_iter(|it, i, time| {
         // ...
     });
 
 // Triggers observer
-game.set(TimeOfDay { value: 1.0 });
-
-// Does not trigger observer
-let e = world.entity().set(TimeOfDay { value: 0.0 });
+game.set(TimeOfDay(1.0));
 ```
 
 </li>
@@ -1713,23 +1738,22 @@ Entity e = world.Entity().Set(new TimeOfDay(0));
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
-world.set(TimeOfDay { value: 0.0 });
+```rust test
+HIDE: let world = World::new();
+
+world.component::<TimeOfDay>().add_trait::<flecs::Singleton>();
+
+world.set(TimeOfDay(0.0));
 
 // Observer with singleton source
 world
     .observer::<flecs::OnSet, &TimeOfDay>()
-    .term_at(0)
-    .singleton()
     .each_iter(|it, i, time| {
         // ...
     });
 
 // Triggers observer
-world.set(TimeOfDay { value: 1.0 });
-
-// Does not trigger observer
-let e = world.entity().set(TimeOfDay { value: 0.0 });
+world.set(TimeOfDay(1.0));
 ```
 
 </li>
@@ -1802,7 +1826,8 @@ parent.Set(new Position(10, 20));
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Create an observer that matches OnSet(Position) events on self and a parent
 world
     .observer::<flecs::OnSet, &Position>()
@@ -1814,7 +1839,7 @@ world
     });
 
 let parent = world.entity();
-let child = world.entity().child_of_id(parent);
+let child = world.entity().child_of(parent);
 
 // Invokes observer twice: once for the parent and once for the child
 parent.set(Position { x: 10.0, y: 20.0 });
@@ -1893,20 +1918,22 @@ Entity child = world.Entity().ChildOf(parent);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Create an observer that matches OnAdd(Position) events on a parent
 world
-    .observer::<flecs::OnAdd, &Position>()
+    .observer::<flecs::OnAdd, ()>()
+    .with(Position::id())
     .term_at(0)
     .up() // .trav(flecs::ChildOf) (default)
-    .each_entity(|e, p| {
+    .each_entity(|e, _| {
         // ...
     });
 
 let parent = world.entity().set(Position { x: 10.0, y: 20.0 });
 
 // Forwards OnAdd event for Position to child
-let child = world.entity().child_of_id(parent);
+let child = world.entity().child_of(parent);
 ```
 
 </li>
@@ -2020,7 +2047,8 @@ world.Emit<Synchronized>()
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Create a custom event
 #[derive(Component)]
 struct Synchronized;
@@ -2040,7 +2068,7 @@ let e = world.entity().set(Position { x: 10.0, y: 20.0 });
 // Emit custom event
 world
     .event()
-    .add::<Position>()
+    .add(Position::id())
     .entity(e)
     .emit(&Synchronized);
 ```
@@ -2121,7 +2149,8 @@ widget.Emit<Clicked>();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Create a custom event
 #[derive(Component)]
 struct Clicked;
@@ -2217,7 +2246,8 @@ widget.Emit<Resize>(new(100, 200));
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Create a custom event
 #[derive(Component)]
 struct Resize {
@@ -2316,7 +2346,9 @@ world.DeferEnd();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
+HIDE: let e = world.entity();
 world
     .observer::<flecs::OnSet, &Position>()
     .each_entity(|e, p| {

--- a/docs/PrefabsManual.md
+++ b/docs/PrefabsManual.md
@@ -79,8 +79,10 @@ ref readonly Defense attack = ref inst1.Get<Defense>();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
-#[derive(Component)]
+```rust test
+HIDE: let world = World::new();
+
+#[derive(Component, Clone)]
 struct Defense {
 value: u32,
 }
@@ -89,8 +91,8 @@ value: u32,
 let spaceship = world.prefab_named("spaceship").set(Defense { value: 50 });
 
 // Create two prefab instances
-let inst_1 = world.entity().is_a_id(spaceship);
-let inst_2 = world.entity().is_a_id(spaceship);
+let inst_1 = world.entity().is_a(spaceship);
+let inst_2 = world.entity().is_a(spaceship);
 
 // Get instantiated component
 inst_1.get::<&Defense>(|defense| {
@@ -138,8 +140,9 @@ Entity myPrefab = world.Prefab();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
-let myprefab = world.entity().add::<flecs::Prefab>();
+```rust test
+HIDE: let world = World::new();
+let myprefab = world.entity().add(flecs::Prefab::id());
 
 // or the shortcut
 
@@ -189,10 +192,11 @@ world.QueryBuilder<Position>()
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Only match prefab entities
 world.query::<&Position>()
-    .with::<flecs::Prefab>()
+    .with(flecs::Prefab::id())
     .build();
 ```
 
@@ -241,10 +245,11 @@ world.QueryBuilder<Position>()
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Only match prefab entities
 world.query::<&Position>()
-    .with::<flecs::Prefab>()
+    .with(flecs::Prefab::id())
     .optional()
     .build();
 ```
@@ -291,7 +296,8 @@ world.QueryBuilder()
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Only match prefab entities
 world.query::<&Position>()
     .query_flags(QueryFlags::MatchPrefab)
@@ -387,7 +393,8 @@ ref readonly Defense defense = ref inst.Get<Defense>();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Make Defense component inheritable
 world
 .component::<Defense>()
@@ -400,7 +407,7 @@ let spaceship = world
 .set(Defense { value: 50 });
 
 // Create prefab instance
-let inst = world.entity().is_a_id(spaceship);
+let inst = world.entity().is_a(spaceship);
 
 // Component is retrieved from instance
 inst.get::<&Health>(|health| {
@@ -449,8 +456,10 @@ if (inst.Owns<Defense>()) {
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
-if inst.owns::<Defense>() {
+```rust test
+HIDE: let world = World::new();
+HIDE: let inst = world.entity();
+if inst.owns(Defense::id()) {
 // not inherited
 }
 ```
@@ -496,8 +505,10 @@ if (inheritedFrom == 0) {
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
-let inherited_from = inst.target::<Defense>(0);
+```rust test
+HIDE: let world = World::new();
+HIDE: let inst = world.entity();
+let inherited_from = inst.target(Defense::id(),0);
 if inherited_from.is_none() {
 // not inherited
 }
@@ -580,7 +591,8 @@ instA.Set(new Defense(75));
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Make Defense component inheritable
 world
 .component::<Defense>()
@@ -590,8 +602,8 @@ world
 let spaceship = world.prefab().set(Defense { value: 50 });
 
 // Create prefab instance
-let inst_a = world.entity().is_a_id(spaceship);
-let inst_b = world.entity().is_a_id(spaceship);
+let inst_a = world.entity().is_a(spaceship);
+let inst_b = world.entity().is_a(spaceship);
 
 // Override Defense only for inst_a
 inst_a.set(Defense { value: 75 });
@@ -674,7 +686,8 @@ instA.Add<Defense>(); // Initialized with value 50
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Make Defense component inheritable
 world
 .component::<Defense>()
@@ -684,11 +697,11 @@ world
 let spaceship = world.prefab().set(Defense { value: 50 });
 
 // Create prefab instance
-let inst_a = world.entity().is_a_id(spaceship);
-let inst_b = world.entity().is_a_id(spaceship);
+let inst_a = world.entity().is_a(spaceship);
+let inst_b = world.entity().is_a(spaceship);
 
 // Override Defense only for inst_a
-inst_a.add::<Defense>(); // Initialized with value 50
+inst_a.add(Defense::id()); // Initialized with value 50
 ```
 
 </li>
@@ -763,7 +776,8 @@ inst.Owns<Defense>(); // true
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Make Defense component inheritable
 world
 .component::<Defense>()
@@ -773,8 +787,8 @@ world
 let spaceship = world.prefab().set_auto_override(Defense { value: 50 }); // Set & auto override Defense
 
 // Create prefab instance
-let inst = world.entity().is_a_id(spaceship);
-inst.owns::<Defense>(); // true
+let inst = world.entity().is_a(spaceship);
+inst.owns(Defense::id()); // true
 ```
 
 </li>
@@ -863,7 +877,8 @@ ref readonly Defense defense = ref inst.Get<Defense>(); // 50
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Create prefab
 let spaceship = world
 .prefab_named("spaceship")
@@ -873,11 +888,11 @@ let spaceship = world
 // Create prefab variant
 let freighter = world
 .prefab_named("Freighter")
-.is_a_id(spaceship)
+.is_a(spaceship)
 .set(Health { value: 150 }); // Override the Health component of the freighter
 
 // Create prefab instance
-let inst = world.entity().is_a_id(freighter);
+let inst = world.entity().is_a(freighter);
 inst.get::<&Health>(|health| {
 println!("Health value: {}", health.value); // 150
 });
@@ -951,12 +966,13 @@ Entity instCockpit = inst.Lookup("Cockpit");
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let spaceship = world.prefab_named("spaceship");
-let cockpit = world.prefab_named("Cockpit").child_of_id(spaceship);
+let cockpit = world.prefab_named("Cockpit").child_of(spaceship);
 
 // Instantiate the prefab hierarchy
-let inst = world.entity().is_a_id(spaceship);
+let inst = world.entity().is_a(spaceship);
 
 // Lookup instantiated child
 let inst_cockpit = inst.lookup("Cockpit");
@@ -1037,15 +1053,16 @@ Entity instCockpit = inst.Target(cockpit);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let spaceship = world.prefab_named("Spaceship");
-let cockpit = world.prefab_named("Cockpit").child_of_id(spaceship).slot(); // Defaults to (SlotOf, spaceship)
+let cockpit = world.prefab_named("Cockpit").child_of(spaceship).slot(); // Defaults to (SlotOf, spaceship)
 
 // Instantiate the prefab hierarchy
-let inst = world.entity().is_a_id(spaceship);
+let inst = world.entity().is_a(spaceship);
 
 // Lookup instantiated child
-let inst_cockpit = inst.target_id(cockpit, 0);
+let inst_cockpit = inst.target(cockpit, 0);
 ```
 
 </li>
@@ -1097,9 +1114,12 @@ Entity prefab = world.Lookup("Spaceship");
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 #[derive(Component)]
 struct Spaceship;
+
+world.component_named::<Spaceship>("Spaceship");
 
 // Create prefab associated with the spaceship type
 world
@@ -1108,10 +1128,10 @@ world
 .set(Health { value: 100 });
 
 // Instantiate prefab with type
-let inst = world.entity().is_a::<Spaceship>();
+let inst = world.entity().is_a(Spaceship::id());
 
 // Lookup prefab handle
-let prefab = world.lookup("spaceship");
+let prefab = world.lookup("Spaceship");
 ```
 
 </li>

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -182,7 +182,7 @@ using World world = World.Create();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
 let world = World::new();
 
 // Do the ECS stuff
@@ -243,7 +243,8 @@ e.IsAlive(); // false!
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let e = world.entity();
 e.is_alive(); // true!
 
@@ -297,11 +298,14 @@ Console.WriteLine($"Entity name: {e.Name()}");
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
+HIDE: let world = World::new();
 let e = world.entity_named("bob");
 
 println!("Entity name: {}", e.name());
 ```
+
 </li>
 <li><b class="tab-title">Clojure</b>
 
@@ -337,8 +341,13 @@ Entity e = world.Lookup("Bob");
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
+HIDE: world.entity_named("bob");
+//if you are sure it exists
 let e = world.lookup("bob");
+//else use
+let e = world.try_lookup("bob");
 ```
 </li>
 <li><b class="tab-title">Clojure</b>
@@ -436,12 +445,19 @@ e.Remove<Position>();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+//notice the Default trait impl
+#[derive(Default, Component)]
+pub struct Velocity {
+    pub x: f32,
+    pub y: f32,
+}
+
+HIDE: let world = World::new();
 let e = world.entity();
 
-// Add a component. This creates the component in the ECS storage, but does not
-// assign it with a value.
-e.add::<Velocity>();
+// Add a component. This creates the component in the ECS storage, and defaults it. This requires the Default trait impl
+e.add(Velocity::id());
 
 // Set the value for the Position & Velocity components. A component will be
 // added if the entity doesn't have it yet.
@@ -454,7 +470,7 @@ e.get::<&Position>(|p| {
 });
 
 // Remove component
-e.remove::<Position>();
+e.remove(Position::id());
 ```
 </li>
 <li><b class="tab-title">Clojure</b>
@@ -523,13 +539,14 @@ posE.Add<Serializable>();
 <li><b class="tab-title">Rust</b>
 
 Rust applications can use the `world::entity_from` function.
-```rust
+```rust test
+HIDE: let world = World::new();
 let pos_e = world.entity_from::<Position>();
 
 println!("Name: {}", pos_e.name()); // outputs 'Name: Position'
 
 // It's possible to add components like you would for any entity
-pos_e.add::<Serializable>();
+pos_e.add(Serializable::id());
 ```
 </li>
 <li><b class="tab-title">Clojure</b>
@@ -583,7 +600,8 @@ Console.WriteLine($"Component size: {c.size}");
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let pos_e = world.entity_from::<Position>();
 
 pos_e.get::<&flecs::Component>(|c| {
@@ -677,27 +695,28 @@ e.Has(Enemy); // false!
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Option 1: create Tag as empty struct
 #[derive(Component)]
 struct Enemy;
 
 // Create entity, add Enemy tag
-let e = world.entity().add::<Enemy>();
-e.has::<Enemy>(); // true!
+let e = world.entity().add(Enemy);
+e.has(Enemy::id()); // true!
 
-e.remove::<Enemy>();
-e.has::<Enemy>(); // false!
+e.remove(Enemy::id());
+e.has(Enemy::id()); // false!
 
 // Option 2: create Tag as entity
 let enemy = world.entity();
 
 // Create entity, add Enemy tag
-let e = world.entity().add_id(enemy);
-e.has_id(enemy); // true!
+let e = world.entity().add(enemy);
+e.has(enemy); // true!
 
-e.remove_id(enemy);
-e.has_id(enemy); // false!
+e.remove(enemy);
+e.has(enemy); // false!
 ```
 </li>
 <li><b class="tab-title">Clojure</b>
@@ -780,7 +799,8 @@ Bob.Has<Likes>(Alice); // false!
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Create Likes relationship as empty type (tag)
 #[derive(Component)]
 struct Likes;
@@ -789,12 +809,12 @@ struct Likes;
 let bob = world.entity();
 let alice = world.entity();
 
-bob.add_first::<Likes>(alice); // bob likes alice
-alice.add_first::<Likes>(bob); // alice likes bob
-bob.has_first::<Likes>(alice); // true!
+bob.add((Likes::id(), alice.id())); // bob likes alice
+alice.add((Likes::id(), bob.id())); // alice likes bob
+bob.has((Likes::id(), alice.id())); // true!
 
-bob.remove_first::<Likes>(alice);
-bob.has_first::<Likes>(alice); // false!
+bob.remove((Likes::id(), alice.id()));
+bob.has((Likes::id(), alice.id())); // false!
 ```
 </li>
 <li><b class="tab-title">Clojure</b>
@@ -839,8 +859,10 @@ Id id = world.Pair<Likes>(bob);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
-let id = world.id_first::<Likes>(bob);
+```rust test
+HIDE: let world = World::new();
+HIDE: let bob = world.entity();
+let id = world.id_from((Likes::id(), bob.id()));
 ```
 </li>
 <li><b class="tab-title">Clojure</b>
@@ -886,8 +908,9 @@ if (id.IsPair())
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
-let id = world.id_from::<(Likes, Apples)>();
+```rust test
+HIDE: let world = World::new();
+let id = world.id_view_from((Likes::id(), Apples::id()));
 if id.is_pair() {
     let relationship = id.first_id();
     let target = id.second_id();
@@ -949,15 +972,20 @@ Bob.Has(Grows, Pears); // true!
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
+HIDE: let eats = world.entity();
+HIDE: let apples = world.entity();
+HIDE: let pears = world.entity();  
+HIDE: let grows = world.entity();
 let bob = world.entity();
-bob.add_id((eats, apples));
-bob.add_id((eats, pears));
-bob.add_id((grows, pears));
+bob.add((eats, apples));
+bob.add((eats, pears));
+bob.add((grows, pears));
 
-bob.has_id((eats, apples)); // true!
-bob.has_id((eats, pears)); // true!
-bob.has_id((grows, pears)); // true!
+bob.has((eats, apples)); // true!
+bob.has((eats, pears)); // true!
+bob.has((grows, pears)); // true!
 ```
 </li>
 <li><b class="tab-title">Clojure</b>
@@ -996,9 +1024,11 @@ Entity o = Alice.Target<Likes>(); // Returns Bob
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
-let alice = world.entity().add_first::<Likes>(bob);
-let o = alice.target::<Likes>(0); // Returns bob
+```rust test
+HIDE: let world = World::new();
+HIDE: let bob = world.entity();
+let alice = world.entity().add((Likes,bob));
+let o = alice.target(Likes,0); // Returns bob
 ```
 </li>
 <li><b class="tab-title">Clojure</b>
@@ -1051,9 +1081,10 @@ parent.Destruct();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let parent = world.entity();
-let child = world.entity().child_of_id(parent);
+let child = world.entity().child_of(parent);
 
 // Deleting the parent also deletes its children
 parent.destruct();
@@ -1125,9 +1156,10 @@ parent.Lookup("child"); // returns child
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let parent = world.entity_named("parent");
-let child = world.entity_named("child").child_of_id(parent);
+let child = world.entity_named("child").child_of(parent);
 
 println!("Child path: {}", child.path().unwrap()); // output: 'parent::child'
 
@@ -1197,7 +1229,8 @@ q.Each((ref Position p, ref Position pParent) =>
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let q = world
     .query::<(&Position, &mut Position)>()
     .term_at(1)
@@ -1268,8 +1301,10 @@ Console.WriteLine(e.Type().Str()); // output: 'Position,Velocity'
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
-let e = world.entity().add::<Position>().add::<Velocity>();
+```rust test
+HIDE: let world = World::new();
+// types added via add or defaulted. If no default trait is implemented, use set instead
+let e = world.entity().add(Position::id()).add(Velocity::id());
 
 println!("Components: {}", e.archetype().to_string().unwrap()); // output: 'Position,Velocity'
 ```
@@ -1324,7 +1359,9 @@ e.Each((Id id) =>
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
+HIDE: let e = world.entity().add(Position::id()).add(Velocity::id());
 e.each_component(|id| {
     if id == world.component_id::<Position>() {
         // Found Position component!
@@ -1386,13 +1423,14 @@ ref readonly Gravity g = ref world.Get<Gravity>();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Set singleton component
-world.set(Gravity { x: 10, y: 20 });
+world.set(Gravity { value: 9.8 });
 
 // Get singleton component
 world.get::<&Gravity>(|g| {
-    println!("Gravity: {}, {}", g.x, g.y);
+    println!("Gravity: {}", g.value);
 });
 ```
 </li>
@@ -1441,13 +1479,14 @@ ref readonly Gravity g = ref gravE.Get<Gravity>();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let grav_e = world.entity_from::<Gravity>();
 
-grav_e.set(Gravity { x: 10, y: 20 });
+grav_e.set(Gravity { value: 9.8 });
 
 grav_e.get::<&Gravity>(|g| {
-    println!("Gravity: {}, {}", g.x, g.y);
+    println!("Gravity: {}", g.value);
 });
 ```
 </li>
@@ -1498,7 +1537,8 @@ world.QueryBuilder<Velocity, Gravity>().Build();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 world
     .query::<(&Velocity, &Gravity)>()
     .build();
@@ -1611,7 +1651,8 @@ q.Iter((Iter it, Field<Position> p) =>
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // For simple queries the world::each function can be used
 world.each::<(&mut Position, &Velocity)>(|(p, v)| {
     // EntityView argument is optional, use each_entity to get it
@@ -1619,10 +1660,11 @@ world.each::<(&mut Position, &Velocity)>(|(p, v)| {
     p.y += v.y;
 });
 
-// More complex queries can first be created, then iterated
+// More complex queries can first be created, then iterated  
+HIDE: let parent = world.entity();
 let q = world
     .query::<&Position>()
-    .with_id((flecs::ChildOf::ID, parent))
+    .with((flecs::ChildOf::ID, parent))
     .build();
 
 // Option 1: the each() callback iterates over each entity
@@ -1633,7 +1675,7 @@ q.each_entity(|e, p| {
 // Option 2: the run() callback offers more control over the iteration
 q.run(|mut it| {
     while it.next() {
-        let p = it.field::<Position>(0).unwrap();
+        let p = it.field::<Position>(0);
 
         for i in it.iter() {
             println!("{}: ({}, {})", it.entity(i).name(), p[i].x, p[i].y);
@@ -1713,11 +1755,12 @@ using Query q = world.QueryBuilder()
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let q = world
     .query::<()>()
-    .with::<(flecs::ChildOf, flecs::Wildcard)>()
-    .with::<Position>()
+    .with((flecs::ChildOf, flecs::Wildcard))
+    .with(Position::id())
     .set_oper(OperKind::Not)
     .build();
 
@@ -1807,7 +1850,8 @@ moveSys.Run();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Use each_entity() function that iterates each individual entity
 let move_sys = world
     .system::<(&mut Position, &Velocity)>()
@@ -1882,9 +1926,11 @@ moveSys.Entity.Destruct();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
+HIDE: let move_sys = world.system::<(&mut Position, &Velocity)>().each(|(p, v)| {});
 println!("System: {}", move_sys.name());
-move_sys.add::<flecs::pipeline::OnUpdate>();
+move_sys.add(flecs::pipeline::OnUpdate);
 move_sys.destruct();
 ```
 </li>
@@ -1945,7 +1991,7 @@ Ecs.OnStore
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
 flecs::pipeline::OnLoad;
 flecs::pipeline::PostLoad;
 flecs::pipeline::PreUpdate;
@@ -2008,20 +2054,21 @@ world.Progress();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 world
     .system_named::<(&mut Position, &Velocity)>("Move")
-    .kind::<flecs::pipeline::OnUpdate>()
+    .kind(flecs::pipeline::OnUpdate)
     .each(|(p, v)| {});
 
 world
     .system_named::<(&mut Position, &Transform)>("Transform")
-    .kind::<flecs::pipeline::PostUpdate>()
+    .kind(flecs::pipeline::PostUpdate)
     .each(|(p, t)| {});
     
 world
     .system_named::<(&Transform, &mut Mesh)>("Render")
-    .kind::<flecs::pipeline::OnStore>()
+    .kind(flecs::pipeline::OnStore)
     .each(|(t, m)| {});
 
 world.progress();
@@ -2089,9 +2136,11 @@ moveSys.Remove(Ecs.PostUpdate);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
-move_sys.add::<flecs::pipeline::OnUpdate>();
-move_sys.remove::<flecs::pipeline::PostUpdate>();
+```rust test
+HIDE: let world = World::new();
+HIDE: let move_sys = world.system::<(&mut Position, &Velocity)>().each(|(p, v)| {});
+move_sys.add(flecs::pipeline::OnUpdate);
+move_sys.remove(flecs::pipeline::PostUpdate);
 ```
 </li>
 <li><b class="tab-title">Clojure</b>
@@ -2160,7 +2209,8 @@ e.Set<Position>(new(20, 30)); // Invokes the observer
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 world
     .observer_named::<flecs::OnSet, (&Position, &Velocity)>("OnSetPosition")
     .each(|(p, v)| {}); // Callback code is same as system
@@ -2264,7 +2314,8 @@ world.Import<MyModule>();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 #[derive(Component)]
 struct MyModule;
 

--- a/docs/Relationships.md
+++ b/docs/Relationships.md
@@ -76,16 +76,17 @@ Bob.Remove(Likes, Alice);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let likes = world.entity();
 let bob = world.entity();
 let alice = world.entity();
 
 // bob likes alice
-bob.add_id((likes, alice));
+bob.add((likes, alice));
 
 // bob likes alice no more
-bob.remove_id((likes, alice));
+bob.remove((likes, alice));
 ```
 
 </li>
@@ -148,18 +149,20 @@ Bob.Has(Eats, Pears); // true
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
+
 let bob = world.entity();
 
 let eats = world.entity();
 let apples = world.entity();
 let pears = world.entity();
 
-bob.add_id((eats, apples));
-bob.add_id((eats, pears));
+bob.add((eats, apples));
+bob.add((eats, pears));
 
-bob.has_id((eats, apples)); // true
-bob.has_id((eats, pears)); // true
+bob.has((eats, apples)); // true
+bob.has((eats, pears)); // true
 ```
 
 </li>
@@ -231,7 +234,12 @@ Query q = world.QueryBuilder()
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
+HIDE: let eats = world.entity();
+HIDE: let apples = world.entity();
+HIDE: world.component_named::<Eats>("Eats");
+HIDE: world.component_named::<Apples>("Apples");
 // Find all entities that eat apples
 let q = world.query::<()>().expr("(Eats, Apples)").build();
 
@@ -239,11 +247,11 @@ let q = world.query::<()>().expr("(Eats, Apples)").build();
 let q = world.query::<()>().expr("(Eats, *)").build();
 
 // With the query builder API:
-let q = world.query::<()>().with_id((eats, apples)).build();
+let q = world.query::<()>().with((eats, apples)).build();
 
 // Or when using pair types, when both relationship & target are compile time types, they can be represented as a tuple:
 
-let q = world.new_query::<&(Eats, Apples)>();
+let q = world.query::<()>().with((Eats::id(), Apples::id())).build();
 ```
 
 </li>
@@ -282,8 +290,12 @@ Bob.Has(Eats, Apples);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
-bob.has_id((eats, apples));
+```rust test
+HIDE: let world = World::new();
+HIDE: let bob = world.entity();
+HIDE: let eats = world.entity();
+HIDE: let apples = world.entity();
+bob.has((eats, apples));
 ```
 
 </li>
@@ -317,8 +329,11 @@ Bob.Has(Eats, Ecs.Wildcard);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
-bob.has_id((eats, flecs::Wildcard::ID));
+```rust test
+HIDE: let world = World::new();
+HIDE: let bob = world.entity();
+HIDE: let eats = world.entity();
+bob.has((eats, flecs::Wildcard));
 ```
 
 </li>
@@ -352,14 +367,18 @@ Entity parent = Bob.Parent();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
+HIDE: let bob = world.entity();
 let parent = bob.parent();
 ```
 
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
+HIDE: let bob = world.entity();
 let parent = bob.parent();
 ```
 
@@ -394,8 +413,11 @@ Entity food = Bob.Target(Eats);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
-let food = bob.target_id(eats, 0); // first target
+```rust test
+HIDE: let world = World::new();
+HIDE: let bob = world.entity();
+HIDE: let eats = world.entity();
+let food = bob.target(eats, 0); // first target
 ```
 
 </li>
@@ -439,9 +461,12 @@ while ((food = Bob.Target(Eats, index++)) != 0)
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
+HIDE: let bob = world.entity();
+HIDE: let eats = world.entity();
 let mut index = 0;
-while bob.target_id(eats, index).is_some() {
+while bob.target(eats, index).is_some() {
     index += 1;
 }
 ```
@@ -477,8 +502,10 @@ Entity parent = Bob.TargetFor<Position>(Ecs.ChildOf);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
-let parent = bob.target_for::<Position>(flecs::ChildOf::ID);
+```rust test
+HIDE: let world = World::new();
+HIDE: let bob = world.entity();
+let parent = bob.target_for(flecs::ChildOf, Position::id());
 ```
 
 </li>
@@ -531,7 +558,9 @@ Bob.Each((Id id) =>
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
+HIDE: let bob = world.entity();
 bob.each_component(|id| {
     if id.is_pair() {
         let first = id.first_id();
@@ -593,10 +622,13 @@ world.FilterBuilder()
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
+HIDE: let eats = world.entity();
+HIDE: let apples = world.entity();
 world
     .query::<()>()
-    .with_id((eats, apples))
+    .with((eats, apples))
     .build()
     .each_entity(|e, _| {
         // Iterate as usual
@@ -661,13 +693,15 @@ world.FilterBuilder()
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
+HIDE: let eats = world.entity();
 world
     .query::<()>()
-    .with_id((eats, flecs::Wildcard::ID))
+    .with((eats, flecs::Wildcard))
     .build()
     .each_iter(|it, i, _| {
-        let food = it.pair(0).unwrap().second_id(); // Apples, ...
+        let food = it.pair(0).second_id(); // Apples, ...
         let e = it.entity(i);
         // Iterate as usual
     });
@@ -716,7 +750,9 @@ parent.Children((Entity child) =>
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
+HIDE: let parent = world.entity();
 parent.each_child(|child| {
     // ...
 });
@@ -850,7 +886,8 @@ e.Add(Ecs.ChildOf, world.Id<Position>());
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Empty types (types without members) are letmatically interpreted as tags
 
 #[derive(Component)]
@@ -859,6 +896,11 @@ struct Begin;
 #[derive(Component)]
 struct End;
 
+#[derive(Component)]
+pub struct Eats {
+    amount: u32,
+}
+
 // Tags
 let likes = world.entity();
 let apples = world.entity();
@@ -866,7 +908,7 @@ let apples = world.entity();
 let e = world.entity();
 
 // Both likes and Apples are tags, so (likes, Apples) is a tag
-e.add_id((likes, apples));
+e.add((likes, apples));
 
 // Eats is a type and Apples is a tag, so (Eats, Apples) has type Eats
 e.set_pair::<Eats, Apples>(Eats { amount: 1 });
@@ -877,8 +919,8 @@ e.set_pair::<End, Position>(Position { x: 100.0, y: 20.0 }); // Same for End
 
 // ChildOf has the Tag property, so even though Position is a type, the pair
 // does not assume the Position type
-e.add_id((flecs::ChildOf::ID, world.component_id::<Position>()));
-e.add::<(flecs::ChildOf, Position)>();
+e.add((flecs::ChildOf, world.component_id::<Position>()));
+e.add((flecs::ChildOf, Position::id()));
 ```
 
 </li>
@@ -952,7 +994,8 @@ e.Set<Position>(third, new(5, 6));
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let e = world.entity();
 
 let first = world.entity();
@@ -1036,18 +1079,20 @@ q.Iter((Iter it) =>
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
+HIDE: let likes = world.entity();
 let q = world
     .query::<()>()
-    .with_id((likes, flecs::Wildcard::ID))
+    .with((likes, flecs::Wildcard))
     .build();
 
 q.each_iter(|it, i, _| {
     println!(
         "entity {} has relationship {} {}",
         it.entity(i),
-        it.pair(0).unwrap().first_id().name(),
-        it.pair(0).unwrap().second_id().name()
+        it.pair(0).first_id().name(),
+        it.pair(0).second_id().name()
     );
 });
 ```
@@ -1085,7 +1130,9 @@ Query q = world.QueryBuilder().Expr("(Likes, *)").Build();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
+HIDE: world.entity_named("likes");
 let q = world.query::<()>().expr("(likes, *)").build();
 ```
 
@@ -1178,7 +1225,8 @@ bob.Each(Eats, (Entity obj) =>
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // bob eats apples and pears
 let bob = world.entity();
 
@@ -1186,16 +1234,16 @@ let eats = world.entity();
 let apples = world.entity();
 let pears = world.entity();
 
-bob.add_id((eats, apples));
-bob.add_id((eats, pears));
+bob.add((eats, apples));
+bob.add((eats, pears));
 
 // Find all (Eats, *) relationships in bob's type
-bob.each_pair(eats, flecs::Wildcard::ID, |id| {
+bob.each_pair(eats, flecs::Wildcard, |id| {
     println!("bob eats {}", id.second_id().name());
 });
 
 // For target wildcard pairs, each_target_id() can be used:
-bob.each_target_id(eats, |entity| {
+bob.each_target(eats, |entity| {
     println!("bob eats {}", entity.name());
 });
 ```
@@ -1241,11 +1289,12 @@ Apple.Add(Ecs.IsA, Fruit);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let apple = world.entity();
 let fruit = world.entity();
 
-apple.add_id((flecs::IsA::ID, fruit));
+apple.add((flecs::IsA::ID, fruit));
 ```
 
 </li>
@@ -1272,8 +1321,11 @@ Apple.IsA(Fruit);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
-apple.is_a_id(fruit);
+```rust test
+HIDE: let world = World::new();
+HIDE: let apple = world.entity();
+HIDE: let fruit = world.entity();
+apple.is_a(fruit);
 ```
 
 </li>
@@ -1312,9 +1364,11 @@ GrannySmith.Add(Ecs.IsA, Apple);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
+HIDE: let apple = world.entity();
 let granny_smith = world.entity();
-granny_smith.add_id((flecs::IsA::ID, apple));
+granny_smith.add((flecs::IsA::ID, apple));
 ```
 
 </li>
@@ -1369,7 +1423,11 @@ Entity Frigate = world.Entity()
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
+
+world.component::<MaxSpeed>().add_trait::<(flecs::OnInstantiate, flecs::Inherit)>();
+
 let spaceship = world
     .entity()
     .set(MaxSpeed { value: 100 })
@@ -1377,7 +1435,7 @@ let spaceship = world
 
 let frigate = world
     .entity()
-    .is_a_id(spaceship) // shorthand for .add(flecs::IsA, Spaceship)
+    .is_a(spaceship) // shorthand for .add(flecs::IsA, Spaceship)
     .set(Defense { value: 75 });
 ```
 
@@ -1418,9 +1476,14 @@ v.Value == 100; // true
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
+HIDE: world.component::<MaxSpeed>().add_trait::<(flecs::OnInstantiate, flecs::Inherit)>();
+HIDE: world.component::<Defense>().add_trait::<(flecs::OnInstantiate, flecs::Inherit)>();
+HIDE: let spaceship = world.entity().set(MaxSpeed { value: 100 }).set(Defense { value: 50 });
+HIDE: let frigate = world.entity().is_a(spaceship).set(Defense { value: 75 });
 // Obtain the inherited component from Spaceship
-let is_100 = frigate.map::<&mut MaxSpeed, _>(|v| {
+let is_100 = frigate.get::<&MaxSpeed>(|v| {
     v.value == 100 // True
 });
 ```
@@ -1461,9 +1524,14 @@ v.Value == 75; // true
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
+HIDE: world.component::<MaxSpeed>().add_trait::<(flecs::OnInstantiate, flecs::Inherit)>();
+HIDE: world.component::<Defense>().add_trait::<(flecs::OnInstantiate, flecs::Inherit)>();
+HIDE: let spaceship = world.entity().set(MaxSpeed { value: 100 }).set(Defense { value: 50 });
+HIDE: let frigate = world.entity().is_a(spaceship).set(Defense { value: 75 });
 // Obtain the overridden component from Frigate
-let is_75 = frigate.map::<&mut Defense, _>(|v| {
+let is_75 = frigate.get::<&mut Defense>(|v| {
     v.value == 75 // True
 });
 ```
@@ -1529,16 +1597,21 @@ d.Value == 75; // true
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
-let fast_frigate = world.entity().is_a_id(frigate).set(MaxSpeed { value: 200 });
+```rust test
+HIDE: let world = World::new();
+HIDE: world.component::<MaxSpeed>().add_trait::<(flecs::OnInstantiate, flecs::Inherit)>();
+HIDE: world.component::<Defense>().add_trait::<(flecs::OnInstantiate, flecs::Inherit)>();
+HIDE: let spaceship = world.entity().set(MaxSpeed { value: 100 }).set(Defense { value: 50 });
+HIDE: let frigate = world.entity().is_a(spaceship).set(Defense { value: 75 });
+let fast_frigate = world.entity().is_a(frigate).set(MaxSpeed { value: 200 });
 
 // Obtain the overridden component from FastFrigate
-let is_200 = fast_frigate.map::<&mut MaxSpeed, _>(|v| {
+let is_200 = fast_frigate.get::<&mut MaxSpeed>(|v| {
     v.value == 200 // True
 });
 
 // Obtain the inherited component from Frigate
-let is_75 = fast_frigate.map::<&mut Defense, _>(|v| {
+let is_75 = fast_frigate.get::<&Defense>(|v| {
     v.value == 75 // True
 });
 ```
@@ -1586,10 +1659,11 @@ Cockpit.Add(Ecs.ChildOf, Spaceship);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let spaceship = world.entity();
 let cockpit = world.entity();
-cockpit.add_id((flecs::ChildOf::ID, spaceship));
+cockpit.add((flecs::ChildOf, spaceship));
 ```
 
 </li>
@@ -1616,8 +1690,11 @@ Cockpit.ChildOf(Spaceship);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
-cockpit.child_of_id(spaceship);
+```rust test
+HIDE: let world = World::new();
+HIDE: let cockpit = world.entity();
+HIDE: let spaceship = world.entity();
+cockpit.child_of(spaceship);
 ```
 
 </li>
@@ -1679,12 +1756,13 @@ child == parent.Lookup("Child"); // true
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let parent = world.entity_named("Parent");
-let child = world.entity_named("Child").child_of_id(parent);
+let child = world.entity_named("Child").child_of(parent);
 
-child == world.lookup("Parent::Child"); // true
-child == parent.lookup("Child"); // true
+assert!(child == world.lookup("Parent::Child")); // true
+assert!(child == parent.lookup("Child")); // true
 ```
 
 </li>
@@ -1751,19 +1829,20 @@ childB.Has(Ecs.ChildOf, parent); // true
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let parent = world.entity();
 
-let prev = world.set_scope_id(parent);
+let prev = world.set_scope(parent);
 
 let child_a = world.entity();
 let child_b = world.entity();
 
 // Restore the previous scope
-world.set_scope_id(prev);
+world.set_scope(prev);
 
-child_a.has_id((flecs::ChildOf::ID, parent)); // true
-child_b.has_id((flecs::ChildOf::ID, parent)); // true
+child_a.has((flecs::ChildOf, parent)); // true
+child_b.has((flecs::ChildOf, parent)); // true
 ```
 
 </li>
@@ -1803,12 +1882,14 @@ Entity parent = world.Entity().Scope(() =>
 </li>
 <<li><b class="tab-title">Rust</b>
 
-```rust
-let parent = world.entity().run_in_scope(|| {
+```rust test
+HIDE: let world = World::new();
+let parent = world.entity();
+parent.run_in_scope(|| {
     let child_a = world.entity();
     let child_b = world.entity();
-    child_a.has_id((flecs::ChildOf::ID, parent)); // true
-    child_b.has_id((flecs::ChildOf::ID, parent)); // true
+    child_a.has((flecs::ChildOf, parent)); // true
+    child_b.has((flecs::ChildOf, parent)); // true
 });
 ```
 

--- a/docs/Systems.md
+++ b/docs/Systems.md
@@ -67,7 +67,8 @@ System<Position, Velocity> sys = world.System<Position, Velocity>("Move")
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // System declaration
 world
     .system_named::<(&mut Position, &Velocity)>("Move")
@@ -105,8 +106,17 @@ sys.Run();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
+HIDE: let sys = world
+HIDE:     .system_named::<(&mut Position, &Velocity)>("Move")
+HIDE:     .each(|(p, v)| {
+HIDE:         p.x += v.x;
+HIDE:         p.y += v.y;
+HIDE:     });
+HIDE: /*
 let sys = ...;
+HIDE: */
 sys.run();
 ```
 </li>
@@ -138,7 +148,8 @@ world.Progress();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 let world = World::new();
 world.progress();
 ```
@@ -173,10 +184,11 @@ System<Position, Velocity> sys = world.System<Position, Velocity>("Move")
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 world
     .system_named::<(&mut Position, &Velocity)>("Move")
-    .kind_id(0)
+    .kind(0)
     .each(|(p, v)| { /* ... */ });
 ```
 </li>
@@ -301,8 +313,11 @@ The `Iter` function can be invoked multiple times per frame, once for each match
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // `.each_entity` if you need the associated entity.
+
+HIDE: let q = world.query::<(&Position, &Velocity)>().build();
 
 // Query iteration (each)
 q.each(|(p, v)| { /* ... */ });
@@ -312,16 +327,15 @@ world
     .system_named::<(&mut Position, &Velocity)>("Move")
     .each(|(p, v)| { /* ... */ });
 ```
-```rust
+```rust test
+HIDE: let world = World::new();
+HIDE: let q = world.query::<(&Position, &Velocity)>().build();
 // Query iteration (run)
 q.run(|mut it| {
     while it.next() {
-        let mut p = it
-            .field::<Position>(0)
-            .expect("query term changed and not at the same index anymore");
-        let v = it
-            .field::<Velocity>(1)
-            .expect("query term changed and not at the same index anymore");
+        let mut p = it.field_mut::<Position>(0);
+        let v = it.field::<Velocity>(1);
+
         for i in it.iter() {
             p[i].x += v[i].x;
             p[i].y += v[i].y;
@@ -334,12 +348,8 @@ world
     .system_named::<(&mut Position, &Velocity)>("Move")
     .run(|mut it| {
         while it.next() {
-            let mut p = it
-                .field::<Position>(0)
-                .expect("query term changed and not at the same index anymore");
-            let v = it
-                .field::<Velocity>(1)
-                .expect("query term changed and not at the same index anymore");
+            let mut p = it.field_mut::<Position>(0);
+            let v = it.field::<Velocity>(1);
             for i in it.iter() {
                 p[i].x += v[i].x;
                 p[i].y += v[i].y;
@@ -347,23 +357,30 @@ world
         }
     });
 ```
-```rust
-// Query iteration (run_iter)
-q.run_iter(|it, (p, v)| {
-    for i in it.iter() {
-        p[i].x += v[i].x;
-        p[i].y += v[i].y;
-    }
-});
+```rust test
+HIDE: let world = World::new();
 
-// System iteration (run_iter)
+HIDE: let q = world.query::<(&mut Position, &Velocity)>().build();
+// Query iteration (run_each_iter)
+    q.run_each_iter(|mut it| {
+        while it.next() {
+            it.each();
+        }
+    }, |it,i,(p, v)| {
+            p.x += v.x;
+            p.y += v.y;
+    });
+
+// System iteration (run_each_iter)
 world
     .system_named::<(&mut Position, &Velocity)>("Move")
-    .run_iter(|it, (p, v)| {
-        for i in it.iter() {
-            p[i].x += v[i].x;
-            p[i].y += v[i].y;
+    .run_each_iter(|mut it| {
+        while it.next() {
+            it.each();
         }
+    }, |it,i,(p, v)| {
+            p.x += v.x;
+            p.y += v.y;
     });
 ```
 
@@ -438,21 +455,13 @@ world.System<Position, Velocity>("Move")
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 world
     .system_named::<(&mut Position, &Velocity)>("Move")
     .each_iter(|it, i, (p, v)| {
         p.x += v.x * it.delta_time();
         p.y += v.y * it.delta_time();
-    });
-    
-world
-    .system_named::<(&mut Position, &Velocity)>("Move")
-    .run_iter(|it, (p, v)| {
-        for i in it.iter() {
-            p[i].x += v[i].x * it.delta_time();
-            p[i].y += v[i].y * it.delta_time();
-        }
     });
 ```
 </li>
@@ -482,7 +491,9 @@ world.Progress(deltaTime);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
+HIDE: let delta_time = 0.016;
 world.progress_time(delta_time);
 ```
 </li>
@@ -512,7 +523,8 @@ world.Progress();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 world.progress();
 ```
 </li>
@@ -578,7 +590,8 @@ world.progress();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 world.system_named::<()>("PrintTime").run(|mut it| {
     while it.next() {
         println!("Time: {}", it.delta_time());
@@ -647,14 +660,16 @@ world.System<Game>("PrintTime")
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
+
+world.component::<Game>().add_trait::<flecs::Singleton>();
+
 world
     .system_named::<&Game>("PrintTime")
-    .term_at(0)
-    .singleton()
-    .kind::<flecs::pipeline::OnUpdate>()
-    .run_iter(|it, game| {
-        println!("Time: {}", game[0].time);
+    .kind(flecs::pipeline::OnUpdate::id())
+    .each(|game| {
+        println!("Time: {}", game.time);
     });
 ```
 </li>
@@ -706,11 +721,12 @@ world.System<Position, Velocity>("Move")
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
  // System is created with (DependsOn, OnUpdate)
  world
      .system_named::<(&mut Position, &Velocity)>("Move")
-     .kind::<flecs::pipeline::OnUpdate>()
+     .kind(flecs::pipeline::OnUpdate::id())
      .each(|(p, v)| {
          // ...
      });
@@ -850,16 +866,17 @@ world.Pipeline()
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 world
     .pipeline()
-    .with::<flecs::system::System>()
-    .with::<flecs::pipeline::Phase>()
-    .cascade_type::<flecs::DependsOn>()
-    .without::<flecs::Disabled>()
-    .up_type::<flecs::DependsOn>()
-    .without::<flecs::Disabled>()
-    .up_type::<flecs::ChildOf>()
+    .with(flecs::system::System::id())
+    .with(flecs::pipeline::Phase::id())
+    .cascade_id(flecs::DependsOn::id())
+    .without(flecs::Disabled::id())
+    .up_id(flecs::DependsOn::id())
+    .without(flecs::Disabled::id())
+    .up_id(flecs::ChildOf::id())
     .build();
 ```
 
@@ -938,21 +955,22 @@ world.Progress();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // Create custom pipeline
 let pipeline = world
     .pipeline()
-    .with::<flecs::system::System>()
-    .with::<Foo>() // or `.with_id(foo) if an id`
+    .with(flecs::system::System::id())
+    .with(Foo::id()) // or `.with(foo) if an id`
     .build();
 
 // Configure the world to use the custom pipeline
-world.set_pipeline_id(pipeline);
+world.set_pipeline(pipeline);
 
 // Create system
 world
     .system_named::<(&mut Position, &Velocity)>("Move")
-    .kind::<Foo>() // or `.kind_id(foo) if an id`
+    .kind(Foo::id())
     .each(|(p, v)| {
         p.x += v.x;
         p.y += v.y;
@@ -992,8 +1010,14 @@ move.Entity.Add(foo);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
-move_sys.add::<Foo>();
+```rust test
+HIDE: let world = World::new();
+HIDE: let move_sys = world
+HIDE: .system_named::<(&mut Position, &Velocity)>("Move").run(|mut it| {
+HIDE: while it.next() {
+HIDE: }
+HIDE: });
+move_sys.add(Foo::id());
 ```
 </ul>
 </div>
@@ -1031,7 +1055,12 @@ s.Entity.Enable();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
+HIDE: let s = world.system_named::<(&mut Position, &Velocity)>("Move").each(|(p, v)| {
+HIDE:     p.x += v.x;
+HIDE:     p.y += v.y;
+HIDE: });
 // Disable system
 s.disable_self();
 // Enable system
@@ -1064,8 +1093,15 @@ s.Entity.Add(Ecs.Disabled);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
-sys.add::<flecs::Disabled>();
+```rust test
+HIDE: let world = World::new();
+HIDE: let sys = world
+HIDE:     .system_named::<(&mut Position, &Velocity)>("Move")
+HIDE:     .each(|(p, v)| {
+HIDE:         p.x += v.x;
+HIDE:         p.y += v.y;
+HIDE:     });
+sys.add(flecs::Disabled::id());
 ```
 </li>
 </ul>
@@ -1157,9 +1193,10 @@ world.System<Position>()
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // In the Rust API, use the write method to indicate commands could be inserted.
-world.system::<&Position>().write::<Transform>().each(|p| {
+world.system::<&Position>().write(Transform::id()).each(|p| {
     // ...
 });
 ```
@@ -1210,9 +1247,10 @@ world.System<Position>()
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 // In the Rust API, use the read method to indicate a component is read using .get
-world.system::<&Position>().read::<Transform>().each(|p| {
+world.system::<&Position>().read(Transform::id()).each(|p| {
     // ...
 });
 ```
@@ -1271,7 +1309,8 @@ ecs.System("AssignPlate")
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 world
     .system_named::<&Plate>("AssignPlate")
     .immediate(true) // disable readonly mode for this system
@@ -1337,7 +1376,11 @@ void AssignPlate(ecs_iter_t *it) {
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
+HIDE: world
+HIDE: .system_named::<&Plate>("AssignPlate")
+HIDE: .immediate(true) // disable readonly mode for this system
 .run(|mut it| {
     while it.next() {
         // ECS operations ran here are visible after running the system
@@ -1378,7 +1421,8 @@ world.SetThreads(4);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 world.set_threads(4);
 ```
 </li>
@@ -1421,8 +1465,9 @@ world.System<Position>()
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
-world.system::<&Position>().multi_threaded().each(|p| {
+```rust test
+HIDE: let world = World::new();
+world.system::<&Position>().par_each(|p| {
     // ...
 });
 ```
@@ -1459,7 +1504,8 @@ world.SetTaskThreads(4);
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 world.set_task_threads(4);
 ```
 </li>
@@ -1521,9 +1567,10 @@ world.System<Position, Velocity>()
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 world.system::<&Position>()
-    .interval(1.0) // Run at 1Hz
+    .set_interval(1.0) // Run at 1Hz
     .each(|p| {
     // ...
 });
@@ -1577,10 +1624,11 @@ world.System<Position, Velocity>()
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
+```rust test
+HIDE: let world = World::new();
 world
     .system::<&Position>()
-    .rate(2) // Run every other frame
+    .set_rate(2) // Run every other frame
     .each(|p| {
         // ...
     });
@@ -1652,8 +1700,14 @@ world.System<Position, Velocity>()
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
-// Timer not yet implemented in Rust
+```rust test
+HIDE: let world = World::new();
+
+let tick_source = world.timer().set_interval(1.0);
+
+world.system::<(&mut Position, &Velocity)>()
+.set_tick_source(tick_source)
+.each(|(p,v)| { /* ... */});
 ```
 </li>
 </ul>
@@ -1694,8 +1748,15 @@ tickSource.Start();
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
-// Timer addon yet to be implemented in rust
+```rust test
+HIDE: let world = World::new();
+HIDE: let tick_source = world.timer().set_interval(1.0);
+
+// Pause timer
+tick_source.stop();
+
+// Resume timer
+tick_source.start();
 ```
 </li>
 </ul>
@@ -1756,8 +1817,17 @@ TimerEntity eachHour = world.Timer()
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
-// Timer not yet implemented in Rust
+```rust test
+HIDE: let world = World::new();
+
+// tick at 1Hz
+let each_second = world.timer().set_interval(1.0);
+
+// tick each minute
+let each_minute = world.timer().set_rate_w_tick_source(60, each_second);
+
+// tick each hour
+let each_hour = world.timer().set_rate_w_tick_source(60, each_minute);
 ```
 </li>
 </ul>
@@ -1846,8 +1916,25 @@ System_ eachHour = world.System("EachHour")
 </li>
 <li><b class="tab-title">Rust</b>
 
-```rust
-// Timer not yet implemented in Rust
+```rust test
+HIDE: let world = World::new();
+let each_second = world.system_named::<()>("EachSecond")
+    .set_interval(1.0)
+    .run(|mut it| {
+        /* ... */
+    });
+let each_minute = world.system_named::<()>("EachMinute")
+    .set_tick_source(each_second)
+    .set_rate(60)
+    .run(|mut it| {
+        /* ... */
+    });
+let each_hour = world.system_named::<()>("EachHour")
+    .set_tick_source(each_minute)
+    .set_rate(60)
+    .run(|mut it| {
+        /* ... */
+    });
 ```
 </li>
 </ul>


### PR DESCRIPTION
title self explanatory. 

Does not depend on #1805 , but uses it. If this is merged before that PR, that means all the rust snippets will render the `HIDE:` statements. 

the generated test code can be found here if interested:
https://github.com/Indra-db/Flecs-Rust/tree/main/flecs_ecs/tests/docs