### PR TITLE
Bugfixes

### DIFF
--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -10620,6 +10620,9 @@ ecs_entity_t ecs_get_target(
     ecs_check(world != NULL, ECS_INVALID_PARAMETER, NULL);
     flecs_assert_entity_valid(world, entity, "get_target");
     ecs_check(rel != 0, ECS_INVALID_PARAMETER, NULL);
+    if (index < 0) {
+        return 0;
+    }
 
     if (rel == EcsChildOf) {
         if (index > 0) {
@@ -32126,6 +32129,7 @@ void flecs_bitset_set(
     int32_t elem,
     bool value)
 {
+    ecs_check(elem >= 0, ECS_INVALID_PARAMETER, NULL);
     ecs_check(elem < bs->count, ECS_INVALID_PARAMETER, NULL);
     uint32_t hi = ((uint32_t)elem) >> 6;
     uint32_t lo = ((uint32_t)elem) & 0x3F;
@@ -32139,6 +32143,7 @@ bool flecs_bitset_get(
     const ecs_bitset_t *bs,
     int32_t elem)
 {
+    ecs_check(elem >= 0, ECS_INVALID_PARAMETER, NULL);
     ecs_check(elem < bs->count, ECS_INVALID_PARAMETER, NULL);
     return !!(bs->data[elem >> 6] & ((uint64_t)1 << ((uint64_t)elem & 0x3F)));
 error:
@@ -32155,6 +32160,7 @@ void flecs_bitset_remove(
     ecs_bitset_t *bs,
     int32_t elem)
 {
+    ecs_check(elem >= 0, ECS_INVALID_PARAMETER, NULL);
     ecs_check(elem < bs->count, ECS_INVALID_PARAMETER, NULL);
     int32_t last = bs->count - 1;
     bool last_value = flecs_bitset_get(bs, last);
@@ -32170,6 +32176,8 @@ void flecs_bitset_swap(
     int32_t elem_a,
     int32_t elem_b)
 {
+    ecs_check(elem_a >= 0, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(elem_b >= 0, ECS_INVALID_PARAMETER, NULL);
     ecs_check(elem_a < bs->count, ECS_INVALID_PARAMETER, NULL);
     ecs_check(elem_b < bs->count, ECS_INVALID_PARAMETER, NULL);
 
@@ -34651,23 +34659,26 @@ char* flecs_strbuf_itoa(
     char *ptr = buf;
     char * p1;
 	char c;
+    uint64_t uv;
 
-	if (!v) {
+    if (v < 0) {
+        ptr[0] = '-';
+        ptr ++;
+        uv = (uint64_t)0 - (uint64_t)v;
+    } else {
+        uv = (uint64_t)v;
+    }
+
+	if (!uv) {
 		*ptr++ = '0';
     } else {
-        if (v < 0) {
-            ptr[0] = '-';
-            ptr ++;
-            v *= -1;
-        }
-
 		char *p = ptr;
-		while (v) {
-            int64_t vdiv = v / 10;
-            int64_t vmod = v - (vdiv * 10);
-			p[0] = (char)('0' + vmod);
+		while (uv) {
+            uint64_t vdiv = uv / 10;
+            uint64_t vmod = uv - (vdiv * 10);
+			p[0] = (char)('0' + (char)vmod);
             p ++;
-			v = vdiv;
+			uv = vdiv;
 		}
 
 		p1 = p;
@@ -35444,8 +35455,18 @@ void ecs_vec_set_min_size_w_type_info(
     int32_t elem_count,
     const ecs_type_info_t *ti)
 {
+    ecs_assert(size != 0, ECS_INVALID_PARAMETER, NULL);
+    ecs_vec_init_if(vec, size);
+#ifdef FLECS_SANITIZE
+    if (!vec->type_name) {
+        vec->type_name = ti ? ti->name : NULL;
+    }
+#else
+    (void)ti;
+#endif
+
     if (elem_count > vec->size) {
-        ecs_vec_set_min_size_w_type_info(allocator, vec, size, elem_count, ti);
+        ecs_vec_set_size(allocator, vec, size, elem_count);
     }
 }
 
@@ -44894,7 +44915,7 @@ ecs_entity_t ecs_table_get_target(
         return 0;
     }
 
-    if (index > tr->count) {
+    if ((index < 0) || (index >= tr->count)) {
         return 0;
     }
 

--- a/src/datastructures/bitset.c
+++ b/src/datastructures/bitset.c
@@ -65,6 +65,7 @@ void flecs_bitset_set(
     int32_t elem,
     bool value)
 {
+    ecs_check(elem >= 0, ECS_INVALID_PARAMETER, NULL);
     ecs_check(elem < bs->count, ECS_INVALID_PARAMETER, NULL);
     uint32_t hi = ((uint32_t)elem) >> 6;
     uint32_t lo = ((uint32_t)elem) & 0x3F;
@@ -78,6 +79,7 @@ bool flecs_bitset_get(
     const ecs_bitset_t *bs,
     int32_t elem)
 {
+    ecs_check(elem >= 0, ECS_INVALID_PARAMETER, NULL);
     ecs_check(elem < bs->count, ECS_INVALID_PARAMETER, NULL);
     return !!(bs->data[elem >> 6] & ((uint64_t)1 << ((uint64_t)elem & 0x3F)));
 error:
@@ -94,6 +96,7 @@ void flecs_bitset_remove(
     ecs_bitset_t *bs,
     int32_t elem)
 {
+    ecs_check(elem >= 0, ECS_INVALID_PARAMETER, NULL);
     ecs_check(elem < bs->count, ECS_INVALID_PARAMETER, NULL);
     int32_t last = bs->count - 1;
     bool last_value = flecs_bitset_get(bs, last);
@@ -109,6 +112,8 @@ void flecs_bitset_swap(
     int32_t elem_a,
     int32_t elem_b)
 {
+    ecs_check(elem_a >= 0, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(elem_b >= 0, ECS_INVALID_PARAMETER, NULL);
     ecs_check(elem_a < bs->count, ECS_INVALID_PARAMETER, NULL);
     ecs_check(elem_b < bs->count, ECS_INVALID_PARAMETER, NULL);
 

--- a/src/datastructures/strbuf.c
+++ b/src/datastructures/strbuf.c
@@ -54,23 +54,26 @@ char* flecs_strbuf_itoa(
     char *ptr = buf;
     char * p1;
 	char c;
+    uint64_t uv;
 
-	if (!v) {
+    if (v < 0) {
+        ptr[0] = '-';
+        ptr ++;
+        uv = (uint64_t)0 - (uint64_t)v;
+    } else {
+        uv = (uint64_t)v;
+    }
+
+	if (!uv) {
 		*ptr++ = '0';
     } else {
-        if (v < 0) {
-            ptr[0] = '-';
-            ptr ++;
-            v *= -1;
-        }
-
 		char *p = ptr;
-		while (v) {
-            int64_t vdiv = v / 10;
-            int64_t vmod = v - (vdiv * 10);
-			p[0] = (char)('0' + vmod);
+		while (uv) {
+            uint64_t vdiv = uv / 10;
+            uint64_t vmod = uv - (vdiv * 10);
+			p[0] = (char)('0' + (char)vmod);
             p ++;
-			v = vdiv;
+			uv = vdiv;
 		}
 
 		p1 = p;

--- a/src/datastructures/vec.c
+++ b/src/datastructures/vec.c
@@ -250,8 +250,18 @@ void ecs_vec_set_min_size_w_type_info(
     int32_t elem_count,
     const ecs_type_info_t *ti)
 {
+    ecs_assert(size != 0, ECS_INVALID_PARAMETER, NULL);
+    ecs_vec_init_if(vec, size);
+#ifdef FLECS_SANITIZE
+    if (!vec->type_name) {
+        vec->type_name = ti ? ti->name : NULL;
+    }
+#else
+    (void)ti;
+#endif
+
     if (elem_count > vec->size) {
-        ecs_vec_set_min_size_w_type_info(allocator, vec, size, elem_count, ti);
+        ecs_vec_set_size(allocator, vec, size, elem_count);
     }
 }
 

--- a/src/entity.c
+++ b/src/entity.c
@@ -2745,6 +2745,9 @@ ecs_entity_t ecs_get_target(
     ecs_check(world != NULL, ECS_INVALID_PARAMETER, NULL);
     flecs_assert_entity_valid(world, entity, "get_target");
     ecs_check(rel != 0, ECS_INVALID_PARAMETER, NULL);
+    if (index < 0) {
+        return 0;
+    }
 
     if (rel == EcsChildOf) {
         if (index > 0) {

--- a/src/storage/table.c
+++ b/src/storage/table.c
@@ -2878,7 +2878,7 @@ ecs_entity_t ecs_table_get_target(
         return 0;
     }
 
-    if (index > tr->count) {
+    if ((index < 0) || (index >= tr->count)) {
         return 0;
     }
 

--- a/test/collections/project.json
+++ b/test/collections/project.json
@@ -71,7 +71,9 @@
                 "is_alive_low_after_ensure_high",
                 "remove_low_after_ensure_high",
                 "recreate_pages_after_shrink",
-                "create_low_page_after_high"
+                "create_low_page_after_high",
+                "bitset_negative_index",
+                "vec_set_min_size_w_type_info"
             ]
         }, {
             "id": "Strbuf",
@@ -111,7 +113,8 @@
                 "append_nan",
                 "append_inf",
                 "append_nan_delim",
-                "append_inf_delim"
+                "append_inf_delim",
+                "append_int64_min"
             ]
         }, {
             "id": "Allocator",

--- a/test/collections/src/Sparse.c
+++ b/test/collections/src/Sparse.c
@@ -1,5 +1,7 @@
 #include <collections.h>
+#include <flecs/datastructures/bitset.h>
 #include <flecs/datastructures/sparse.h>
+#include <flecs/datastructures/vec.h>
 
 void Sparse_setup(void) {
     ecs_os_set_api_defaults();
@@ -423,4 +425,28 @@ void Sparse_create_low_page_after_high(void) {
     populate(sp, 1000);
 
     flecs_sparse_free(sp);
+}
+
+void Sparse_bitset_negative_index(void) {
+    install_test_abort();
+
+    ecs_bitset_t bs = {0};
+    flecs_bitset_init(&bs);
+    flecs_bitset_addn(&bs, 1);
+
+    test_expect_abort();
+    flecs_bitset_get(&bs, -1);
+
+    flecs_bitset_fini(&bs);
+}
+
+void Sparse_vec_set_min_size_w_type_info(void) {
+    ecs_vec_t vec = {0};
+
+    ecs_vec_set_min_size_w_type_info(NULL, &vec, ECS_SIZEOF(int32_t), 8, NULL);
+
+    test_assert(vec.array != NULL);
+    test_assert(vec.size >= 8);
+
+    ecs_vec_fini(NULL, &vec, ECS_SIZEOF(int32_t));
 }

--- a/test/collections/src/Strbuf.c
+++ b/test/collections/src/Strbuf.c
@@ -1,5 +1,6 @@
 #include <collections.h>
 #include <math.h>
+#include <stdint.h>
 
 void Strbuf_setup(void) {
     ecs_os_set_api_defaults();
@@ -528,4 +529,14 @@ void Strbuf_append_inf_delim(void) {
         test_str(str, "\"Inf\"");
         ecs_os_free(str);
     }
+}
+
+void Strbuf_append_int64_min(void) {
+    ecs_strbuf_t b = ECS_STRBUF_INIT;
+    ecs_strbuf_appendint(&b, INT64_MIN);
+
+    char *str = ecs_strbuf_get(&b);
+    test_assert(str != NULL);
+    test_str(str, "-9223372036854775808");
+    ecs_os_free(str);
 }

--- a/test/collections/src/main.c
+++ b/test/collections/src/main.c
@@ -65,6 +65,8 @@ void Sparse_is_alive_low_after_ensure_high(void);
 void Sparse_remove_low_after_ensure_high(void);
 void Sparse_recreate_pages_after_shrink(void);
 void Sparse_create_low_page_after_high(void);
+void Sparse_bitset_negative_index(void);
+void Sparse_vec_set_min_size_w_type_info(void);
 
 // Testsuite 'Strbuf'
 void Strbuf_setup(void);
@@ -103,6 +105,7 @@ void Strbuf_append_nan(void);
 void Strbuf_append_inf(void);
 void Strbuf_append_nan_delim(void);
 void Strbuf_append_inf_delim(void);
+void Strbuf_append_int64_min(void);
 
 // Testsuite 'Allocator'
 void Allocator_setup(void);
@@ -319,6 +322,14 @@ bake_test_case Sparse_testcases[] = {
     {
         "create_low_page_after_high",
         Sparse_create_low_page_after_high
+    },
+    {
+        "bitset_negative_index",
+        Sparse_bitset_negative_index
+    },
+    {
+        "vec_set_min_size_w_type_info",
+        Sparse_vec_set_min_size_w_type_info
     }
 };
 
@@ -462,6 +473,10 @@ bake_test_case Strbuf_testcases[] = {
     {
         "append_inf_delim",
         Strbuf_append_inf_delim
+    },
+    {
+        "append_int64_min",
+        Strbuf_append_int64_min
     }
 };
 
@@ -485,14 +500,14 @@ static bake_test_suite suites[] = {
         "Sparse",
         Sparse_setup,
         NULL,
-        23,
+        25,
         Sparse_testcases
     },
     {
         "Strbuf",
         Strbuf_setup,
         NULL,
-        35,
+        36,
         Strbuf_testcases
     },
     {

--- a/test/core/project.json
+++ b/test/core/project.json
@@ -987,6 +987,7 @@
                 "get_parent",
                 "get_parent_from_nested",
                 "get_parent_from_nested_2",
+                "get_target_negative_index",
                 "get_object_from_0",
                 "tree_iter_empty",
                 "tree_iter_1_table",
@@ -1136,10 +1137,12 @@
                 "prefab_w_nested_ordered_children",
                 "prefab_w_nested_ordered_children_2",
                 "prefab_w_slots",
+                "prefab_get_target_after_reorder",
                 "recreate_named_child",
                 "lookup_after_move_to_root",
                 "lookup_after_clear",
                 "bulk_create_ordered_children",
+                "delete_many_children_perf",
                 "get_ordered_children_from_prefab_instance_nested_children",
                 "ordered_children_parent_is_traversable"
             ]
@@ -3228,6 +3231,7 @@
                 "has_pair",
                 "has_wildcard_pair",
                 "has_any_pair",
+                "get_target_out_of_range",
                 "clear_table_kills_entities",
                 "clear_table_add_new",
                 "clear_table_check_size",

--- a/test/core/src/Hierarchies.c
+++ b/test/core/src/Hierarchies.c
@@ -49,6 +49,31 @@ void Hierarchies_get_parent_from_nested_2(void) {
     ecs_fini(world);
 }
 
+void Hierarchies_get_target_negative_index(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ecs_entity_t parent = ecs_new(world);
+    ecs_entity_t child = ecs_new_w_pair(world, EcsChildOf, parent);
+    test_uint(ecs_get_target(world, child, EcsChildOf, -1), 0);
+
+    ECS_TAG(world, Rel0);
+    ECS_TAG(world, Rel);
+    ECS_TAG(world, Rel2);
+    ECS_TAG(world, Tgt0);
+    ECS_TAG(world, Tgt1);
+    ECS_TAG(world, Tgt2);
+
+    ecs_entity_t e = ecs_new(world);
+    ecs_add_pair(world, e, Rel0, Tgt0);
+    ecs_add_pair(world, e, Rel, Tgt1);
+    ecs_add_pair(world, e, Rel2, Tgt2);
+
+    test_uint(ecs_get_target(world, e, Rel, 0), Tgt1);
+    test_uint(ecs_get_target(world, e, Rel, -1), 0);
+
+    ecs_fini(world);
+}
+
 void Hierarchies_get_object_from_0(void) {
     install_test_abort();
     ecs_world_t *world = ecs_mini();

--- a/test/core/src/OrderedChildren.c
+++ b/test/core/src/OrderedChildren.c
@@ -1605,6 +1605,26 @@ void OrderedChildren_prefab_w_slots(void) {
     ecs_fini(world);
 }
 
+void OrderedChildren_prefab_get_target_after_reorder(void) {
+    install_test_abort();
+    ecs_world_t *world = ecs_mini();
+
+    ecs_entity_t p = ecs_new_w_id(world, EcsPrefab);
+    ecs_add_id(world, p, EcsOrderedChildren);
+
+    ecs_entity_t pc1 = ecs_new_w_pair(world, EcsChildOf, p);
+    ecs_entity_t pc2 = ecs_new_w_pair(world, EcsChildOf, p);
+    ecs_entity_t pc3 = ecs_new_w_pair(world, EcsChildOf, p);
+
+    ecs_entity_t i = ecs_new_w_pair(world, EcsIsA, p);
+
+    ecs_entity_t children[] = {pc3, pc1, pc2};
+    ecs_set_child_order(world, p, children, 3);
+
+    test_expect_abort();
+    ecs_get_target(world, i, pc1, 0);
+}
+
 void OrderedChildren_recreate_named_child(void) {
     ecs_world_t *world = ecs_mini();
 
@@ -1717,6 +1737,55 @@ void OrderedChildren_bulk_create_ordered_children(void) {
     }
 
     ecs_fini(world);
+}
+
+static
+double delete_children_elapsed(
+    int32_t child_count)
+{
+    ecs_world_t *world = ecs_mini();
+
+    ecs_entity_t parent = ecs_new(world);
+    ecs_add_id(world, parent, EcsOrderedChildren);
+
+    for (int32_t i = 0; i < child_count; i ++) {
+        ecs_new_w_pair(world, EcsChildOf, parent);
+    }
+
+    ecs_time_t t;
+    ecs_os_get_time(&t);
+
+    ecs_delete(world, parent);
+
+    double result = ecs_time_measure(&t);
+
+    ecs_fini(world);
+
+    return result;
+}
+
+static
+double delete_children_elapsed_best_of(
+    int32_t child_count,
+    int32_t attempts)
+{
+    double result = 0;
+
+    for (int32_t i = 0; i < attempts; i ++) {
+        double elapsed = delete_children_elapsed(child_count);
+        if (!i || (elapsed < result)) {
+            result = elapsed;
+        }
+    }
+
+    return result;
+}
+
+void OrderedChildren_delete_many_children_perf(void) {
+    double t_small = delete_children_elapsed_best_of(10000, 3);
+    double t_large = delete_children_elapsed_best_of(20000, 3);
+
+    test_assert(t_large < (t_small * 4.5));
 }
 
 void OrderedChildren_ordered_children_parent_is_traversable(void) {

--- a/test/core/src/Table.c
+++ b/test/core/src/Table.c
@@ -618,6 +618,31 @@ void Table_has_any_pair(void) {
     ecs_fini(world);
 }
 
+void Table_get_target_out_of_range(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, Rel0);
+    ECS_TAG(world, Rel);
+    ECS_TAG(world, Rel2);
+    ECS_TAG(world, Tgt0);
+    ECS_TAG(world, Tgt1);
+    ECS_TAG(world, Tgt2);
+
+    ecs_entity_t e = ecs_new(world);
+    ecs_add_pair(world, e, Rel0, Tgt0);
+    ecs_add_pair(world, e, Rel, Tgt1);
+    ecs_add_pair(world, e, Rel2, Tgt2);
+
+    ecs_table_t *table = ecs_get_table(world, e);
+    test_assert(table != NULL);
+
+    test_uint(ecs_table_get_target(world, table, Rel, 0), Tgt1);
+    test_uint(ecs_table_get_target(world, table, Rel, -1), 0);
+    test_uint(ecs_table_get_target(world, table, Rel, 1), 0);
+
+    ecs_fini(world);
+}
+
 void Table_clear_table_kills_entities(void) {
     ecs_world_t *world = ecs_mini();
 

--- a/test/core/src/main.c
+++ b/test/core/src/main.c
@@ -953,6 +953,7 @@ void Hierarchies_empty_scope(void);
 void Hierarchies_get_parent(void);
 void Hierarchies_get_parent_from_nested(void);
 void Hierarchies_get_parent_from_nested_2(void);
+void Hierarchies_get_target_negative_index(void);
 void Hierarchies_get_object_from_0(void);
 void Hierarchies_tree_iter_empty(void);
 void Hierarchies_tree_iter_1_table(void);
@@ -1100,10 +1101,12 @@ void OrderedChildren_get_ordered_children_from_prefab_instance_nested_children(v
 void OrderedChildren_prefab_w_nested_ordered_children(void);
 void OrderedChildren_prefab_w_nested_ordered_children_2(void);
 void OrderedChildren_prefab_w_slots(void);
+void OrderedChildren_prefab_get_target_after_reorder(void);
 void OrderedChildren_recreate_named_child(void);
 void OrderedChildren_lookup_after_move_to_root(void);
 void OrderedChildren_lookup_after_clear(void);
 void OrderedChildren_bulk_create_ordered_children(void);
+void OrderedChildren_delete_many_children_perf(void);
 void OrderedChildren_get_ordered_children_from_prefab_instance_nested_children(void);
 void OrderedChildren_ordered_children_parent_is_traversable(void);
 
@@ -3133,6 +3136,7 @@ void Table_has_id(void);
 void Table_has_pair(void);
 void Table_has_wildcard_pair(void);
 void Table_has_any_pair(void);
+void Table_get_target_out_of_range(void);
 void Table_clear_table_kills_entities(void);
 void Table_clear_table_add_new(void);
 void Table_clear_table_check_size(void);
@@ -6913,6 +6917,10 @@ bake_test_case Hierarchies_testcases[] = {
         Hierarchies_get_parent_from_nested_2
     },
     {
+        "get_target_negative_index",
+        Hierarchies_get_target_negative_index
+    },
+    {
         "get_object_from_0",
         Hierarchies_get_object_from_0
     },
@@ -7496,6 +7504,10 @@ bake_test_case OrderedChildren_testcases[] = {
         OrderedChildren_prefab_w_slots
     },
     {
+        "prefab_get_target_after_reorder",
+        OrderedChildren_prefab_get_target_after_reorder
+    },
+    {
         "recreate_named_child",
         OrderedChildren_recreate_named_child
     },
@@ -7510,6 +7522,10 @@ bake_test_case OrderedChildren_testcases[] = {
     {
         "bulk_create_ordered_children",
         OrderedChildren_bulk_create_ordered_children
+    },
+    {
+        "delete_many_children_perf",
+        OrderedChildren_delete_many_children_perf
     },
     {
         "get_ordered_children_from_prefab_instance_nested_children",
@@ -15439,6 +15455,10 @@ bake_test_case Table_testcases[] = {
         Table_has_any_pair
     },
     {
+        "get_target_out_of_range",
+        Table_get_target_out_of_range
+    },
+    {
         "clear_table_kills_entities",
         Table_clear_table_kills_entities
     },
@@ -15827,14 +15847,14 @@ static bake_test_suite suites[] = {
         "Hierarchies",
         Hierarchies_setup,
         NULL,
-        108,
+        109,
         Hierarchies_testcases
     },
     {
         "OrderedChildren",
         NULL,
         NULL,
-        47,
+        49,
         OrderedChildren_testcases
     },
     {
@@ -16037,7 +16057,7 @@ static bake_test_suite suites[] = {
         "Table",
         NULL,
         NULL,
-        31,
+        32,
         Table_testcases
     },
     {


### PR DESCRIPTION
- Return 0 for negative indices in ecs_get_target
- Fix ecs_table_get_target bounds check to reject negative and >=count indices.
- Stabilize OrderedChildren.delete_many_children_perf with best-of sampling.
- Add collection regression tests for bitset negative index, vec_set_min_size_w_type_info and strbuf INT64_MIN formatting.
