### PR TITLE
Fixed Tick Rate Timer

### DIFF
--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -30902,28 +30902,39 @@ void ProgressTimers(ecs_iter_t *it) {
         if (!timer[i].active) {
             continue;
         }
-
         const ecs_world_info_t *info = ecs_get_world_info(it->world);
-        ecs_ftime_t time_elapsed = timer[i].time + info->delta_time_raw;
-        ecs_ftime_t timeout = timer[i].timeout;
-        
-        if (time_elapsed >= timeout) {
-            ecs_ftime_t t = time_elapsed - timeout;
-            if (t > timeout) {
-                t = 0;
-            }
-
-            timer[i].time = t; /* Initialize with remainder */
-            tick_source[i].ticks = 1;
-            tick_source[i].time_elapsed = time_elapsed - timer[i].overshoot;
-            timer[i].overshoot = t;
-
-            if (timer[i].single_shot) {
-                timer[i].active = false;
+        if (timer[i].fixed_interval) {
+            timer[i].time += info->delta_time_raw;
+            tick_source[i].time_elapsed = timer[i].timeout;
+            while (timer[i].time >= timer[i].timeout && timer[i].active) {
+                timer[i].time -= timer[i].timeout;
+                tick_source[i].ticks++;
+                if (timer[i].single_shot) {
+                    timer[i].active = false;
+                }
             }
         } else {
-            timer[i].time = time_elapsed;
-        }  
+            ecs_ftime_t time_elapsed = timer[i].time + info->delta_time_raw;
+            ecs_ftime_t timeout = timer[i].timeout;
+            
+            if (time_elapsed >= timeout) {
+                ecs_ftime_t t = time_elapsed - timeout;
+                if (t > timeout) {
+                    t = 0;
+                }
+
+                timer[i].time = t; /* Initialize with remainder */
+                tick_source[i].ticks = 1;
+                tick_source[i].time_elapsed = time_elapsed - timer[i].overshoot;
+                timer[i].overshoot = t;
+
+                if (timer[i].single_shot) {
+                    timer[i].active = false;
+                }
+            } else {
+                timer[i].time = time_elapsed;
+            }  
+        }
     }
 }
 
@@ -31019,6 +31030,34 @@ error:
     return 0;
 }
 
+FLECS_API
+ecs_entity_t ecs_set_fixed_timeout(
+    ecs_world_t *world,
+    ecs_entity_t timer,
+    ecs_ftime_t timeout) {
+
+    ecs_check(world != NULL, ECS_INVALID_PARAMETER, NULL);
+
+    if (!timer) {
+        timer = ecs_entity(world, {0});
+    }
+
+    ecs_set(world, timer, EcsTimer, {
+        .timeout = timeout,
+        .single_shot = true,
+        .fixed_interval = true,
+        .active = true
+    });
+
+    ecs_system_t *system_data = flecs_poly_get(world, timer, ecs_system_t);
+    if (system_data) {
+        system_data->tick_source = timer;
+    }
+
+error:
+    return timer;
+}
+
 ecs_entity_t ecs_set_interval(
     ecs_world_t *world,
     ecs_entity_t timer,
@@ -31044,6 +31083,32 @@ error:
     return timer;  
 }
 
+ecs_entity_t ecs_set_fixed_interval(
+    ecs_world_t *world,
+    ecs_entity_t timer,
+    ecs_ftime_t interval)
+{
+    ecs_check(world != NULL, ECS_INVALID_PARAMETER, NULL);
+
+    if (!timer) {
+        timer = ecs_new_w(world, EcsTimer);
+    }
+
+    EcsTimer *t = ecs_ensure(world, timer, EcsTimer);
+    ecs_check(t != NULL, ECS_INTERNAL_ERROR, NULL);
+    t->timeout = interval;
+    t->active = true;
+    t->fixed_interval = true;
+    ecs_modified(world, timer, EcsTimer);
+
+    ecs_system_t *system_data = flecs_poly_get(world, timer, ecs_system_t);
+    if (system_data) {
+        system_data->tick_source = timer;
+    }
+error:
+    return timer;  
+}
+
 ecs_ftime_t ecs_get_interval(
     const ecs_world_t *world,
     ecs_entity_t timer)
@@ -31057,6 +31122,36 @@ ecs_ftime_t ecs_get_interval(
     const EcsTimer *value = ecs_get(world, timer, EcsTimer);
     if (value) {
         return value->timeout;
+    }
+error:
+    return 0;
+}
+
+void ecs_set_is_fixed_timer(
+    ecs_world_t *world,
+    ecs_entity_t timer,
+    bool is_fixed)
+{
+    EcsTimer *ptr = ecs_ensure(world, timer, EcsTimer);
+    ecs_check(ptr != NULL, ECS_INTERNAL_ERROR, NULL);
+    ptr->fixed_interval = is_fixed;
+error:
+    return;
+}
+
+bool ecs_is_fixed_timer(
+    ecs_world_t *world,
+    ecs_entity_t timer) {
+    
+    ecs_check(world != NULL, ECS_INVALID_PARAMETER, NULL);
+
+    if (!timer) {
+        return 0;
+    }
+
+    const EcsTimer *value = ecs_get(world, timer, EcsTimer);
+    if (value) {
+        return value->fixed_interval;
     }
 error:
     return 0;
@@ -77428,6 +77523,7 @@ ecs_entity_t flecs_run_system(
 {
     flecs_poly_assert(world, ecs_world_t);
     ecs_ftime_t time_elapsed = delta_time;
+    uint32_t num_ticks = 1;
     ecs_entity_t tick_source = system_data->tick_source;
 
     /* Support legacy behavior */
@@ -77439,12 +77535,12 @@ ecs_entity_t flecs_run_system(
         const EcsTickSource *tick = ecs_get(world, tick_source, EcsTickSource);
 
         if (tick) {
-            time_elapsed = tick->time_elapsed;
-
             /* If timer hasn't fired we shouldn't run the system */
-            if (!tick->ticks == 0) {
+            if (tick->ticks == 0) {
                 return 0;
             }
+            time_elapsed = tick->time_elapsed;
+            num_ticks = tick->ticks;
         } else {
             /* If a timer has been set but the timer entity does not have the
              * EcsTimer component, don't run the system. This can be the result
@@ -77478,67 +77574,71 @@ ecs_entity_t flecs_run_system(
 
     flecs_poly_assert(stage, ecs_stage_t);
 
-    /* Prepare the query iterator */
-    ecs_iter_t wit, qit = ecs_query_iter(thread_ctx, system_data->query);
-    ecs_iter_t *it = &qit;
-
-    qit.system = system;
-    qit.delta_time = delta_time;
-    qit.delta_system_time = time_elapsed;
-    qit.param = param;
-    qit.ctx = system_data->ctx;
-    qit.callback_ctx = system_data->callback_ctx;
-    qit.run_ctx = system_data->run_ctx;
-
-    if (system_data->group_id_set) {
-        ecs_iter_set_group(&qit, system_data->group_id);
-    }
-
-    if (stage_count > 1 && system_data->multi_threaded) {
-        wit = ecs_worker_iter(it, stage_index, stage_count);
-        it = &wit;
-    }
-
     ecs_entity_t old_system = flecs_stage_set_system(stage, system);
-    ecs_iter_action_t action = system_data->action;
-    it->callback = action;
+    ecs_entity_t interrupted_by = 0;
+    for (uint32_t i = 0; i < num_ticks; i++) {
+        /* Prepare the query iterator */
+        ecs_iter_t wit, qit = ecs_query_iter(thread_ctx, system_data->query);
+        ecs_iter_t *it = &qit;
 
-    ecs_run_action_t run = system_data->run;
-    if (run) {
-        /* If system query matches nothing, the system run callback doesn't have
-         * anything to iterate, so the iterator resources don't get cleaned up
-         * automatically, so clean it up here. */
-        if (system_data->query->flags & EcsQueryMatchNothing) {
-            it->next = flecs_default_next_callback; /* Return once */
-            run(it);
-            ecs_iter_fini(&qit);
-        } else {
-            if (it == &qit && (qit.flags & EcsIterTrivialCached)) {
-                it->next = flecs_query_trivial_cached_next;
-            }
-            run(it);
+        qit.system = system;
+        qit.delta_time = delta_time;
+        qit.delta_system_time = time_elapsed;
+        qit.param = param;
+        qit.ctx = system_data->ctx;
+        qit.callback_ctx = system_data->callback_ctx;
+        qit.run_ctx = system_data->run_ctx;
+
+        if (system_data->group_id_set) {
+            ecs_iter_set_group(&qit, system_data->group_id);
         }
-    } else {
-        if (system_data->query->term_count) {
-            if (it == &qit) {
-                if (qit.flags & EcsIterTrivialCached) {
-                    while (flecs_query_trivial_cached_next(&qit)) {
-                        action(&qit);
+
+        if (stage_count > 1 && system_data->multi_threaded) {
+            wit = ecs_worker_iter(it, stage_index, stage_count);
+            it = &wit;
+        }
+
+        ecs_iter_action_t action = system_data->action;
+        it->callback = action;
+
+        ecs_run_action_t run = system_data->run;
+        if (run) {
+            /* If system query matches nothing, the system run callback doesn't have
+            * anything to iterate, so the iterator resources don't get cleaned up
+            * automatically, so clean it up here. */
+            if (system_data->query->flags & EcsQueryMatchNothing) {
+                it->next = flecs_default_next_callback; /* Return once */
+                run(it);
+                ecs_iter_fini(&qit);
+            } else {
+                if (it == &qit && (qit.flags & EcsIterTrivialCached)) {
+                    it->next = flecs_query_trivial_cached_next;
+                }
+                run(it);
+            }
+        } else {
+            if (system_data->query->term_count) {
+                if (it == &qit) {
+                    if (qit.flags & EcsIterTrivialCached) {
+                        while (flecs_query_trivial_cached_next(&qit)) {
+                            action(&qit);
+                        }
+                    } else {
+                        while (ecs_query_next(&qit)) {
+                            action(&qit);
+                        }
                     }
                 } else {
-                    while (ecs_query_next(&qit)) {
-                        action(&qit);
+                    while (ecs_iter_next(it)) {
+                        action(it);
                     }
                 }
             } else {
-                while (ecs_iter_next(it)) {
-                    action(it);
-                }
+                action(&qit);
+                ecs_iter_fini(&qit);
             }
-        } else {
-            action(&qit);
-            ecs_iter_fini(&qit);
         }
+        interrupted_by = it->interrupted_by;
     }
 
     flecs_stage_set_system(stage, old_system);
@@ -77549,7 +77649,7 @@ ecs_entity_t flecs_run_system(
 
     ecs_os_perf_trace_pop(system_data->name);
 
-    return it->interrupted_by;
+    return interrupted_by;
 }
 
 

--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -30886,7 +30886,6 @@ ecs_entity_t flecs_run_system(
 
 #endif
 
-
 #ifdef FLECS_TIMER
 
 static
@@ -30898,7 +30897,7 @@ void ProgressTimers(ecs_iter_t *it) {
 
     int i;
     for (i = 0; i < it->count; i ++) {
-        tick_source[i].tick = false;
+        tick_source[i].ticks = 0;
 
         if (!timer[i].active) {
             continue;
@@ -30915,7 +30914,7 @@ void ProgressTimers(ecs_iter_t *it) {
             }
 
             timer[i].time = t; /* Initialize with remainder */
-            tick_source[i].tick = true;
+            tick_source[i].ticks = 1;
             tick_source[i].time_elapsed = time_elapsed - timer[i].overshoot;
             timer[i].overshoot = t;
 
@@ -30944,7 +30943,7 @@ void ProgressRateFilters(ecs_iter_t *it) {
             const EcsTickSource *tick_src = ecs_get(
                 it->world, src, EcsTickSource);
             if (tick_src) {
-                inc = tick_src->tick;
+                inc = tick_src->ticks > 0;
             } else {
                 inc = true;
             }
@@ -30955,14 +30954,14 @@ void ProgressRateFilters(ecs_iter_t *it) {
         if (inc) {
             filter[i].tick_count ++;
             bool triggered = !(filter[i].tick_count % filter[i].rate);
-            tick_dst[i].tick = triggered;
+            tick_dst[i].ticks = triggered ? 1 : 0;
             tick_dst[i].time_elapsed = filter[i].time_elapsed;
 
             if (triggered) {
                 filter[i].time_elapsed = 0;
             }            
         } else {
-            tick_dst[i].tick = false;
+            tick_dst[i].ticks = 0;
         }
     }
 }
@@ -30974,7 +30973,7 @@ void ProgressTickSource(ecs_iter_t *it) {
     /* If tick source has no filters, tick unconditionally */
     int i;
     for (i = 0; i < it->count; i ++) {
-        tick_src[i].tick = true;
+        tick_src[i].ticks = 1;
         tick_src[i].time_elapsed = it->delta_time;
     }
 }
@@ -77443,7 +77442,7 @@ ecs_entity_t flecs_run_system(
             time_elapsed = tick->time_elapsed;
 
             /* If timer hasn't fired we shouldn't run the system */
-            if (!tick->tick) {
+            if (!tick->ticks == 0) {
                 return 0;
             }
         } else {

--- a/distr/flecs.h
+++ b/distr/flecs.h
@@ -14627,7 +14627,7 @@ extern "C" {
 
 /** Component used to provide a tick source to systems. */
 typedef struct EcsTickSource {
-    bool tick;                 /**< True if providing a tick. */
+    uint32_t ticks;                 /**< Number of ticks provided this frame. */
     ecs_ftime_t time_elapsed;  /**< Time elapsed since the last tick. */
 } EcsTickSource;
 

--- a/distr/flecs.h
+++ b/distr/flecs.h
@@ -14220,7 +14220,7 @@ ecs_entity_t ecs_set_fixed_interval(
  *
  * @param world The world.
  * @param tick_source The timer for which to set the interval (0 to create one).
- * @param interval The interval value.
+ * @param is_fixed True if this timer should use a fixed interval.
  */
 FLECS_API
 void ecs_set_is_fixed_timer(

--- a/distr/flecs.h
+++ b/distr/flecs.h
@@ -14051,6 +14051,7 @@ typedef struct EcsTimer {
     int32_t fired_count;         /**< Number of times ticked. */
     bool active;                 /**< Is the timer active or not. */
     bool single_shot;            /**< Is this a single-shot timer. */
+	bool fixed_interval;		 /**< Timer fires at fixed interval (no overshoot). */
 } EcsTimer;
 
 /** Apply a rate filter to a tick source. */
@@ -14072,7 +14073,7 @@ typedef struct EcsRateFilter {
  *
  * The tick_source entity will be a tick source after this operation. Tick
  * sources can be read by getting the EcsTickSource component. If the tick
- * source ticked this frame, the 'tick' member will be true. When the tick
+ * source ticked this frame, the 'ticks' member will be > 0. When the tick
  * source is a system, the system will tick when the timer ticks.
  *
  * @param world The world.
@@ -14103,6 +14104,32 @@ ecs_ftime_t ecs_get_timeout(
     const ecs_world_t *world,
     ecs_entity_t tick_source);
 
+/** Set fixed timer timeout.
+ * This operation executes any systems associated with the timer after the
+ * specified timeout value. Differs from set_timeout, which can fire with a
+ * delta_time larger than the specified timeout if the pipeline is progressed
+ * with a larger value. If the entity contains an existing timer, the
+ * timeout value will be reset. The timer can be started and stopped with
+ * ecs_start_timer() and ecs_stop_timer().
+ *
+ * The timer is synchronous, and is incremented each frame by delta_time.
+ *
+ * The tick_source entity will be a tick source after this operation. Tick
+ * sources can be read by getting the EcsTickSource component. If the tick
+ * source ticked this frame, the 'ticks' member will be 1. When the tick
+ * source is a system, the system will tick when the timer ticks.
+ *
+ * @param world The world.
+ * @param tick_source The timer for which to set the timeout (0 to create one).
+ * @param timeout The timeout value.
+ * @return The timer entity.
+ */
+FLECS_API
+ecs_entity_t ecs_set_fixed_timeout(
+    ecs_world_t *world,
+    ecs_entity_t tick_source,
+    ecs_ftime_t timeout);
+
 /** Set timer interval.
  * This operation will continuously invoke systems associated with the timer
  * after the interval period expires. If the entity contains an existing timer,
@@ -14112,7 +14139,7 @@ ecs_ftime_t ecs_get_timeout(
  *
  * The tick_source entity will be a tick source after this operation. Tick
  * sources can be read by getting the EcsTickSource component. If the tick
- * source ticked this frame, the 'tick' member will be true. When the tick
+ * source ticked this frame, the 'ticks' member will be > 0. When the tick
  * source is a system, the system will tick when the timer ticks.
  *
  * @param world The world.
@@ -14125,6 +14152,7 @@ ecs_entity_t ecs_set_interval(
     ecs_world_t *world,
     ecs_entity_t tick_source,
     ecs_ftime_t interval);
+
 
 /** Get current interval value for the specified timer.
  * This operation returns the value set by ecs_set_interval(). If the entity is
@@ -14147,6 +14175,68 @@ ecs_ftime_t ecs_get_interval(
  */
 FLECS_API
 void ecs_start_timer(
+    ecs_world_t *world,
+    ecs_entity_t tick_source);
+
+
+/** Set timer fixed interval.
+ * This operation will continuously invoke systems associated with the timer.
+ * Unlike set_interval, this timer can invoke the system multiple times per frame,
+ * in the case where the frame is progressed more than the length of the interval.
+ *
+ * This is useful to have a fixed rate tick system in the middle of a pipeline,
+ * like a physics system or other system desiring a fixed delta time.
+ *
+ * Users can retrieve the interval with ecs_get_interval().
+ *
+ * This is the same as calling:
+ * ecs_set_interval(x);
+ * ecs_set_interval_fixed(true);
+ *
+ * All invocations of the associated system will be called with the exact interval.
+ *
+ * If the entity contains an existing timer, the interval value will be reset.
+ *
+ * The timer is synchronous, and is incremented each frame by delta_time.
+ *
+ * The tick_source entity will be a tick source after this operation. Tick
+ * sources can be read by getting the EcsTickSource component. If the tick
+ * source ticked this frame, the 'ticks' member will contain the number of ticks.
+ *
+ * @param world The world.
+ * @param tick_source The timer for which to set the interval (0 to create one).
+ * @param interval The interval value.
+ * @return The timer entity.
+ */
+FLECS_API
+ecs_entity_t ecs_set_fixed_interval(
+    ecs_world_t *world,
+    ecs_entity_t tick_source,
+    ecs_ftime_t interval);
+
+/** Set timer is fixed.
+ * This operation sets the timer to use a fixed interval, or
+ * a non-fixed interval if the parameter is false.
+ *
+ * @param world The world.
+ * @param tick_source The timer for which to set the interval (0 to create one).
+ * @param interval The interval value.
+ */
+FLECS_API
+void ecs_set_is_fixed_timer(
+    ecs_world_t *world,
+    ecs_entity_t tick_source,
+    bool is_fixed);
+
+/** Get timer is fixed.
+ * Returns if the timer is using fixed ticks.
+ *
+ * @param world The world.
+ * @param tick_source The timer for which to set the interval (0 to create one).
+ * @return return if the timer is using fixed ticks.
+ */
+FLECS_API
+bool ecs_is_fixed_timer(
     ecs_world_t *world,
     ecs_entity_t tick_source);
 
@@ -14203,7 +14293,7 @@ void ecs_randomize_timers(
  *
  * The tick_source entity will be a tick source after this operation. Tick
  * sources can be read by getting the EcsTickSource component. If the tick
- * source ticked this frame, the 'tick' member will be true. When the tick
+ * source ticked this frame, the 'ticks' member will be > 0. When the tick
  * source is a system, the system will tick when the timer ticks.
  *
  * @param world The world.

--- a/include/flecs/addons/system.h
+++ b/include/flecs/addons/system.h
@@ -30,7 +30,7 @@ extern "C" {
 
 /** Component used to provide a tick source to systems. */
 typedef struct EcsTickSource {
-    bool tick;                 /**< True if providing a tick. */
+    uint32_t ticks;                 /**< Number of ticks provided this frame. */
     ecs_ftime_t time_elapsed;  /**< Time elapsed since the last tick. */
 } EcsTickSource;
 

--- a/include/flecs/addons/timer.h
+++ b/include/flecs/addons/timer.h
@@ -208,7 +208,7 @@ ecs_entity_t ecs_set_fixed_interval(
  *
  * @param world The world.
  * @param tick_source The timer for which to set the interval (0 to create one).
- * @param interval The interval value.
+ * @param is_fixed True if this timer should use a fixed interval.
  */
 FLECS_API
 void ecs_set_is_fixed_timer(

--- a/include/flecs/addons/timer.h
+++ b/include/flecs/addons/timer.h
@@ -61,7 +61,7 @@ typedef struct EcsRateFilter {
  *
  * The tick_source entity will be a tick source after this operation. Tick
  * sources can be read by getting the EcsTickSource component. If the tick
- * source ticked this frame, the 'tick' member will be true. When the tick
+ * source ticked this frame, the 'ticks' member will be > 0. When the tick
  * source is a system, the system will tick when the timer ticks.
  *
  * @param world The world.
@@ -92,6 +92,32 @@ ecs_ftime_t ecs_get_timeout(
     const ecs_world_t *world,
     ecs_entity_t tick_source);
 
+/** Set fixed timer timeout.
+ * This operation executes any systems associated with the timer after the
+ * specified timeout value. Differs from set_timeout, which can fire with a
+ * delta_time larger than the specified timeout if the pipeline is progressed
+ * with a larger value. If the entity contains an existing timer, the
+ * timeout value will be reset. The timer can be started and stopped with
+ * ecs_start_timer() and ecs_stop_timer().
+ *
+ * The timer is synchronous, and is incremented each frame by delta_time.
+ *
+ * The tick_source entity will be a tick source after this operation. Tick
+ * sources can be read by getting the EcsTickSource component. If the tick
+ * source ticked this frame, the 'ticks' member will be 1. When the tick
+ * source is a system, the system will tick when the timer ticks.
+ *
+ * @param world The world.
+ * @param tick_source The timer for which to set the timeout (0 to create one).
+ * @param timeout The timeout value.
+ * @return The timer entity.
+ */
+FLECS_API
+ecs_entity_t ecs_set_fixed_timeout(
+    ecs_world_t *world,
+    ecs_entity_t tick_source,
+    ecs_ftime_t timeout);
+
 /** Set timer interval.
  * This operation will continuously invoke systems associated with the timer
  * after the interval period expires. If the entity contains an existing timer,
@@ -101,7 +127,7 @@ ecs_ftime_t ecs_get_timeout(
  *
  * The tick_source entity will be a tick source after this operation. Tick
  * sources can be read by getting the EcsTickSource component. If the tick
- * source ticked this frame, the 'tick' member will be true. When the tick
+ * source ticked this frame, the 'ticks' member will be > 0. When the tick
  * source is a system, the system will tick when the timer ticks.
  *
  * @param world The world.
@@ -115,11 +141,6 @@ ecs_entity_t ecs_set_interval(
     ecs_entity_t tick_source,
     ecs_ftime_t interval);
 
-FLECS_API
-ecs_entity_t ecs_set_fixed_interval(
-    ecs_world_t *world,
-    ecs_entity_t tick_source,
-    ecs_ftime_t interval);
 
 /** Get current interval value for the specified timer.
  * This operation returns the value set by ecs_set_interval(). If the entity is
@@ -142,6 +163,68 @@ ecs_ftime_t ecs_get_interval(
  */
 FLECS_API
 void ecs_start_timer(
+    ecs_world_t *world,
+    ecs_entity_t tick_source);
+
+
+/** Set timer fixed interval.
+ * This operation will continuously invoke systems associated with the timer.
+ * Unlike set_interval, this timer can invoke the system multiple times per frame,
+ * in the case where the frame is progressed more than the length of the interval.
+ *
+ * This is useful to have a fixed rate tick system in the middle of a pipeline,
+ * like a physics system or other system desiring a fixed delta time.
+ *
+ * Users can retrieve the interval with ecs_get_interval().
+ *
+ * This is the same as calling:
+ * ecs_set_interval(x);
+ * ecs_set_interval_fixed(true);
+ *
+ * All invocations of the associated system will be called with the exact interval.
+ *
+ * If the entity contains an existing timer, the interval value will be reset.
+ *
+ * The timer is synchronous, and is incremented each frame by delta_time.
+ *
+ * The tick_source entity will be a tick source after this operation. Tick
+ * sources can be read by getting the EcsTickSource component. If the tick
+ * source ticked this frame, the 'ticks' member will contain the number of ticks.
+ *
+ * @param world The world.
+ * @param tick_source The timer for which to set the interval (0 to create one).
+ * @param interval The interval value.
+ * @return The timer entity.
+ */
+FLECS_API
+ecs_entity_t ecs_set_fixed_interval(
+    ecs_world_t *world,
+    ecs_entity_t tick_source,
+    ecs_ftime_t interval);
+
+/** Set timer is fixed.
+ * This operation sets the timer to use a fixed interval, or
+ * a non-fixed interval if the parameter is false.
+ *
+ * @param world The world.
+ * @param tick_source The timer for which to set the interval (0 to create one).
+ * @param interval The interval value.
+ */
+FLECS_API
+void ecs_set_is_fixed_timer(
+    ecs_world_t *world,
+    ecs_entity_t tick_source,
+    bool is_fixed);
+
+/** Get timer is fixed.
+ * Returns if the timer is using fixed ticks.
+ *
+ * @param world The world.
+ * @param tick_source The timer for which to set the interval (0 to create one).
+ * @return return if the timer is using fixed ticks.
+ */
+FLECS_API
+bool ecs_is_fixed_timer(
     ecs_world_t *world,
     ecs_entity_t tick_source);
 
@@ -198,7 +281,7 @@ void ecs_randomize_timers(
  *
  * The tick_source entity will be a tick source after this operation. Tick
  * sources can be read by getting the EcsTickSource component. If the tick
- * source ticked this frame, the 'tick' member will be true. When the tick
+ * source ticked this frame, the 'ticks' member will be > 0. When the tick
  * source is a system, the system will tick when the timer ticks.
  *
  * @param world The world.

--- a/include/flecs/addons/timer.h
+++ b/include/flecs/addons/timer.h
@@ -39,7 +39,7 @@ typedef struct EcsTimer {
     int32_t fired_count;         /**< Number of times ticked. */
     bool active;                 /**< Is the timer active or not. */
     bool single_shot;            /**< Is this a single-shot timer. */
-	bool multi_tick;			/**< Can this timer fire multiple times per frame? */
+	bool fixed_interval;		 /**< Timer fires at fixed interval (no overshoot). */
 } EcsTimer;
 
 /** Apply a rate filter to a tick source. */

--- a/include/flecs/addons/timer.h
+++ b/include/flecs/addons/timer.h
@@ -39,6 +39,7 @@ typedef struct EcsTimer {
     int32_t fired_count;         /**< Number of times ticked. */
     bool active;                 /**< Is the timer active or not. */
     bool single_shot;            /**< Is this a single-shot timer. */
+	bool multi_tick;			/**< Can this timer fire multiple times per frame? */
 } EcsTimer;
 
 /** Apply a rate filter to a tick source. */
@@ -110,6 +111,12 @@ ecs_ftime_t ecs_get_timeout(
  */
 FLECS_API
 ecs_entity_t ecs_set_interval(
+    ecs_world_t *world,
+    ecs_entity_t tick_source,
+    ecs_ftime_t interval);
+
+FLECS_API
+ecs_entity_t ecs_set_fixed_interval(
     ecs_world_t *world,
     ecs_entity_t tick_source,
     ecs_ftime_t interval);

--- a/src/addons/system/system.c
+++ b/src/addons/system/system.c
@@ -45,7 +45,7 @@ ecs_entity_t flecs_run_system(
             time_elapsed = tick->time_elapsed;
 
             /* If timer hasn't fired we shouldn't run the system */
-            if (!tick->tick) {
+            if (tick->ticks == 0) {
                 return 0;
             }
         } else {

--- a/src/addons/system/system.c
+++ b/src/addons/system/system.c
@@ -31,6 +31,7 @@ ecs_entity_t flecs_run_system(
 {
     flecs_poly_assert(world, ecs_world_t);
     ecs_ftime_t time_elapsed = delta_time;
+    uint32_t num_ticks = 1;
     ecs_entity_t tick_source = system_data->tick_source;
 
     /* Support legacy behavior */
@@ -38,17 +39,15 @@ ecs_entity_t flecs_run_system(
         param = system_data->ctx;
     }
 
-    uint32_t num_ticks = 1;
     if (tick_source) {
         const EcsTickSource *tick = ecs_get(world, tick_source, EcsTickSource);
 
         if (tick) {
-            time_elapsed = tick->time_elapsed;
-
             /* If timer hasn't fired we shouldn't run the system */
             if (tick->ticks == 0) {
                 return 0;
             }
+            time_elapsed = tick->time_elapsed;
             num_ticks = tick->ticks;
         } else {
             /* If a timer has been set but the timer entity does not have the

--- a/src/addons/system/system.c
+++ b/src/addons/system/system.c
@@ -83,6 +83,8 @@ ecs_entity_t flecs_run_system(
 
     flecs_poly_assert(stage, ecs_stage_t);
 
+    ecs_entity_t old_system = flecs_stage_set_system(stage, system);
+    ecs_entity_t interrupted_by = 0;
     for (uint32_t i = 0; i < num_ticks; i++) {
         /* Prepare the query iterator */
         ecs_iter_t wit, qit = ecs_query_iter(thread_ctx, system_data->query);
@@ -105,7 +107,6 @@ ecs_entity_t flecs_run_system(
             it = &wit;
         }
 
-        ecs_entity_t old_system = flecs_stage_set_system(stage, system);
         ecs_iter_action_t action = system_data->action;
         it->callback = action;
 
@@ -146,9 +147,10 @@ ecs_entity_t flecs_run_system(
                 ecs_iter_fini(&qit);
             }
         }
-        flecs_stage_set_system(stage, old_system);
+        interrupted_by = it->interrupted_by;
     }
 
+    flecs_stage_set_system(stage, old_system);
 
     if (measure_time) {
         system_data->time_spent += (ecs_ftime_t)ecs_time_measure(&time_start);
@@ -156,8 +158,7 @@ ecs_entity_t flecs_run_system(
 
     ecs_os_perf_trace_pop(system_data->name);
 
-    // return it->interrupted_by;
-    return 0;
+    return interrupted_by;
 }
 
 

--- a/src/addons/system/system.c
+++ b/src/addons/system/system.c
@@ -38,6 +38,7 @@ ecs_entity_t flecs_run_system(
         param = system_data->ctx;
     }
 
+    uint32_t num_ticks = 1;
     if (tick_source) {
         const EcsTickSource *tick = ecs_get(world, tick_source, EcsTickSource);
 
@@ -48,6 +49,7 @@ ecs_entity_t flecs_run_system(
             if (tick->ticks == 0) {
                 return 0;
             }
+            num_ticks = tick->ticks;
         } else {
             /* If a timer has been set but the timer entity does not have the
              * EcsTimer component, don't run the system. This can be the result
@@ -81,70 +83,72 @@ ecs_entity_t flecs_run_system(
 
     flecs_poly_assert(stage, ecs_stage_t);
 
-    /* Prepare the query iterator */
-    ecs_iter_t wit, qit = ecs_query_iter(thread_ctx, system_data->query);
-    ecs_iter_t *it = &qit;
+    for (uint32_t i = 0; i < num_ticks; i++) {
+        /* Prepare the query iterator */
+        ecs_iter_t wit, qit = ecs_query_iter(thread_ctx, system_data->query);
+        ecs_iter_t *it = &qit;
 
-    qit.system = system;
-    qit.delta_time = delta_time;
-    qit.delta_system_time = time_elapsed;
-    qit.param = param;
-    qit.ctx = system_data->ctx;
-    qit.callback_ctx = system_data->callback_ctx;
-    qit.run_ctx = system_data->run_ctx;
+        qit.system = system;
+        qit.delta_time = delta_time;
+        qit.delta_system_time = time_elapsed;
+        qit.param = param;
+        qit.ctx = system_data->ctx;
+        qit.callback_ctx = system_data->callback_ctx;
+        qit.run_ctx = system_data->run_ctx;
 
-    if (system_data->group_id_set) {
-        ecs_iter_set_group(&qit, system_data->group_id);
-    }
-
-    if (stage_count > 1 && system_data->multi_threaded) {
-        wit = ecs_worker_iter(it, stage_index, stage_count);
-        it = &wit;
-    }
-
-    ecs_entity_t old_system = flecs_stage_set_system(stage, system);
-    ecs_iter_action_t action = system_data->action;
-    it->callback = action;
-
-    ecs_run_action_t run = system_data->run;
-    if (run) {
-        /* If system query matches nothing, the system run callback doesn't have
-         * anything to iterate, so the iterator resources don't get cleaned up
-         * automatically, so clean it up here. */
-        if (system_data->query->flags & EcsQueryMatchNothing) {
-            it->next = flecs_default_next_callback; /* Return once */
-            run(it);
-            ecs_iter_fini(&qit);
-        } else {
-            if (it == &qit && (qit.flags & EcsIterTrivialCached)) {
-                it->next = flecs_query_trivial_cached_next;
-            }
-            run(it);
+        if (system_data->group_id_set) {
+            ecs_iter_set_group(&qit, system_data->group_id);
         }
-    } else {
-        if (system_data->query->term_count) {
-            if (it == &qit) {
-                if (qit.flags & EcsIterTrivialCached) {
-                    while (flecs_query_trivial_cached_next(&qit)) {
-                        action(&qit);
+
+        if (stage_count > 1 && system_data->multi_threaded) {
+            wit = ecs_worker_iter(it, stage_index, stage_count);
+            it = &wit;
+        }
+
+        ecs_entity_t old_system = flecs_stage_set_system(stage, system);
+        ecs_iter_action_t action = system_data->action;
+        it->callback = action;
+
+        ecs_run_action_t run = system_data->run;
+        if (run) {
+            /* If system query matches nothing, the system run callback doesn't have
+            * anything to iterate, so the iterator resources don't get cleaned up
+            * automatically, so clean it up here. */
+            if (system_data->query->flags & EcsQueryMatchNothing) {
+                it->next = flecs_default_next_callback; /* Return once */
+                run(it);
+                ecs_iter_fini(&qit);
+            } else {
+                if (it == &qit && (qit.flags & EcsIterTrivialCached)) {
+                    it->next = flecs_query_trivial_cached_next;
+                }
+                run(it);
+            }
+        } else {
+            if (system_data->query->term_count) {
+                if (it == &qit) {
+                    if (qit.flags & EcsIterTrivialCached) {
+                        while (flecs_query_trivial_cached_next(&qit)) {
+                            action(&qit);
+                        }
+                    } else {
+                        while (ecs_query_next(&qit)) {
+                            action(&qit);
+                        }
                     }
                 } else {
-                    while (ecs_query_next(&qit)) {
-                        action(&qit);
+                    while (ecs_iter_next(it)) {
+                        action(it);
                     }
                 }
             } else {
-                while (ecs_iter_next(it)) {
-                    action(it);
-                }
+                action(&qit);
+                ecs_iter_fini(&qit);
             }
-        } else {
-            action(&qit);
-            ecs_iter_fini(&qit);
         }
+        flecs_stage_set_system(stage, old_system);
     }
 
-    flecs_stage_set_system(stage, old_system);
 
     if (measure_time) {
         system_data->time_spent += (ecs_ftime_t)ecs_time_measure(&time_start);
@@ -152,7 +156,8 @@ ecs_entity_t flecs_run_system(
 
     ecs_os_perf_trace_pop(system_data->name);
 
-    return it->interrupted_by;
+    // return it->interrupted_by;
+    return 0;
 }
 
 

--- a/src/addons/timer.c
+++ b/src/addons/timer.c
@@ -22,13 +22,16 @@ void ProgressTimers(ecs_iter_t *it) {
         if (!timer[i].active) {
             continue;
         }
-        
         const ecs_world_info_t *info = ecs_get_world_info(it->world);
-        if (timer[i].fixed_interval && !timer[i].single_shot) {
+        if (timer[i].fixed_interval) {
             timer[i].time += info->delta_time_raw;
-            while (timer[i].time >= timer[i].timeout) {
+            tick_source[i].time_elapsed = timer[i].timeout;
+            while (timer[i].time >= timer[i].timeout && timer[i].active) {
                 timer[i].time -= timer[i].timeout;
                 tick_source[i].ticks++;
+                if (timer[i].single_shot) {
+                    timer[i].active = false;
+                }
             }
         } else {
             ecs_ftime_t time_elapsed = timer[i].time + info->delta_time_raw;
@@ -147,6 +150,34 @@ error:
     return 0;
 }
 
+FLECS_API
+ecs_entity_t ecs_set_fixed_timeout(
+    ecs_world_t *world,
+    ecs_entity_t timer,
+    ecs_ftime_t timeout) {
+
+    ecs_check(world != NULL, ECS_INVALID_PARAMETER, NULL);
+
+    if (!timer) {
+        timer = ecs_entity(world, {0});
+    }
+
+    ecs_set(world, timer, EcsTimer, {
+        .timeout = timeout,
+        .single_shot = true,
+        .fixed_interval = true,
+        .active = true
+    });
+
+    ecs_system_t *system_data = flecs_poly_get(world, timer, ecs_system_t);
+    if (system_data) {
+        system_data->tick_source = timer;
+    }
+
+error:
+    return timer;
+}
+
 ecs_entity_t ecs_set_interval(
     ecs_world_t *world,
     ecs_entity_t timer,
@@ -211,6 +242,36 @@ ecs_ftime_t ecs_get_interval(
     const EcsTimer *value = ecs_get(world, timer, EcsTimer);
     if (value) {
         return value->timeout;
+    }
+error:
+    return 0;
+}
+
+void ecs_set_is_fixed_timer(
+    ecs_world_t *world,
+    ecs_entity_t timer,
+    bool is_fixed)
+{
+    EcsTimer *ptr = ecs_ensure(world, timer, EcsTimer);
+    ecs_check(ptr != NULL, ECS_INTERNAL_ERROR, NULL);
+    ptr->fixed_interval = is_fixed;
+error:
+    return;
+}
+
+bool ecs_is_fixed_timer(
+    ecs_world_t *world,
+    ecs_entity_t timer) {
+    
+    ecs_check(world != NULL, ECS_INVALID_PARAMETER, NULL);
+
+    if (!timer) {
+        return 0;
+    }
+
+    const EcsTimer *value = ecs_get(world, timer, EcsTimer);
+    if (value) {
+        return value->fixed_interval;
     }
 error:
     return 0;

--- a/src/addons/timer.c
+++ b/src/addons/timer.c
@@ -22,9 +22,9 @@ void ProgressTimers(ecs_iter_t *it) {
         if (!timer[i].active) {
             continue;
         }
-
+        
         const ecs_world_info_t *info = ecs_get_world_info(it->world);
-        if (timer[i].multi_tick && !timer[i].single_shot) {
+        if (timer[i].fixed_interval && !timer[i].single_shot) {
             timer[i].time += info->delta_time_raw;
             while (timer[i].time >= timer[i].timeout) {
                 timer[i].time -= timer[i].timeout;
@@ -187,7 +187,7 @@ ecs_entity_t ecs_set_fixed_interval(
     ecs_check(t != NULL, ECS_INTERNAL_ERROR, NULL);
     t->timeout = interval;
     t->active = true;
-    t->multi_tick = true;
+    t->fixed_interval = true;
     ecs_modified(world, timer, EcsTimer);
 
     ecs_system_t *system_data = flecs_poly_get(world, timer, ecs_system_t);

--- a/src/addons/timer.c
+++ b/src/addons/timer.c
@@ -24,26 +24,34 @@ void ProgressTimers(ecs_iter_t *it) {
         }
 
         const ecs_world_info_t *info = ecs_get_world_info(it->world);
-        ecs_ftime_t time_elapsed = timer[i].time + info->delta_time_raw;
-        ecs_ftime_t timeout = timer[i].timeout;
-        
-        if (time_elapsed >= timeout) {
-            ecs_ftime_t t = time_elapsed - timeout;
-            if (t > timeout) {
-                t = 0;
-            }
-
-            timer[i].time = t; /* Initialize with remainder */
-            tick_source[i].ticks = 1;
-            tick_source[i].time_elapsed = time_elapsed - timer[i].overshoot;
-            timer[i].overshoot = t;
-
-            if (timer[i].single_shot) {
-                timer[i].active = false;
+        if (timer[i].multi_tick && !timer[i].single_shot) {
+            timer[i].time += info->delta_time_raw;
+            while (timer[i].time >= timer[i].timeout) {
+                timer[i].time -= timer[i].timeout;
+                tick_source[i].ticks++;
             }
         } else {
-            timer[i].time = time_elapsed;
-        }  
+            ecs_ftime_t time_elapsed = timer[i].time + info->delta_time_raw;
+            ecs_ftime_t timeout = timer[i].timeout;
+            
+            if (time_elapsed >= timeout) {
+                ecs_ftime_t t = time_elapsed - timeout;
+                if (t > timeout) {
+                    t = 0;
+                }
+
+                timer[i].time = t; /* Initialize with remainder */
+                tick_source[i].ticks = 1;
+                tick_source[i].time_elapsed = time_elapsed - timer[i].overshoot;
+                timer[i].overshoot = t;
+
+                if (timer[i].single_shot) {
+                    timer[i].active = false;
+                }
+            } else {
+                timer[i].time = time_elapsed;
+            }  
+        }
     }
 }
 
@@ -154,6 +162,32 @@ ecs_entity_t ecs_set_interval(
     ecs_check(t != NULL, ECS_INTERNAL_ERROR, NULL);
     t->timeout = interval;
     t->active = true;
+    ecs_modified(world, timer, EcsTimer);
+
+    ecs_system_t *system_data = flecs_poly_get(world, timer, ecs_system_t);
+    if (system_data) {
+        system_data->tick_source = timer;
+    }
+error:
+    return timer;  
+}
+
+ecs_entity_t ecs_set_fixed_interval(
+    ecs_world_t *world,
+    ecs_entity_t timer,
+    ecs_ftime_t interval)
+{
+    ecs_check(world != NULL, ECS_INVALID_PARAMETER, NULL);
+
+    if (!timer) {
+        timer = ecs_new_w(world, EcsTimer);
+    }
+
+    EcsTimer *t = ecs_ensure(world, timer, EcsTimer);
+    ecs_check(t != NULL, ECS_INTERNAL_ERROR, NULL);
+    t->timeout = interval;
+    t->active = true;
+    t->multi_tick = true;
     ecs_modified(world, timer, EcsTimer);
 
     ecs_system_t *system_data = flecs_poly_get(world, timer, ecs_system_t);

--- a/src/addons/timer.c
+++ b/src/addons/timer.c
@@ -6,7 +6,6 @@
 #include "flecs.h"
 #include "system/system.h"
 #include "../private_api.h"
-
 #ifdef FLECS_TIMER
 
 static
@@ -18,7 +17,7 @@ void ProgressTimers(ecs_iter_t *it) {
 
     int i;
     for (i = 0; i < it->count; i ++) {
-        tick_source[i].tick = false;
+        tick_source[i].ticks = 0;
 
         if (!timer[i].active) {
             continue;
@@ -35,7 +34,7 @@ void ProgressTimers(ecs_iter_t *it) {
             }
 
             timer[i].time = t; /* Initialize with remainder */
-            tick_source[i].tick = true;
+            tick_source[i].ticks = 1;
             tick_source[i].time_elapsed = time_elapsed - timer[i].overshoot;
             timer[i].overshoot = t;
 
@@ -64,7 +63,7 @@ void ProgressRateFilters(ecs_iter_t *it) {
             const EcsTickSource *tick_src = ecs_get(
                 it->world, src, EcsTickSource);
             if (tick_src) {
-                inc = tick_src->tick;
+                inc = tick_src->ticks > 0;
             } else {
                 inc = true;
             }
@@ -75,14 +74,14 @@ void ProgressRateFilters(ecs_iter_t *it) {
         if (inc) {
             filter[i].tick_count ++;
             bool triggered = !(filter[i].tick_count % filter[i].rate);
-            tick_dst[i].tick = triggered;
+            tick_dst[i].ticks = triggered ? 1 : 0;
             tick_dst[i].time_elapsed = filter[i].time_elapsed;
 
             if (triggered) {
                 filter[i].time_elapsed = 0;
             }            
         } else {
-            tick_dst[i].tick = false;
+            tick_dst[i].ticks = 0;
         }
     }
 }
@@ -94,7 +93,7 @@ void ProgressTickSource(ecs_iter_t *it) {
     /* If tick source has no filters, tick unconditionally */
     int i;
     for (i = 0; i < it->count; i ++) {
-        tick_src[i].tick = true;
+        tick_src[i].ticks = 1;
         tick_src[i].time_elapsed = it->delta_time;
     }
 }

--- a/test/addons/project.json
+++ b/test/addons/project.json
@@ -272,6 +272,7 @@
                 "one_shot_timer_entity",
                 "interval_timer_entity",
                 "rate_entity",
+				"interval_timer_entity_multi_tick",
                 "nested_rate_entity",
                 "nested_rate_entity_empty_src",
                 "naked_tick_entity",

--- a/test/addons/project.json
+++ b/test/addons/project.json
@@ -273,6 +273,8 @@
                 "interval_timer_entity",
                 "rate_entity",
 				"fixed_interval",
+				"fixed_interval_set_after_init",
+				"fixed_interval_single_shot",
                 "nested_rate_entity",
                 "nested_rate_entity_empty_src",
                 "naked_tick_entity",

--- a/test/addons/project.json
+++ b/test/addons/project.json
@@ -272,7 +272,7 @@
                 "one_shot_timer_entity",
                 "interval_timer_entity",
                 "rate_entity",
-				"interval_timer_entity_multi_tick",
+				"fixed_interval",
                 "nested_rate_entity",
                 "nested_rate_entity_empty_src",
                 "naked_tick_entity",

--- a/test/addons/src/Timer.c
+++ b/test/addons/src/Timer.c
@@ -446,18 +446,18 @@ void Timer_one_shot_timer_entity(void) {
         ecs_progress(world, 0.3);
         const EcsTickSource *src = ecs_get(world, timer, EcsTickSource);
         test_assert(src != NULL);
-        test_bool(src->tick, false);
+		test_int(src->ticks, 0);
     }
 
     ecs_progress(world, 0.3);
     const EcsTickSource *src = ecs_get(world, timer, EcsTickSource);
     test_assert(src != NULL);
-    test_bool(src->tick, true);   
+    test_int(src->ticks, 1);   
 
     /* Ensure timer doesn't tick again */
     for (i = 0; i < 12; i ++) {
         ecs_progress(world, 0.3);
-        test_bool(src->tick, false);
+        test_int(src->ticks, 0);
     }
 
     ecs_fini(world);
@@ -473,22 +473,22 @@ void Timer_interval_timer_entity(void) {
         ecs_progress(world, 0.3);
         const EcsTickSource *src = ecs_get(world, timer, EcsTickSource);
         test_assert(src != NULL);
-        test_bool(src->tick, false);
+        test_int(src->ticks, 0);
     }
 
     ecs_progress(world, 0.3);
     const EcsTickSource *src = ecs_get(world, timer, EcsTickSource);
     test_assert(src != NULL);
-    test_bool(src->tick, true);   
+    test_int(src->ticks, 1);   
 
     for (i = 0; i < 2; i ++) {
         ecs_progress(world, 0.3);
-        test_bool(src->tick, false);
+        test_int(src->ticks, 0);
     }
 
     /* Timer should tick again */
     ecs_progress(world, 0.3);
-    test_bool(src->tick, true);
+    test_int(src->ticks, 1);
 
     ecs_fini(world);
 }
@@ -504,24 +504,24 @@ void Timer_rate_entity(void) {
         ecs_progress(world, 0);
         const EcsTickSource *src = ecs_get(world, rate, EcsTickSource);
         test_assert(src != NULL);
-        test_bool(src->tick, false);
+        test_int(src->ticks, 0);
     }
 
     ecs_progress(world, 0);
     const EcsTickSource *src = ecs_get(world, rate, EcsTickSource);
     test_assert(src != NULL);
-    test_bool(src->tick, true);   
+    test_int(src->ticks, 1);   
 
     for (i = 0; i < 3; i ++) {
         ecs_progress(world, 0);
         const EcsTickSource *src = ecs_get(world, rate, EcsTickSource);
         test_assert(src != NULL);
-        test_bool(src->tick, false);
+        test_int(src->ticks, 0);
     }
 
     /* Query should tick again */
     ecs_progress(world, 0);
-    test_bool(src->tick, true);
+    test_int(src->ticks, 1);
 
     ecs_fini(world);
 }
@@ -538,24 +538,24 @@ void Timer_nested_rate_entity(void) {
         ecs_progress(world, 0);
         const EcsTickSource *src = ecs_get(world, rate, EcsTickSource);
         test_assert(src != NULL);
-        test_bool(src->tick, false);
+        test_int(src->ticks, 0);
     }
 
     ecs_progress(world, 0);
     const EcsTickSource *src = ecs_get(world, rate, EcsTickSource);
     test_assert(src != NULL);
-    test_bool(src->tick, true);   
+    test_int(src->ticks, 1);   
 
     for (i = 0; i < 3; i ++) {
         ecs_progress(world, 0);
         const EcsTickSource *src = ecs_get(world, rate, EcsTickSource);
         test_assert(src != NULL);
-        test_bool(src->tick, false);
+        test_int(src->ticks, 0);
     }
 
     /* Query should tick again */
     ecs_progress(world, 0);
-    test_bool(src->tick, true);
+    test_int(src->ticks, 1);
 
     ecs_fini(world);
 }
@@ -572,24 +572,24 @@ void Timer_nested_rate_entity_empty_src(void) {
         ecs_progress(world, 0);
         const EcsTickSource *src = ecs_get(world, rate, EcsTickSource);
         test_assert(src != NULL);
-        test_bool(src->tick, false);
+        test_int(src->ticks, 0);
     }
 
     ecs_progress(world, 0);
     const EcsTickSource *src = ecs_get(world, rate, EcsTickSource);
     test_assert(src != NULL);
-    test_bool(src->tick, true);   
+    test_int(src->ticks, 1);   
 
     for (i = 0; i < 3; i ++) {
         ecs_progress(world, 0);
         const EcsTickSource *src = ecs_get(world, rate, EcsTickSource);
         test_assert(src != NULL);
-        test_bool(src->tick, false);
+        test_int(src->ticks, 0);
     }
 
     /* Query should tick again */
     ecs_progress(world, 0);
-    test_bool(src->tick, true);
+    test_int(src->ticks, 1);
 
     ecs_fini(world);
 }
@@ -606,7 +606,7 @@ void Timer_naked_tick_entity(void) {
         test_assert(src != NULL);
 
         /* Tick should always be true, no filter is applied */
-        test_bool(src->tick, true);
+        test_int(src->ticks, 1);
     }
 
     ecs_fini(world);
@@ -622,7 +622,7 @@ void Timer_stop_timer_w_rate(void) {
         ecs_progress(world, 0.5);
         const EcsTickSource *src = ecs_get(world, rate, EcsTickSource);
         test_assert(src != NULL);
-        test_bool(src->tick, false);
+        test_int(src->ticks, 0);
     }
 
     ecs_progress(world, 0.5);
@@ -630,7 +630,7 @@ void Timer_stop_timer_w_rate(void) {
     {
         const EcsTickSource *src = ecs_get(world, rate, EcsTickSource);
         test_assert(src != NULL);
-        test_bool(src->tick, true);
+        test_int(src->ticks, 1);
     }
 
     ecs_stop_timer(world, timer);
@@ -639,7 +639,7 @@ void Timer_stop_timer_w_rate(void) {
         ecs_progress(world, 0.5);
         const EcsTickSource *src = ecs_get(world, rate, EcsTickSource);
         test_assert(src != NULL);
-        test_bool(src->tick, false);
+        test_int(src->ticks, 0);
     }
 
     ecs_progress(world, 0.5);
@@ -647,7 +647,7 @@ void Timer_stop_timer_w_rate(void) {
     {
         const EcsTickSource *src = ecs_get(world, rate, EcsTickSource);
         test_assert(src != NULL);
-        test_bool(src->tick, false);
+        test_int(src->ticks, 0);
     }
     
     ecs_start_timer(world, timer);
@@ -656,7 +656,7 @@ void Timer_stop_timer_w_rate(void) {
         ecs_progress(world, 0.5);
         const EcsTickSource *src = ecs_get(world, rate, EcsTickSource);
         test_assert(src != NULL);
-        test_bool(src->tick, false);
+        test_int(src->ticks, 0);
     }
 
     ecs_progress(world, 0.5);
@@ -664,7 +664,7 @@ void Timer_stop_timer_w_rate(void) {
     {
         const EcsTickSource *src = ecs_get(world, rate, EcsTickSource);
         test_assert(src != NULL);
-        test_bool(src->tick, true);
+        test_int(src->ticks, 1);
     }
 
     ecs_fini(world);
@@ -681,7 +681,7 @@ void Timer_stop_timer_w_rate_same_src(void) {
         ecs_progress(world, 0.5);
         const EcsTickSource *src = ecs_get(world, rate, EcsTickSource);
         test_assert(src != NULL);
-        test_bool(src->tick, false);
+        test_int(src->ticks, 0);
     }
 
     ecs_progress(world, 0.5);
@@ -689,7 +689,7 @@ void Timer_stop_timer_w_rate_same_src(void) {
     {
         const EcsTickSource *src = ecs_get(world, rate, EcsTickSource);
         test_assert(src != NULL);
-        test_bool(src->tick, true);
+        test_int(src->ticks, 1);
     }
 
     ecs_stop_timer(world, timer);
@@ -698,7 +698,7 @@ void Timer_stop_timer_w_rate_same_src(void) {
         ecs_progress(world, 0.5);
         const EcsTickSource *src = ecs_get(world, rate, EcsTickSource);
         test_assert(src != NULL);
-        test_bool(src->tick, false);
+        test_int(src->ticks, 0);
     }
 
     ecs_progress(world, 0.5);
@@ -706,7 +706,7 @@ void Timer_stop_timer_w_rate_same_src(void) {
     {
         const EcsTickSource *src = ecs_get(world, rate, EcsTickSource);
         test_assert(src != NULL);
-        test_bool(src->tick, false);
+        test_int(src->ticks, 0);
     }
     
     ecs_start_timer(world, timer);
@@ -715,7 +715,7 @@ void Timer_stop_timer_w_rate_same_src(void) {
         ecs_progress(world, 0.5);
         const EcsTickSource *src = ecs_get(world, rate, EcsTickSource);
         test_assert(src != NULL);
-        test_bool(src->tick, false);
+        test_int(src->ticks, 0);
     }
 
     ecs_progress(world, 0.5);
@@ -723,7 +723,7 @@ void Timer_stop_timer_w_rate_same_src(void) {
     {
         const EcsTickSource *src = ecs_get(world, rate, EcsTickSource);
         test_assert(src != NULL);
-        test_bool(src->tick, true);
+        test_int(src->ticks, 1);
     }
 
     ecs_fini(world);

--- a/test/addons/src/Timer.c
+++ b/test/addons/src/Timer.c
@@ -526,21 +526,6 @@ void Timer_rate_entity(void) {
     ecs_fini(world);
 }
 
-void Timer_interval_timer_entity_multi_tick(void) {
-    ecs_world_t *world = ecs_init();
-
-    ecs_entity_t timer = ecs_set_fixed_interval(world, 0, 1.0);
-
-    ecs_progress(world, 10.0);
-    const EcsTickSource *src = ecs_get(world, timer, EcsTickSource);
-    test_assert(src != NULL);
-    test_int(src->ticks, 10);   
-    test_flt(src->time_elapsed, 0);   
-
-
-    ecs_fini(world);
-}
-
 void Timer_nested_rate_entity(void) {
     ecs_world_t *world = ecs_init();
 
@@ -768,6 +753,20 @@ void Timer_randomize_timers(void) {
         test_assert(t != NULL);
         test_assert(t->time != 0);
     }
+
+    ecs_fini(world);
+}
+
+void Timer_fixed_interval(void) {
+    ecs_world_t *world = ecs_init();
+
+    ecs_entity_t timer = ecs_set_fixed_interval(world, 0, 1.0);
+
+    ecs_progress(world, 10.0);
+    const EcsTickSource *src = ecs_get(world, timer, EcsTickSource);
+    test_assert(src != NULL);
+    test_int(src->ticks, 10);   
+    test_flt(src->time_elapsed, 0);   
 
     ecs_fini(world);
 }

--- a/test/addons/src/Timer.c
+++ b/test/addons/src/Timer.c
@@ -760,13 +760,47 @@ void Timer_randomize_timers(void) {
 void Timer_fixed_interval(void) {
     ecs_world_t *world = ecs_init();
 
-    ecs_entity_t timer = ecs_set_fixed_interval(world, 0, 1.0);
+    ecs_entity_t timer = ecs_set_fixed_interval(world, 0, 0.5);
 
     ecs_progress(world, 10.0);
     const EcsTickSource *src = ecs_get(world, timer, EcsTickSource);
     test_assert(src != NULL);
-    test_int(src->ticks, 10);   
-    test_flt(src->time_elapsed, 0);   
+    test_int(src->ticks, 20.0);   
+    test_flt(src->time_elapsed, 0.5);   
+
+    ecs_fini(world);
+}
+
+void Timer_fixed_interval_set_after_init(void) {
+    ecs_world_t *world = ecs_init();
+
+    ecs_entity_t timer = ecs_set_interval(world, 0, 0.5);
+
+    ecs_progress(world, 10.0);
+    const EcsTickSource *src = ecs_get(world, timer, EcsTickSource);
+    test_assert(src != NULL);
+    test_int(src->ticks, 1);   
+    test_flt(src->time_elapsed, 10.0);
+
+    ecs_set_is_fixed_timer(world, timer, true);
+
+    ecs_progress(world, 10.0);
+    test_int(src->ticks, 20.0);   
+    test_flt(src->time_elapsed, 0.5);   
+
+    ecs_fini(world);
+}
+
+void Timer_fixed_interval_single_shot(void) {
+    ecs_world_t *world = ecs_init();
+
+    ecs_entity_t timer = ecs_set_fixed_timeout(world, 0, 0.5);
+
+    ecs_progress(world, 10.0);
+    const EcsTickSource *src = ecs_get(world, timer, EcsTickSource);
+    test_assert(src != NULL);
+    test_int(src->ticks, 1);   
+    test_flt(src->time_elapsed, 0.5);
 
     ecs_fini(world);
 }

--- a/test/addons/src/Timer.c
+++ b/test/addons/src/Timer.c
@@ -526,6 +526,21 @@ void Timer_rate_entity(void) {
     ecs_fini(world);
 }
 
+void Timer_interval_timer_entity_multi_tick(void) {
+    ecs_world_t *world = ecs_init();
+
+    ecs_entity_t timer = ecs_set_fixed_interval(world, 0, 1.0);
+
+    ecs_progress(world, 10.0);
+    const EcsTickSource *src = ecs_get(world, timer, EcsTickSource);
+    test_assert(src != NULL);
+    test_int(src->ticks, 10);   
+    test_flt(src->time_elapsed, 0);   
+
+
+    ecs_fini(world);
+}
+
 void Timer_nested_rate_entity(void) {
     ecs_world_t *world = ecs_init();
 

--- a/test/addons/src/main.c
+++ b/test/addons/src/main.c
@@ -260,7 +260,7 @@ void Timer_rate_filter_with_empty_src(void);
 void Timer_one_shot_timer_entity(void);
 void Timer_interval_timer_entity(void);
 void Timer_rate_entity(void);
-void Timer_interval_timer_entity_multi_tick(void);
+void Timer_fixed_interval(void);
 void Timer_nested_rate_entity(void);
 void Timer_nested_rate_entity_empty_src(void);
 void Timer_naked_tick_entity(void);
@@ -1570,8 +1570,8 @@ bake_test_case Timer_testcases[] = {
         Timer_rate_entity
     },
     {
-        "interval_timer_entity_multi_tick",
-        Timer_interval_timer_entity_multi_tick
+        "fixed_interval",
+        Timer_fixed_interval
     },
     {
         "nested_rate_entity",

--- a/test/addons/src/main.c
+++ b/test/addons/src/main.c
@@ -2748,7 +2748,6 @@ const char* MultiThread_worker_kind_param[] = {"thread", "task"};
 bake_test_param MultiThread_params[] = {
     {"worker_kind", (char**)MultiThread_worker_kind_param, 2}
 };
-
 const char* MultiThreadStaging_worker_kind_param[] = {"thread", "task"};
 bake_test_param MultiThreadStaging_params[] = {
     {"worker_kind", (char**)MultiThreadStaging_worker_kind_param, 2}

--- a/test/addons/src/main.c
+++ b/test/addons/src/main.c
@@ -261,6 +261,8 @@ void Timer_one_shot_timer_entity(void);
 void Timer_interval_timer_entity(void);
 void Timer_rate_entity(void);
 void Timer_fixed_interval(void);
+void Timer_fixed_interval_set_after_init(void);
+void Timer_fixed_interval_single_shot(void);
 void Timer_nested_rate_entity(void);
 void Timer_nested_rate_entity_empty_src(void);
 void Timer_naked_tick_entity(void);
@@ -1574,6 +1576,14 @@ bake_test_case Timer_testcases[] = {
         Timer_fixed_interval
     },
     {
+        "fixed_interval_set_after_init",
+        Timer_fixed_interval_set_after_init
+    },
+    {
+        "fixed_interval_single_shot",
+        Timer_fixed_interval_single_shot
+    },
+    {
         "nested_rate_entity",
         Timer_nested_rate_entity
     },
@@ -2791,7 +2801,7 @@ static bake_test_suite suites[] = {
         "Timer",
         NULL,
         NULL,
-        20,
+        22,
         Timer_testcases
     },
     {

--- a/test/addons/src/main.c
+++ b/test/addons/src/main.c
@@ -260,6 +260,7 @@ void Timer_rate_filter_with_empty_src(void);
 void Timer_one_shot_timer_entity(void);
 void Timer_interval_timer_entity(void);
 void Timer_rate_entity(void);
+void Timer_interval_timer_entity_multi_tick(void);
 void Timer_nested_rate_entity(void);
 void Timer_nested_rate_entity_empty_src(void);
 void Timer_naked_tick_entity(void);
@@ -1569,6 +1570,10 @@ bake_test_case Timer_testcases[] = {
         Timer_rate_entity
     },
     {
+        "interval_timer_entity_multi_tick",
+        Timer_interval_timer_entity_multi_tick
+    },
+    {
         "nested_rate_entity",
         Timer_nested_rate_entity
     },
@@ -2786,7 +2791,7 @@ static bake_test_suite suites[] = {
         "Timer",
         NULL,
         NULL,
-        19,
+        20,
         Timer_testcases
     },
     {


### PR DESCRIPTION
Adds a new set of methods allowing a 'fixed interval' timer to be created and managed.

Core new method is
```
ecs_set_fixed_interval(world, entity_id, fixed_interval)
```

This PR adjusts tick sources to be able to tick multiple times per pipeline run with a fixed delta time.

Addresses this [issue](https://github.com/SanderMertens/flecs/issues/2094).

I think this should improve the ergonomics of defining a core game loop that requires parts of the pipeline to run at a fixed interval.

I think this test demonstrates the core difference:

```
void Timer_fixed_interval(void) {
    ecs_world_t *world = ecs_init();

    ecs_entity_t timer = ecs_set_fixed_interval(world, 0, 0.5);

    ecs_progress(world, 10.0);
    const EcsTickSource *src = ecs_get(world, timer, EcsTickSource);
    test_assert(src != NULL);
    test_int(src->ticks, 20.0); // with regular interval, this ticks once
    test_flt(src->time_elapsed, 0.5);   // with regular interval, this is 10.0

    ecs_fini(world);
}
```

Looking for discussion on this approach.



My understanding of the built in timer mechanism is that if you use it, you expose yourself to perhaps unexpected behavior if you progress a pipeline with a longer duration than 2.0*timer_interval. There is no built in mechanism from what I can tell in flecs that allows a system to be gaurenteed to be called with a fixed delta time. 

This PR additively allows this key concept in a simulation loop to be expressed elegantly using the built in flecs pipeline and timers APIs.

My instinct is that this should be the default mechanics of timers, but this is written to be backwards compatible, and does not change timers or systems at all unless the new fixed_interval set of APIs are used.

Let me know if I'm missing something or my understanding is incorrect!

Thanks for the awesome library!