### PR TITLE
[observers] Add names to singleton constraint observers

### DIFF
--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -4475,7 +4475,7 @@ void flecs_register_singleton(ecs_iter_t *it) {
 #ifdef FLECS_DEBUG
         ecs_observer(world, {
             .entity = ecs_entity(world, {
-                .name = "SingletonSelfAdd", .parent = component
+                .name = "debug_only_SingletonInvariantCheck", .parent = component
             }),
             .query.terms[0] = {
                 .id = component, .src.id = EcsThis|EcsSelf
@@ -4486,7 +4486,7 @@ void flecs_register_singleton(ecs_iter_t *it) {
 
         ecs_observer(world, {
             .entity = ecs_entity(world, {
-                .name = "SingletonPairSelfAdd", .parent = component
+                .name = "debug_only_SingletonPairInvariantCheck", .parent = component
             }),
             .query.terms[0] = {
                 .id = ecs_pair(component, EcsWildcard), .src.id = EcsThis|EcsSelf

--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -4474,18 +4474,22 @@ void flecs_register_singleton(ecs_iter_t *it) {
         /* Create observer that enforces that singleton is only added to self */
 #ifdef FLECS_DEBUG
         ecs_observer(world, {
-            .entity = ecs_entity(world, { .parent = component }),
-            .query.terms[0] = { 
-                .id = component, .src.id = EcsThis|EcsSelf 
+            .entity = ecs_entity(world, {
+                .name = "SingletonSelfAdd", .parent = component
+            }),
+            .query.terms[0] = {
+                .id = component, .src.id = EcsThis|EcsSelf
             },
             .callback = flecs_on_singleton_add_remove,
             .events = {EcsOnAdd}
         });
 
         ecs_observer(world, {
-            .entity = ecs_entity(world, { .parent = component }),
-            .query.terms[0] = { 
-                .id = ecs_pair(component, EcsWildcard), .src.id = EcsThis|EcsSelf 
+            .entity = ecs_entity(world, {
+                .name = "SingletonPairSelfAdd", .parent = component
+            }),
+            .query.terms[0] = {
+                .id = ecs_pair(component, EcsWildcard), .src.id = EcsThis|EcsSelf
             },
             .callback = flecs_on_singleton_add_remove,
             .events = {EcsOnAdd}

--- a/distr/flecs_no_addons.c
+++ b/distr/flecs_no_addons.c
@@ -4409,18 +4409,22 @@ void flecs_register_singleton(ecs_iter_t *it) {
         /* Create observer that enforces that singleton is only added to self */
 #ifdef FLECS_DEBUG
         ecs_observer(world, {
-            .entity = ecs_entity(world, { .parent = component }),
-            .query.terms[0] = { 
-                .id = component, .src.id = EcsThis|EcsSelf 
+            .entity = ecs_entity(world, {
+                .name = "SingletonSelfAdd", .parent = component
+            }),
+            .query.terms[0] = {
+                .id = component, .src.id = EcsThis|EcsSelf
             },
             .callback = flecs_on_singleton_add_remove,
             .events = {EcsOnAdd}
         });
 
         ecs_observer(world, {
-            .entity = ecs_entity(world, { .parent = component }),
-            .query.terms[0] = { 
-                .id = ecs_pair(component, EcsWildcard), .src.id = EcsThis|EcsSelf 
+            .entity = ecs_entity(world, {
+                .name = "SingletonPairSelfAdd", .parent = component
+            }),
+            .query.terms[0] = {
+                .id = ecs_pair(component, EcsWildcard), .src.id = EcsThis|EcsSelf
             },
             .callback = flecs_on_singleton_add_remove,
             .events = {EcsOnAdd}

--- a/distr/flecs_no_addons.c
+++ b/distr/flecs_no_addons.c
@@ -4410,7 +4410,7 @@ void flecs_register_singleton(ecs_iter_t *it) {
 #ifdef FLECS_DEBUG
         ecs_observer(world, {
             .entity = ecs_entity(world, {
-                .name = "SingletonSelfAdd", .parent = component
+                .name = "debug_only_SingletonInvariantCheck", .parent = component
             }),
             .query.terms[0] = {
                 .id = component, .src.id = EcsThis|EcsSelf
@@ -4421,7 +4421,7 @@ void flecs_register_singleton(ecs_iter_t *it) {
 
         ecs_observer(world, {
             .entity = ecs_entity(world, {
-                .name = "SingletonPairSelfAdd", .parent = component
+                .name = "debug_only_SingletonPairInvariantCheck", .parent = component
             }),
             .query.terms[0] = {
                 .id = ecs_pair(component, EcsWildcard), .src.id = EcsThis|EcsSelf

--- a/src/bootstrap.c
+++ b/src/bootstrap.c
@@ -444,7 +444,7 @@ void flecs_register_singleton(ecs_iter_t *it) {
 #ifdef FLECS_DEBUG
         ecs_observer(world, {
             .entity = ecs_entity(world, {
-                .name = "SingletonSelfAdd", .parent = component
+                .name = "debug_only_SingletonInvariantCheck", .parent = component
             }),
             .query.terms[0] = {
                 .id = component, .src.id = EcsThis|EcsSelf
@@ -455,7 +455,7 @@ void flecs_register_singleton(ecs_iter_t *it) {
 
         ecs_observer(world, {
             .entity = ecs_entity(world, {
-                .name = "SingletonPairSelfAdd", .parent = component
+                .name = "debug_only_SingletonPairInvariantCheck", .parent = component
             }),
             .query.terms[0] = {
                 .id = ecs_pair(component, EcsWildcard), .src.id = EcsThis|EcsSelf

--- a/src/bootstrap.c
+++ b/src/bootstrap.c
@@ -443,18 +443,22 @@ void flecs_register_singleton(ecs_iter_t *it) {
         /* Create observer that enforces that singleton is only added to self */
 #ifdef FLECS_DEBUG
         ecs_observer(world, {
-            .entity = ecs_entity(world, { .parent = component }),
-            .query.terms[0] = { 
-                .id = component, .src.id = EcsThis|EcsSelf 
+            .entity = ecs_entity(world, {
+                .name = "SingletonSelfAdd", .parent = component
+            }),
+            .query.terms[0] = {
+                .id = component, .src.id = EcsThis|EcsSelf
             },
             .callback = flecs_on_singleton_add_remove,
             .events = {EcsOnAdd}
         });
 
         ecs_observer(world, {
-            .entity = ecs_entity(world, { .parent = component }),
-            .query.terms[0] = { 
-                .id = ecs_pair(component, EcsWildcard), .src.id = EcsThis|EcsSelf 
+            .entity = ecs_entity(world, {
+                .name = "SingletonPairSelfAdd", .parent = component
+            }),
+            .query.terms[0] = {
+                .id = ecs_pair(component, EcsWildcard), .src.id = EcsThis|EcsSelf
             },
             .callback = flecs_on_singleton_add_remove,
             .events = {EcsOnAdd}


### PR DESCRIPTION
This PR adds names to the internal singleton constraint observers created in debug mode.

The naming scheme is a proposal on my part.
I wasn't sure what the preferred naming convention for these internal observers should be, so I chose names that seemed descriptive and easy to identify in Explorer.