### PR TITLE
Fix assert on same-table name-index reparent in deferred batch

### DIFF
--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -11661,8 +11661,9 @@ void flecs_reparent_name_index(
 
     ecs_hashmap_t *src_index = flecs_table_get_name_index(world, src);
     ecs_hashmap_t *dst_index = flecs_table_get_name_index(world, dst);
-    ecs_assert(src_index != dst_index, ECS_INTERNAL_ERROR, NULL);
-    if ((!src_index && !dst_index)) {
+    if (src_index == dst_index) {
+        /* Both tables share a name index, so the entry doesn't need to move.
+         * Also covers the case where neither table has a name index. */
         return;
     }
 

--- a/distr/flecs_no_addons.c
+++ b/distr/flecs_no_addons.c
@@ -11526,8 +11526,9 @@ void flecs_reparent_name_index(
 
     ecs_hashmap_t *src_index = flecs_table_get_name_index(world, src);
     ecs_hashmap_t *dst_index = flecs_table_get_name_index(world, dst);
-    ecs_assert(src_index != dst_index, ECS_INTERNAL_ERROR, NULL);
-    if ((!src_index && !dst_index)) {
+    if (src_index == dst_index) {
+        /* Both tables share a name index, so the entry doesn't need to move.
+         * Also covers the case where neither table has a name index. */
         return;
     }
 

--- a/src/entity_name.c
+++ b/src/entity_name.c
@@ -521,8 +521,9 @@ void flecs_reparent_name_index(
 
     ecs_hashmap_t *src_index = flecs_table_get_name_index(world, src);
     ecs_hashmap_t *dst_index = flecs_table_get_name_index(world, dst);
-    ecs_assert(src_index != dst_index, ECS_INTERNAL_ERROR, NULL);
-    if ((!src_index && !dst_index)) {
+    if (src_index == dst_index) {
+        /* Both tables share a name index, so the entry doesn't need to move.
+         * Also covers the case where neither table has a name index. */
         return;
     }
 

--- a/test/core/project.json
+++ b/test/core/project.json
@@ -1144,6 +1144,7 @@
                 "lookup_after_delete_from_parent",
                 "defer_batch_remove_name_w_add_childof",
                 "defer_batch_remove_childof_w_add_name",
+                "defer_batch_remove_add_childof_same_pair_named",
                 "add_path_w_sep_null_path"
             ]
         }, {

--- a/test/core/src/Hierarchies.c
+++ b/test/core/src/Hierarchies.c
@@ -2077,6 +2077,38 @@ void Hierarchies_defer_batch_remove_childof_w_add_name(void) {
     ecs_fini(world);
 }
 
+void Hierarchies_defer_batch_remove_add_childof_same_pair_named(void) {
+    ecs_world_t *world = ecs_mini();
+
+    ecs_entity_t parent = ecs_new(world);
+    ecs_add_id(world, parent, EcsOrderedChildren);
+
+    ecs_entity_t c1 = ecs_new_w_pair(world, EcsChildOf, parent);
+    ecs_set_name(world, c1, "c1");
+    ecs_entity_t c2 = ecs_new_w_pair(world, EcsChildOf, parent);
+    ecs_set_name(world, c2, "c2");
+
+    /* Remove + re-add the same (ChildOf, parent) in a defer batch moves a
+     * named child to the end of its siblings. The child returns to its
+     * original table, so the name-index reparent is a no-op. */
+    ecs_defer_begin(world);
+    ecs_remove_pair(world, c1, EcsChildOf, parent);
+    ecs_add_pair(world, c1, EcsChildOf, parent);
+    ecs_defer_end(world);
+
+    test_assert(ecs_has_pair(world, c1, EcsChildOf, parent));
+    test_str("c1", ecs_get_name(world, c1));
+    test_assert(ecs_lookup_child(world, parent, "c1") == c1);
+    test_assert(ecs_lookup_child(world, parent, "c2") == c2);
+
+    ecs_entities_t children = ecs_get_ordered_children(world, parent);
+    test_int(children.count, 2);
+    test_uint(children.ids[0], c2);
+    test_uint(children.ids[1], c1);
+
+    ecs_fini(world);
+}
+
 void Hierarchies_recreated_parent_w_named_children(void) {
     ecs_world_t *world = ecs_mini();
 

--- a/test/core/src/main.c
+++ b/test/core/src/main.c
@@ -1110,6 +1110,7 @@ void Hierarchies_lookup_after_delete_from_root(void);
 void Hierarchies_lookup_after_delete_from_parent(void);
 void Hierarchies_defer_batch_remove_name_w_add_childof(void);
 void Hierarchies_defer_batch_remove_childof_w_add_name(void);
+void Hierarchies_defer_batch_remove_add_childof_same_pair_named(void);
 void Hierarchies_add_path_w_sep_null_path(void);
 
 // Testsuite 'OrderedChildren'
@@ -7702,6 +7703,10 @@ bake_test_case Hierarchies_testcases[] = {
     {
         "defer_batch_remove_childof_w_add_name",
         Hierarchies_defer_batch_remove_childof_w_add_name
+    },
+    {
+        "defer_batch_remove_add_childof_same_pair_named",
+        Hierarchies_defer_batch_remove_add_childof_same_pair_named
     },
     {
         "add_path_w_sep_null_path",
@@ -16642,7 +16647,7 @@ static bake_test_suite suites[] = {
         "Hierarchies",
         Hierarchies_setup,
         NULL,
-        116,
+        117,
         Hierarchies_testcases
     },
     {


### PR DESCRIPTION
(bug in upstream flecs found by AI subagent while hunting a different bug that seems not to be in upstream flecs. I do not understand what it's about but trust it to have likely found something real. AI remarks follow:) 

A deferred command batch that removes and re-adds the same exclusive pair — e.g. `remove(ChildOf, parent)` then `add(ChildOf, parent)` to move a named child to the end of its ordered siblings — ends the batch with the entity in its original table. `flecs_reparent_name_index` then computes `src_index == dst_index` and trips `ecs_assert(src_index != dst_index, ...)`, aborting in debug builds. Release builds were unaffected: the reparent is a benign remove-and-re-add of the same entity in the same name hashmap.

Replace the assert with a graceful early return when the indices are equal — the entity's name entry does not need to move. This subsumes the existing both-NULL early return.

Repro (debug build): a named child under a parent with `EcsOrderedChildren`, `ecs_remove_pair` + `ecs_add_pair` of `(ChildOf, parent)` inside one `ecs_defer_begin`/`ecs_defer_end`, aborts at `entity_name.c` without this fix.

Adds regression test
`Hierarchies_defer_batch_remove_add_childof_same_pair_named`.

(additional AI remark: "One judgment note: I kept the PR to just the debug-assert fix — the minimal, uncontroversial change. The deeper "should deferred remove+add of an identical exclusive pair be a no-op vs. move-to-end?" semantics question (which the subagent flagged) is deliberately not in this PR; that's a maintainer design call better raised as an issue if you want to pursue it.")