### PR TITLE
Bugfixes

### DIFF
--- a/src/datastructures/strbuf.c
+++ b/src/datastructures/strbuf.c
@@ -438,8 +438,13 @@ char* ecs_strbuf_get(
     ecs_strbuf_appendch(b, '\0');
     result = b->content;
 
+#ifdef FLECS_SANITIZE
+    ecs_assert(ecs_os_strlen(result) <= (b->length - 1), 
+        ECS_INTERNAL_ERROR, NULL);
+#endif
+
     if (result == b->small_string) {
-        result = ecs_os_memdup_n(result, char, b->length + 1);
+        result = ecs_os_memdup_n(result, char, b->length);
     }
 
     b->length = 0;

--- a/test/addons/project.json
+++ b/test/addons/project.json
@@ -527,7 +527,11 @@
                 "get_pipeline_stats_after_delete_system",
                 "request_world_summary_before_monitor_sys_run",
                 "escape_backslash",
-                "request_small_buffer_plus_one"
+                "request_small_buffer_plus_one",
+                "request_ending_in_pct",
+                "request_ending_in_2_pct",
+                "request_ending_in_pct_single_digit",
+                "request_ending_in_pct_invalid_code"
             ]
         }, {
             "id": "Metrics",

--- a/test/addons/src/Rest.c
+++ b/test/addons/src/Rest.c
@@ -709,3 +709,99 @@ void Rest_request_small_buffer_plus_one(void) {
 
     ecs_fini(world);
 }
+
+void Rest_request_ending_in_pct(void) {
+    ecs_world_t *world = ecs_init();
+
+    ecs_http_server_t *srv = ecs_rest_server_init(world, NULL);
+    test_assert(srv != NULL);
+
+    ecs_entity(world, { .name = "foo/bar" });
+
+    ecs_http_reply_t reply = ECS_HTTP_REPLY_INIT;
+    ecs_log_set_level(-4);
+    test_int(-1, ecs_http_server_request(srv, "GET",
+        "/entity/foo%", NULL, &reply));
+    test_int(reply.code, 404);
+    
+    char *reply_str = ecs_strbuf_get(&reply.body);
+    test_assert(reply_str != NULL);
+    test_str(reply_str, "{\"error\":\"entity 'foo%' not found\"}");
+    ecs_os_free(reply_str);
+
+    ecs_rest_server_fini(srv);
+
+    ecs_fini(world);
+}
+
+void Rest_request_ending_in_2_pct(void) {
+    ecs_world_t *world = ecs_init();
+
+    ecs_http_server_t *srv = ecs_rest_server_init(world, NULL);
+    test_assert(srv != NULL);
+
+    ecs_entity(world, { .name = "foo/bar" });
+
+    ecs_http_reply_t reply = ECS_HTTP_REPLY_INIT;
+    ecs_log_set_level(-4);
+    test_int(-1, ecs_http_server_request(srv, "GET",
+        "/entity/foo%%", NULL, &reply));
+    test_int(reply.code, 404);
+    
+    char *reply_str = ecs_strbuf_get(&reply.body);
+    test_assert(reply_str != NULL);
+    test_str(reply_str, "{\"error\":\"entity 'foo' not found\"}");
+    ecs_os_free(reply_str);
+
+    ecs_rest_server_fini(srv);
+
+    ecs_fini(world);
+}
+
+void Rest_request_ending_in_pct_single_digit(void) {
+    ecs_world_t *world = ecs_init();
+
+    ecs_http_server_t *srv = ecs_rest_server_init(world, NULL);
+    test_assert(srv != NULL);
+
+    ecs_entity(world, { .name = "foo/bar" });
+
+    ecs_http_reply_t reply = ECS_HTTP_REPLY_INIT;
+    ecs_log_set_level(-4);
+    test_int(-1, ecs_http_server_request(srv, "GET",
+        "/entity/foo%9", NULL, &reply));
+    test_int(reply.code, 404);
+    
+    char *reply_str = ecs_strbuf_get(&reply.body);
+    test_assert(reply_str != NULL);
+    test_str(reply_str, "{\"error\":\"entity 'foo`' not found\"}");
+    ecs_os_free(reply_str);
+
+    ecs_rest_server_fini(srv);
+
+    ecs_fini(world);
+}
+
+void Rest_request_ending_in_pct_invalid_code(void) {
+    ecs_world_t *world = ecs_init();
+
+    ecs_http_server_t *srv = ecs_rest_server_init(world, NULL);
+    test_assert(srv != NULL);
+
+    ecs_entity(world, { .name = "foo/bar" });
+
+    ecs_http_reply_t reply = ECS_HTTP_REPLY_INIT;
+    ecs_log_set_level(-4);
+    test_int(-1, ecs_http_server_request(srv, "GET",
+        "/entity/foo%--", NULL, &reply));
+    test_int(reply.code, 404);
+    
+    char *reply_str = ecs_strbuf_get(&reply.body);
+    test_assert(reply_str != NULL);
+    test_str(reply_str, "{\"error\":\"entity 'foo' not found\"}");
+    ecs_os_free(reply_str);
+
+    ecs_rest_server_fini(srv);
+
+    ecs_fini(world);
+}

--- a/test/addons/src/main.c
+++ b/test/addons/src/main.c
@@ -478,6 +478,10 @@ void Rest_get_pipeline_stats_after_delete_system(void);
 void Rest_request_world_summary_before_monitor_sys_run(void);
 void Rest_escape_backslash(void);
 void Rest_request_small_buffer_plus_one(void);
+void Rest_request_ending_in_pct(void);
+void Rest_request_ending_in_2_pct(void);
+void Rest_request_ending_in_pct_single_digit(void);
+void Rest_request_ending_in_pct_invalid_code(void);
 
 // Testsuite 'Metrics'
 void Metrics_member_gauge_1_entity(void);
@@ -2308,6 +2312,22 @@ bake_test_case Rest_testcases[] = {
     {
         "request_small_buffer_plus_one",
         Rest_request_small_buffer_plus_one
+    },
+    {
+        "request_ending_in_pct",
+        Rest_request_ending_in_pct
+    },
+    {
+        "request_ending_in_2_pct",
+        Rest_request_ending_in_2_pct
+    },
+    {
+        "request_ending_in_pct_single_digit",
+        Rest_request_ending_in_pct_single_digit
+    },
+    {
+        "request_ending_in_pct_invalid_code",
+        Rest_request_ending_in_pct_invalid_code
     }
 };
 
@@ -2767,7 +2787,7 @@ static bake_test_suite suites[] = {
         "Rest",
         NULL,
         NULL,
-        22,
+        26,
         Rest_testcases
     },
     {


### PR DESCRIPTION
This PR has fixes for the following issues:
- `ecs_strbuf_get` would allocate one character too much
- Fix issue where the HTTP socket timeout would be set to an incorrect value
- Fix issue where parsing an URI with invalid `%` codes could result in undefined behavior
- Fix potential buffer overflow when parsing HTTP request header