### PR TITLE
Fix crashes caused by stale state in hierarchy and pair cleanup 

### DIFF
--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -39305,6 +39305,14 @@ void flecs_component_ordered_children_init(
 {
     cr->flags |= EcsIdOrderedChildren;
     flecs_ordered_children_init(world, cr);
+
+    ecs_table_cache_iter_t it;
+    if (flecs_table_cache_all_iter(&cr->cache, &it)) {
+        const ecs_table_record_t *tr;
+        while ((tr = flecs_table_cache_next(&it, ecs_table_record_t))) {
+            tr->hdr.table->flags |= EcsTableHasOrderedChildren;
+        }
+    }
 }
 
 static

--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -3173,6 +3173,11 @@ void flecs_emit_propagate_invalidate(
     int32_t offset,
     int32_t count);
 
+/* Invalidate reachable cache for traversable relationships targeting cr. */
+void flecs_emit_propagate_invalidate_tables(
+    ecs_world_t *world,
+    ecs_component_record_t *tgt_cr);
+
 /* Set bit indicating that observer is disabled. */
 void flecs_observer_set_disable_bit(
     ecs_world_t *world,
@@ -14989,7 +14994,6 @@ void flecs_emit_propagate(
     ecs_log_pop_3();
 }
 
-static
 void flecs_emit_propagate_invalidate_tables(
     ecs_world_t *world,
     ecs_component_record_t *tgt_cr)
@@ -17960,6 +17964,12 @@ void flecs_component_delete_non_fragmenting_childof(
         ecs_assert(r != NULL, ECS_INTERNAL_ERROR, NULL);
 
         if ((r->row & EcsEntityIsTarget)) {
+            ecs_component_record_t *tgt_cr = flecs_components_get(
+                world, ecs_pair(EcsWildcard, e));
+            if (tgt_cr) {
+                flecs_emit_propagate_invalidate_tables(world, tgt_cr);
+            }
+
             ecs_component_record_t *child_cr = flecs_components_get(
                 world, ecs_childof(e));
             if (child_cr &&

--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -46213,8 +46213,7 @@ void flecs_compute_table_diff(
     if (ECS_IS_PAIR(id) && ECS_PAIR_FIRST(id) == EcsChildOf) {
         if (added_count) {
             diff->added_flags |= EcsTableEdgeReparent;
-        } else {
-            ecs_assert(removed_count != 0, ECS_INTERNAL_ERROR, NULL);
+        } else if (removed_count) {
             diff->removed_flags |= EcsTableEdgeReparent;
         }
     }

--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -40149,7 +40149,10 @@ void flecs_entities_update_childof_depth(
         int32_t i, count = ecs_vec_count(&cr->pair->ordered_children);
         for (i = 0; i < count; i ++) {
             ecs_entity_t tgt = entities[i];
-            ecs_record_t *r = flecs_entities_get(world, tgt);
+            ecs_record_t *r = flecs_entities_try(world, tgt);
+            if (!r) {
+                continue;
+            }
             ecs_table_t *table = r->table;
 
             if (table->flags & EcsTableHasParent) {

--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -6948,13 +6948,20 @@ void flecs_on_unparent(
     ecs_table_t *table,
     ecs_table_t *other_table,
     int32_t row,
-    int32_t count)
+    int32_t count,
+    ecs_flags32_t diff_flags)
 {
-    if (other_table) {
-        flecs_unparent_name_index(world, table, other_table, row, count);
+    if (diff_flags & EcsTableEdgeReparent) {
+        if (other_table) {
+            flecs_unparent_name_index(world, table, other_table, row, count);
+        }
+        flecs_non_fragmenting_childof_unparent(
+            world, other_table, table, row, count);
     }
-    flecs_ordered_children_unparent(world, table, row, count);
-    flecs_non_fragmenting_childof_unparent(world, other_table, table, row, count);
+
+    if (diff_flags & EcsTableHasOrderedChildren) {
+        flecs_ordered_children_unparent(world, table, row, count);
+    }
 }
 
 bool flecs_sparse_on_add_cr(
@@ -7215,7 +7222,8 @@ void flecs_actions_on_remove_intern_w_reparent(
 
     if (diff_flags & (EcsTableEdgeReparent|EcsTableHasOrderedChildren)) {
         if (!other_table || !(other_table->flags & EcsTableHasChildOf)) {
-            flecs_on_unparent(world, table, other_table, row, count);
+            flecs_on_unparent(
+                world, table, other_table, row, count, diff_flags);
         }
     }
 

--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -1114,6 +1114,11 @@ void flecs_ordered_entities_append(
     ecs_component_record_t *cr,
     ecs_entity_t e);
 
+/* Promote ordered children storage to track prefab children. */
+void flecs_ordered_children_set_prefab(
+    ecs_world_t *world,
+    ecs_component_record_t *cr);
+
 /* Directly remove child from ordered children array. */
 void flecs_ordered_entities_remove(
     ecs_world_t *world,
@@ -4617,7 +4622,13 @@ void flecs_on_add_prefab(ecs_iter_t *it) {
 
     for (int32_t i = 0; i < it->count; i ++) {
         ecs_entity_t p = it->entities[i];
-        
+
+        ecs_component_record_t *cr = flecs_components_get(
+            world, ecs_childof(p));
+        if (cr && (cr->flags & EcsIdOrderedChildren)) {
+            flecs_ordered_children_set_prefab(world, cr);
+        }
+
         ecs_iter_t cit = ecs_children(world, p);
         while (ecs_children_next(&cit)) {
             for (int32_t j = 0; j < cit.count; j ++) {
@@ -41407,6 +41418,28 @@ void flecs_ordered_entities_append(
         ecs_assert(
             !ecs_owns_id(world, ecs_pair_second(world, cr->id), EcsPrefab),
             ECS_INTERNAL_ERROR, NULL);
+    }
+}
+
+void flecs_ordered_children_set_prefab(
+    ecs_world_t *world,
+    ecs_component_record_t *cr)
+{
+    ecs_assert(cr != NULL, ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(cr->pair != NULL, ECS_INTERNAL_ERROR, NULL);
+
+    if (cr->flags & EcsIdPrefabChildren) {
+        return;
+    }
+
+    cr->flags |= EcsIdPrefabChildren;
+
+    ecs_vec_t *vec = &cr->pair->ordered_children;
+    int32_t i, count = ecs_vec_count(vec);
+    ecs_entity_t *entities = ecs_vec_first_t(vec, ecs_entity_t);
+    for (i = 0; i < count; i ++) {
+        ecs_map_ensure(&world->prefab_child_indices, entities[i])[0] =
+            flecs_ito(uint64_t, i);
     }
 }
 

--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -17789,12 +17789,14 @@ void flecs_component_mark_for_delete(
     ecs_world_t *world,
     ecs_component_record_t *cr,
     ecs_entity_t action,
-    bool delete_id);
+    bool delete_id,
+    bool force_delete);
 
 static
 void flecs_target_mark_for_delete(
     ecs_world_t *world,
-    ecs_entity_t e)
+    ecs_entity_t e,
+    bool force_delete)
 {
     ecs_component_record_t *cr;
     ecs_record_t *r = flecs_entities_get(world, e);
@@ -17809,22 +17811,22 @@ void flecs_target_mark_for_delete(
 
     if (flags & EcsEntityIsId) {
         if ((cr = flecs_components_get(world, e))) {
-            flecs_component_mark_for_delete(world, cr, 
-                ECS_ID_ON_DELETE(cr->flags), true);
+            flecs_component_mark_for_delete(world, cr,
+                ECS_ID_ON_DELETE(cr->flags), true, force_delete);
         }
         if ((cr = flecs_components_get(world, ecs_pair(e, EcsWildcard)))) {
-            flecs_component_mark_for_delete(world, cr, 
-                ECS_ID_ON_DELETE(cr->flags), true);
+            flecs_component_mark_for_delete(world, cr,
+                ECS_ID_ON_DELETE(cr->flags), true, force_delete);
         }
     }
     if (flags & EcsEntityIsTarget) {
         if ((cr = flecs_components_get(world, ecs_pair(EcsWildcard, e)))) {
-            flecs_component_mark_for_delete(world, cr, 
-                ECS_ID_ON_DELETE_TARGET(cr->flags), true);
+            flecs_component_mark_for_delete(world, cr,
+                ECS_ID_ON_DELETE_TARGET(cr->flags), true, force_delete);
         }
         if ((cr = flecs_components_get(world, ecs_pair(EcsFlag, e)))) {
-            flecs_component_mark_for_delete(world, cr, 
-                ECS_ID_ON_DELETE_TARGET(cr->flags), true);
+            flecs_component_mark_for_delete(world, cr,
+                ECS_ID_ON_DELETE_TARGET(cr->flags), true, force_delete);
         }
     }
 }
@@ -17832,12 +17834,13 @@ void flecs_target_mark_for_delete(
 static
 void flecs_targets_mark_for_delete(
     ecs_world_t *world,
-    ecs_table_t *table)
+    ecs_table_t *table,
+    bool force_delete)
 {
     const ecs_entity_t *entities = ecs_table_entities(table);
     int32_t i, count = ecs_table_count(table);
     for (i = 0; i < count; i ++) {
-        flecs_target_mark_for_delete(world, entities[i]);
+        flecs_target_mark_for_delete(world, entities[i], force_delete);
     }
 }
 
@@ -17961,7 +17964,8 @@ bool flecs_is_childof_tgt_only(
 static
 void flecs_component_delete_non_fragmenting_childof(
     ecs_world_t *world,
-    ecs_component_record_t *cr)
+    ecs_component_record_t *cr,
+    bool force_delete)
 {
     cr->flags |= EcsIdMarkedForDelete;
 
@@ -17998,15 +18002,15 @@ void flecs_component_delete_non_fragmenting_childof(
                 if (!flecs_is_childof_tgt_only(child_cr)) {
                     /* Entity is used as target with other relationships, go
                      * through regular cleanup path. */
-                    flecs_target_mark_for_delete(world, e);
+                    flecs_target_mark_for_delete(world, e, force_delete);
                 } else {
                     flecs_component_delete_non_fragmenting_childof(
-                        world, child_cr);
+                        world, child_cr, force_delete);
                 }
             } else {
                 /* Entity is a target but is not a (non-fragmenting) ChildOf
                  * target. Go through regular cleanup path. */
-                flecs_target_mark_for_delete(world, e);
+                flecs_target_mark_for_delete(world, e, force_delete);
             }
         }
 
@@ -18023,7 +18027,8 @@ void flecs_component_delete_non_fragmenting_childof(
 static
 bool flecs_component_mark_non_fragmenting_childof(
     ecs_world_t *world,
-    ecs_component_record_t *cr)
+    ecs_component_record_t *cr,
+    bool force_delete)
 {
     ecs_entity_t tgt = ECS_PAIR_SECOND(cr->id);
 
@@ -18050,7 +18055,8 @@ bool flecs_component_mark_non_fragmenting_childof(
     if (!pr->second.next) {
         if (ECS_PAIR_FIRST(pr->second.prev->id) == EcsWildcard) {
             /* Entity is only used as ChildOf target */
-            flecs_component_delete_non_fragmenting_childof(world, childof_cr);
+            flecs_component_delete_non_fragmenting_childof(
+                world, childof_cr, force_delete);
             return true;
         }
     }
@@ -18068,7 +18074,7 @@ bool flecs_component_mark_non_fragmenting_childof(
             continue;
         }
 
-        flecs_component_mark_for_delete(world, tgt_cr, 0, true);
+        flecs_component_mark_for_delete(world, tgt_cr, 0, true, force_delete);
     }
 
     return false;
@@ -18079,7 +18085,8 @@ void flecs_component_mark_for_delete(
     ecs_world_t *world,
     ecs_component_record_t *cr,
     ecs_entity_t action,
-    bool delete_id)
+    bool delete_id,
+    bool force_delete)
 {
     if (cr->flags & EcsIdMarkedForDelete) {
         return;
@@ -18093,7 +18100,7 @@ void flecs_component_mark_for_delete(
     if (delete_target ||
         (ecs_id_is_pair(id) && ECS_PAIR_FIRST(id) == EcsWildcard))
     {
-        if (flecs_component_mark_non_fragmenting_childof(world, cr)) {
+        if (flecs_component_mark_non_fragmenting_childof(world, cr, force_delete)) {
             return;
         }
     }
@@ -18108,6 +18115,13 @@ void flecs_component_mark_for_delete(
                 continue;
             }
 
+            /* Don't mark prefab tables in case of delete_with/remove_all. */
+            if (!delete_id && !force_delete &&
+                (table->flags & EcsTableIsPrefab))
+            {
+                continue;
+            }
+
             ecs_entity_t cur_action = flecs_get_delete_action(table, tr, action,
                 delete_target);
 
@@ -18115,7 +18129,7 @@ void flecs_component_mark_for_delete(
             if (cur_action == EcsDelete) {
                 table->flags |= EcsTableMarkedForDelete;
                 ecs_log_push_2();
-                flecs_targets_mark_for_delete(world, table);
+                flecs_targets_mark_for_delete(world, table, force_delete);
                 ecs_log_pop_2();
             } else if (cur_action == EcsPanic) {
                 flecs_throw_invalid_delete(world, id);
@@ -18180,7 +18194,8 @@ bool flecs_on_delete_mark(
     ecs_world_t *world,
     ecs_id_t id,
     ecs_entity_t action,
-    bool delete_id)
+    bool delete_id,
+    bool force_delete)
 {
     ecs_component_record_t *cr = flecs_components_get(world, id);
     if (!cr) {
@@ -18203,7 +18218,7 @@ bool flecs_on_delete_mark(
         return false;
     }
 
-    flecs_component_mark_for_delete(world, cr, action, delete_id);
+    flecs_component_mark_for_delete(world, cr, action, delete_id, force_delete);
 
     return true;
 }
@@ -18298,9 +18313,11 @@ bool flecs_on_delete_clear_entities(
                      * If force_delete is true, it means that one of the 
                      * components, relationships or relationship targets is 
                      * being deleted in which case the table must go too. */
-                    if ((table->flags & EcsTableIsPrefab) && !force_delete) {
-                        table->flags &= ~EcsTableMarkedForDelete;
-                        continue;
+                    if (!ids[i].delete_id) {
+                        if ((table->flags & EcsTableIsPrefab) && !force_delete) {
+                            table->flags &= ~EcsTableMarkedForDelete;
+                            continue;
+                        }
                     }
 
                     if ((action == EcsRemove) || 
@@ -18413,7 +18430,7 @@ bool flecs_on_delete_clear_ids(
 
             if (flecs_component_release_tables(world, cr)) {
                 ecs_assert(!force_delete, ECS_INVALID_OPERATION, 
-                    "cannot delete component '%s': tables are keeping it alive",
+                    "cannot delete component '%s': tables are keeping it alive (likely because of used prefab)",
                     flecs_errstr(ecs_id_str(world, cr->id)));
 
                 /* There are still tables remaining. This can happen when 
@@ -18477,7 +18494,7 @@ void flecs_on_delete(
     int32_t i, count = ecs_vec_count(&world->store.marked_ids);
 
     /* Collect all ids that need to be deleted */
-    flecs_on_delete_mark(world, id, action, delete_id);
+    flecs_on_delete_mark(world, id, action, delete_id, force_delete);
 
     /* Only perform cleanup if we're the first stack frame doing it */
     if (!count && ecs_vec_count(&world->store.marked_ids)) {

--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -10005,6 +10005,13 @@ void ecs_set_id(
             flecs_errstr(ecs_id_str(world, component)),
             flecs_errstr_1(ecs_id_str(world, entity)));
 
+    if (component == ecs_id(EcsParent)) {
+        ecs_check(!((const EcsParent*)ptr)->value ||
+            ecs_is_alive(world, ((const EcsParent*)ptr)->value),
+            ECS_INVALID_OPERATION,
+            "cannot set Parent component to entity that is not alive");
+    }
+
     ecs_stage_t *stage = flecs_stage_from_world(&world);
 
     if (flecs_defer_cmd(stage)) {

--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -3352,6 +3352,9 @@ void flecs_spawner_instantiate(
     ecs_entity_t instance,
     const ecs_instantiate_ctx_t *ctx);
 
+void flecs_fini_tree_spawners(
+    ecs_world_t *world);
+
 #endif
 
 #ifndef FLECS_STAGE_H
@@ -20751,6 +20754,19 @@ void flecs_spawner_instantiate(
     }
 }
 
+void flecs_fini_tree_spawners(
+    ecs_world_t *world)
+{
+    ecs_iter_t it = ecs_each(world, EcsTreeSpawner);
+    while (ecs_each_next(&it)) {
+        EcsTreeSpawner *t = ecs_field(&it, EcsTreeSpawner, 0);
+        int32_t i;
+        for (i = 0; i < it.count; i ++) {
+            EcsTreeSpawner_free(&t[i]);
+        }
+    }
+}
+
 void flecs_bootstrap_spawner(
     ecs_world_t *world)
 {
@@ -23137,6 +23153,11 @@ int ecs_fini(
     ecs_log_push();
 
     world->flags |= EcsWorldQuit;
+
+    /* Tree spawners can keep tables alive, which can conflict with entity
+     * cleanup. Cleanup treespawners first before cleaning up other entities.
+     * This means that prefab spawning does not work during world cleanup. */
+    flecs_fini_tree_spawners(world);
 
     /* Delete root entities first using regular APIs. This ensures that cleanup
      * policies get a chance to execute. */

--- a/distr/flecs_no_addons.c
+++ b/distr/flecs_no_addons.c
@@ -1114,6 +1114,11 @@ void flecs_ordered_entities_append(
     ecs_component_record_t *cr,
     ecs_entity_t e);
 
+/* Promote ordered children storage to track prefab children. */
+void flecs_ordered_children_set_prefab(
+    ecs_world_t *world,
+    ecs_component_record_t *cr);
+
 /* Directly remove child from ordered children array. */
 void flecs_ordered_entities_remove(
     ecs_world_t *world,
@@ -3173,6 +3178,11 @@ void flecs_emit_propagate_invalidate(
     int32_t offset,
     int32_t count);
 
+/* Invalidate reachable cache for traversable relationships targeting cr. */
+void flecs_emit_propagate_invalidate_tables(
+    ecs_world_t *world,
+    ecs_component_record_t *tgt_cr);
+
 /* Set bit indicating that observer is disabled. */
 void flecs_observer_set_disable_bit(
     ecs_world_t *world,
@@ -3351,6 +3361,9 @@ void flecs_spawner_instantiate(
     ecs_entity_t base,
     ecs_entity_t instance,
     const ecs_instantiate_ctx_t *ctx);
+
+void flecs_fini_tree_spawners(
+    ecs_world_t *world);
 
 #endif
 
@@ -4544,7 +4557,13 @@ void flecs_on_add_prefab(ecs_iter_t *it) {
 
     for (int32_t i = 0; i < it->count; i ++) {
         ecs_entity_t p = it->entities[i];
-        
+
+        ecs_component_record_t *cr = flecs_components_get(
+            world, ecs_childof(p));
+        if (cr && (cr->flags & EcsIdOrderedChildren)) {
+            flecs_ordered_children_set_prefab(world, cr);
+        }
+
         ecs_iter_t cit = ecs_children(world, p);
         while (ecs_children_next(&cit)) {
             for (int32_t j = 0; j < cit.count; j ++) {
@@ -6875,13 +6894,20 @@ void flecs_on_unparent(
     ecs_table_t *table,
     ecs_table_t *other_table,
     int32_t row,
-    int32_t count)
+    int32_t count,
+    ecs_flags32_t diff_flags)
 {
-    if (other_table) {
-        flecs_unparent_name_index(world, table, other_table, row, count);
+    if (diff_flags & EcsTableEdgeReparent) {
+        if (other_table) {
+            flecs_unparent_name_index(world, table, other_table, row, count);
+        }
+        flecs_non_fragmenting_childof_unparent(
+            world, other_table, table, row, count);
     }
-    flecs_ordered_children_unparent(world, table, row, count);
-    flecs_non_fragmenting_childof_unparent(world, other_table, table, row, count);
+
+    if (diff_flags & EcsTableHasOrderedChildren) {
+        flecs_ordered_children_unparent(world, table, row, count);
+    }
 }
 
 bool flecs_sparse_on_add_cr(
@@ -7142,7 +7168,8 @@ void flecs_actions_on_remove_intern_w_reparent(
 
     if (diff_flags & (EcsTableEdgeReparent|EcsTableHasOrderedChildren)) {
         if (!other_table || !(other_table->flags & EcsTableHasChildOf)) {
-            flecs_on_unparent(world, table, other_table, row, count);
+            flecs_on_unparent(
+                world, table, other_table, row, count, diff_flags);
         }
     }
 
@@ -9869,6 +9896,13 @@ void ecs_set_id(
         "component value provided",
             flecs_errstr(ecs_id_str(world, component)),
             flecs_errstr_1(ecs_id_str(world, entity)));
+
+    if (component == ecs_id(EcsParent)) {
+        ecs_check(!((const EcsParent*)ptr)->value ||
+            ecs_is_alive(world, ((const EcsParent*)ptr)->value),
+            ECS_INVALID_OPERATION,
+            "cannot set Parent component to entity that is not alive");
+    }
 
     ecs_stage_t *stage = flecs_stage_from_world(&world);
 
@@ -14827,7 +14861,6 @@ void flecs_emit_propagate(
     ecs_log_pop_3();
 }
 
-static
 void flecs_emit_propagate_invalidate_tables(
     ecs_world_t *world,
     ecs_component_record_t *tgt_cr)
@@ -17604,12 +17637,14 @@ void flecs_component_mark_for_delete(
     ecs_world_t *world,
     ecs_component_record_t *cr,
     ecs_entity_t action,
-    bool delete_id);
+    bool delete_id,
+    bool force_delete);
 
 static
 void flecs_target_mark_for_delete(
     ecs_world_t *world,
-    ecs_entity_t e)
+    ecs_entity_t e,
+    bool force_delete)
 {
     ecs_component_record_t *cr;
     ecs_record_t *r = flecs_entities_get(world, e);
@@ -17624,22 +17659,22 @@ void flecs_target_mark_for_delete(
 
     if (flags & EcsEntityIsId) {
         if ((cr = flecs_components_get(world, e))) {
-            flecs_component_mark_for_delete(world, cr, 
-                ECS_ID_ON_DELETE(cr->flags), true);
+            flecs_component_mark_for_delete(world, cr,
+                ECS_ID_ON_DELETE(cr->flags), true, force_delete);
         }
         if ((cr = flecs_components_get(world, ecs_pair(e, EcsWildcard)))) {
-            flecs_component_mark_for_delete(world, cr, 
-                ECS_ID_ON_DELETE(cr->flags), true);
+            flecs_component_mark_for_delete(world, cr,
+                ECS_ID_ON_DELETE(cr->flags), true, force_delete);
         }
     }
     if (flags & EcsEntityIsTarget) {
         if ((cr = flecs_components_get(world, ecs_pair(EcsWildcard, e)))) {
-            flecs_component_mark_for_delete(world, cr, 
-                ECS_ID_ON_DELETE_TARGET(cr->flags), true);
+            flecs_component_mark_for_delete(world, cr,
+                ECS_ID_ON_DELETE_TARGET(cr->flags), true, force_delete);
         }
         if ((cr = flecs_components_get(world, ecs_pair(EcsFlag, e)))) {
-            flecs_component_mark_for_delete(world, cr, 
-                ECS_ID_ON_DELETE_TARGET(cr->flags), true);
+            flecs_component_mark_for_delete(world, cr,
+                ECS_ID_ON_DELETE_TARGET(cr->flags), true, force_delete);
         }
     }
 }
@@ -17647,12 +17682,13 @@ void flecs_target_mark_for_delete(
 static
 void flecs_targets_mark_for_delete(
     ecs_world_t *world,
-    ecs_table_t *table)
+    ecs_table_t *table,
+    bool force_delete)
 {
     const ecs_entity_t *entities = ecs_table_entities(table);
     int32_t i, count = ecs_table_count(table);
     for (i = 0; i < count; i ++) {
-        flecs_target_mark_for_delete(world, entities[i]);
+        flecs_target_mark_for_delete(world, entities[i], force_delete);
     }
 }
 
@@ -17776,7 +17812,8 @@ bool flecs_is_childof_tgt_only(
 static
 void flecs_component_delete_non_fragmenting_childof(
     ecs_world_t *world,
-    ecs_component_record_t *cr)
+    ecs_component_record_t *cr,
+    bool force_delete)
 {
     cr->flags |= EcsIdMarkedForDelete;
 
@@ -17798,6 +17835,12 @@ void flecs_component_delete_non_fragmenting_childof(
         ecs_assert(r != NULL, ECS_INTERNAL_ERROR, NULL);
 
         if ((r->row & EcsEntityIsTarget)) {
+            ecs_component_record_t *tgt_cr = flecs_components_get(
+                world, ecs_pair(EcsWildcard, e));
+            if (tgt_cr) {
+                flecs_emit_propagate_invalidate_tables(world, tgt_cr);
+            }
+
             ecs_component_record_t *child_cr = flecs_components_get(
                 world, ecs_childof(e));
             if (child_cr &&
@@ -17807,15 +17850,15 @@ void flecs_component_delete_non_fragmenting_childof(
                 if (!flecs_is_childof_tgt_only(child_cr)) {
                     /* Entity is used as target with other relationships, go
                      * through regular cleanup path. */
-                    flecs_target_mark_for_delete(world, e);
+                    flecs_target_mark_for_delete(world, e, force_delete);
                 } else {
                     flecs_component_delete_non_fragmenting_childof(
-                        world, child_cr);
+                        world, child_cr, force_delete);
                 }
             } else {
                 /* Entity is a target but is not a (non-fragmenting) ChildOf
                  * target. Go through regular cleanup path. */
-                flecs_target_mark_for_delete(world, e);
+                flecs_target_mark_for_delete(world, e, force_delete);
             }
         }
 
@@ -17832,7 +17875,8 @@ void flecs_component_delete_non_fragmenting_childof(
 static
 bool flecs_component_mark_non_fragmenting_childof(
     ecs_world_t *world,
-    ecs_component_record_t *cr)
+    ecs_component_record_t *cr,
+    bool force_delete)
 {
     ecs_entity_t tgt = ECS_PAIR_SECOND(cr->id);
 
@@ -17859,7 +17903,8 @@ bool flecs_component_mark_non_fragmenting_childof(
     if (!pr->second.next) {
         if (ECS_PAIR_FIRST(pr->second.prev->id) == EcsWildcard) {
             /* Entity is only used as ChildOf target */
-            flecs_component_delete_non_fragmenting_childof(world, childof_cr);
+            flecs_component_delete_non_fragmenting_childof(
+                world, childof_cr, force_delete);
             return true;
         }
     }
@@ -17877,7 +17922,7 @@ bool flecs_component_mark_non_fragmenting_childof(
             continue;
         }
 
-        flecs_component_mark_for_delete(world, tgt_cr, 0, true);
+        flecs_component_mark_for_delete(world, tgt_cr, 0, true, force_delete);
     }
 
     return false;
@@ -17888,7 +17933,8 @@ void flecs_component_mark_for_delete(
     ecs_world_t *world,
     ecs_component_record_t *cr,
     ecs_entity_t action,
-    bool delete_id)
+    bool delete_id,
+    bool force_delete)
 {
     if (cr->flags & EcsIdMarkedForDelete) {
         return;
@@ -17902,7 +17948,7 @@ void flecs_component_mark_for_delete(
     if (delete_target ||
         (ecs_id_is_pair(id) && ECS_PAIR_FIRST(id) == EcsWildcard))
     {
-        if (flecs_component_mark_non_fragmenting_childof(world, cr)) {
+        if (flecs_component_mark_non_fragmenting_childof(world, cr, force_delete)) {
             return;
         }
     }
@@ -17917,6 +17963,13 @@ void flecs_component_mark_for_delete(
                 continue;
             }
 
+            /* Don't mark prefab tables in case of delete_with/remove_all. */
+            if (!delete_id && !force_delete &&
+                (table->flags & EcsTableIsPrefab))
+            {
+                continue;
+            }
+
             ecs_entity_t cur_action = flecs_get_delete_action(table, tr, action,
                 delete_target);
 
@@ -17924,7 +17977,7 @@ void flecs_component_mark_for_delete(
             if (cur_action == EcsDelete) {
                 table->flags |= EcsTableMarkedForDelete;
                 ecs_log_push_2();
-                flecs_targets_mark_for_delete(world, table);
+                flecs_targets_mark_for_delete(world, table, force_delete);
                 ecs_log_pop_2();
             } else if (cur_action == EcsPanic) {
                 flecs_throw_invalid_delete(world, id);
@@ -17989,7 +18042,8 @@ bool flecs_on_delete_mark(
     ecs_world_t *world,
     ecs_id_t id,
     ecs_entity_t action,
-    bool delete_id)
+    bool delete_id,
+    bool force_delete)
 {
     ecs_component_record_t *cr = flecs_components_get(world, id);
     if (!cr) {
@@ -18012,7 +18066,7 @@ bool flecs_on_delete_mark(
         return false;
     }
 
-    flecs_component_mark_for_delete(world, cr, action, delete_id);
+    flecs_component_mark_for_delete(world, cr, action, delete_id, force_delete);
 
     return true;
 }
@@ -18107,9 +18161,11 @@ bool flecs_on_delete_clear_entities(
                      * If force_delete is true, it means that one of the 
                      * components, relationships or relationship targets is 
                      * being deleted in which case the table must go too. */
-                    if ((table->flags & EcsTableIsPrefab) && !force_delete) {
-                        table->flags &= ~EcsTableMarkedForDelete;
-                        continue;
+                    if (!ids[i].delete_id) {
+                        if ((table->flags & EcsTableIsPrefab) && !force_delete) {
+                            table->flags &= ~EcsTableMarkedForDelete;
+                            continue;
+                        }
                     }
 
                     if ((action == EcsRemove) || 
@@ -18222,7 +18278,7 @@ bool flecs_on_delete_clear_ids(
 
             if (flecs_component_release_tables(world, cr)) {
                 ecs_assert(!force_delete, ECS_INVALID_OPERATION, 
-                    "cannot delete component '%s': tables are keeping it alive",
+                    "cannot delete component '%s': tables are keeping it alive (likely because of used prefab)",
                     flecs_errstr(ecs_id_str(world, cr->id)));
 
                 /* There are still tables remaining. This can happen when 
@@ -18286,7 +18342,7 @@ void flecs_on_delete(
     int32_t i, count = ecs_vec_count(&world->store.marked_ids);
 
     /* Collect all ids that need to be deleted */
-    flecs_on_delete_mark(world, id, action, delete_id);
+    flecs_on_delete_mark(world, id, action, delete_id, force_delete);
 
     /* Only perform cleanup if we're the first stack frame doing it */
     if (!count && ecs_vec_count(&world->store.marked_ids)) {
@@ -20586,6 +20642,19 @@ void flecs_spawner_instantiate(
     }
 }
 
+void flecs_fini_tree_spawners(
+    ecs_world_t *world)
+{
+    ecs_iter_t it = ecs_each(world, EcsTreeSpawner);
+    while (ecs_each_next(&it)) {
+        EcsTreeSpawner *t = ecs_field(&it, EcsTreeSpawner, 0);
+        int32_t i;
+        for (i = 0; i < it.count; i ++) {
+            EcsTreeSpawner_free(&t[i]);
+        }
+    }
+}
+
 void flecs_bootstrap_spawner(
     ecs_world_t *world)
 {
@@ -22671,6 +22740,11 @@ int ecs_fini(
     ecs_log_push();
 
     world->flags |= EcsWorldQuit;
+
+    /* Tree spawners can keep tables alive, which can conflict with entity
+     * cleanup. Cleanup treespawners first before cleaning up other entities.
+     * This means that prefab spawning does not work during world cleanup. */
+    flecs_fini_tree_spawners(world);
 
     /* Delete root entities first using regular APIs. This ensures that cleanup
      * policies get a chance to execute. */
@@ -31128,6 +31202,14 @@ void flecs_component_ordered_children_init(
 {
     cr->flags |= EcsIdOrderedChildren;
     flecs_ordered_children_init(world, cr);
+
+    ecs_table_cache_iter_t it;
+    if (flecs_table_cache_all_iter(&cr->cache, &it)) {
+        const ecs_table_record_t *tr;
+        while ((tr = flecs_table_cache_next(&it, ecs_table_record_t))) {
+            tr->hdr.table->flags |= EcsTableHasOrderedChildren;
+        }
+    }
 }
 
 static
@@ -31964,7 +32046,10 @@ void flecs_entities_update_childof_depth(
         int32_t i, count = ecs_vec_count(&cr->pair->ordered_children);
         for (i = 0; i < count; i ++) {
             ecs_entity_t tgt = entities[i];
-            ecs_record_t *r = flecs_entities_get(world, tgt);
+            ecs_record_t *r = flecs_entities_try(world, tgt);
+            if (!r) {
+                continue;
+            }
             ecs_table_t *table = r->table;
 
             if (table->flags & EcsTableHasParent) {
@@ -33201,6 +33286,28 @@ void flecs_ordered_entities_append(
         ecs_assert(
             !ecs_owns_id(world, ecs_pair_second(world, cr->id), EcsPrefab),
             ECS_INTERNAL_ERROR, NULL);
+    }
+}
+
+void flecs_ordered_children_set_prefab(
+    ecs_world_t *world,
+    ecs_component_record_t *cr)
+{
+    ecs_assert(cr != NULL, ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(cr->pair != NULL, ECS_INTERNAL_ERROR, NULL);
+
+    if (cr->flags & EcsIdPrefabChildren) {
+        return;
+    }
+
+    cr->flags |= EcsIdPrefabChildren;
+
+    ecs_vec_t *vec = &cr->pair->ordered_children;
+    int32_t i, count = ecs_vec_count(vec);
+    ecs_entity_t *entities = ecs_vec_first_t(vec, ecs_entity_t);
+    for (i = 0; i < count; i ++) {
+        ecs_map_ensure(&world->prefab_child_indices, entities[i])[0] =
+            flecs_ito(uint64_t, i);
     }
 }
 
@@ -37957,8 +38064,7 @@ void flecs_compute_table_diff(
     if (ECS_IS_PAIR(id) && ECS_PAIR_FIRST(id) == EcsChildOf) {
         if (added_count) {
             diff->added_flags |= EcsTableEdgeReparent;
-        } else {
-            ecs_assert(removed_count != 0, ECS_INTERNAL_ERROR, NULL);
+        } else if (removed_count) {
             diff->removed_flags |= EcsTableEdgeReparent;
         }
     }

--- a/src/bootstrap.c
+++ b/src/bootstrap.c
@@ -591,7 +591,13 @@ void flecs_on_add_prefab(ecs_iter_t *it) {
 
     for (int32_t i = 0; i < it->count; i ++) {
         ecs_entity_t p = it->entities[i];
-        
+
+        ecs_component_record_t *cr = flecs_components_get(
+            world, ecs_childof(p));
+        if (cr && (cr->flags & EcsIdOrderedChildren)) {
+            flecs_ordered_children_set_prefab(world, cr);
+        }
+
         ecs_iter_t cit = ecs_children(world, p);
         while (ecs_children_next(&cit)) {
             for (int32_t j = 0; j < cit.count; j ++) {

--- a/src/component_actions.c
+++ b/src/component_actions.c
@@ -135,13 +135,20 @@ void flecs_on_unparent(
     ecs_table_t *table,
     ecs_table_t *other_table,
     int32_t row,
-    int32_t count)
+    int32_t count,
+    ecs_flags32_t diff_flags)
 {
-    if (other_table) {
-        flecs_unparent_name_index(world, table, other_table, row, count);
+    if (diff_flags & EcsTableEdgeReparent) {
+        if (other_table) {
+            flecs_unparent_name_index(world, table, other_table, row, count);
+        }
+        flecs_non_fragmenting_childof_unparent(
+            world, other_table, table, row, count);
     }
-    flecs_ordered_children_unparent(world, table, row, count);
-    flecs_non_fragmenting_childof_unparent(world, other_table, table, row, count);
+
+    if (diff_flags & EcsTableHasOrderedChildren) {
+        flecs_ordered_children_unparent(world, table, row, count);
+    }
 }
 
 bool flecs_sparse_on_add_cr(
@@ -402,7 +409,8 @@ void flecs_actions_on_remove_intern_w_reparent(
 
     if (diff_flags & (EcsTableEdgeReparent|EcsTableHasOrderedChildren)) {
         if (!other_table || !(other_table->flags & EcsTableHasChildOf)) {
-            flecs_on_unparent(world, table, other_table, row, count);
+            flecs_on_unparent(
+                world, table, other_table, row, count, diff_flags);
         }
     }
 

--- a/src/entity.c
+++ b/src/entity.c
@@ -2360,6 +2360,13 @@ void ecs_set_id(
             flecs_errstr(ecs_id_str(world, component)),
             flecs_errstr_1(ecs_id_str(world, entity)));
 
+    if (component == ecs_id(EcsParent)) {
+        ecs_check(!((const EcsParent*)ptr)->value ||
+            ecs_is_alive(world, ((const EcsParent*)ptr)->value),
+            ECS_INVALID_OPERATION,
+            "cannot set Parent component to entity that is not alive");
+    }
+
     ecs_stage_t *stage = flecs_stage_from_world(&world);
 
     if (flecs_defer_cmd(stage)) {

--- a/src/observable.c
+++ b/src/observable.c
@@ -420,7 +420,6 @@ void flecs_emit_propagate(
     ecs_log_pop_3();
 }
 
-static
 void flecs_emit_propagate_invalidate_tables(
     ecs_world_t *world,
     ecs_component_record_t *tgt_cr)

--- a/src/observable.h
+++ b/src/observable.h
@@ -115,6 +115,11 @@ void flecs_emit_propagate_invalidate(
     int32_t offset,
     int32_t count);
 
+/* Invalidate reachable cache for traversable relationships targeting cr. */
+void flecs_emit_propagate_invalidate_tables(
+    ecs_world_t *world,
+    ecs_component_record_t *tgt_cr);
+
 /* Set bit indicating that observer is disabled. */
 void flecs_observer_set_disable_bit(
     ecs_world_t *world,

--- a/src/on_delete.c
+++ b/src/on_delete.c
@@ -224,6 +224,12 @@ void flecs_component_delete_non_fragmenting_childof(
         ecs_assert(r != NULL, ECS_INTERNAL_ERROR, NULL);
 
         if ((r->row & EcsEntityIsTarget)) {
+            ecs_component_record_t *tgt_cr = flecs_components_get(
+                world, ecs_pair(EcsWildcard, e));
+            if (tgt_cr) {
+                flecs_emit_propagate_invalidate_tables(world, tgt_cr);
+            }
+
             ecs_component_record_t *child_cr = flecs_components_get(
                 world, ecs_childof(e));
             if (child_cr &&

--- a/src/on_delete.c
+++ b/src/on_delete.c
@@ -30,12 +30,14 @@ void flecs_component_mark_for_delete(
     ecs_world_t *world,
     ecs_component_record_t *cr,
     ecs_entity_t action,
-    bool delete_id);
+    bool delete_id,
+    bool force_delete);
 
 static
 void flecs_target_mark_for_delete(
     ecs_world_t *world,
-    ecs_entity_t e)
+    ecs_entity_t e,
+    bool force_delete)
 {
     ecs_component_record_t *cr;
     ecs_record_t *r = flecs_entities_get(world, e);
@@ -50,22 +52,22 @@ void flecs_target_mark_for_delete(
 
     if (flags & EcsEntityIsId) {
         if ((cr = flecs_components_get(world, e))) {
-            flecs_component_mark_for_delete(world, cr, 
-                ECS_ID_ON_DELETE(cr->flags), true);
+            flecs_component_mark_for_delete(world, cr,
+                ECS_ID_ON_DELETE(cr->flags), true, force_delete);
         }
         if ((cr = flecs_components_get(world, ecs_pair(e, EcsWildcard)))) {
-            flecs_component_mark_for_delete(world, cr, 
-                ECS_ID_ON_DELETE(cr->flags), true);
+            flecs_component_mark_for_delete(world, cr,
+                ECS_ID_ON_DELETE(cr->flags), true, force_delete);
         }
     }
     if (flags & EcsEntityIsTarget) {
         if ((cr = flecs_components_get(world, ecs_pair(EcsWildcard, e)))) {
-            flecs_component_mark_for_delete(world, cr, 
-                ECS_ID_ON_DELETE_TARGET(cr->flags), true);
+            flecs_component_mark_for_delete(world, cr,
+                ECS_ID_ON_DELETE_TARGET(cr->flags), true, force_delete);
         }
         if ((cr = flecs_components_get(world, ecs_pair(EcsFlag, e)))) {
-            flecs_component_mark_for_delete(world, cr, 
-                ECS_ID_ON_DELETE_TARGET(cr->flags), true);
+            flecs_component_mark_for_delete(world, cr,
+                ECS_ID_ON_DELETE_TARGET(cr->flags), true, force_delete);
         }
     }
 }
@@ -73,12 +75,13 @@ void flecs_target_mark_for_delete(
 static
 void flecs_targets_mark_for_delete(
     ecs_world_t *world,
-    ecs_table_t *table)
+    ecs_table_t *table,
+    bool force_delete)
 {
     const ecs_entity_t *entities = ecs_table_entities(table);
     int32_t i, count = ecs_table_count(table);
     for (i = 0; i < count; i ++) {
-        flecs_target_mark_for_delete(world, entities[i]);
+        flecs_target_mark_for_delete(world, entities[i], force_delete);
     }
 }
 
@@ -202,7 +205,8 @@ bool flecs_is_childof_tgt_only(
 static
 void flecs_component_delete_non_fragmenting_childof(
     ecs_world_t *world,
-    ecs_component_record_t *cr)
+    ecs_component_record_t *cr,
+    bool force_delete)
 {
     cr->flags |= EcsIdMarkedForDelete;
 
@@ -239,15 +243,15 @@ void flecs_component_delete_non_fragmenting_childof(
                 if (!flecs_is_childof_tgt_only(child_cr)) {
                     /* Entity is used as target with other relationships, go
                      * through regular cleanup path. */
-                    flecs_target_mark_for_delete(world, e);
+                    flecs_target_mark_for_delete(world, e, force_delete);
                 } else {
                     flecs_component_delete_non_fragmenting_childof(
-                        world, child_cr);
+                        world, child_cr, force_delete);
                 }
             } else {
                 /* Entity is a target but is not a (non-fragmenting) ChildOf
                  * target. Go through regular cleanup path. */
-                flecs_target_mark_for_delete(world, e);
+                flecs_target_mark_for_delete(world, e, force_delete);
             }
         }
 
@@ -264,7 +268,8 @@ void flecs_component_delete_non_fragmenting_childof(
 static
 bool flecs_component_mark_non_fragmenting_childof(
     ecs_world_t *world,
-    ecs_component_record_t *cr)
+    ecs_component_record_t *cr,
+    bool force_delete)
 {
     ecs_entity_t tgt = ECS_PAIR_SECOND(cr->id);
 
@@ -291,7 +296,8 @@ bool flecs_component_mark_non_fragmenting_childof(
     if (!pr->second.next) {
         if (ECS_PAIR_FIRST(pr->second.prev->id) == EcsWildcard) {
             /* Entity is only used as ChildOf target */
-            flecs_component_delete_non_fragmenting_childof(world, childof_cr);
+            flecs_component_delete_non_fragmenting_childof(
+                world, childof_cr, force_delete);
             return true;
         }
     }
@@ -309,7 +315,7 @@ bool flecs_component_mark_non_fragmenting_childof(
             continue;
         }
 
-        flecs_component_mark_for_delete(world, tgt_cr, 0, true);
+        flecs_component_mark_for_delete(world, tgt_cr, 0, true, force_delete);
     }
 
     return false;
@@ -320,7 +326,8 @@ void flecs_component_mark_for_delete(
     ecs_world_t *world,
     ecs_component_record_t *cr,
     ecs_entity_t action,
-    bool delete_id)
+    bool delete_id,
+    bool force_delete)
 {
     if (cr->flags & EcsIdMarkedForDelete) {
         return;
@@ -334,7 +341,7 @@ void flecs_component_mark_for_delete(
     if (delete_target ||
         (ecs_id_is_pair(id) && ECS_PAIR_FIRST(id) == EcsWildcard))
     {
-        if (flecs_component_mark_non_fragmenting_childof(world, cr)) {
+        if (flecs_component_mark_non_fragmenting_childof(world, cr, force_delete)) {
             return;
         }
     }
@@ -349,6 +356,13 @@ void flecs_component_mark_for_delete(
                 continue;
             }
 
+            /* Don't mark prefab tables in case of delete_with/remove_all. */
+            if (!delete_id && !force_delete &&
+                (table->flags & EcsTableIsPrefab))
+            {
+                continue;
+            }
+
             ecs_entity_t cur_action = flecs_get_delete_action(table, tr, action,
                 delete_target);
 
@@ -356,7 +370,7 @@ void flecs_component_mark_for_delete(
             if (cur_action == EcsDelete) {
                 table->flags |= EcsTableMarkedForDelete;
                 ecs_log_push_2();
-                flecs_targets_mark_for_delete(world, table);
+                flecs_targets_mark_for_delete(world, table, force_delete);
                 ecs_log_pop_2();
             } else if (cur_action == EcsPanic) {
                 flecs_throw_invalid_delete(world, id);
@@ -421,7 +435,8 @@ bool flecs_on_delete_mark(
     ecs_world_t *world,
     ecs_id_t id,
     ecs_entity_t action,
-    bool delete_id)
+    bool delete_id,
+    bool force_delete)
 {
     ecs_component_record_t *cr = flecs_components_get(world, id);
     if (!cr) {
@@ -444,7 +459,7 @@ bool flecs_on_delete_mark(
         return false;
     }
 
-    flecs_component_mark_for_delete(world, cr, action, delete_id);
+    flecs_component_mark_for_delete(world, cr, action, delete_id, force_delete);
 
     return true;
 }
@@ -539,9 +554,11 @@ bool flecs_on_delete_clear_entities(
                      * If force_delete is true, it means that one of the 
                      * components, relationships or relationship targets is 
                      * being deleted in which case the table must go too. */
-                    if ((table->flags & EcsTableIsPrefab) && !force_delete) {
-                        table->flags &= ~EcsTableMarkedForDelete;
-                        continue;
+                    if (!ids[i].delete_id) {
+                        if ((table->flags & EcsTableIsPrefab) && !force_delete) {
+                            table->flags &= ~EcsTableMarkedForDelete;
+                            continue;
+                        }
                     }
 
                     if ((action == EcsRemove) || 
@@ -654,7 +671,7 @@ bool flecs_on_delete_clear_ids(
 
             if (flecs_component_release_tables(world, cr)) {
                 ecs_assert(!force_delete, ECS_INVALID_OPERATION, 
-                    "cannot delete component '%s': tables are keeping it alive",
+                    "cannot delete component '%s': tables are keeping it alive (likely because of used prefab)",
                     flecs_errstr(ecs_id_str(world, cr->id)));
 
                 /* There are still tables remaining. This can happen when 
@@ -718,7 +735,7 @@ void flecs_on_delete(
     int32_t i, count = ecs_vec_count(&world->store.marked_ids);
 
     /* Collect all ids that need to be deleted */
-    flecs_on_delete_mark(world, id, action, delete_id);
+    flecs_on_delete_mark(world, id, action, delete_id, force_delete);
 
     /* Only perform cleanup if we're the first stack frame doing it */
     if (!count && ecs_vec_count(&world->store.marked_ids)) {

--- a/src/storage/component_index.c
+++ b/src/storage/component_index.c
@@ -292,6 +292,14 @@ void flecs_component_ordered_children_init(
 {
     cr->flags |= EcsIdOrderedChildren;
     flecs_ordered_children_init(world, cr);
+
+    ecs_table_cache_iter_t it;
+    if (flecs_table_cache_all_iter(&cr->cache, &it)) {
+        const ecs_table_record_t *tr;
+        while ((tr = flecs_table_cache_next(&it, ecs_table_record_t))) {
+            tr->hdr.table->flags |= EcsTableHasOrderedChildren;
+        }
+    }
 }
 
 static

--- a/src/storage/component_index.c
+++ b/src/storage/component_index.c
@@ -1136,7 +1136,10 @@ void flecs_entities_update_childof_depth(
         int32_t i, count = ecs_vec_count(&cr->pair->ordered_children);
         for (i = 0; i < count; i ++) {
             ecs_entity_t tgt = entities[i];
-            ecs_record_t *r = flecs_entities_get(world, tgt);
+            ecs_record_t *r = flecs_entities_try(world, tgt);
+            if (!r) {
+                continue;
+            }
             ecs_table_t *table = r->table;
 
             if (table->flags & EcsTableHasParent) {

--- a/src/storage/ordered_children.c
+++ b/src/storage/ordered_children.c
@@ -83,6 +83,28 @@ void flecs_ordered_entities_append(
     }
 }
 
+void flecs_ordered_children_set_prefab(
+    ecs_world_t *world,
+    ecs_component_record_t *cr)
+{
+    ecs_assert(cr != NULL, ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(cr->pair != NULL, ECS_INTERNAL_ERROR, NULL);
+
+    if (cr->flags & EcsIdPrefabChildren) {
+        return;
+    }
+
+    cr->flags |= EcsIdPrefabChildren;
+
+    ecs_vec_t *vec = &cr->pair->ordered_children;
+    int32_t i, count = ecs_vec_count(vec);
+    ecs_entity_t *entities = ecs_vec_first_t(vec, ecs_entity_t);
+    for (i = 0; i < count; i ++) {
+        ecs_map_ensure(&world->prefab_child_indices, entities[i])[0] =
+            flecs_ito(uint64_t, i);
+    }
+}
+
 void flecs_ordered_entities_remove(
     ecs_world_t *world,
     ecs_component_record_t *cr,

--- a/src/storage/ordered_children.h
+++ b/src/storage/ordered_children.h
@@ -53,6 +53,11 @@ void flecs_ordered_entities_append(
     ecs_component_record_t *cr,
     ecs_entity_t e);
 
+/* Promote ordered children storage to track prefab children. */
+void flecs_ordered_children_set_prefab(
+    ecs_world_t *world,
+    ecs_component_record_t *cr);
+
 /* Directly remove child from ordered children array. */
 void flecs_ordered_entities_remove(
     ecs_world_t *world,

--- a/src/storage/table_graph.c
+++ b/src/storage/table_graph.c
@@ -920,8 +920,7 @@ void flecs_compute_table_diff(
     if (ECS_IS_PAIR(id) && ECS_PAIR_FIRST(id) == EcsChildOf) {
         if (added_count) {
             diff->added_flags |= EcsTableEdgeReparent;
-        } else {
-            ecs_assert(removed_count != 0, ECS_INTERNAL_ERROR, NULL);
+        } else if (removed_count) {
             diff->removed_flags |= EcsTableEdgeReparent;
         }
     }

--- a/src/tree_spawner.c
+++ b/src/tree_spawner.c
@@ -340,6 +340,19 @@ void flecs_spawner_instantiate(
     }
 }
 
+void flecs_fini_tree_spawners(
+    ecs_world_t *world)
+{
+    ecs_iter_t it = ecs_each(world, EcsTreeSpawner);
+    while (ecs_each_next(&it)) {
+        EcsTreeSpawner *t = ecs_field(&it, EcsTreeSpawner, 0);
+        int32_t i;
+        for (i = 0; i < it.count; i ++) {
+            EcsTreeSpawner_free(&t[i]);
+        }
+    }
+}
+
 void flecs_bootstrap_spawner(
     ecs_world_t *world)
 {

--- a/src/tree_spawner.h
+++ b/src/tree_spawner.h
@@ -21,4 +21,7 @@ void flecs_spawner_instantiate(
     ecs_entity_t instance,
     const ecs_instantiate_ctx_t *ctx);
 
+void flecs_fini_tree_spawners(
+    ecs_world_t *world);
+
 #endif

--- a/src/world.c
+++ b/src/world.c
@@ -1272,6 +1272,11 @@ int ecs_fini(
 
     world->flags |= EcsWorldQuit;
 
+    /* Tree spawners can keep tables alive, which can conflict with entity
+     * cleanup. Cleanup treespawners first before cleaning up other entities.
+     * This means that prefab spawning does not work during world cleanup. */
+    flecs_fini_tree_spawners(world);
+
     /* Delete root entities first using regular APIs. This ensures that cleanup
      * policies get a chance to execute. */
     ecs_dbg_1("#[bold]cleanup root entities");

--- a/test/core/project.json
+++ b/test/core/project.json
@@ -751,7 +751,8 @@
                 "defer_set_w_sparse_w_observer",
                 "defer_ensure_modified_w_sparse_w_observer",
                 "defer_remove_override",
-                "defer_remove_add_override"
+                "defer_remove_add_override",
+                "fini_w_dont_fragment_pair_prefab_exclusive_delete_with"
             ]
         }, {
             "id": "NonFragmentingChildOf",
@@ -2710,7 +2711,10 @@
                 "remove_all",
                 "delete_with",
                 "prefab_children_after_adding_prefab",
-                "add_base_w_exclusive_override"
+                "add_base_w_exclusive_override",
+                "fini_w_prefab_child_exclusive_pair_delete_with",
+                "delete_with_component_used_by_prefab",
+                "delete_component_used_by_prefab"
             ]
         }, {
             "id": "World",

--- a/test/core/project.json
+++ b/test/core/project.json
@@ -1008,7 +1008,8 @@
                 "fini_delete_component_of_prefab_child",
                 "delete_pair_of_prefab_child",
                 "fini_delete_pair_of_prefab_child",
-                "fini_w_mixed_childof_different_parents"
+                "fini_w_mixed_childof_different_parents",
+                "fini_w_ordered_child_w_up_traversable"
             ]
         }, {
             "id": "Hierarchies",

--- a/test/core/project.json
+++ b/test/core/project.json
@@ -1007,7 +1007,8 @@
                 "delete_component_of_prefab_child",
                 "fini_delete_component_of_prefab_child",
                 "delete_pair_of_prefab_child",
-                "fini_delete_pair_of_prefab_child"
+                "fini_delete_pair_of_prefab_child",
+                "fini_w_mixed_childof_different_parents"
             ]
         }, {
             "id": "Hierarchies",

--- a/test/core/project.json
+++ b/test/core/project.json
@@ -752,7 +752,8 @@
                 "defer_ensure_modified_w_sparse_w_observer",
                 "defer_remove_override",
                 "defer_remove_add_override",
-                "fini_w_dont_fragment_pair_prefab_exclusive_delete_with"
+                "fini_w_dont_fragment_pair_prefab_exclusive_delete_with",
+                "remove_childof_pair_w_dont_fragment_component"
             ]
         }, {
             "id": "NonFragmentingChildOf",

--- a/test/core/project.json
+++ b/test/core/project.json
@@ -2381,6 +2381,7 @@
                 "cache_test_14",
                 "cache_test_15",
                 "cache_test_16",
+                "cache_test_17",
                 "multi_term_on_set_w_base_and_3_instances_in_different_tables"
             ]
         }, {

--- a/test/core/project.json
+++ b/test/core/project.json
@@ -1009,7 +1009,8 @@
                 "delete_pair_of_prefab_child",
                 "fini_delete_pair_of_prefab_child",
                 "fini_w_mixed_childof_different_parents",
-                "fini_w_ordered_child_w_up_traversable"
+                "fini_w_ordered_child_w_up_traversable",
+                "defer_reparent_mixed_childof"
             ]
         }, {
             "id": "Hierarchies",

--- a/test/core/project.json
+++ b/test/core/project.json
@@ -1003,7 +1003,11 @@
                 "defer_set_parent_and_remove_tag",
                 "defer_set_parent_to_deleted_entity",
                 "defer_reparent_to_deleted_entity_w_sparse",
-                "set_parent_to_deleted_entity_w_ordered_child"
+                "set_parent_to_deleted_entity_w_ordered_child",
+                "delete_component_of_prefab_child",
+                "fini_delete_component_of_prefab_child",
+                "delete_pair_of_prefab_child",
+                "fini_delete_pair_of_prefab_child"
             ]
         }, {
             "id": "Hierarchies",

--- a/test/core/project.json
+++ b/test/core/project.json
@@ -1010,7 +1010,8 @@
                 "fini_delete_pair_of_prefab_child",
                 "fini_w_mixed_childof_different_parents",
                 "fini_w_ordered_child_w_up_traversable",
-                "defer_reparent_mixed_childof"
+                "defer_reparent_mixed_childof",
+                "prefab_parent_w_mixed_childof"
             ]
         }, {
             "id": "Hierarchies",

--- a/test/core/project.json
+++ b/test/core/project.json
@@ -1000,7 +1000,10 @@
                 "defer_add_prefab_tag_after_hierarchy_creation",
                 "add_prefab_tag_after_hierarchy_creation_2",
                 "defer_add_prefab_tag_after_hierarchy_creation_2",
-                "defer_set_parent_and_remove_tag"
+                "defer_set_parent_and_remove_tag",
+                "defer_set_parent_to_deleted_entity",
+                "defer_reparent_to_deleted_entity_w_sparse",
+                "set_parent_to_deleted_entity_w_ordered_child"
             ]
         }, {
             "id": "Hierarchies",

--- a/test/core/src/NonFragmentingChildOf.c
+++ b/test/core/src/NonFragmentingChildOf.c
@@ -6528,3 +6528,80 @@ void NonFragmentingChildOf_defer_set_parent_and_remove_tag(void) {
 
     ecs_fini(world);
 }
+
+void NonFragmentingChildOf_defer_set_parent_to_deleted_entity(void) {
+    install_test_abort();
+
+    ecs_world_t *world = ecs_mini();
+
+    ecs_entity_t dont_fragment = ecs_new(world);
+    ecs_add_id(world, dont_fragment, EcsDontFragment);
+
+    ecs_entity_t deleted = ecs_new(world);
+    ecs_entity_t child = ecs_new(world);
+    ecs_entity_t other = ecs_new(world);
+    ecs_entity_t grandchild = ecs_new(world);
+    ecs_delete(world, deleted);
+
+    test_assert(!ecs_is_alive(world, deleted));
+
+    ecs_defer_begin(world);
+    test_expect_abort();
+    ecs_set(world, child, EcsParent, {deleted});
+    ecs_add_id(world, other, dont_fragment);
+    ecs_remove_pair(world, grandchild, EcsChildOf, child);
+    ecs_defer_end(world);
+
+    ecs_fini(world);
+}
+
+void NonFragmentingChildOf_defer_reparent_to_deleted_entity_w_sparse(void) {
+    install_test_abort();
+
+    ecs_world_t *world = ecs_mini();
+
+    ecs_entity_t sparse = ecs_new(world);
+    ecs_add_id(world, sparse, EcsSparse);
+
+    ecs_entity_t tag = ecs_new(world);
+    ecs_entity_t deleted = ecs_new(world);
+    ecs_entity_t parent = ecs_new(world);
+    ecs_entity_t child = ecs_new(world);
+
+    ecs_add_id(world, deleted, tag);
+    ecs_set(world, child, EcsParent, {parent});
+    ecs_delete_with(world, tag);
+
+    test_assert(ecs_get_parent(world, child) == parent);
+    test_assert(!ecs_is_alive(world, deleted));
+
+    ecs_defer_begin(world);
+    ecs_add_id(world, child, sparse);
+    test_expect_abort();
+    ecs_set(world, child, EcsParent, {deleted});
+    ecs_defer_end(world);
+
+    ecs_fini(world);
+}
+
+void NonFragmentingChildOf_set_parent_to_deleted_entity_w_ordered_child(void) {
+    install_test_abort();
+
+    ecs_world_t *world = ecs_mini();
+
+    ecs_entity_t deleted = ecs_new(world);
+    ecs_entity_t parent = ecs_new(world);
+    ecs_entity_t child = ecs_new(world);
+    ecs_delete(world, deleted);
+
+    ecs_add_id(world, child, EcsOrderedChildren);
+    ecs_add_pair(world, child, EcsChildOf, parent);
+
+    test_assert(ecs_get_parent(world, child) == parent);
+    test_assert(!ecs_is_alive(world, deleted));
+
+    test_expect_abort();
+    ecs_set(world, parent, EcsParent, {deleted});
+
+    ecs_fini(world);
+}

--- a/test/core/src/NonFragmentingChildOf.c
+++ b/test/core/src/NonFragmentingChildOf.c
@@ -6605,3 +6605,93 @@ void NonFragmentingChildOf_set_parent_to_deleted_entity_w_ordered_child(void) {
 
     ecs_fini(world);
 }
+
+void NonFragmentingChildOf_delete_component_of_prefab_child(void) {
+    install_test_abort();
+
+    ecs_world_t *world = ecs_mini();
+
+    ecs_entity_t tag = ecs_new(world);
+    ecs_entity_t prefab = ecs_new(world);
+    ecs_add_id(world, prefab, EcsPrefab);
+
+    ecs_entity_t tgt = ecs_new(world);
+    ecs_entity_t child = ecs_new(world);
+    ecs_add_id(world, child, tag);
+    ecs_set(world, child, EcsParent, {prefab});
+
+    ecs_entity_t inst_a = ecs_new_w_pair(world, EcsIsA, prefab);
+    ecs_entities_t children_a = ecs_get_ordered_children(world, inst_a);
+    test_int(1, children_a.count);
+    test_assert(ecs_has_id(world, children_a.ids[0], tag));
+
+    test_expect_abort();
+    ecs_delete(world, tag);
+
+    ecs_fini(world);
+}
+
+void NonFragmentingChildOf_fini_delete_component_of_prefab_child(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ecs_entity_t tag = ecs_new(world);
+    ecs_entity_t prefab = ecs_new(world);
+    ecs_add_id(world, prefab, EcsPrefab);
+
+    ecs_entity_t tgt = ecs_new(world);
+    ecs_entity_t child = ecs_new(world);
+    ecs_add_id(world, child, tag);
+    ecs_set(world, child, EcsParent, {prefab});
+
+    ecs_entity_t inst_a = ecs_new_w_pair(world, EcsIsA, prefab);
+    ecs_entities_t children_a = ecs_get_ordered_children(world, inst_a);
+    test_int(1, children_a.count);
+    test_assert(ecs_has_id(world, children_a.ids[0], tag));
+
+    ecs_fini(world);
+}
+
+void NonFragmentingChildOf_delete_pair_of_prefab_child(void) {
+    install_test_abort();
+
+    ecs_world_t *world = ecs_mini();
+
+    ecs_entity_t rel = ecs_new(world);
+    ecs_entity_t prefab = ecs_new(world);
+    ecs_add_id(world, prefab, EcsPrefab);
+
+    ecs_entity_t tgt = ecs_new(world);
+    ecs_entity_t child = ecs_new(world);
+    ecs_add_pair(world, child, rel, tgt);
+    ecs_set(world, child, EcsParent, {prefab});
+
+    ecs_entity_t inst_a = ecs_new_w_pair(world, EcsIsA, prefab);
+    ecs_entities_t children_a = ecs_get_ordered_children(world, inst_a);
+    test_int(1, children_a.count);
+    test_assert(ecs_has_pair(world, children_a.ids[0], rel, tgt));
+
+    test_expect_abort();
+    ecs_delete(world, rel);
+
+    ecs_fini(world);
+}
+
+void NonFragmentingChildOf_fini_delete_pair_of_prefab_child(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ecs_entity_t rel = ecs_new(world);
+    ecs_entity_t prefab = ecs_new(world);
+    ecs_add_id(world, prefab, EcsPrefab);
+
+    ecs_entity_t tgt = ecs_new(world);
+    ecs_entity_t child = ecs_new(world);
+    ecs_add_pair(world, child, rel, tgt);
+    ecs_set(world, child, EcsParent, {prefab});
+
+    ecs_entity_t inst_a = ecs_new_w_pair(world, EcsIsA, prefab);
+    ecs_entities_t children_a = ecs_get_ordered_children(world, inst_a);
+    test_int(1, children_a.count);
+    test_assert(ecs_has_pair(world, children_a.ids[0], rel, tgt));
+
+    ecs_fini(world);
+}

--- a/test/core/src/NonFragmentingChildOf.c
+++ b/test/core/src/NonFragmentingChildOf.c
@@ -6695,3 +6695,26 @@ void NonFragmentingChildOf_fini_delete_pair_of_prefab_child(void) {
 
     ecs_fini(world);
 }
+
+void NonFragmentingChildOf_fini_w_mixed_childof_different_parents(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ecs_entity_t parent_a = ecs_new(world);
+    ecs_entity_t parent_b = ecs_new(world);
+    ecs_entity_t child_a = ecs_new(world);
+    ecs_entity_t child_b = ecs_new(world);
+
+    ecs_add_pair(world, child_b, EcsChildOf, parent_a);
+    ecs_set(world, child_a, EcsParent, {parent_a});
+    ecs_set(world, child_b, EcsParent, {parent_b});
+
+    ecs_entities_t children_a = ecs_get_ordered_children(world, parent_a);
+    test_int(1, children_a.count);
+    test_uint(child_a, children_a.ids[0]);
+
+    ecs_entities_t children_b = ecs_get_ordered_children(world, parent_b);
+    test_int(1, children_b.count);
+    test_uint(child_b, children_b.ids[0]);
+
+    ecs_fini(world);
+}

--- a/test/core/src/NonFragmentingChildOf.c
+++ b/test/core/src/NonFragmentingChildOf.c
@@ -6718,3 +6718,38 @@ void NonFragmentingChildOf_fini_w_mixed_childof_different_parents(void) {
 
     ecs_fini(world);
 }
+
+void NonFragmentingChildOf_fini_w_ordered_child_w_up_traversable(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ecs_entity_t rel = ecs_new(world);
+    ecs_add_id(world, rel, EcsTraversable);
+    ecs_add_pair(world, rel, EcsOnInstantiate, EcsInherit);
+
+    ecs_entity_t grandparent = ecs_new(world);
+    ecs_entity_t parent = ecs_new(world);
+    ecs_entity_t other = ecs_new(world);
+    ecs_entity_t child = ecs_new(world);
+
+    ecs_add_pair(world, other, rel, grandparent);
+    ecs_add_pair(world, child, EcsChildOf, parent);
+    ecs_add_id(world, parent, EcsOrderedChildren);
+    ecs_set(world, parent, EcsParent, {grandparent});
+
+    test_assert(ecs_get_parent(world, parent) == grandparent);
+    test_assert(ecs_get_parent(world, child) == parent);
+
+    ecs_entities_t children = ecs_get_ordered_children(world, parent);
+    test_int(1, children.count);
+    test_uint(child, children.ids[0]);
+
+    ecs_delete(world, grandparent);
+
+    test_assert(!ecs_is_alive(world, grandparent));
+    test_assert(!ecs_is_alive(world, parent));
+    test_assert(!ecs_is_alive(world, child));
+    test_assert(ecs_is_alive(world, other));
+    test_assert(!ecs_has_pair(world, other, rel, grandparent));
+
+    ecs_fini(world);
+}

--- a/test/core/src/NonFragmentingChildOf.c
+++ b/test/core/src/NonFragmentingChildOf.c
@@ -6774,3 +6774,30 @@ void NonFragmentingChildOf_defer_reparent_mixed_childof(void) {
 
     ecs_fini(world);
 }
+
+void NonFragmentingChildOf_prefab_parent_w_mixed_childof(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ecs_entity_t parent = ecs_new(world);
+    ecs_entity_t child_a = ecs_new(world);
+    ecs_entity_t child_b = ecs_new(world);
+
+    ecs_set(world, child_b, EcsParent, {parent});
+    ecs_add_id(world, parent, EcsPrefab);
+    ecs_add_pair(world, child_a, EcsChildOf, parent);
+
+    test_assert(ecs_has_id(world, child_a, EcsPrefab));
+    test_assert(ecs_has_id(world, child_b, EcsPrefab));
+
+    ecs_entity_t instance = ecs_new_w_pair(world, EcsIsA, parent);
+    test_assert(instance != 0);
+
+    {
+        ecs_entity_t i_b = ecs_get_target(world, instance, child_b, 0);
+        test_assert(i_b != 0);
+        test_assert(ecs_has_pair(world, i_b, EcsIsA, child_b));
+        test_assert(ecs_get_parent(world, i_b) == instance);
+    }
+
+    ecs_fini(world);
+}

--- a/test/core/src/NonFragmentingChildOf.c
+++ b/test/core/src/NonFragmentingChildOf.c
@@ -6753,3 +6753,24 @@ void NonFragmentingChildOf_fini_w_ordered_child_w_up_traversable(void) {
 
     ecs_fini(world);
 }
+
+void NonFragmentingChildOf_defer_reparent_mixed_childof(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ecs_entity_t parent_a = ecs_new(world);
+    ecs_entity_t parent_b = ecs_new(world);
+    ecs_entity_t child = ecs_new(world);
+
+    ecs_defer_begin(world);
+    ecs_set(world, parent_b, EcsParent, {parent_a});
+    ecs_add_pair(world, child, EcsChildOf, parent_a);
+    ecs_set(world, child, EcsParent, {parent_b});
+    ecs_defer_end(world);
+
+    test_assert(ecs_get_parent(world, parent_b) == parent_a);
+    test_assert(ecs_get_parent(world, child) == parent_b);
+    test_assert(!ecs_has_pair(world, child, EcsChildOf, parent_a));
+    test_assert(ecs_has_pair(world, child, EcsChildOf, parent_b));
+
+    ecs_fini(world);
+}

--- a/test/core/src/Observer.c
+++ b/test/core/src/Observer.c
@@ -8965,6 +8965,27 @@ void Observer_cache_test_16(void) {
     ecs_fini(world);
 }
 
+void Observer_cache_test_17(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ecs_entity_t r = ecs_new(world);
+    ecs_add_id(world, r, EcsTraversable);
+    ecs_add_pair(world, r, EcsOnInstantiate, EcsInherit);
+
+    ecs_entity_t parent = ecs_new(world);
+    ecs_entity_t child = ecs_new(world);
+    ecs_set(world, child, EcsParent, {parent});
+
+    ecs_entity_t e = ecs_new(world);
+    ecs_add_id(world, e, EcsOrderedChildren);
+    ecs_add_pair(world, e, r, child);
+    ecs_add_pair(world, e, EcsChildOf, parent);
+
+    test_assert(true);
+
+    ecs_fini(world);
+}
+
 static int Observer_a_invoked = 0;
 static int Observer_b_invoked = 0;
 

--- a/test/core/src/Prefab.c
+++ b/test/core/src/Prefab.c
@@ -6370,6 +6370,7 @@ void Prefab_delete_with(void) {
 
     ecs_entity_t p = ecs_new_w_id(world, EcsPrefab);
     ecs_set(world, p, Position, {10, 20});
+    ecs_set_name(world, p, "p");
 
     ecs_entity_t c = ecs_new_w_pair(world, EcsChildOf, p);
     ecs_set(world, c, Position, {10, 20});
@@ -6438,6 +6439,67 @@ void Prefab_add_base_w_exclusive_override(void) {
     ecs_add_pair(world, i, EcsIsA, base);
 
     test_assert(ecs_has_pair(world, i, Rel, TgtB));
+
+    ecs_fini(world);
+}
+
+void Prefab_fini_w_prefab_child_exclusive_pair_delete_with(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_ENTITY(world, Rel, Exclusive);
+    ECS_TAG(world, Tag);
+
+    ecs_entity_t tgt = ecs_new(world);
+    ecs_entity_t parent = ecs_new(world);
+    ecs_entity_t prefab = ecs_new(world);
+
+    ecs_add_pair(world, prefab, Rel, tgt);
+    ecs_add_id(world, parent, Tag);
+    ecs_add_id(world, prefab, EcsPrefab);
+    ecs_add_pair(world, prefab, EcsChildOf, parent);
+
+    ecs_delete_with(world, Tag);
+
+    test_assert(true);
+
+    ecs_fini(world);
+}
+
+void Prefab_delete_with_component_used_by_prefab(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, Foo);
+    ECS_TAG(world, Bar);
+
+    ecs_entity_t prefab = ecs_new(world);
+    ecs_add_id(world, prefab, EcsPrefab);
+    ecs_add(world, prefab, Foo);
+
+    ecs_add_id(world, Foo, Bar);
+
+    ecs_delete_with(world, Bar);
+
+    test_assert(!ecs_is_alive(world, Foo));
+    test_assert(ecs_is_alive(world, prefab));
+    test_assert(!ecs_has(world, prefab, Foo));
+
+    ecs_fini(world);
+}
+
+void Prefab_delete_component_used_by_prefab(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ECS_TAG(world, Foo);
+
+    ecs_entity_t prefab = ecs_new(world);
+    ecs_add_id(world, prefab, EcsPrefab);
+    ecs_add(world, prefab, Foo);
+
+    ecs_delete(world, Foo);
+
+    test_assert(!ecs_is_alive(world, Foo));
+    test_assert(ecs_is_alive(world, prefab));
+    test_assert(!ecs_has(world, prefab, Foo));
 
     ecs_fini(world);
 }

--- a/test/core/src/Sparse.c
+++ b/test/core/src/Sparse.c
@@ -7648,3 +7648,21 @@ void Sparse_fini_w_dont_fragment_pair_prefab_exclusive_delete_with(void) {
     ecs_fini(world);
 }
 
+void Sparse_remove_childof_pair_w_dont_fragment_component(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ecs_entity_t df = ecs_new(world);
+    ecs_add_id(world, df, EcsDontFragment);
+
+    ecs_entity_t a = ecs_new(world);
+    ecs_entity_t b = ecs_new(world);
+    ecs_entity_t c = ecs_new(world);
+
+    ecs_add_pair(world, a, df, b);
+    ecs_remove_pair(world, c, EcsChildOf, b);
+
+    test_assert(true);
+
+    ecs_fini(world);
+}
+

--- a/test/core/src/Sparse.c
+++ b/test/core/src/Sparse.c
@@ -7620,3 +7620,31 @@ void Sparse_defer_remove_add_override(void) {
     ecs_fini(world);
 }
 
+void Sparse_fini_w_dont_fragment_pair_prefab_exclusive_delete_with(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ecs_entity_t rel = ecs_new(world);
+    ecs_add_id(world, rel, EcsExclusive);
+
+    ecs_entity_t df = ecs_new(world);
+    ecs_add_id(world, df, EcsDontFragment);
+
+    ecs_entity_t tag = ecs_new(world);
+
+    ecs_entity_t tgt = ecs_new(world);
+    ecs_entity_t pair_tgt = ecs_new(world);
+    ecs_entity_t base = ecs_new(world);
+    ecs_entity_t prefab = ecs_new(world);
+
+    ecs_add_pair(world, prefab, rel, tgt);
+    ecs_add_pair(world, pair_tgt, df, tgt);
+    ecs_add_id(world, prefab, EcsPrefab);
+    ecs_add_id(world, tgt, tag);
+    ecs_delete_with(world, tag);
+    ecs_add_pair(world, base, EcsIsA, pair_tgt);
+
+    test_assert(true);
+
+    ecs_fini(world);
+}
+

--- a/test/core/src/main.c
+++ b/test/core/src/main.c
@@ -979,6 +979,7 @@ void NonFragmentingChildOf_fini_delete_pair_of_prefab_child(void);
 void NonFragmentingChildOf_fini_w_mixed_childof_different_parents(void);
 void NonFragmentingChildOf_fini_w_ordered_child_w_up_traversable(void);
 void NonFragmentingChildOf_defer_reparent_mixed_childof(void);
+void NonFragmentingChildOf_prefab_parent_w_mixed_childof(void);
 
 // Testsuite 'Hierarchies'
 void Hierarchies_setup(void);
@@ -7143,6 +7144,10 @@ bake_test_case NonFragmentingChildOf_testcases[] = {
     {
         "defer_reparent_mixed_childof",
         NonFragmentingChildOf_defer_reparent_mixed_childof
+    },
+    {
+        "prefab_parent_w_mixed_childof",
+        NonFragmentingChildOf_prefab_parent_w_mixed_childof
     }
 };
 
@@ -16415,7 +16420,7 @@ static bake_test_suite suites[] = {
         "NonFragmentingChildOf",
         NULL,
         NULL,
-        255,
+        256,
         NonFragmentingChildOf_testcases
     },
     {

--- a/test/core/src/main.c
+++ b/test/core/src/main.c
@@ -2314,6 +2314,7 @@ void Observer_cache_test_13(void);
 void Observer_cache_test_14(void);
 void Observer_cache_test_15(void);
 void Observer_cache_test_16(void);
+void Observer_cache_test_17(void);
 void Observer_multi_term_on_set_w_base_and_3_instances_in_different_tables(void);
 
 // Testsuite 'ObserverOnSet'
@@ -12374,6 +12375,10 @@ bake_test_case Observer_testcases[] = {
         Observer_cache_test_16
     },
     {
+        "cache_test_17",
+        Observer_cache_test_17
+    },
+    {
         "multi_term_on_set_w_base_and_3_instances_in_different_tables",
         Observer_multi_term_on_set_w_base_and_3_instances_in_different_tables
     }
@@ -16524,7 +16529,7 @@ static bake_test_suite suites[] = {
         "Observer",
         NULL,
         NULL,
-        339,
+        340,
         Observer_testcases
     },
     {

--- a/test/core/src/main.c
+++ b/test/core/src/main.c
@@ -978,6 +978,7 @@ void NonFragmentingChildOf_delete_pair_of_prefab_child(void);
 void NonFragmentingChildOf_fini_delete_pair_of_prefab_child(void);
 void NonFragmentingChildOf_fini_w_mixed_childof_different_parents(void);
 void NonFragmentingChildOf_fini_w_ordered_child_w_up_traversable(void);
+void NonFragmentingChildOf_defer_reparent_mixed_childof(void);
 
 // Testsuite 'Hierarchies'
 void Hierarchies_setup(void);
@@ -7138,6 +7139,10 @@ bake_test_case NonFragmentingChildOf_testcases[] = {
     {
         "fini_w_ordered_child_w_up_traversable",
         NonFragmentingChildOf_fini_w_ordered_child_w_up_traversable
+    },
+    {
+        "defer_reparent_mixed_childof",
+        NonFragmentingChildOf_defer_reparent_mixed_childof
     }
 };
 
@@ -16410,7 +16415,7 @@ static bake_test_suite suites[] = {
         "NonFragmentingChildOf",
         NULL,
         NULL,
-        254,
+        255,
         NonFragmentingChildOf_testcases
     },
     {

--- a/test/core/src/main.c
+++ b/test/core/src/main.c
@@ -977,6 +977,7 @@ void NonFragmentingChildOf_fini_delete_component_of_prefab_child(void);
 void NonFragmentingChildOf_delete_pair_of_prefab_child(void);
 void NonFragmentingChildOf_fini_delete_pair_of_prefab_child(void);
 void NonFragmentingChildOf_fini_w_mixed_childof_different_parents(void);
+void NonFragmentingChildOf_fini_w_ordered_child_w_up_traversable(void);
 
 // Testsuite 'Hierarchies'
 void Hierarchies_setup(void);
@@ -7132,6 +7133,10 @@ bake_test_case NonFragmentingChildOf_testcases[] = {
     {
         "fini_w_mixed_childof_different_parents",
         NonFragmentingChildOf_fini_w_mixed_childof_different_parents
+    },
+    {
+        "fini_w_ordered_child_w_up_traversable",
+        NonFragmentingChildOf_fini_w_ordered_child_w_up_traversable
     }
 };
 
@@ -16400,7 +16405,7 @@ static bake_test_suite suites[] = {
         "NonFragmentingChildOf",
         NULL,
         NULL,
-        253,
+        254,
         NonFragmentingChildOf_testcases
     },
     {

--- a/test/core/src/main.c
+++ b/test/core/src/main.c
@@ -723,6 +723,7 @@ void Sparse_defer_ensure_modified_w_sparse_w_observer(void);
 void Sparse_defer_remove_override(void);
 void Sparse_defer_remove_add_override(void);
 void Sparse_fini_w_dont_fragment_pair_prefab_exclusive_delete_with(void);
+void Sparse_remove_childof_pair_w_dont_fragment_component(void);
 
 // Testsuite 'NonFragmentingChildOf'
 void NonFragmentingChildOf_set_parent_no_ordered_children(void);
@@ -6129,6 +6130,10 @@ bake_test_case Sparse_testcases[] = {
     {
         "fini_w_dont_fragment_pair_prefab_exclusive_delete_with",
         Sparse_fini_w_dont_fragment_pair_prefab_exclusive_delete_with
+    },
+    {
+        "remove_childof_pair_w_dont_fragment_component",
+        Sparse_remove_childof_pair_w_dont_fragment_component
     }
 };
 
@@ -16431,7 +16436,7 @@ static bake_test_suite suites[] = {
         "Sparse",
         Sparse_setup,
         NULL,
-        229,
+        230,
         Sparse_testcases,
         1,
         Sparse_params

--- a/test/core/src/main.c
+++ b/test/core/src/main.c
@@ -972,6 +972,10 @@ void NonFragmentingChildOf_defer_set_parent_and_remove_tag(void);
 void NonFragmentingChildOf_defer_set_parent_to_deleted_entity(void);
 void NonFragmentingChildOf_defer_reparent_to_deleted_entity_w_sparse(void);
 void NonFragmentingChildOf_set_parent_to_deleted_entity_w_ordered_child(void);
+void NonFragmentingChildOf_delete_component_of_prefab_child(void);
+void NonFragmentingChildOf_fini_delete_component_of_prefab_child(void);
+void NonFragmentingChildOf_delete_pair_of_prefab_child(void);
+void NonFragmentingChildOf_fini_delete_pair_of_prefab_child(void);
 
 // Testsuite 'Hierarchies'
 void Hierarchies_setup(void);
@@ -7107,6 +7111,22 @@ bake_test_case NonFragmentingChildOf_testcases[] = {
     {
         "set_parent_to_deleted_entity_w_ordered_child",
         NonFragmentingChildOf_set_parent_to_deleted_entity_w_ordered_child
+    },
+    {
+        "delete_component_of_prefab_child",
+        NonFragmentingChildOf_delete_component_of_prefab_child
+    },
+    {
+        "fini_delete_component_of_prefab_child",
+        NonFragmentingChildOf_fini_delete_component_of_prefab_child
+    },
+    {
+        "delete_pair_of_prefab_child",
+        NonFragmentingChildOf_delete_pair_of_prefab_child
+    },
+    {
+        "fini_delete_pair_of_prefab_child",
+        NonFragmentingChildOf_fini_delete_pair_of_prefab_child
     }
 };
 
@@ -16375,7 +16395,7 @@ static bake_test_suite suites[] = {
         "NonFragmentingChildOf",
         NULL,
         NULL,
-        248,
+        252,
         NonFragmentingChildOf_testcases
     },
     {

--- a/test/core/src/main.c
+++ b/test/core/src/main.c
@@ -976,6 +976,7 @@ void NonFragmentingChildOf_delete_component_of_prefab_child(void);
 void NonFragmentingChildOf_fini_delete_component_of_prefab_child(void);
 void NonFragmentingChildOf_delete_pair_of_prefab_child(void);
 void NonFragmentingChildOf_fini_delete_pair_of_prefab_child(void);
+void NonFragmentingChildOf_fini_w_mixed_childof_different_parents(void);
 
 // Testsuite 'Hierarchies'
 void Hierarchies_setup(void);
@@ -7127,6 +7128,10 @@ bake_test_case NonFragmentingChildOf_testcases[] = {
     {
         "fini_delete_pair_of_prefab_child",
         NonFragmentingChildOf_fini_delete_pair_of_prefab_child
+    },
+    {
+        "fini_w_mixed_childof_different_parents",
+        NonFragmentingChildOf_fini_w_mixed_childof_different_parents
     }
 };
 
@@ -16395,7 +16400,7 @@ static bake_test_suite suites[] = {
         "NonFragmentingChildOf",
         NULL,
         NULL,
-        252,
+        253,
         NonFragmentingChildOf_testcases
     },
     {

--- a/test/core/src/main.c
+++ b/test/core/src/main.c
@@ -722,6 +722,7 @@ void Sparse_defer_set_w_sparse_w_observer(void);
 void Sparse_defer_ensure_modified_w_sparse_w_observer(void);
 void Sparse_defer_remove_override(void);
 void Sparse_defer_remove_add_override(void);
+void Sparse_fini_w_dont_fragment_pair_prefab_exclusive_delete_with(void);
 
 // Testsuite 'NonFragmentingChildOf'
 void NonFragmentingChildOf_set_parent_no_ordered_children(void);
@@ -2632,6 +2633,9 @@ void Prefab_remove_all(void);
 void Prefab_delete_with(void);
 void Prefab_prefab_children_after_adding_prefab(void);
 void Prefab_add_base_w_exclusive_override(void);
+void Prefab_fini_w_prefab_child_exclusive_pair_delete_with(void);
+void Prefab_delete_with_component_used_by_prefab(void);
+void Prefab_delete_component_used_by_prefab(void);
 
 // Testsuite 'World'
 void World_setup(void);
@@ -6121,6 +6125,10 @@ bake_test_case Sparse_testcases[] = {
     {
         "defer_remove_add_override",
         Sparse_defer_remove_add_override
+    },
+    {
+        "fini_w_dont_fragment_pair_prefab_exclusive_delete_with",
+        Sparse_fini_w_dont_fragment_pair_prefab_exclusive_delete_with
     }
 };
 
@@ -13609,6 +13617,18 @@ bake_test_case Prefab_testcases[] = {
     {
         "add_base_w_exclusive_override",
         Prefab_add_base_w_exclusive_override
+    },
+    {
+        "fini_w_prefab_child_exclusive_pair_delete_with",
+        Prefab_fini_w_prefab_child_exclusive_pair_delete_with
+    },
+    {
+        "delete_with_component_used_by_prefab",
+        Prefab_delete_with_component_used_by_prefab
+    },
+    {
+        "delete_component_used_by_prefab",
+        Prefab_delete_component_used_by_prefab
     }
 };
 
@@ -16411,7 +16431,7 @@ static bake_test_suite suites[] = {
         "Sparse",
         Sparse_setup,
         NULL,
-        228,
+        229,
         Sparse_testcases,
         1,
         Sparse_params
@@ -16581,7 +16601,7 @@ static bake_test_suite suites[] = {
         "Prefab",
         Prefab_setup,
         NULL,
-        198,
+        201,
         Prefab_testcases
     },
     {

--- a/test/core/src/main.c
+++ b/test/core/src/main.c
@@ -969,6 +969,9 @@ void NonFragmentingChildOf_defer_add_prefab_tag_after_hierarchy_creation(void);
 void NonFragmentingChildOf_add_prefab_tag_after_hierarchy_creation_2(void);
 void NonFragmentingChildOf_defer_add_prefab_tag_after_hierarchy_creation_2(void);
 void NonFragmentingChildOf_defer_set_parent_and_remove_tag(void);
+void NonFragmentingChildOf_defer_set_parent_to_deleted_entity(void);
+void NonFragmentingChildOf_defer_reparent_to_deleted_entity_w_sparse(void);
+void NonFragmentingChildOf_set_parent_to_deleted_entity_w_ordered_child(void);
 
 // Testsuite 'Hierarchies'
 void Hierarchies_setup(void);
@@ -7092,6 +7095,18 @@ bake_test_case NonFragmentingChildOf_testcases[] = {
     {
         "defer_set_parent_and_remove_tag",
         NonFragmentingChildOf_defer_set_parent_and_remove_tag
+    },
+    {
+        "defer_set_parent_to_deleted_entity",
+        NonFragmentingChildOf_defer_set_parent_to_deleted_entity
+    },
+    {
+        "defer_reparent_to_deleted_entity_w_sparse",
+        NonFragmentingChildOf_defer_reparent_to_deleted_entity_w_sparse
+    },
+    {
+        "set_parent_to_deleted_entity_w_ordered_child",
+        NonFragmentingChildOf_set_parent_to_deleted_entity_w_ordered_child
     }
 };
 
@@ -16360,7 +16375,7 @@ static bake_test_suite suites[] = {
         "NonFragmentingChildOf",
         NULL,
         NULL,
-        245,
+        248,
         NonFragmentingChildOf_testcases
     },
     {


### PR DESCRIPTION
- Prefab spawner cached tables kept components alive past root entity deletion at fini
- Ordered-children tracking flag not propagated to pre-existing child tables
- Depth propagation dereferenced already-deleted ordered children at fini
- Reachable-id cache not invalidated when target deleted via non-fragmenting cleanup
- ChildOf edge removal recomputed depth from ordered-children flag without a parent change
- Prefab-parent flag on ChildOf record not updated when parent promoted to prefab
- delete_with left dangling pairs to deleted target on prefab tables and sparse storage
- Non-fragmenting-pair table flag forced an empty ChildOf diff that broke the reparent invariant