### PR TITLE
[draft] Allow tick sources to tick multiple times per frame

### DIFF
--- a/include/flecs/addons/system.h
+++ b/include/flecs/addons/system.h
@@ -30,7 +30,7 @@ extern "C" {
 
 /** Component used to provide a tick source to systems. */
 typedef struct EcsTickSource {
-    bool tick;                 /**< True if providing a tick. */
+    uint32_t ticks;                 /**< Count of ticks to be fired. */
     ecs_ftime_t time_elapsed;  /**< Time elapsed since the last tick. */
 } EcsTickSource;
 

--- a/src/addons/system/system.c
+++ b/src/addons/system/system.c
@@ -38,6 +38,7 @@ ecs_entity_t flecs_run_system(
         param = system_data->ctx;
     }
 
+    int ticks = 1;
     if (tick_source) {
         const EcsTickSource *tick = ecs_get(world, tick_source, EcsTickSource);
 
@@ -45,15 +46,16 @@ ecs_entity_t flecs_run_system(
             time_elapsed = tick->time_elapsed;
 
             /* If timer hasn't fired we shouldn't run the system */
-            if (!tick->tick) {
+            if (tick->ticks == 0) {
                 return 0;
             }
+            ticks = tick->ticks;
         } else {
             /* If a timer has been set but the timer entity does not have the
              * EcsTimer component, don't run the system. This can be the result
              * of a single-shot timer that has fired already. Not resetting the
              * timer field of the system will ensure that the system won't be
-             * run after the timer has fired. */
+             * ran after the timer has fired. */
             return 0;
         }
     }
@@ -81,70 +83,68 @@ ecs_entity_t flecs_run_system(
 
     flecs_poly_assert(stage, ecs_stage_t);
 
-    /* Prepare the query iterator */
-    ecs_iter_t wit, qit = ecs_query_iter(thread_ctx, system_data->query);
-    ecs_iter_t *it = &qit;
+    for (int i = 0; i < ticks; i++) {
+        /* Prepare the query iterator */
+        ecs_iter_t wit, qit = ecs_query_iter(thread_ctx, system_data->query);
+        ecs_iter_t *it = &qit;
 
-    qit.system = system;
-    qit.delta_time = delta_time;
-    qit.delta_system_time = time_elapsed;
-    qit.param = param;
-    qit.ctx = system_data->ctx;
-    qit.callback_ctx = system_data->callback_ctx;
-    qit.run_ctx = system_data->run_ctx;
+        qit.system = system;
+        qit.delta_time = delta_time;
+        qit.delta_system_time = time_elapsed;
+        qit.param = param;
+        qit.ctx = system_data->ctx;
+        qit.callback_ctx = system_data->callback_ctx;
+        qit.run_ctx = system_data->run_ctx;
 
-    if (system_data->group_id_set) {
-        ecs_iter_set_group(&qit, system_data->group_id);
-    }
-
-    if (stage_count > 1 && system_data->multi_threaded) {
-        wit = ecs_worker_iter(it, stage_index, stage_count);
-        it = &wit;
-    }
-
-    ecs_entity_t old_system = flecs_stage_set_system(stage, system);
-    ecs_iter_action_t action = system_data->action;
-    it->callback = action;
-
-    ecs_run_action_t run = system_data->run;
-    if (run) {
-        /* If system query matches nothing, the system run callback doesn't have
-         * anything to iterate, so the iterator resources don't get cleaned up
-         * automatically, so clean it up here. */
-        if (system_data->query->flags & EcsQueryMatchNothing) {
-            it->next = flecs_default_next_callback; /* Return once */
-            run(it);
-            ecs_iter_fini(&qit);
-        } else {
-            if (it == &qit && (qit.flags & EcsIterTrivialCached)) {
-                it->next = flecs_query_trivial_cached_next;
-            }
-            run(it);
+        if (stage_count > 1 && system_data->multi_threaded) {
+            wit = ecs_worker_iter(it, stage_index, stage_count);
+            it = &wit;
         }
-    } else {
-        if (system_data->query->term_count) {
-            if (it == &qit) {
-                if (qit.flags & EcsIterTrivialCached) {
-                    while (flecs_query_trivial_cached_next(&qit)) {
-                        action(&qit);
+
+        ecs_entity_t old_system = flecs_stage_set_system(stage, system);
+        ecs_iter_action_t action = system_data->action;
+        it->callback = action;
+
+        ecs_run_action_t run = system_data->run;
+        if (run) {
+            /* If system query matches nothing, the system run callback doesn't have
+            * anything to iterate, so the iterator resources don't get cleaned up
+            * automatically, so clean it up here. */
+            if (system_data->query->flags & EcsQueryMatchNothing) {
+                it->next = flecs_default_next_callback; /* Return once */
+                run(it);
+                ecs_iter_fini(&qit);
+            } else {
+                if (it == &qit && (qit.flags & EcsIterTrivialCached)) {
+                    it->next = flecs_query_trivial_cached_next;
+                }
+                run(it);
+            }
+        } else {
+            if (system_data->query->term_count) {
+                if (it == &qit) {
+                    if (qit.flags & EcsIterTrivialCached) {
+                        while (flecs_query_trivial_cached_next(&qit)) {
+                            action(&qit);
+                        }
+                    } else {
+                        while (ecs_query_next(&qit)) {
+                            action(&qit);
+                        }
                     }
                 } else {
-                    while (ecs_query_next(&qit)) {
-                        action(&qit);
+                    while (ecs_iter_next(it)) {
+                        action(it);
                     }
                 }
             } else {
-                while (ecs_iter_next(it)) {
-                    action(it);
-                }
+                action(&qit);
+                ecs_iter_fini(&qit);
             }
-        } else {
-            action(&qit);
-            ecs_iter_fini(&qit);
         }
+        flecs_stage_set_system(stage, old_system);
     }
 
-    flecs_stage_set_system(stage, old_system);
 
     if (measure_time) {
         system_data->time_spent += (ecs_ftime_t)ecs_time_measure(&time_start);
@@ -152,9 +152,9 @@ ecs_entity_t flecs_run_system(
 
     ecs_os_perf_trace_pop(system_data->name);
 
-    return it->interrupted_by;
+    // return it->interrupted_by;
+    return 0; // TODO idk what interrupted_by means
 }
-
 
 /* -- Public API -- */
 

--- a/src/addons/timer.c
+++ b/src/addons/timer.c
@@ -18,33 +18,20 @@ void ProgressTimers(ecs_iter_t *it) {
 
     int i;
     for (i = 0; i < it->count; i ++) {
-        tick_source[i].tick = false;
+        tick_source[i].ticks = 0;
 
         if (!timer[i].active) {
             continue;
         }
 
         const ecs_world_info_t *info = ecs_get_world_info(it->world);
-        ecs_ftime_t time_elapsed = timer[i].time + info->delta_time_raw;
+        timer[i].time += info->delta_time_raw;
         ecs_ftime_t timeout = timer[i].timeout;
         
-        if (time_elapsed >= timeout) {
-            ecs_ftime_t t = time_elapsed - timeout;
-            if (t > timeout) {
-                t = 0;
-            }
-
-            timer[i].time = t; /* Initialize with remainder */
-            tick_source[i].tick = true;
-            tick_source[i].time_elapsed = time_elapsed - timer[i].overshoot;
-            timer[i].overshoot = t;
-
-            if (timer[i].single_shot) {
-                timer[i].active = false;
-            }
-        } else {
-            timer[i].time = time_elapsed;
-        }  
+        while (timer[i].time >= timer[i].timeout) {
+            timer[i].time -= timer[i].timeout;
+            tick_source[i].ticks++;
+        }
     }
 }
 
@@ -64,7 +51,8 @@ void ProgressRateFilters(ecs_iter_t *it) {
             const EcsTickSource *tick_src = ecs_get(
                 it->world, src, EcsTickSource);
             if (tick_src) {
-                inc = tick_src->tick;
+                // TODO use ticks
+                // inc = tick_src->tick;
             } else {
                 inc = true;
             }
@@ -75,14 +63,16 @@ void ProgressRateFilters(ecs_iter_t *it) {
         if (inc) {
             filter[i].tick_count ++;
             bool triggered = !(filter[i].tick_count % filter[i].rate);
-            tick_dst[i].tick = triggered;
+            // TODO use ticks
+            // tick_dst[i].tick = triggered;
             tick_dst[i].time_elapsed = filter[i].time_elapsed;
 
             if (triggered) {
                 filter[i].time_elapsed = 0;
             }            
         } else {
-            tick_dst[i].tick = false;
+            // TODO use ticks
+            // tick_dst[i].tick = false;
         }
     }
 }
@@ -94,7 +84,7 @@ void ProgressTickSource(ecs_iter_t *it) {
     /* If tick source has no filters, tick unconditionally */
     int i;
     for (i = 0; i < it->count; i ++) {
-        tick_src[i].tick = true;
+        tick_src[i].ticks = 1;
         tick_src[i].time_elapsed = it->delta_time;
     }
 }


### PR DESCRIPTION
Experimental draft pr for this issue:
https://github.com/SanderMertens/flecs/issues/2094

Allows tick sources to tick multiple times per pipeline run.

Should improve ergonomics of defining a core game loop that requires parts of the pipeline to run at a fixed interval.