### PR TITLE
Fix OrderedChildren bug when using is_a relationships with prefabs

### DIFF
--- a/test/cpp/project.json
+++ b/test/cpp/project.json
@@ -394,7 +394,8 @@
                 "iter_no_children",
                 "children_1_table",
                 "children_2_tables",
-                "set_child_order"
+                "set_child_order",
+                "prefab_children_with_is_a"
             ]
         }, {
             "id": "Pairs",

--- a/test/cpp/src/OrderedChildren.cpp
+++ b/test/cpp/src/OrderedChildren.cpp
@@ -82,3 +82,46 @@ void OrderedChildren_set_child_order(void) {
         test_assert(v[2] == child_b);
     }
 }
+
+void OrderedChildren_prefab_children_with_is_a(void) {
+    flecs::world world;
+
+    struct Id { uint32_t value; };
+
+    flecs::entity child_type_a = world.prefab("TypeA");
+    flecs::entity child_type_b = world.prefab("TypeB");
+
+    flecs::entity parent_prefab = world.prefab("parent")
+        .add(flecs::OrderedChildren);
+
+    world.prefab()
+        .is_a(child_type_a)
+        .child_of(parent_prefab)
+        .set<Id>({0});
+
+    world.prefab()
+        .is_a(child_type_b)
+        .child_of(parent_prefab)
+        .set<Id>({1});
+
+    world.prefab()
+        .is_a(child_type_a)
+        .child_of(parent_prefab)
+        .set<Id>({2});
+
+    flecs::entity instance = world.entity("instance")
+        .is_a(parent_prefab)
+        .add(flecs::OrderedChildren);
+
+    std::vector<uint32_t> ids;
+    instance.children([&](flecs::entity child) {
+        const Id* id = child.get<Id>();
+        test_assert(id != nullptr);
+        ids.push_back(id->value);
+    });
+
+    test_int(ids.size(), 3);
+    test_int(ids[0], 0);
+    test_int(ids[1], 1);
+    test_int(ids[2], 2);
+}

--- a/test/cpp/src/main.cpp
+++ b/test/cpp/src/main.cpp
@@ -382,6 +382,7 @@ void OrderedChildren_iter_no_children(void);
 void OrderedChildren_children_1_table(void);
 void OrderedChildren_children_2_tables(void);
 void OrderedChildren_set_child_order(void);
+void OrderedChildren_prefab_children_with_is_a(void);
 
 // Testsuite 'Pairs'
 void Pairs_add_component_pair(void);
@@ -3139,6 +3140,10 @@ bake_test_case OrderedChildren_testcases[] = {
     {
         "set_child_order",
         OrderedChildren_set_child_order
+    },
+    {
+        "prefab_children_with_is_a",
+        OrderedChildren_prefab_children_with_is_a
     }
 };
 


### PR DESCRIPTION
When a parent prefab has OrderedChildren and children with is_a relationships, instances created via is_a were not iterating children in the correct order.

The bug occurred because after instantiating children from multiple tables, flecs_ordered_children_populate() would rebuild the ordered children list using ecs_each_id(), which iterates in table order rather than creation order.

This caused children to be ordered by their table (e.g., all TypeA children, then all TypeB children) instead of their original order in the prefab.

The fix:
- When instantiating children from a prefab with OrderedChildren, use the base prefab's ordered children list to determine the correct order
- For each child in the base's ordered list, find the corresponding instance child (identified by the IsA relationship) and add it in the same order
- Falls back to the original populate method if base has no ordered children

Added test case: OrderedChildren_prefab_children_with_is_a