### PR TITLE
Don't create component records unnecessarily

### DIFF
--- a/distr/flecs.h
+++ b/distr/flecs.h
@@ -431,14 +431,14 @@ extern "C" {
 #define EcsIdWith                      (1u << 12)
 #define EcsIdCanToggle                 (1u << 13)
 #define EcsIdIsTransitive              (1u << 14)
-#define EcsIdInheritable             (1u << 15)
+#define EcsIdInheritable               (1u << 15)
 
 #define EcsIdHasOnAdd                  (1u << 16) /* Same values as table flags */
 #define EcsIdHasOnRemove               (1u << 17) 
 #define EcsIdHasOnSet                  (1u << 18)
 #define EcsIdHasOnTableCreate          (1u << 19)
 #define EcsIdHasOnTableDelete          (1u << 20)
-#define EcsIdSparse                  (1u << 21)
+#define EcsIdSparse                    (1u << 21)
 #define EcsIdDontFragment              (1u << 22)
 #define EcsIdMatchDontFragment         (1u << 23) /* For (*, T) wildcards */
 #define EcsIdOrderedChildren           (1u << 24)
@@ -532,6 +532,7 @@ extern "C" {
 #define EcsQueryCacheYieldEmptyTables (1u << 27u) /* Does query cache empty tables */
 #define EcsQueryTrivialCache          (1u << 28u) /* Trivial cache (no wildcards, traversal, order_by, group_by, change detection) */
 #define EcsQueryNested                (1u << 29u) /* Query created by a query (for observer, cache) */
+#define EcsQueryValid                 (1u << 30u)
 
 ////////////////////////////////////////////////////////////////////////////////
 //// Term flags (used by ecs_term_t::flags_)
@@ -547,7 +548,6 @@ extern "C" {
 #define EcsTermIsScope                (1u << 8)
 #define EcsTermIsMember               (1u << 9)
 #define EcsTermIsToggle               (1u << 10)
-#define EcsTermKeepAlive              (1u << 11)
 #define EcsTermIsSparse               (1u << 12)
 #define EcsTermIsOr                   (1u << 13)
 #define EcsTermDontFragment           (1u << 14)
@@ -4653,6 +4653,16 @@ FLECS_ALWAYS_INLINE ecs_component_record_t* flecs_components_get(
 FLECS_API
 ecs_id_t flecs_component_get_id(
     const ecs_component_record_t *cr);
+
+/** Get component flags for component.
+ * 
+ * @param id The component id.
+ * @return The flags for the component id.
+ */
+FLECS_API
+ecs_flags32_t flecs_component_get_flags(
+    const ecs_world_t *world,
+    ecs_id_t id);
 
 /** Find table record for component record.
  * This operation returns the table record for the table/component record if it
@@ -9653,6 +9663,23 @@ bool ecs_table_has_id(
     const ecs_world_t *world,
     const ecs_table_t *table,
     ecs_id_t component);
+
+/** Get relationship target for table.
+ * 
+ * @param world The world.
+ * @param table The table.
+ * @param relationship The relationship for which to obtain the target.
+ * @param index The index, in case the table has multiple instances of the relationship.
+ * @return The requested relationship target.
+ * 
+ * @see ecs_get_target()
+ */
+FLECS_API
+ecs_entity_t ecs_table_get_target(
+    const ecs_world_t *world,
+    const ecs_table_t *table,
+    ecs_entity_t relationship,
+    int32_t index);
 
 /** Return depth for table in tree for relationship rel.
  * Depth is determined by counting the number of targets encountered while

--- a/include/flecs.h
+++ b/include/flecs.h
@@ -5876,6 +5876,23 @@ bool ecs_table_has_id(
     const ecs_table_t *table,
     ecs_id_t component);
 
+/** Get relationship target for table.
+ * 
+ * @param world The world.
+ * @param table The table.
+ * @param relationship The relationship for which to obtain the target.
+ * @param index The index, in case the table has multiple instances of the relationship.
+ * @return The requested relationship target.
+ * 
+ * @see ecs_get_target()
+ */
+FLECS_API
+ecs_entity_t ecs_table_get_target(
+    const ecs_world_t *world,
+    const ecs_table_t *table,
+    ecs_entity_t relationship,
+    int32_t index);
+
 /** Return depth for table in tree for relationship rel.
  * Depth is determined by counting the number of targets encountered while
  * traversing up the relationship tree for rel. Only acyclic relationships are

--- a/include/flecs/private/api_flags.h
+++ b/include/flecs/private/api_flags.h
@@ -75,14 +75,14 @@ extern "C" {
 #define EcsIdWith                      (1u << 12)
 #define EcsIdCanToggle                 (1u << 13)
 #define EcsIdIsTransitive              (1u << 14)
-#define EcsIdInheritable             (1u << 15)
+#define EcsIdInheritable               (1u << 15)
 
 #define EcsIdHasOnAdd                  (1u << 16) /* Same values as table flags */
 #define EcsIdHasOnRemove               (1u << 17) 
 #define EcsIdHasOnSet                  (1u << 18)
 #define EcsIdHasOnTableCreate          (1u << 19)
 #define EcsIdHasOnTableDelete          (1u << 20)
-#define EcsIdSparse                  (1u << 21)
+#define EcsIdSparse                    (1u << 21)
 #define EcsIdDontFragment              (1u << 22)
 #define EcsIdMatchDontFragment         (1u << 23) /* For (*, T) wildcards */
 #define EcsIdOrderedChildren           (1u << 24)
@@ -176,6 +176,7 @@ extern "C" {
 #define EcsQueryCacheYieldEmptyTables (1u << 27u) /* Does query cache empty tables */
 #define EcsQueryTrivialCache          (1u << 28u) /* Trivial cache (no wildcards, traversal, order_by, group_by, change detection) */
 #define EcsQueryNested                (1u << 29u) /* Query created by a query (for observer, cache) */
+#define EcsQueryValid                 (1u << 30u)
 
 ////////////////////////////////////////////////////////////////////////////////
 //// Term flags (used by ecs_term_t::flags_)
@@ -191,7 +192,6 @@ extern "C" {
 #define EcsTermIsScope                (1u << 8)
 #define EcsTermIsMember               (1u << 9)
 #define EcsTermIsToggle               (1u << 10)
-#define EcsTermKeepAlive              (1u << 11)
 #define EcsTermIsSparse               (1u << 12)
 #define EcsTermIsOr                   (1u << 13)
 #define EcsTermDontFragment           (1u << 14)

--- a/include/flecs/private/api_internals.h
+++ b/include/flecs/private/api_internals.h
@@ -232,6 +232,16 @@ FLECS_API
 ecs_id_t flecs_component_get_id(
     const ecs_component_record_t *cr);
 
+/** Get component flags for component.
+ * 
+ * @param id The component id.
+ * @return The flags for the component id.
+ */
+FLECS_API
+ecs_flags32_t flecs_component_get_flags(
+    const ecs_world_t *world,
+    ecs_id_t id);
+
 /** Find table record for component record.
  * This operation returns the table record for the table/component record if it
  * exists. If the record exists, it means the table has the component.

--- a/src/bootstrap.c
+++ b/src/bootstrap.c
@@ -127,14 +127,6 @@ bool flecs_set_id_flag(
     (void)trait;
 
     if (!(cr->flags & flag)) {
-        if (!(world->flags & EcsWorldInit)) {
-            ecs_check(!cr->keep_alive, ECS_INVALID_OPERATION, 
-                "cannot set '%s' trait for component '%s' because it is already"
-                    " queried for (apply traits before creating queries)",
-                        flecs_errstr(ecs_get_path(world, trait)),
-                        flecs_errstr_1(ecs_id_str(world, cr->id)));
-        }
-
         cr->flags |= flag;
         if (flag == EcsIdSparse) {
             flecs_component_init_sparse(world, cr);
@@ -148,16 +140,9 @@ bool flecs_set_id_flag(
             flecs_component_record_init_exclusive(world, cr);
         }
 
-        if (flag == EcsIdOnInstantiateInherit) {
-            if (cr->id < FLECS_HI_COMPONENT_ID) {
-                world->non_trivial_lookup[cr->id] |= EcsNonTrivialIdInherit;
-            }
-        }
-
         return true;
     }
 
-error:
     return false;
 }
 
@@ -178,8 +163,23 @@ bool flecs_unset_id_flag(
     return false;
 }
 
+typedef struct ecs_on_trait_ctx_t {
+    ecs_flags32_t flag, not_flag;
+} ecs_on_trait_ctx_t;
+
 static
-void flecs_register_id_flag_for_relation(
+bool flecs_trait_can_add_after_query(
+    ecs_entity_t trait)
+{
+    if (trait == EcsWith) {
+        return true;
+    }
+
+    return false;
+}
+
+static
+void flecs_register_flag_for_trait(
     ecs_iter_t *it,
     ecs_entity_t trait,
     ecs_flags32_t flag,
@@ -195,18 +195,32 @@ void flecs_register_id_flag_for_relation(
         bool changed = false;
 
         if (event == EcsOnAdd) {
-            ecs_component_record_t *cr;
-            if (!ecs_has_id(world, e, EcsRelationship) &&
-                !ecs_has_id(world, e, EcsTarget)) 
-            {
-                cr = flecs_components_ensure(world, e);
+            if (flag == EcsIdOnInstantiateInherit) {
+                if (e < FLECS_HI_COMPONENT_ID) {
+                    world->non_trivial_lookup[e] |= EcsNonTrivialIdInherit;
+                }
+            }
+
+            if (!(world->flags & EcsWorldInit) && !flecs_trait_can_add_after_query(trait)) {
+                ecs_check(!flecs_component_is_locked(world, e), ECS_INVALID_OPERATION, 
+                    "cannot set '%s' trait for component '%s' because it is already"
+                        " queried for (apply traits before creating queries)",
+                            flecs_errstr(ecs_get_path(world, trait)),
+                            flecs_errstr_1(ecs_id_str(world, e)));
+            }
+
+            ecs_component_record_t *cr = flecs_components_ensure(world, e);
+            if (cr) {
                 changed |= flecs_set_id_flag(world, cr, flag, trait);
             }
 
-            cr = flecs_components_ensure(world, ecs_pair(e, EcsWildcard));
-            do {
-                changed |= flecs_set_id_flag(world, cr, flag, trait);
-            } while ((cr = flecs_component_first_next(cr)));
+            cr = flecs_components_get(world, ecs_pair(e, EcsWildcard));
+            if (cr) {
+                do {
+                    changed |= flecs_set_id_flag(world, cr, flag, trait);
+                } while ((cr = flecs_component_first_next(cr)));
+            }
+
             if (entity_flag) flecs_add_flag(world, e, entity_flag);
         } else if (event == EcsOnRemove) {
             ecs_component_record_t *cr = flecs_components_get(world, e);
@@ -223,6 +237,8 @@ void flecs_register_id_flag_for_relation(
             flecs_assert_relation_unused(world, e, trait);
         }
     }
+error:
+    return;
 }
 
 static
@@ -238,13 +254,10 @@ void flecs_register_final(ecs_iter_t *it) {
                     flecs_errstr(ecs_get_path(world, e)));
         }
 
-        ecs_component_record_t *cr = flecs_components_get(world, e);
-        if (cr) {
-            ecs_check(!cr->keep_alive, ECS_INVALID_OPERATION, "cannot change "
-                "trait 'Final' for '%s': already queried for (apply traits "
-                "before creating queries)", 
-                    flecs_errstr(ecs_get_path(world, e)));
-        }
+        ecs_check(!flecs_component_is_locked(world, e), ECS_INVALID_OPERATION, "cannot change "
+            "trait 'Final' for '%s': already queried for (apply traits "
+            "before creating queries)", 
+                flecs_errstr(ecs_get_path(world, e)));
 
         error:
             continue;
@@ -253,7 +266,7 @@ void flecs_register_final(ecs_iter_t *it) {
 
 static
 void flecs_register_tag(ecs_iter_t *it) {
-    flecs_register_id_flag_for_relation(it, EcsPairIsTag, EcsIdPairIsTag, EcsIdPairIsTag, 0);
+    flecs_register_flag_for_trait(it, EcsPairIsTag, EcsIdPairIsTag, EcsIdPairIsTag, 0);
 
     /* Ensure that all id records for tag have type info set to NULL */
     ecs_world_t *world = it->real_world;
@@ -264,13 +277,14 @@ void flecs_register_tag(ecs_iter_t *it) {
         if (it->event == EcsOnAdd) {
             ecs_component_record_t *cr = flecs_components_get(world, 
                 ecs_pair(e, EcsWildcard));
-            ecs_assert(cr != NULL, ECS_INTERNAL_ERROR, NULL);
-            do {
-                if (cr->type_info != NULL) {
-                    flecs_assert_relation_unused(world, e, EcsPairIsTag);
-                }
-                cr->type_info = NULL;
-            } while ((cr = flecs_component_first_next(cr)));
+            if (cr) {
+                do {
+                    if (cr->type_info != NULL) {
+                        flecs_assert_relation_unused(world, e, EcsPairIsTag);
+                    }
+                    cr->type_info = NULL;
+                } while ((cr = flecs_component_first_next(cr)));
+            }
         }
     }
 }
@@ -278,7 +292,7 @@ void flecs_register_tag(ecs_iter_t *it) {
 static
 void flecs_register_on_delete(ecs_iter_t *it) {
     ecs_id_t id = ecs_field_id(it, 0);
-    flecs_register_id_flag_for_relation(it, EcsOnDelete, 
+    flecs_register_flag_for_trait(it, EcsOnDelete, 
         ECS_ID_ON_DELETE_FLAG(ECS_PAIR_SECOND(id)),
         EcsIdOnDeleteMask,
         EcsEntityIsId);
@@ -287,7 +301,7 @@ void flecs_register_on_delete(ecs_iter_t *it) {
 static
 void flecs_register_on_delete_object(ecs_iter_t *it) {
     ecs_id_t id = ecs_field_id(it, 0);
-    flecs_register_id_flag_for_relation(it, EcsOnDeleteTarget, 
+    flecs_register_flag_for_trait(it, EcsOnDeleteTarget, 
         ECS_ID_ON_DELETE_TARGET_FLAG(ECS_PAIR_SECOND(id)),
         EcsIdOnDeleteTargetMask,
         EcsEntityIsId);  
@@ -296,26 +310,22 @@ void flecs_register_on_delete_object(ecs_iter_t *it) {
 static
 void flecs_register_on_instantiate(ecs_iter_t *it) {
     ecs_id_t id = ecs_field_id(it, 0);
-    flecs_register_id_flag_for_relation(it, EcsOnInstantiate, 
+    flecs_register_flag_for_trait(it, EcsOnInstantiate, 
         ECS_ID_ON_INSTANTIATE_FLAG(ECS_PAIR_SECOND(id)),
         0, 0);
 }
 
-typedef struct ecs_on_trait_ctx_t {
-    ecs_flags32_t flag, not_flag;
-} ecs_on_trait_ctx_t;
-
 static
 void flecs_register_trait(ecs_iter_t *it) {
     ecs_on_trait_ctx_t *ctx = it->ctx;
-    flecs_register_id_flag_for_relation(
+    flecs_register_flag_for_trait(
         it, it->ids[0], ctx->flag, ctx->not_flag, 0);
 }
 
 static
 void flecs_register_trait_pair(ecs_iter_t *it) {
     ecs_on_trait_ctx_t *ctx = it->ctx;
-    flecs_register_id_flag_for_relation(
+    flecs_register_flag_for_trait(
         it, ecs_pair_first(it->world, it->ids[0]), ctx->flag, ctx->not_flag, 0);
 }
 
@@ -422,15 +432,11 @@ void flecs_register_singleton(ecs_iter_t *it) {
 
     (void)world;
 
-    flecs_register_id_flag_for_relation(it, EcsSingleton, EcsIdSingleton, 0, 0);
+    flecs_register_flag_for_trait(it, EcsSingleton, EcsIdSingleton, 0, 0);
 
     int i, count = it->count;
     for (i = 0; i < count; i ++) {
         ecs_entity_t component = it->entities[i];
-
-        ecs_assert(flecs_components_get(world, component) != NULL, 
-            ECS_INTERNAL_ERROR, NULL);
-
         (void)component;
 
         /* Create observer that enforces that singleton is only added to self */

--- a/src/instantiate.c
+++ b/src/instantiate.c
@@ -382,8 +382,8 @@ void flecs_instantiate_override_dont_fragment(
 
         id &= ~ECS_AUTO_OVERRIDE;
 
-        ecs_component_record_t *cr = flecs_components_get(world, id);
-        if (!cr || !(cr->flags & EcsIdDontFragment)) {
+        ecs_flags32_t flags = flecs_component_get_flags(world, id);
+        if (!(flags & EcsIdDontFragment)) {
             continue;
         }
 

--- a/src/observable.c
+++ b/src/observable.c
@@ -232,7 +232,7 @@ int32_t flecs_event_observers_get(
 }
 
 bool flecs_observers_exist(
-    ecs_observable_t *observable,
+    const ecs_observable_t *observable,
     ecs_id_t id,
     ecs_entity_t event)
 {

--- a/src/observable.h
+++ b/src/observable.h
@@ -76,7 +76,7 @@ void flecs_observable_fini(
 
 /* Check if any observers exist for event/component. */
 bool flecs_observers_exist(
-    ecs_observable_t *observable,
+    const ecs_observable_t *observable,
     ecs_id_t id,
     ecs_entity_t event);
 

--- a/src/observer.c
+++ b/src/observer.c
@@ -1038,25 +1038,13 @@ ecs_observer_t* flecs_observer_init(
             if (trivial_observer) {
                 dummy_query.flags |= desc->query.flags;
                 query = &dummy_query;
-                if (terms[0].flags_ & EcsTermKeepAlive) {
-                    impl->flags |= EcsObserverKeepAlive;
-                }
             } else {
                 /* We're going to create an actual query, so undo the keep_alive
                  * increment of the dummy_query. */
                 int32_t i, count = dummy_query.term_count;
                 for (i = 0; i < count; i ++) {
                     ecs_term_t *term = &terms[i];
-                    if (term->flags_ & EcsTermKeepAlive) {
-                        ecs_component_record_t *cr = flecs_components_get(
-                            world, term->id);
-
-                        /* If keep_alive was set, component record must exist */
-                        ecs_assert(cr != NULL, ECS_INTERNAL_ERROR, NULL);
-                        cr->keep_alive --;
-                        ecs_assert(cr->keep_alive >= 0, 
-                            ECS_INTERNAL_ERROR, NULL);
-                    }
+                    flecs_component_unlock(world, term->id);
                 }
             }
         }
@@ -1331,20 +1319,8 @@ void flecs_observer_fini(
     /* Cleanup queries */
     if (o->query) {
         ecs_query_fini(o->query);
-    } else if (impl->flags & EcsObserverKeepAlive) {
-        /* Observer is keeping a refcount on the observed component. */
-        ecs_component_record_t *cr = flecs_components_get(
-            world, impl->register_id);
-        
-        /* Component record should still exist since we had a refcount, except
-         * during the final stages of world fini where refcounts are no longer 
-         * checked. */
-        if (cr) {
-            cr->keep_alive --;
-            ecs_assert(cr->keep_alive >= 0, ECS_INTERNAL_ERROR, NULL);
-        } else {
-            ecs_assert(world->flags & EcsWorldQuit, ECS_INTERNAL_ERROR, NULL);
-        }
+    } else if (impl->register_id) {
+        flecs_component_unlock(world, impl->register_id);
     }
 
     if (impl->not_query) {

--- a/src/private_api.h
+++ b/src/private_api.h
@@ -196,6 +196,10 @@ bool flecs_type_can_inherit_id(
 void flecs_fini_type_info(
     ecs_world_t *world);
 
+const ecs_type_info_t* flecs_determine_type_info_for_component(
+    const ecs_world_t *world,
+    ecs_id_t component);
+
 /* Utility for using allocated strings in assert/error messages */
 const char* flecs_errstr(
     char *str);

--- a/src/query/engine/eval_sparse.c
+++ b/src/query/engine/eval_sparse.c
@@ -150,6 +150,9 @@ bool flecs_query_sparse_select_wildcard(
 
     if (!redo) {
         ecs_component_record_t *cr = flecs_components_get(ctx->world, id);
+        if (!cr) {
+            return false;
+        }
 
         if (ECS_PAIR_FIRST(id) == EcsWildcard) {
             op_ctx->cr = cr->pair->second.next;
@@ -365,6 +368,9 @@ bool flecs_query_sparse_with_wildcard(
 
     if (!redo) {
         ecs_component_record_t *cr = flecs_components_get(ctx->world, id);
+        if (!cr) {
+            return false;
+        }
 
         if (cr->flags & EcsIdExclusive) {
             op_ctx->cr = cr;

--- a/src/storage/component_index.c
+++ b/src/storage/component_index.c
@@ -258,17 +258,270 @@ void flecs_component_fini_sparse(
 
 static
 ecs_flags32_t flecs_component_event_flags(
-    ecs_world_t *world,
+    const ecs_world_t *world,
     ecs_id_t id)
 {
-    ecs_observable_t *o = &world->observable;
+    const ecs_observable_t *o = &world->observable;
     ecs_flags32_t result = 0;
     result |= flecs_observers_exist(o, id, EcsOnAdd) * EcsIdHasOnAdd;
     result |= flecs_observers_exist(o, id, EcsOnRemove) * EcsIdHasOnRemove;
     result |= flecs_observers_exist(o, id, EcsOnSet) * EcsIdHasOnSet;
     result |= flecs_observers_exist(o, id, EcsOnTableCreate) * EcsIdHasOnTableCreate;
     result |= flecs_observers_exist(o, id, EcsOnTableDelete) * EcsIdHasOnTableDelete;
+    result |= flecs_observers_exist(o, id, EcsWildcard) * (
+         EcsIdHasOnAdd
+        |EcsIdHasOnRemove
+        |EcsIdHasOnSet
+        |EcsIdHasOnTableCreate
+        |EcsIdHasOnTableDelete);
     return result;
+}
+
+static
+ecs_flags32_t flecs_component_get_flags_intern(
+    const ecs_world_t *world,
+    ecs_id_t id,
+    ecs_entity_t rel,
+    ecs_entity_t tgt,
+    const ecs_type_info_t *ti)
+{
+    ecs_flags32_t result = 0;
+
+    if (id & ECS_ID_FLAGS_MASK) {
+        if ((id & ECS_ID_FLAGS_MASK) != ECS_PAIR) {
+            return 0;
+        }
+    }
+
+    ecs_record_t *r = flecs_entities_get_any(world, rel);
+    ecs_assert(r != NULL, ECS_INTERNAL_ERROR, NULL);
+    ecs_table_t *table = r->table;
+
+    if (ecs_table_has_id(world, table, ecs_pair(EcsWith, EcsWildcard))) {
+        result |= EcsIdWith;
+    }
+
+    if (ecs_table_has_id(world, table, EcsCanToggle)) {
+        result |= EcsIdCanToggle;
+    }
+
+    if (ecs_table_has_id(world, table, EcsInheritable)) {
+        result |= EcsIdInheritable;
+    }
+
+    if (ecs_table_has_id(world, table, EcsSingleton)) {
+        result |= EcsIdSingleton;
+    }
+
+    ecs_entity_t on_delete_kind = ecs_table_get_target(world, table, EcsOnDelete, 0);
+    if (on_delete_kind == EcsRemove) {
+        result |= EcsIdOnDeleteRemove;
+    } else if (on_delete_kind == EcsDelete) {
+        result |= EcsIdOnDeleteDelete;
+    } else if (on_delete_kind == EcsPanic) {
+        result |= EcsIdOnDeletePanic;
+    }
+
+    on_delete_kind = ecs_table_get_target(world, table, EcsOnDeleteTarget, 0);
+    if (on_delete_kind == EcsRemove) {
+        result |= EcsIdOnDeleteTargetRemove;
+    } else if (on_delete_kind == EcsDelete) {
+        result |= EcsIdOnDeleteTargetDelete;
+    } else if (on_delete_kind == EcsPanic) {
+        result |= EcsIdOnDeleteTargetPanic;
+    }
+
+    ecs_entity_t inherit_kind = ecs_table_get_target(world, table, EcsOnInstantiate, 0);
+    if (inherit_kind == EcsInherit) {
+        result |= EcsIdOnInstantiateInherit;
+    } else if (inherit_kind == EcsDontInherit) {
+        result |= EcsIdOnInstantiateDontInherit;
+    } else if (inherit_kind == EcsOverride) {
+        result |= EcsIdOnInstantiateOverride;
+    }
+
+    if (tgt) {
+        if (ecs_table_has_id(world, table, EcsExclusive)) {
+            result |= EcsIdExclusive;
+        }
+
+        if (ecs_table_has_id(world, table, EcsTraversable)) {
+            result |= EcsIdTraversable;
+        }
+
+        if (ecs_table_has_id(world, table, EcsPairIsTag)) {
+            result |= EcsIdPairIsTag;
+        }
+
+        if (ecs_table_has_id(world, table, EcsTransitive)) {
+            result |= EcsIdIsTransitive;
+        }
+
+        if (rel == EcsChildOf) {
+            if (ecs_has_id(world, tgt, EcsOrderedChildren)) {
+                result |= EcsIdOrderedChildren;
+            }
+        }
+    }
+
+    if (tgt && ti && (ti->component == tgt)) {
+        if (ecs_has_id(world, tgt, EcsSparse)) {
+            result |= EcsIdSparse;
+        }
+
+        if (ecs_has_id(world, tgt, EcsDontFragment)) {
+            result |= EcsIdDontFragment;
+        }
+    } else {
+        if (ecs_table_has_id(world, table, EcsSparse)) {
+            result |= EcsIdSparse;
+        }
+
+        if (ecs_table_has_id(world, table, EcsDontFragment)) {
+            result |= EcsIdDontFragment;
+        }
+    }
+
+    result |= flecs_component_event_flags(world, id);
+
+    return result;
+}
+
+ecs_flags32_t flecs_component_get_flags(
+    const ecs_world_t *world,
+    ecs_id_t id)
+{
+    const ecs_component_record_t *cr = flecs_components_get(world, id);
+    if (cr) {
+        return cr->flags;
+    }
+
+    const ecs_type_info_t *ti = flecs_determine_type_info_for_component(world, id);
+    ecs_entity_t rel = 0, tgt = 0;
+
+    if (ECS_IS_PAIR(id)) {
+        rel = ECS_PAIR_FIRST(id);
+        rel = flecs_entities_get_alive(world, rel);
+
+        tgt = ECS_PAIR_SECOND(id);
+        tgt = flecs_entities_get_alive(world, tgt);
+    } else {
+        rel = id & ECS_COMPONENT_MASK;
+        ecs_assert(rel != 0, ECS_INTERNAL_ERROR, NULL);
+    }
+
+    return flecs_component_get_flags_intern(world, id, rel, tgt, ti);
+}
+
+static
+void flecs_component_record_check_constraints(
+    ecs_world_t *world,
+    ecs_component_record_t *cr,
+    ecs_entity_t rel,
+    ecs_entity_t tgt)
+{
+    (void)world;
+    (void)cr;
+    (void)rel;
+    (void)tgt;
+
+#ifdef FLECS_DEBUG
+    if (ECS_IS_PAIR(cr->id)) {
+        if (tgt) {
+            ecs_assert(tgt != 0, ECS_INTERNAL_ERROR, NULL);
+
+            /* Can't use relationship as target */
+            if (ecs_has_id(world, tgt, EcsRelationship)) {
+                if (!ecs_id_is_wildcard(rel) && 
+                    !ecs_has_id(world, rel, EcsTrait)) 
+                {
+                    ecs_throw(ECS_CONSTRAINT_VIOLATED, "cannot use '%s' as target"
+                        " in pair '%s': '%s' has the Relationship trait",
+                            flecs_errstr(ecs_get_path(world, tgt)),
+                            flecs_errstr_1(ecs_id_str(world, cr->id)),
+                            flecs_errstr_2(ecs_get_path(world, tgt)));
+                }
+            }
+        }
+
+        if (ecs_has_id(world, rel, EcsTarget)) {
+            ecs_throw(ECS_CONSTRAINT_VIOLATED, "cannot use '%s' as relationship "
+                "in pair '%s': '%s' has the Target trait",
+                    flecs_errstr(ecs_get_path(world, rel)),
+                    flecs_errstr_1(ecs_id_str(world, cr->id)),
+                    flecs_errstr_2(ecs_get_path(world, rel)));
+        }
+
+        if (tgt && !ecs_id_is_wildcard(tgt)) {
+            /* Check if target of relationship satisfies OneOf property */
+            ecs_entity_t oneof = flecs_get_oneof(world, rel);
+            if (oneof) {
+                if (!ecs_has_pair(world, tgt, EcsChildOf, oneof)) {
+                    if (oneof == rel) {
+                        ecs_throw(ECS_CONSTRAINT_VIOLATED, 
+                            "cannot use '%s' as target in pair '%s': "
+                            "relationship '%s' has the OneOf trait and '%s' "
+                            "is not a child of '%s'",
+                                flecs_errstr(ecs_get_path(world, tgt)),
+                                flecs_errstr_1(ecs_id_str(world, cr->id)),
+                                flecs_errstr_2(ecs_get_path(world, rel)),
+                                flecs_errstr_3(ecs_get_path(world, tgt)),
+                                flecs_errstr_4(ecs_get_path(world, rel)));
+                        } else {
+                            ecs_throw(ECS_CONSTRAINT_VIOLATED, 
+                                "cannot use '%s' as target in pair '%s': "
+                                "relationship '%s' has (OneOf, %s) and '%s' "
+                                "is not a child of '%s'",
+                                    flecs_errstr(ecs_get_path(world, tgt)),
+                                    flecs_errstr_1(ecs_id_str(world, cr->id)),
+                                    flecs_errstr_2(ecs_get_path(world, rel)),
+                                    flecs_errstr_3(ecs_get_path(world, oneof)),
+                                    flecs_errstr_4(ecs_get_path(world, tgt)),
+                                    flecs_errstr_5(ecs_get_path(world, oneof)));
+                        }
+                }
+            }
+
+            /* Check if we're not trying to inherit from a final target */
+            if (rel == EcsIsA) {
+                if (ecs_has_id(world, tgt, EcsFinal)) {
+                    ecs_throw(ECS_CONSTRAINT_VIOLATED, 
+                        "cannot add '(IsA, %s)': '%s' has the Final trait",
+                            flecs_errstr(ecs_get_path(world, tgt)),
+                            flecs_errstr_1(ecs_get_path(world, tgt)));
+                }
+
+                if (flecs_component_is_locked(world, tgt)) {
+                    if (!ecs_has_id(world, tgt, EcsInheritable) && !ecs_has_pair(world, tgt, EcsIsA, EcsWildcard)) {
+                        ecs_throw(ECS_INVALID_OPERATION, 
+                            "cannot add '(IsA, %s)': '%s' is already queried for",
+                                    flecs_errstr(ecs_get_path(world, tgt)),
+                                    flecs_errstr_1(ecs_get_path(world, tgt)));
+                    }
+                }
+            }
+        }
+    } else {
+        bool is_tgt = false;
+        if (ecs_has_id(world, rel, EcsRelationship) ||
+            (is_tgt = ecs_has_id(world, rel, EcsTarget)))
+        {
+            if (is_tgt) {
+                ecs_throw(ECS_CONSTRAINT_VIOLATED, 
+                    "cannot use '%s' by itself: it has the Target trait and "
+                    "must be used in pair with relationship",
+                        flecs_errstr(ecs_get_path(world, rel)));
+            } else {
+                ecs_throw(ECS_CONSTRAINT_VIOLATED, 
+                    "cannot use '%s' by itself: it has the Relationhip trait "
+                    "and must be used in pair with target",
+                        flecs_errstr(ecs_get_path(world, rel)));
+            }
+        }
+    }
+error:
+    return;
+#endif
 }
 
 static
@@ -280,6 +533,10 @@ ecs_component_record_t* flecs_component_new(
     ecs_id_t hash = flecs_component_hash(id);
     cr = flecs_bcalloc_w_dbg_info(
         &world->allocators.component_record, "ecs_component_record_t");
+
+    if (id == ecs_id(EcsPoly)) {
+        flecs_dump_backtrace(stdout);
+    }
 
     if (hash >= FLECS_HI_ID_RECORD_ID) {
         ecs_map_insert_ptr(&world->id_index_hi, hash, cr);
@@ -295,7 +552,7 @@ ecs_component_record_t* flecs_component_new(
     bool is_wildcard = ecs_id_is_wildcard(id);
     bool is_pair = ECS_IS_PAIR(id);
 
-    ecs_entity_t rel = 0, tgt = 0, role = id & ECS_ID_FLAGS_MASK;
+    ecs_entity_t rel = 0, tgt = 0;
     if (is_pair) {
         cr->pair = flecs_bcalloc_w_dbg_info(
             &world->allocators.pair_record, "ecs_pair_record_t");
@@ -319,86 +576,7 @@ ecs_component_record_t* flecs_component_new(
             tgt = alive_tgt;
         }
 
-#ifdef FLECS_DEBUG
-        /* Check constraints */
-        if (tgt) {
-            ecs_assert(tgt != 0, ECS_INTERNAL_ERROR, NULL);
-
-            /* Can't use relationship as target */
-            if (ecs_has_id(world, tgt, EcsRelationship)) {
-                if (!ecs_id_is_wildcard(rel) && 
-                    !ecs_has_id(world, rel, EcsTrait)) 
-                {
-                    ecs_throw(ECS_CONSTRAINT_VIOLATED, "cannot use '%s' as target"
-                        " in pair '%s': '%s' has the Relationship trait",
-                            flecs_errstr(ecs_get_path(world, tgt)),
-                            flecs_errstr_1(ecs_id_str(world, id)),
-                            flecs_errstr_2(ecs_get_path(world, tgt)));
-                }
-            }
-        }
-
-        if (ecs_has_id(world, rel, EcsTarget)) {
-            ecs_throw(ECS_CONSTRAINT_VIOLATED, "cannot use '%s' as relationship "
-                "in pair '%s': '%s' has the Target trait",
-                    flecs_errstr(ecs_get_path(world, rel)),
-                    flecs_errstr_1(ecs_id_str(world, id)),
-                    flecs_errstr_2(ecs_get_path(world, rel)));
-        }
-
-        if (tgt && !ecs_id_is_wildcard(tgt)) {
-            /* Check if target of relationship satisfies OneOf property */
-            ecs_entity_t oneof = flecs_get_oneof(world, rel);
-            if (oneof) {
-                if (!ecs_has_pair(world, tgt, EcsChildOf, oneof)) {
-                    if (oneof == rel) {
-                        ecs_throw(ECS_CONSTRAINT_VIOLATED, 
-                            "cannot use '%s' as target in pair '%s': "
-                            "relationship '%s' has the OneOf trait and '%s' "
-                            "is not a child of '%s'",
-                                flecs_errstr(ecs_get_path(world, tgt)),
-                                flecs_errstr_1(ecs_id_str(world, id)),
-                                flecs_errstr_2(ecs_get_path(world, rel)),
-                                flecs_errstr_3(ecs_get_path(world, tgt)),
-                                flecs_errstr_4(ecs_get_path(world, rel)));
-                        } else {
-                            ecs_throw(ECS_CONSTRAINT_VIOLATED, 
-                                "cannot use '%s' as target in pair '%s': "
-                                "relationship '%s' has (OneOf, %s) and '%s' "
-                                "is not a child of '%s'",
-                                    flecs_errstr(ecs_get_path(world, tgt)),
-                                    flecs_errstr_1(ecs_id_str(world, id)),
-                                    flecs_errstr_2(ecs_get_path(world, rel)),
-                                    flecs_errstr_3(ecs_get_path(world, oneof)),
-                                    flecs_errstr_4(ecs_get_path(world, tgt)),
-                                    flecs_errstr_5(ecs_get_path(world, oneof)));
-                        }
-                }
-            }
-
-            /* Check if we're not trying to inherit from a final target */
-            if (rel == EcsIsA) {
-                if (ecs_has_id(world, tgt, EcsFinal)) {
-                    ecs_throw(ECS_CONSTRAINT_VIOLATED, 
-                        "cannot add '(IsA, %s)': '%s' has the Final trait",
-                            flecs_errstr(ecs_get_path(world, tgt)),
-                            flecs_errstr_1(ecs_get_path(world, tgt)));
-                }
-
-                ecs_component_record_t *cr_tgt = flecs_components_get(world, tgt);
-                if (cr_tgt && cr_tgt->keep_alive) {
-                    if (!ecs_has_id(world, tgt, EcsInheritable)) {
-                        ecs_throw(ECS_INVALID_OPERATION, 
-                            "cannot add '(IsA, %s)': '%s' is already queried for",
-                                    flecs_errstr(ecs_get_path(world, tgt)),
-                                    flecs_errstr_1(ecs_get_path(world, tgt)));
-                    }
-                }
-            }
-        }
-#endif
-
-        if (!is_wildcard && (rel != EcsFlag)) {
+        if (!is_wildcard && (rel != EcsFlag) && is_pair) {
             /* Inherit flags from (relationship, *) record */
             ecs_component_record_t *cr_r = flecs_components_ensure(
                 world, ecs_pair(rel, EcsWildcard));
@@ -416,37 +594,15 @@ ecs_component_record_t* flecs_component_new(
     } else {
         rel = id & ECS_COMPONENT_MASK;
         ecs_assert(rel != 0, ECS_INTERNAL_ERROR, NULL);
-
-        /* Can't use relationship outside of a pair */
-#ifdef FLECS_DEBUG
         rel = flecs_entities_get_alive(world, rel);
-        bool is_tgt = false;
-        if (ecs_has_id(world, rel, EcsRelationship) ||
-            (is_tgt = ecs_has_id(world, rel, EcsTarget)))
-        {
-            if (is_tgt) {
-                ecs_throw(ECS_CONSTRAINT_VIOLATED, 
-                    "cannot use '%s' by itself: it has the Target trait and must be used in pair with relationship",
-                        flecs_errstr(ecs_get_path(world, rel)));
-            } else {
-                ecs_throw(ECS_CONSTRAINT_VIOLATED, 
-                    "cannot use '%s' by itself: it has the Relationhip trait and must be used in pair with target",
-                        flecs_errstr(ecs_get_path(world, rel)));
-            }
-        }
-#endif
     }
 
-    /* Initialize type info if id is not a tag */
-    if (!is_wildcard && (!role || is_pair)) {
-        if (!(cr->flags & EcsIdPairIsTag)) {
-            const ecs_type_info_t *ti = flecs_type_info_get(world, rel);
-            if (!ti && tgt) {
-                ti = flecs_type_info_get(world, tgt);
-            }
-            cr->type_info = ti;
-        }
-    }
+    cr->type_info = flecs_determine_type_info_for_component(world, id);
+
+    cr->flags |= flecs_component_get_flags_intern(
+        world, id, rel, tgt, cr->type_info);
+
+    flecs_component_record_check_constraints(world, cr, rel, tgt);
 
     /* Mark entities that are used as component/pair ids. When a tracked
      * entity is deleted, cleanup policies are applied so that the store
@@ -454,11 +610,12 @@ ecs_component_record_t* flecs_component_new(
 
     /* Flag for OnDelete policies */
     flecs_add_flag(world, rel, EcsEntityIsId);
-    if (tgt) {
+    if (tgt && tgt != EcsWildcard) {
         /* Flag for OnDeleteTarget policies */
         ecs_record_t *tgt_r = flecs_entities_get_any(world, tgt);
         ecs_assert(tgt_r != NULL, ECS_INTERNAL_ERROR, NULL);
         flecs_record_add_flag(tgt_r, EcsEntityIsTarget);
+
         if (cr->flags & EcsIdTraversable) {
             /* Flag used to determine if object should be traversed when
              * propagating events or with super/subset queries */
@@ -468,35 +625,17 @@ ecs_component_record_t* flecs_component_new(
             tgt_r->cr = cr_t;
         }
 
-        /* If second element of pair determines the type, check if the pair 
-         * should be stored as a sparse component. */
-        if (cr->type_info && cr->type_info->component == tgt) {
-            if (ecs_has_id(world, tgt, EcsSparse)) {
-                cr->flags |= EcsIdSparse;
-            }
-            if (ecs_has_id(world, tgt, EcsDontFragment)) {
-                cr->flags |= EcsIdDontFragment;
-            }
-        }
-
-        /* Check if we should keep a list of ordered children for parent */
-        if (rel == EcsChildOf) {
-            if (ecs_has_id(world, tgt, EcsOrderedChildren)) {
-                cr->flags |= EcsIdOrderedChildren;
-            }
-        }
-
         /* Mark (*, tgt) record with HasDontFragment so that queries can quickly
          * detect if there are any non-fragmenting records to consider for a
          * (*, tgt) query. */
         if (cr->flags & EcsIdDontFragment && ECS_PAIR_FIRST(id) != EcsFlag) {
-            ecs_assert(cr_t != NULL, ECS_INTERNAL_ERROR, NULL);
-            cr_t->flags |= EcsIdMatchDontFragment;
+            if (cr_t) {
+                cr_t->flags |= EcsIdMatchDontFragment;
+            }
         }
     }
 
-    cr->flags |= flecs_component_event_flags(world, id);
-
+    /* Initialize storage */
     if (cr->flags & EcsIdSparse) {
         flecs_component_init_sparse(world, cr);
     }
@@ -522,10 +661,6 @@ ecs_component_record_t* flecs_component_new(
     world->info.pair_id_count += is_pair;
 
     return cr;
-#ifdef FLECS_DEBUG
-error:
-    return NULL;
-#endif
 }
 
 static
@@ -549,7 +684,8 @@ void flecs_component_free(
     flecs_component_assert_empty(cr);
 
     /* Id is still in use by a query */
-    ecs_assert((world->flags & EcsWorldQuit) || (cr->keep_alive == 0), 
+    ecs_assert((world->flags & EcsWorldQuit) || 
+            !flecs_component_is_locked(world, id), 
         ECS_INVALID_OPERATION, 
         "cannot delete component '%s' as it is still in use by queries",
             flecs_errstr(ecs_id_str(world, id)));
@@ -670,6 +806,19 @@ ecs_component_record_t* flecs_components_get(
         cr = world->id_index_lo[hash];
     }
 
+    return cr;
+}
+
+ecs_component_record_t* flecs_components_try_ensure(
+    ecs_world_t *world,
+    ecs_id_t id)
+{
+    ecs_component_record_t *cr = flecs_components_get(world, id);
+    if (!cr) {
+        if (!(world->flags & EcsWorldMultiThreaded)) {
+            cr = flecs_component_new(world, id);
+        }
+    }
     return cr;
 }
 
@@ -809,15 +958,12 @@ ecs_flags32_t flecs_id_flags(
     ecs_world_t *world,
     ecs_id_t id)
 {
-    const ecs_component_record_t *cr = flecs_components_get(world, id);
-    if (cr) {
-        ecs_flags32_t extra_flags = 0;
-        if (cr->flags & EcsIdOnInstantiateInherit) {
-            extra_flags |= EcsIdHasOnAdd|EcsIdHasOnRemove;
-        }
-        return cr->flags|extra_flags;
+    ecs_flags32_t cr_flags = flecs_component_get_flags(world, id);
+    ecs_flags32_t extra_flags = 0;
+    if (cr_flags & EcsIdOnInstantiateInherit) {
+        extra_flags |= EcsIdHasOnAdd|EcsIdHasOnRemove;
     }
-    return flecs_component_event_flags(world, id);
+    return cr_flags|extra_flags;
 }
 
 ecs_flags32_t flecs_id_flags_get(

--- a/src/storage/component_index.h
+++ b/src/storage/component_index.h
@@ -81,11 +81,6 @@ struct ecs_component_record_t {
 
     /* Refcount */
     int32_t refcount;
-
-    /* Keep alive count. This count must be 0 when the component record is deleted. If
-     * it is not 0, an application attempted to delete an id that was still
-     * queried for. */
-    int32_t keep_alive;
 };
 
 /* Bootstrap cached id records */
@@ -98,6 +93,11 @@ void flecs_components_fini(
 
 /* Ensure component record for id */
 ecs_component_record_t* flecs_components_ensure(
+    ecs_world_t *world,
+    ecs_id_t id);
+
+/* Like flecs_components_ensure, but creates only if world is not in threaded mode */
+ecs_component_record_t* flecs_components_try_ensure(
     ecs_world_t *world,
     ecs_id_t id);
 

--- a/src/storage/table.c
+++ b/src/storage/table.c
@@ -2752,6 +2752,35 @@ bool ecs_table_has_id(
     return ecs_table_get_type_index(world, table, id) != -1;
 }
 
+ecs_entity_t ecs_table_get_target(
+    const ecs_world_t *world,
+    const ecs_table_t *table,
+    ecs_entity_t relationship,
+    int32_t index)
+{
+    flecs_poly_assert(world, ecs_world_t);
+
+    ecs_component_record_t *cr = flecs_components_get(world, 
+        ecs_pair(relationship, EcsWildcard));
+    if (!cr) {
+        return 0;
+    }
+
+    const ecs_table_record_t *tr = flecs_component_get_table(cr, table);
+    if (!tr) {
+        return 0;
+    }
+
+    if (index > tr->count) {
+        return 0;
+    }
+
+    ecs_id_t id = table->type.array[tr->index + index];
+    ecs_assert(ECS_IS_PAIR(id), ECS_INTERNAL_ERROR, NULL);
+    ecs_entity_t tgt = ECS_PAIR_SECOND(id);
+    return flecs_entities_get_alive(world, tgt);
+}
+
 int32_t ecs_table_get_depth(
     const ecs_world_t *world,
     const ecs_table_t *table,

--- a/src/world.c
+++ b/src/world.c
@@ -1008,6 +1008,7 @@ ecs_world_t *ecs_mini(void) {
     ecs_allocator_t *a = &world->allocator;
 
     ecs_map_init(&world->type_info, a);
+    ecs_map_init(&world->locked_components, a);
     ecs_map_init_w_params(&world->id_index_hi, &world->allocators.ptr);
     world->id_index_lo = ecs_os_calloc_n(
         ecs_component_record_t*, FLECS_HI_ID_RECORD_ID);
@@ -1315,6 +1316,7 @@ int ecs_fini(
     flecs_entities_fini(world);
     flecs_components_fini(world);
     flecs_fini_type_info(world);
+    ecs_map_fini(&world->locked_components);
     flecs_observable_fini(&world->observable);
     flecs_name_index_fini(&world->aliases);
     flecs_name_index_fini(&world->symbols);
@@ -1901,4 +1903,73 @@ ecs_id_t ecs_get_with(
     return stage->with;
 error:
     return 0;
+}
+
+static
+void flecs_component_lock_inc(
+    ecs_world_t *world,
+    ecs_id_t component)
+{
+    ecs_assert(component != 0, ECS_INTERNAL_ERROR, NULL);
+
+    int32_t *rc = (int32_t*)ecs_map_ensure(&world->locked_components, component);
+    if (ecs_os_has_threading()) {
+        ecs_os_ainc(rc);
+    } else {
+        rc[0] ++;
+    }
+}
+
+static
+void flecs_component_lock_dec(
+    ecs_world_t *world,
+    ecs_id_t component)
+{
+    ecs_assert(component != 0, ECS_INTERNAL_ERROR, NULL);
+    int32_t *rc = (int32_t*)ecs_map_get(&world->locked_components, component);
+
+    ecs_assert(rc != NULL, ECS_INTERNAL_ERROR, 
+        "component '%s' is unlocked more times than it was locked",
+        flecs_errstr(ecs_id_str(world, component)));
+
+    if (ecs_os_has_threading()) {
+        ecs_os_adec(rc);
+    } else {
+        rc[0] --;
+    }
+
+    ecs_assert(rc[0] >= 0, ECS_INTERNAL_ERROR, 
+        "component '%s' is unlocked more times than it was locked",
+        flecs_errstr(ecs_id_str(world, component)));
+
+    if (!rc[0]) {
+        ecs_map_remove(&world->locked_components, component);
+    }
+}
+
+void flecs_component_lock(
+    ecs_world_t *world,
+    ecs_id_t component)
+{
+    flecs_component_lock_inc(world, component);
+    if (ECS_IS_PAIR(component)) {
+        flecs_component_lock_inc(world, ECS_PAIR_FIRST(component));
+    }
+}
+
+void flecs_component_unlock(
+    ecs_world_t *world,
+    ecs_id_t component)
+{
+    flecs_component_lock_dec(world, component);
+    if (ECS_IS_PAIR(component)) {
+        flecs_component_lock_dec(world, ECS_PAIR_FIRST(component));
+    }
+}
+
+bool flecs_component_is_locked(
+    ecs_world_t *world,
+    ecs_id_t component)
+{
+    return ecs_map_get(&world->locked_components, component) != NULL;
 }

--- a/src/world.h
+++ b/src/world.h
@@ -90,6 +90,10 @@ struct ecs_world_t {
     ecs_map_t id_index_hi;           /* map<id, ecs_component_record_t*> */
     ecs_map_t type_info;             /* map<type_id, type_info_t> */
 
+    /* A refcount per queried for component that ensures that applications 
+     * cannot modify traits after a component has been queried for. */
+    ecs_map_t locked_components;     /* map<id_t, int64_t> */
+
     /* -- Cached handle to id records -- */
     ecs_component_record_t *cr_wildcard;
     ecs_component_record_t *cr_wildcard_wildcard;
@@ -286,6 +290,18 @@ uint32_t flecs_get_table_column_version(
 void flecs_throw_invalid_delete(
     ecs_world_t *world,
     ecs_id_t id);
+
+void flecs_component_lock(
+    ecs_world_t *world,
+    ecs_id_t component);
+
+void flecs_component_unlock(
+    ecs_world_t *world,
+    ecs_id_t component);
+
+bool flecs_component_is_locked(
+    ecs_world_t *world,
+    ecs_id_t component);
 
 /* Convenience macro's for world allocator */
 #define flecs_walloc(world, size)\

--- a/test/core/project.json
+++ b/test/core/project.json
@@ -2367,6 +2367,8 @@
                 "user_entity_w_flecs_parent",
                 "add_exclusive_after_query",
                 "add_with_after_query",
+                "add_oneof_after_query",
+                "add_oneof_pair_after_query",
                 "add_final_after_query",
                 "add_isa_after_query",
                 "add_isa_after_query_tgt",
@@ -2377,7 +2379,22 @@
                 "add_sparse_after_query",
                 "add_dont_fragment_after_query",
                 "add_can_toggle_after_query",
-                "add_traversable_after_query"
+                "add_traversable_after_query",
+                "add_exclusive_after_pair_query",
+                "add_with_after_pair_query",
+                "add_oneof_after_pair_query",
+                "add_oneof_pair_after_pair_query",
+                "add_final_after_pair_query",
+                "add_isa_after_pair_query",
+                "add_isa_after_pair_query_tgt",
+                "add_inheritable_after_pair_query",
+                "add_isa_after_pair_query_after_inheritable",
+                "add_isa_after_pair_query_after_isa",
+                "add_on_instantiate_inherit_after_pair_query",
+                "add_sparse_after_pair_query",
+                "add_dont_fragment_after_pair_query",
+                "add_can_toggle_after_pair_query",
+                "add_traversable_after_pair_query"
             ]
         }, {
             "id": "ExclusiveAccess",
@@ -2852,7 +2869,6 @@
                 "activate_deactivate_activate_other",
                 "no_double_system_table_after_merge",
                 "recreate_deleted_table",
-                "create_65k_tables",
                 "no_duplicate_root_table_id",
                 "override_os_api_w_addon",
                 "records_resize_on_override",
@@ -2865,7 +2881,9 @@
                 "table_create_leak_check",
                 "component_record_has_table",
                 "component_record_iter_tables",
-                "table_get_records"
+                "table_get_records",
+                "childof_tgt_exists_after_query",
+                "create_65k_tables"
             ]
         }, {
             "id": "Error",

--- a/test/core/src/Internals.c
+++ b/test/core/src/Internals.c
@@ -676,3 +676,22 @@ void Internals_table_get_records(void) {
 
     ecs_fini(world);
 }
+
+void Internals_childof_tgt_exists_after_query(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ecs_entity_t parent = ecs_new(world);
+
+    ecs_query_t *q = ecs_query(world, {
+        .terms = {{ ecs_childof(parent) }}
+    });
+
+    test_assert(q != NULL);
+
+    /* Make sure just querying for a pair doesn't create a component record */
+    test_assert(flecs_components_get(world, ecs_childof(parent)) == NULL);
+
+    ecs_query_fini(q);
+
+    ecs_fini(world);
+}

--- a/test/core/src/Observer.c
+++ b/test/core/src/Observer.c
@@ -6635,9 +6635,11 @@ void Observer_on_remove_target_component_from_base_at_offset(void) {
 }
 
 static void Observer_w_other_table(ecs_iter_t *it) {
-    probe_system_w_ctx(it, it->ctx);
-    test_assert(it->table != NULL);
-    test_assert(it->other_table != NULL);
+    if (it->event == EcsOnAdd) {
+        probe_system_w_ctx(it, it->ctx);
+        test_assert(it->table != NULL);
+        test_assert(it->other_table != NULL);
+    }
 }
 
 static void Observer_dummy(ecs_iter_t *it) {}

--- a/test/core/src/Pairs.c
+++ b/test/core/src/Pairs.c
@@ -2645,8 +2645,8 @@ void Pairs_add_symmetric_exclusive_relation(void) {
     ECS_TAG(world, ObjB);
     ECS_TAG(world, ObjC);
 
-    ecs_add_id(world, Rel, EcsSymmetric);
     ecs_add_id(world, Rel, EcsExclusive);
+    ecs_add_id(world, Rel, EcsSymmetric);
 
     ecs_add_pair(world, ObjA, Rel, ObjB);
     test_assert(ecs_has_pair(world, ObjA, Rel, ObjB));

--- a/test/core/src/Prefab.c
+++ b/test/core/src/Prefab.c
@@ -1989,6 +1989,7 @@ void Prefab_no_instantiate_on_2nd_add(void) {
 
     ecs_entity_t e = ecs_new_w_pair(world, EcsIsA, Prefab);
     test_assert( ecs_has_pair(world, e, EcsIsA, Prefab));
+
     const Position *p = ecs_get(world, e, Position);
     test_assert(p != NULL);
     test_int(p->x, 1);

--- a/test/core/src/Sparse.c
+++ b/test/core/src/Sparse.c
@@ -5542,7 +5542,6 @@ void Sparse_on_delete_target_sparse_panic(void) {
     ecs_world_t *world = ecs_mini();
 
     ECS_TAG(world, Rel);
-    
 
     ecs_add_id(world, Rel, EcsSparse);
     if (!fragment) ecs_add_id(world, Rel, EcsDontFragment);

--- a/test/core/src/World.c
+++ b/test/core/src/World.c
@@ -2986,8 +2986,6 @@ void World_add_exclusive_after_query(void) {
 }
 
 void World_add_with_after_query(void) {
-    install_test_abort();
-
     ecs_world_t *world = ecs_mini();
 
     ECS_COMPONENT(world, Position);
@@ -2999,9 +2997,55 @@ void World_add_with_after_query(void) {
 
     test_assert(q != NULL);
 
-    test_expect_abort();
-
     ecs_add_pair(world, ecs_id(Position), EcsWith, Foo);
+
+    ecs_query_fini(q);
+
+    ecs_fini(world);
+
+    test_assert(true); // Should not assert
+}
+
+void World_add_oneof_after_query(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_COMPONENT(world, Position);
+    ECS_TAG(world, Foo);
+
+    ecs_query_t *q = ecs_query(world, {
+        .terms = {{ ecs_id(Position) }}
+    });
+
+    test_assert(q != NULL);
+
+    ecs_add_id(world, ecs_id(Position), EcsOneOf);
+
+    ecs_query_fini(q);
+
+    ecs_fini(world);
+
+    test_assert(true); // Should not assert
+}
+
+void World_add_oneof_pair_after_query(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_COMPONENT(world, Position);
+    ECS_TAG(world, Foo);
+
+    ecs_query_t *q = ecs_query(world, {
+        .terms = {{ ecs_id(Position) }}
+    });
+
+    test_assert(q != NULL);
+
+    ecs_add_pair(world, ecs_id(Position), EcsOneOf, Foo);
+
+    ecs_query_fini(q);
+
+    ecs_fini(world);
+
+    test_assert(true); // Should not assert
 }
 
 void World_add_final_after_query(void) {
@@ -3202,6 +3246,294 @@ void World_add_traversable_after_query(void) {
 
     ecs_query_t *q = ecs_query(world, {
         .terms = {{ ecs_id(Position) }}
+    });
+
+    test_assert(q != NULL);
+
+    test_expect_abort();
+
+    ecs_add_id(world, ecs_id(Position), EcsTraversable);
+}
+
+void World_add_exclusive_after_pair_query(void) {
+    install_test_abort();
+
+    ecs_world_t *world = ecs_mini();
+
+    ECS_COMPONENT(world, Position);
+
+    ecs_query_t *q = ecs_query(world, {
+        .terms = {{ ecs_pair_t(Position, EcsWildcard) }}
+    });
+
+    test_assert(q != NULL);
+
+    test_expect_abort();
+
+    ecs_add_id(world, ecs_id(Position), EcsExclusive);
+}
+
+void World_add_with_after_pair_query(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_COMPONENT(world, Position);
+    ECS_TAG(world, Foo);
+
+    ecs_query_t *q = ecs_query(world, {
+        .terms = {{ ecs_pair_t(Position, EcsWildcard) }}
+    });
+
+    test_assert(q != NULL);
+
+    ecs_add_pair(world, ecs_id(Position), EcsWith, Foo);
+
+    ecs_query_fini(q);
+
+    ecs_fini(world);
+
+    test_assert(true); // Should not assert
+}
+
+void World_add_oneof_after_pair_query(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_COMPONENT(world, Position);
+    ECS_TAG(world, Foo);
+
+    ecs_query_t *q = ecs_query(world, {
+        .terms = {{ ecs_pair_t(Position, EcsWildcard) }}
+    });
+
+    test_assert(q != NULL);
+
+    ecs_add_id(world, ecs_id(Position), EcsOneOf);
+
+    ecs_query_fini(q);
+
+    ecs_fini(world);
+
+    test_assert(true); // Should not assert
+}
+
+void World_add_oneof_pair_after_pair_query(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_COMPONENT(world, Position);
+    ECS_TAG(world, Foo);
+
+    ecs_query_t *q = ecs_query(world, {
+        .terms = {{ ecs_pair_t(Position, EcsWildcard) }}
+    });
+
+    test_assert(q != NULL);
+
+    ecs_add_pair(world, ecs_id(Position), EcsOneOf, Foo);
+
+    ecs_query_fini(q);
+
+    ecs_fini(world);
+
+    test_assert(true); // Should not assert
+}
+
+void World_add_final_after_pair_query(void) {
+    install_test_abort();
+
+    ecs_world_t *world = ecs_mini();
+
+    ECS_COMPONENT(world, Position);
+
+    ecs_query_t *q = ecs_query(world, {
+        .terms = {{ ecs_pair_t(Position, EcsWildcard) }}
+    });
+
+    test_assert(q != NULL);
+
+    test_expect_abort();
+
+    ecs_add_id(world, ecs_id(Position), EcsFinal);
+}
+
+void World_add_isa_after_pair_query(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_COMPONENT(world, Position);
+    ECS_TAG(world, Foo);
+
+    ecs_query_t *q = ecs_query(world, {
+        .terms = {{ ecs_pair_t(Position, EcsWildcard) }}
+    });
+
+    test_assert(q != NULL);
+
+    ecs_add_pair(world, ecs_id(Position), EcsIsA, Foo);
+
+    ecs_query_fini(q);
+
+    ecs_fini(world);
+}
+
+void World_add_isa_after_pair_query_tgt(void) {
+    install_test_abort();
+
+    ecs_world_t *world = ecs_mini();
+
+    ECS_COMPONENT(world, Position);
+    ECS_COMPONENT(world, Velocity);
+
+    ecs_query_t *q = ecs_query(world, {
+        .terms = {{ ecs_pair_t(Velocity, EcsWildcard) }}
+    });
+
+    test_assert(q != NULL);
+
+    test_expect_abort();
+
+    ecs_add_pair(world, ecs_id(Position), EcsIsA, ecs_id(Velocity));
+}
+
+void World_add_inheritable_after_pair_query(void) {
+    install_test_abort();
+
+    ecs_world_t *world = ecs_mini();
+
+    ECS_COMPONENT(world, Position);
+
+    ecs_query_t *q = ecs_query(world, {
+        .terms = {{ ecs_pair_t(Position, EcsWildcard) }}
+    });
+
+    test_assert(q != NULL);
+
+    test_expect_abort();
+
+    ecs_add_id(world, ecs_id(Position), EcsInheritable);
+}
+
+void World_add_isa_after_pair_query_after_inheritable(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_COMPONENT(world, Position);
+    ECS_TAG(world, Foo);
+
+    ecs_add_id(world, ecs_id(Position), EcsInheritable);
+
+    ecs_query_t *q = ecs_query(world, {
+        .terms = {{ ecs_pair_t(Position, EcsWildcard) }}
+    });
+
+    test_assert(q != NULL);
+
+    ecs_add_pair(world, Foo, EcsIsA, ecs_id(Position));
+
+    ecs_query_fini(q);
+
+    ecs_fini(world);
+}
+
+void World_add_isa_after_pair_query_after_isa(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_COMPONENT(world, Position);
+    ECS_TAG(world, Foo);
+    ECS_TAG(world, Bar);
+
+    ecs_add_pair(world, ecs_id(Position), EcsIsA, Foo);
+
+    ecs_query_t *q = ecs_query(world, {
+        .terms = {{ ecs_pair_t(Position, EcsWildcard) }}
+    });
+
+    test_assert(q != NULL);
+
+    ecs_add_pair(world, ecs_id(Position), EcsIsA, Bar);
+
+    ecs_query_fini(q);
+
+    ecs_fini(world);
+}
+
+void World_add_on_instantiate_inherit_after_pair_query(void) {
+    install_test_abort();
+
+    ecs_world_t *world = ecs_mini();
+
+    ECS_COMPONENT(world, Position);
+
+    ecs_query_t *q = ecs_query(world, {
+        .terms = {{ ecs_pair_t(Position, EcsWildcard) }}
+    });
+
+    test_assert(q != NULL);
+
+    test_expect_abort();
+
+    ecs_add_pair(world, ecs_id(Position), EcsOnInstantiate, EcsInherit);
+}
+
+void World_add_sparse_after_pair_query(void) {
+    install_test_abort();
+
+    ecs_world_t *world = ecs_mini();
+
+    ECS_COMPONENT(world, Position);
+
+    ecs_query_t *q = ecs_query(world, {
+        .terms = {{ ecs_pair_t(Position, EcsWildcard) }}
+    });
+
+    test_assert(q != NULL);
+
+    test_expect_abort();
+
+    ecs_add_id(world, ecs_id(Position), EcsSparse);
+}
+
+void World_add_dont_fragment_after_pair_query(void) {
+    install_test_abort();
+
+    ecs_world_t *world = ecs_mini();
+
+    ECS_COMPONENT(world, Position);
+
+    ecs_query_t *q = ecs_query(world, {
+        .terms = {{ ecs_pair_t(Position, EcsWildcard) }}
+    });
+
+    test_assert(q != NULL);
+
+    test_expect_abort();
+
+    ecs_add_id(world, ecs_id(Position), EcsDontFragment);
+}
+
+void World_add_can_toggle_after_pair_query(void) {
+    install_test_abort();
+
+    ecs_world_t *world = ecs_mini();
+
+    ECS_COMPONENT(world, Position);
+
+    ecs_query_t *q = ecs_query(world, {
+        .terms = {{ ecs_pair_t(Position, EcsWildcard) }}
+    });
+
+    test_assert(q != NULL);
+
+    test_expect_abort();
+
+    ecs_add_id(world, ecs_id(Position), EcsCanToggle);
+}
+
+void World_add_traversable_after_pair_query(void) {
+    install_test_abort();
+
+    ecs_world_t *world = ecs_mini();
+
+    ECS_COMPONENT(world, Position);
+
+    ecs_query_t *q = ecs_query(world, {
+        .terms = {{ ecs_pair_t(Position, EcsWildcard) }}
     });
 
     test_assert(q != NULL);

--- a/test/core/src/WorldInfo.c
+++ b/test/core/src/WorldInfo.c
@@ -125,7 +125,7 @@ void WorldInfo_id_tag_component_count(void) {
 
     ecs_add(world, e, Position);
     test_delta(&prev_1, cur, tag_id_count, 0);
-    test_delta(&prev_2, cur, component_id_count, 0);
+    test_delta(&prev_2, cur, component_id_count, 1);
 
     ecs_delete(world, c_1);
     test_delta(&prev_1, cur, tag_id_count, -1);
@@ -137,7 +137,7 @@ void WorldInfo_id_tag_component_count(void) {
 
     ecs_delete(world, ecs_id(Position));
     test_delta(&prev_1, cur, tag_id_count, 0);
-    test_delta(&prev_2, cur, component_id_count, -3);
+    test_delta(&prev_2, cur, component_id_count, -1);
 
     ecs_fini(world);
 }

--- a/test/core/src/main.c
+++ b/test/core/src/main.c
@@ -2288,6 +2288,8 @@ void World_rename_flecs_core(void);
 void World_user_entity_w_flecs_parent(void);
 void World_add_exclusive_after_query(void);
 void World_add_with_after_query(void);
+void World_add_oneof_after_query(void);
+void World_add_oneof_pair_after_query(void);
 void World_add_final_after_query(void);
 void World_add_isa_after_query(void);
 void World_add_isa_after_query_tgt(void);
@@ -2299,6 +2301,21 @@ void World_add_sparse_after_query(void);
 void World_add_dont_fragment_after_query(void);
 void World_add_can_toggle_after_query(void);
 void World_add_traversable_after_query(void);
+void World_add_exclusive_after_pair_query(void);
+void World_add_with_after_pair_query(void);
+void World_add_oneof_after_pair_query(void);
+void World_add_oneof_pair_after_pair_query(void);
+void World_add_final_after_pair_query(void);
+void World_add_isa_after_pair_query(void);
+void World_add_isa_after_pair_query_tgt(void);
+void World_add_inheritable_after_pair_query(void);
+void World_add_isa_after_pair_query_after_inheritable(void);
+void World_add_isa_after_pair_query_after_isa(void);
+void World_add_on_instantiate_inherit_after_pair_query(void);
+void World_add_sparse_after_pair_query(void);
+void World_add_dont_fragment_after_pair_query(void);
+void World_add_can_toggle_after_pair_query(void);
+void World_add_traversable_after_pair_query(void);
 
 // Testsuite 'ExclusiveAccess'
 void ExclusiveAccess_self(void);
@@ -2755,7 +2772,6 @@ void Internals_activate_deactivate_reactive(void);
 void Internals_activate_deactivate_activate_other(void);
 void Internals_no_double_system_table_after_merge(void);
 void Internals_recreate_deleted_table(void);
-void Internals_create_65k_tables(void);
 void Internals_no_duplicate_root_table_id(void);
 void Internals_override_os_api_w_addon(void);
 void Internals_records_resize_on_override(void);
@@ -2769,6 +2785,8 @@ void Internals_table_create_leak_check(void);
 void Internals_component_record_has_table(void);
 void Internals_component_record_iter_tables(void);
 void Internals_table_get_records(void);
+void Internals_childof_tgt_exists_after_query(void);
+void Internals_create_65k_tables(void);
 
 // Testsuite 'Error'
 void Error_setup(void);
@@ -11688,6 +11706,14 @@ bake_test_case World_testcases[] = {
         World_add_with_after_query
     },
     {
+        "add_oneof_after_query",
+        World_add_oneof_after_query
+    },
+    {
+        "add_oneof_pair_after_query",
+        World_add_oneof_pair_after_query
+    },
+    {
         "add_final_after_query",
         World_add_final_after_query
     },
@@ -11730,6 +11756,66 @@ bake_test_case World_testcases[] = {
     {
         "add_traversable_after_query",
         World_add_traversable_after_query
+    },
+    {
+        "add_exclusive_after_pair_query",
+        World_add_exclusive_after_pair_query
+    },
+    {
+        "add_with_after_pair_query",
+        World_add_with_after_pair_query
+    },
+    {
+        "add_oneof_after_pair_query",
+        World_add_oneof_after_pair_query
+    },
+    {
+        "add_oneof_pair_after_pair_query",
+        World_add_oneof_pair_after_pair_query
+    },
+    {
+        "add_final_after_pair_query",
+        World_add_final_after_pair_query
+    },
+    {
+        "add_isa_after_pair_query",
+        World_add_isa_after_pair_query
+    },
+    {
+        "add_isa_after_pair_query_tgt",
+        World_add_isa_after_pair_query_tgt
+    },
+    {
+        "add_inheritable_after_pair_query",
+        World_add_inheritable_after_pair_query
+    },
+    {
+        "add_isa_after_pair_query_after_inheritable",
+        World_add_isa_after_pair_query_after_inheritable
+    },
+    {
+        "add_isa_after_pair_query_after_isa",
+        World_add_isa_after_pair_query_after_isa
+    },
+    {
+        "add_on_instantiate_inherit_after_pair_query",
+        World_add_on_instantiate_inherit_after_pair_query
+    },
+    {
+        "add_sparse_after_pair_query",
+        World_add_sparse_after_pair_query
+    },
+    {
+        "add_dont_fragment_after_pair_query",
+        World_add_dont_fragment_after_pair_query
+    },
+    {
+        "add_can_toggle_after_pair_query",
+        World_add_can_toggle_after_pair_query
+    },
+    {
+        "add_traversable_after_pair_query",
+        World_add_traversable_after_pair_query
     }
 };
 
@@ -13495,10 +13581,6 @@ bake_test_case Internals_testcases[] = {
         Internals_recreate_deleted_table
     },
     {
-        "create_65k_tables",
-        Internals_create_65k_tables
-    },
-    {
         "no_duplicate_root_table_id",
         Internals_no_duplicate_root_table_id
     },
@@ -13549,6 +13631,14 @@ bake_test_case Internals_testcases[] = {
     {
         "table_get_records",
         Internals_table_get_records
+    },
+    {
+        "childof_tgt_exists_after_query",
+        Internals_childof_tgt_exists_after_query
+    },
+    {
+        "create_65k_tables",
+        Internals_create_65k_tables
     }
 };
 
@@ -13871,7 +13961,7 @@ static bake_test_suite suites[] = {
         "World",
         World_setup,
         NULL,
-        125,
+        142,
         World_testcases
     },
     {
@@ -13934,7 +14024,7 @@ static bake_test_suite suites[] = {
         "Internals",
         Internals_setup,
         NULL,
-        21,
+        22,
         Internals_testcases
     },
     {

--- a/test/query/src/ComponentInheritance.c
+++ b/test/query/src/ComponentInheritance.c
@@ -3410,12 +3410,9 @@ void ComponentInheritance_query_before_isa_relationship_1st_term(void) {
 
     test_assert(q != NULL);
 
-    ECS_ENTITY(world, Warrior, (IsA, Unit));
-    ECS_ENTITY(world, Wizard, (IsA, Unit));
-
     test_expect_abort();
 
-    ecs_query_iter(world, q);
+    ECS_ENTITY(world, Warrior, (IsA, Unit));
 }
 
 void ComponentInheritance_query_before_isa_relationship_2nd_term(void) {
@@ -3432,12 +3429,9 @@ void ComponentInheritance_query_before_isa_relationship_2nd_term(void) {
 
     test_assert(q != NULL);
 
-    ECS_ENTITY(world, Warrior, (IsA, Unit));
-    ECS_ENTITY(world, Wizard, (IsA, Unit));
-
     test_expect_abort();
 
-    ecs_query_iter(world, q);
+    ECS_ENTITY(world, Warrior, (IsA, Unit));
 }
 
 void ComponentInheritance_query_before_isa_relationship_subtype(void) {

--- a/test/query/src/Validator.c
+++ b/test/query/src/Validator.c
@@ -69,7 +69,7 @@ void query_flags_to_str(uint64_t value) {
 }
 
 #define test_query_flags(expect, value)\
-    if ((expect) != (value)) {\
+    if ((EcsQueryValid|expect) != (value)) {\
         printf("expected: ");\
         query_flags_to_str(expect);\
         printf("got:      ");\
@@ -3099,7 +3099,7 @@ void Validator_validate_simple_1_term_is_cacheable(void) {
     test_int(q->terms[0].field_index, 0);
     test_uint(q->terms[0].first.id, ecs_id(Position)|EcsSelf|EcsIsEntity);
     test_uint(q->terms[0].src.id, EcsThis|EcsSelf|EcsIsVariable);
-    test_uint(q->terms[0].flags_, EcsTermIsCacheable|EcsTermIsTrivial|EcsTermKeepAlive);
+    test_uint(q->terms[0].flags_, EcsTermIsCacheable|EcsTermIsTrivial);
 
     test_assert((q->data_fields & (1 << 0)));
 
@@ -3137,7 +3137,7 @@ void Validator_validate_simple_1_term_tag_is_cacheable(void) {
     test_int(q->terms[0].field_index, 0);
     test_uint(q->terms[0].first.id, Tag|EcsSelf|EcsIsEntity);
     test_uint(q->terms[0].src.id, EcsThis|EcsSelf|EcsIsVariable);
-    test_uint(q->terms[0].flags_, EcsTermIsCacheable|EcsTermIsTrivial|EcsTermKeepAlive);
+    test_uint(q->terms[0].flags_, EcsTermIsCacheable|EcsTermIsTrivial);
 
     test_assert(!(q->data_fields & (1 << 0)));
 
@@ -3177,7 +3177,7 @@ void Validator_validate_simple_1_term_pair_is_cacheable(void) {
     test_uint(q->terms[0].first.id, rel|EcsSelf|EcsIsEntity);
     test_uint(q->terms[0].second.id, tgt|EcsSelf|EcsIsEntity);
     test_uint(q->terms[0].src.id, EcsThis|EcsSelf|EcsIsVariable);
-    test_uint(q->terms[0].flags_, EcsTermIsCacheable|EcsTermIsTrivial|EcsTermKeepAlive);
+    test_uint(q->terms[0].flags_, EcsTermIsCacheable|EcsTermIsTrivial);
 
     test_assert(!(q->data_fields & (1 << 0)));
 
@@ -3224,7 +3224,7 @@ void Validator_validate_simple_1_term_pair_recycled_is_cacheable(void) {
     test_uint(q->terms[0].first.id, rel|EcsSelf|EcsIsEntity);
     test_uint(q->terms[0].second.id, tgt|EcsSelf|EcsIsEntity);
     test_uint(q->terms[0].src.id, EcsThis|EcsSelf|EcsIsVariable);
-    test_uint(q->terms[0].flags_, EcsTermIsCacheable|EcsTermIsTrivial|EcsTermKeepAlive);
+    test_uint(q->terms[0].flags_, EcsTermIsCacheable|EcsTermIsTrivial);
 
     test_assert(!(q->data_fields & (1 << 0)));
 
@@ -3262,14 +3262,14 @@ void Validator_validate_simple_2_term_is_cacheable(void) {
     test_int(q->terms[0].field_index, 0);
     test_uint(q->terms[0].first.id, ecs_id(Position)|EcsSelf|EcsIsEntity);
     test_uint(q->terms[0].src.id, EcsThis|EcsSelf|EcsIsVariable);
-    test_uint(q->terms[0].flags_, EcsTermIsCacheable|EcsTermIsTrivial|EcsTermKeepAlive);
+    test_uint(q->terms[0].flags_, EcsTermIsCacheable|EcsTermIsTrivial);
 
     test_uint(q->terms[1].id, ecs_id(Velocity));
     test_int(q->terms[1].oper, EcsAnd);
     test_int(q->terms[1].field_index, 1);
     test_uint(q->terms[1].first.id, ecs_id(Velocity)|EcsSelf|EcsIsEntity);
     test_uint(q->terms[1].src.id, EcsThis|EcsSelf|EcsIsVariable);
-    test_uint(q->terms[1].flags_, EcsTermIsCacheable|EcsTermIsTrivial|EcsTermKeepAlive);
+    test_uint(q->terms[1].flags_, EcsTermIsCacheable|EcsTermIsTrivial);
 
     test_assert((q->data_fields & (1 << 0)));
     test_assert((q->data_fields & (1 << 1)));
@@ -3308,7 +3308,7 @@ void Validator_validate_simple_w_can_inherit(void) {
     test_int(q->terms[0].field_index, 0);
     test_uint(q->terms[0].first.id, ecs_id(Position)|EcsSelf|EcsIsEntity);
     test_uint(q->terms[0].src.id, EcsThis|EcsSelf|EcsUp|EcsIsVariable);
-    test_uint(q->terms[0].flags_, EcsTermIsCacheable|EcsTermIsTrivial|EcsTermKeepAlive);
+    test_uint(q->terms[0].flags_, EcsTermIsCacheable|EcsTermIsTrivial);
 
     test_assert((q->data_fields & (1 << 0)));
 
@@ -3346,7 +3346,7 @@ void Validator_validate_simple_w_can_toggle(void) {
     test_int(q->terms[0].field_index, 0);
     test_uint(q->terms[0].first.id, ecs_id(Position)|EcsSelf|EcsIsEntity);
     test_uint(q->terms[0].src.id, EcsThis|EcsSelf|EcsIsVariable);
-    test_uint(q->terms[0].flags_, EcsTermKeepAlive|EcsTermIsToggle|EcsTermIsCacheable);
+    test_uint(q->terms[0].flags_, EcsTermIsToggle|EcsTermIsCacheable);
 
     test_assert((q->data_fields & (1 << 0)));
 
@@ -3383,7 +3383,7 @@ void Validator_validate_simple_w_sparse(void) {
     test_int(q->terms[0].field_index, 0);
     test_uint(q->terms[0].first.id, ecs_id(Position)|EcsSelf|EcsIsEntity);
     test_uint(q->terms[0].src.id, EcsThis|EcsSelf|EcsIsVariable);
-    test_uint(q->terms[0].flags_, EcsTermKeepAlive|EcsTermIsSparse);
+    test_uint(q->terms[0].flags_, EcsTermIsSparse);
 
     test_assert((q->data_fields & (1 << 0)));
 
@@ -3420,7 +3420,7 @@ void Validator_validate_simple_w_transitive(void) {
     test_int(q->terms[0].field_index, 0);
     test_uint(q->terms[0].first.id, ecs_id(Position)|EcsSelf|EcsIsEntity);
     test_uint(q->terms[0].src.id, EcsThis|EcsSelf|EcsIsVariable);
-    test_uint(q->terms[0].flags_, EcsTermIsCacheable|EcsTermIsTrivial|EcsTermKeepAlive);
+    test_uint(q->terms[0].flags_, EcsTermIsCacheable|EcsTermIsTrivial);
 
     test_assert((q->data_fields & (1 << 0)));
 
@@ -3461,7 +3461,7 @@ void Validator_validate_simple_w_transitive_pair(void) {
     test_int(q->terms[0].field_index, 0);
     test_uint(q->terms[0].first.id, ecs_id(Position)|EcsSelf|EcsIsEntity);
     test_uint(q->terms[0].src.id, EcsThis|EcsSelf|EcsIsVariable);
-    test_uint(q->terms[0].flags_, EcsTermKeepAlive|EcsTermTransitive);
+    test_uint(q->terms[0].flags_, EcsTermTransitive);
 
     test_assert((q->data_fields & (1 << 0)));
 
@@ -3498,7 +3498,7 @@ void Validator_validate_simple_w_reflexive(void) {
     test_int(q->terms[0].field_index, 0);
     test_uint(q->terms[0].first.id, ecs_id(Position)|EcsSelf|EcsIsEntity);
     test_uint(q->terms[0].src.id, EcsThis|EcsSelf|EcsIsVariable);
-    test_uint(q->terms[0].flags_, EcsTermIsCacheable|EcsTermIsTrivial|EcsTermKeepAlive);
+    test_uint(q->terms[0].flags_, EcsTermIsCacheable|EcsTermIsTrivial);
 
     test_assert((q->data_fields & (1 << 0)));
 
@@ -3539,7 +3539,7 @@ void Validator_validate_simple_w_reflexive_pair(void) {
     test_int(q->terms[0].field_index, 0);
     test_uint(q->terms[0].first.id, ecs_id(Position)|EcsSelf|EcsIsEntity);
     test_uint(q->terms[0].src.id, EcsThis|EcsSelf|EcsIsVariable);
-    test_uint(q->terms[0].flags_, EcsTermKeepAlive|EcsTermReflexive);
+    test_uint(q->terms[0].flags_, EcsTermReflexive);
 
     test_assert((q->data_fields & (1 << 0)));
 
@@ -3577,7 +3577,7 @@ void Validator_validate_simple_w_inherited_component(void) {
     test_int(q->terms[0].field_index, 0);
     test_uint(q->terms[0].first.id, Unit|EcsSelf|EcsIsEntity);
     test_uint(q->terms[0].src.id, EcsThis|EcsSelf|EcsIsVariable);
-    test_uint(q->terms[0].flags_, EcsTermKeepAlive|EcsTermIdInherited);
+    test_uint(q->terms[0].flags_, EcsTermIdInherited);
 
     test_assert(!(q->data_fields & (1 << 0)));
 


### PR DESCRIPTION
Currently registering any component creates a `(Component, *)` component record, which is used in the code to keep track of trait flags (bitsets for quickly checking traits). This is however a very heavy weight mechanism just for checking traits, and in most scenarios a component won't be used in a pair.

This PR implements a different mechanism to get trait flags for when a component record doesn't exist yet, which allows the code to not create the `(Component, *)` records, which saves memory and reduces time spent on component registration.