### PR TITLE
Fix ecs_import MODULE_UNDEFINED assert when loading modules dynamically

### DIFF
--- a/src/addons/module.c
+++ b/src/addons/module.c
@@ -44,7 +44,6 @@ ecs_entity_t ecs_import(
 
     char *path = flecs_module_path_from_c(module_name);
     ecs_entity_t e = ecs_lookup(world, path);
-    ecs_os_free(path);
     
     if (!e) {
         ecs_trace("#[magenta]import#[reset] %s", module_name);
@@ -54,7 +53,7 @@ ecs_entity_t ecs_import(
         module(world);
 
         /* Lookup module entity (must be registered by module) */
-        e = ecs_lookup(world, module_name);
+        e = ecs_lookup(world, path);
         ecs_check(e != 0, ECS_MODULE_UNDEFINED, "%s", module_name);
 
         ecs_log_pop();
@@ -62,10 +61,12 @@ ecs_entity_t ecs_import(
 
     /* Restore to previous state */
     ecs_set_scope(world, old_scope);
+    ecs_os_free(path);
     world->info.name_prefix = old_name_prefix;
 
     return e;
 error:
+    ecs_os_free(path);
     return 0;
 }
 


### PR DESCRIPTION
The second lookup in ecs_import() used the raw module_name (PascalCase) instead of the converted path (dot.separated). This caused ecs_import_from_library() to always fail with MODULE_UNDEFINED because ECS_MODULE registers the entity with the dot-separated path (e.g. 'physics.plugin'), but the post-import lookup searched for the PascalCase name (e.g. 'PhysicsPlugin') which doesn't exist.

Fix: use the already-converted 'path' variable for both lookups, and defer ecs_os_free(path) to the end of the function.

Fixes #2071
Fixes #1755