### PR TITLE
[http] Fix idle HTTP connection purge and the stale-fd race it exposes

### DIFF
--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -48480,7 +48480,17 @@ void http_recv_connection(
     }
 
     if (retries == ECS_HTTP_REQUEST_RECV_RETRY) {
-        http_close(&sock);
+        ecs_os_mutex_lock(srv->lock);
+        bool still_owns_sock = conn->pub.id == conn_id;
+        if (still_owns_sock) {
+            conn->sock = HTTP_SOCKET_INVALID;
+        }
+        ecs_os_mutex_unlock(srv->lock);
+        if (still_owns_sock) {
+            http_close(&sock);
+        } else {
+            sock = HTTP_SOCKET_INVALID;
+        }
     }
 
 done:

--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -49010,11 +49010,12 @@ void ecs_http_server_dequeue(
     srv->stats_timeout += (double)delta_time;
 
     if ((1000 * srv->dequeue_timeout) > (double)ECS_HTTP_MIN_DEQUEUE_INTERVAL) {
+        double elapsed = srv->dequeue_timeout;
         srv->dequeue_timeout = 0;
 
         ecs_time_t t = {0};
         ecs_time_measure(&t);
-        int32_t request_count = http_dequeue_requests(srv, srv->dequeue_timeout);
+        int32_t request_count = http_dequeue_requests(srv, elapsed);
         srv->requests_processed += request_count;
         srv->requests_processed_total += request_count;
         double time_spent = ecs_time_measure(&t);

--- a/src/addons/http/http.c
+++ b/src/addons/http/http.c
@@ -937,7 +937,17 @@ void http_recv_connection(
     }
 
     if (retries == ECS_HTTP_REQUEST_RECV_RETRY) {
-        http_close(&sock);
+        ecs_os_mutex_lock(srv->lock);
+        bool still_owns_sock = conn->pub.id == conn_id;
+        if (still_owns_sock) {
+            conn->sock = HTTP_SOCKET_INVALID;
+        }
+        ecs_os_mutex_unlock(srv->lock);
+        if (still_owns_sock) {
+            http_close(&sock);
+        } else {
+            sock = HTTP_SOCKET_INVALID;
+        }
     }
 
 done:

--- a/src/addons/http/http.c
+++ b/src/addons/http/http.c
@@ -1467,11 +1467,12 @@ void ecs_http_server_dequeue(
     srv->stats_timeout += (double)delta_time;
 
     if ((1000 * srv->dequeue_timeout) > (double)ECS_HTTP_MIN_DEQUEUE_INTERVAL) {
+        double elapsed = srv->dequeue_timeout;
         srv->dequeue_timeout = 0;
 
         ecs_time_t t = {0};
         ecs_time_measure(&t);
-        int32_t request_count = http_dequeue_requests(srv, srv->dequeue_timeout);
+        int32_t request_count = http_dequeue_requests(srv, elapsed);
         srv->requests_processed += request_count;
         srv->requests_processed_total += request_count;
         double time_spent = ecs_time_measure(&t);


### PR DESCRIPTION
Fixes #2103.

Both the memory growth and the CPU climb reported in #2103 originate
from the same disabled purge timer, restored by the first commit.
The second commit fixes a latent stale-fd race that the restored
purge then exposes.

## 1. Restore idle-connection purge timer

`ecs_http_server_dequeue` zeroed `srv->dequeue_timeout` before
passing it to `http_dequeue_requests`, so `delta_time` was always 0.
As a result `conn->dequeue_timeout` never accumulated, the
`ECS_HTTP_CONNECTION_PURGE_TIMEOUT` (1.0 s) branch was unreachable,
and idle HTTP connections were never purged.

Left unchecked, `srv->connections` (a `flecs_sparse_t`) grew
monotonically with concurrent-connection peaks, which surfaces as
`mem_rest` climbing linearly with request count and CPU eventually
reaching 100 % under sustained polling.

Fix — capture the elapsed time before resetting:

```c
double elapsed = srv->dequeue_timeout;
srv->dequeue_timeout = 0;
...
int32_t request_count = http_dequeue_requests(srv, elapsed);
```

## 2. Fix stale-fd double-close that the restored purge exposes

With the purge re-enabled, `http_dequeue_requests` started running
`http_close(&conn->sock)` on connections whose sock had already
been closed by `http_recv_connection`'s retry-exhausted branch.
That branch closes the sock but never clears `conn->sock`, so the
purge loop double-closes a stale fd. When the OS has reused the
fd for a fresh `accept()`, the second close silently hits someone
else's live socket, which the send-queue thread later observes as

```
http: failed to set socket NONBLOCK: Bad file descriptor
http: failed to write HTTP response headers: Bad file descriptor
```

The retry-exhausted branch now takes `srv->lock` to synchronize
with the purge: it clears `conn->sock` before closing it, or — if
the purge has already reclaimed the connection — skips the close
entirely so it doesn't touch a fd that may now belong to someone
else.

The race manifests under sustained polling once the purge starts
running — the warnings above are the symptom that the synchronized
close eliminates.

## Reproduction

Minimal repro (drop `repro.cpp` next to `distr/flecs.c` and build
from the repo root):

```cpp
#include <chrono>
#include <cstdio>
#include <thread>
#include "flecs.h"

int main() {
    flecs::world world;
    world.import<flecs::stats>();
    world.set<flecs::Rest>({});  // listens on port 27750

    auto start = std::chrono::steady_clock::now();
    auto next_report = start + std::chrono::seconds(10);

    while (true) {
        world.progress();

        auto now = std::chrono::steady_clock::now();
        if (now >= next_report) {
            ecs_world_stats_t stats = {};
            ecs_world_stats_get(world, &stats);
            ecs_misc_memory_t mem = ecs_misc_memory_get(world);
            int t = stats.t;
            double received =
                stats.http.request_received_count.counter.value[t];
            int elapsed = static_cast<int>(
                std::chrono::duration_cast<std::chrono::seconds>(now - start)
                    .count());
            std::printf("t=%4ds  http_received=%-8.0f  mem_rest=%d\n",
                        elapsed, received, mem.bytes_rest);
            std::fflush(stdout);
            next_report = now + std::chrono::seconds(10);
        }
        std::this_thread::sleep_for(std::chrono::milliseconds(16));
    }
}
```

```sh
gcc -c -std=gnu11 -I distr distr/flecs.c -o /tmp/flecs.o
g++ -std=c++17 -I distr repro.cpp /tmp/flecs.o -lpthread -o /tmp/rest_leak_repro

# terminal 1
/tmp/rest_leak_repro

# terminal 2 (~10 req/s)
while sleep 0.1; do curl -s localhost:27750/entity/flecs > /dev/null; done
```

Without the timer fix, `mem_rest` grows in discrete ~10 KB jumps
as the connection sparse set bumps to a new page; with the fix it
plateaus once the request cache is warm.

## Verification

49 h Flecs Explorer test on a TUI app with the purge-timer fix
(debug build, target 30 fps, ~120 req/min, `flecs::stats` +
`flecs::Rest`). `pcpu_avg` is `ps -o pcpu`; 100 % = one full CPU
core.

| Build                    | duration  | `mem_rest` delta                            | runtime                                                                                  |
|---                       |---        |---                                          |---                                                                                       |
| v4.1.5 (unpatched)       | 88 h      | +60.4 MB (linear 14 KB/min, never plateaus) | `pcpu_avg` ~8 % → 100.2 %; **FPS fell from 30 to 9.34** (~107 ms/frame vs 33 ms budget)  |
| v4.1.5 + purge-timer fix | 49 h 45 m | **+144 bytes** total (90,120 → 90,264)      | `vmrss` byte-stable after warmup, `pcpu_avg` 7.4 – 8.8 % flat, **FPS held at ~30**       |

The unpatched build reached `pcpu_avg` 51 % by the 23 h mark,
showing the CPU drift is gradual rather than a late-stage spike.

The 49 h run above used the purge-timer fix only; the stale-fd
race fix in commit 2 was validated by code inspection and by the
`Bad file descriptor` warnings ceasing under the same workload.

- Environment: g++ 13, Linux x86_64 (WSL2), `-O0 -g -DDEBUG`
- flecs version: v4.1.5

---

*This PR was drafted with the assistance of Claude Code and manually
verified through the 49 h test described above.*

