### PR TITLE
docs/EntitiesComponents.md: minor fixes

### DIFF
--- a/docs/EntitiesComponents.md
+++ b/docs/EntitiesComponents.md
@@ -1174,7 +1174,7 @@ e.add::<flecs::Disabled>();
 </div>
 
 ## Components
-A component is something that is added to an entity. Components can simply tag an entity (this entity is an `Npc`), attach data to an entity (this entity is at `Position` `{10, 20}`) and create relationships between entities (bob `Likes` alice) that may also contain data (bob `Eats` `{10}` apples).
+A component is something that is added to an entity. Components can simply tag an entity ("this entity is an Npc"), attach data to an entity ("this entity is at Position {10, 20}") and create relationships between entities ("bob Likes alice") that may also contain data ("bob Eats {10} apples").
 
 To disambiguate between the different kinds of components in Flecs, they are named separately in Flecs:
 


### PR DESCRIPTION
Hi,
I am a french enthusiast mocking up a streaming software out of SDL3, flecs and ImGui for no good reasons.

I think I have spotted minor details that can be improved in docs/EntitiesComponents.md and here a PR.
- a missing `;`
- quotes seems to cancel back-ticks in the resulting https://www.flecs.dev/flecs/md_docs_2EntitiesComponents.html
- `set` mentioned on `assign` line (previous line duplicate ?), hoping it correct to say the same as for `set` 

Your work seems very impressive!
Thanks for all the fish,
Ludolpif