### PR TITLE
Fix OrderedChildren: track children added after enabling trait

### DIFF
--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -4700,9 +4700,10 @@ void flecs_register_ordered_children(ecs_iter_t *it) {
             ecs_component_record_t *cr = flecs_components_ensure(
                 it->world, ecs_childof(parent));
             if (!(cr->flags & EcsIdOrderedChildren)) {
-                flecs_ordered_children_init(it->world, cr);
+                /* Also flags existing child tables so children added after the
+                 * trait are tracked in the ordered list. */
+                flecs_component_ordered_children_init(it->world, cr);
                 flecs_ordered_children_populate(it->world, cr);
-                cr->flags |= EcsIdOrderedChildren;
             }
         }
     } else if (!(it->real_world->flags & EcsWorldFini) && it->other_table) {

--- a/distr/flecs_no_addons.c
+++ b/distr/flecs_no_addons.c
@@ -4635,9 +4635,10 @@ void flecs_register_ordered_children(ecs_iter_t *it) {
             ecs_component_record_t *cr = flecs_components_ensure(
                 it->world, ecs_childof(parent));
             if (!(cr->flags & EcsIdOrderedChildren)) {
-                flecs_ordered_children_init(it->world, cr);
+                /* Also flags existing child tables so children added after the
+                 * trait are tracked in the ordered list. */
+                flecs_component_ordered_children_init(it->world, cr);
                 flecs_ordered_children_populate(it->world, cr);
-                cr->flags |= EcsIdOrderedChildren;
             }
         }
     } else if (!(it->real_world->flags & EcsWorldFini) && it->other_table) {

--- a/src/bootstrap.c
+++ b/src/bootstrap.c
@@ -620,9 +620,10 @@ void flecs_register_ordered_children(ecs_iter_t *it) {
             ecs_component_record_t *cr = flecs_components_ensure(
                 it->world, ecs_childof(parent));
             if (!(cr->flags & EcsIdOrderedChildren)) {
-                flecs_ordered_children_init(it->world, cr);
+                /* Also flags existing child tables so children added after the
+                 * trait are tracked in the ordered list. */
+                flecs_component_ordered_children_init(it->world, cr);
                 flecs_ordered_children_populate(it->world, cr);
-                cr->flags |= EcsIdOrderedChildren;
             }
         }
     } else if (!(it->real_world->flags & EcsWorldFini) && it->other_table) {

--- a/test/core/project.json
+++ b/test/core/project.json
@@ -1170,6 +1170,7 @@
                 "delete_with_tag_some_children",
                 "add_remove_ordered_children_after_in_use",
                 "add_remove_ordered_children_no_children",
+                "add_child_after_late_ordered_children",
                 "change_order_no_children",
                 "change_order_mismatching_child_count",
                 "change_order_mismatching_child_id",

--- a/test/core/src/OrderedChildren.c
+++ b/test/core/src/OrderedChildren.c
@@ -1016,6 +1016,52 @@ void OrderedChildren_add_remove_ordered_children_no_children(void) {
     test_assert(true);
 }
 
+void OrderedChildren_add_child_after_late_ordered_children(void) {
+    /* Adding EcsOrderedChildren to a parent that already has children must
+     * still track children added afterwards. */
+    ecs_world_t *world = ecs_mini();
+
+    ecs_entity_t parent = ecs_new(world);
+
+    ecs_entity_t e1 = ecs_new_w_pair(world, EcsChildOf, parent);
+    ecs_entity_t e2 = ecs_new_w_pair(world, EcsChildOf, parent);
+
+    /* Trait added after children exist. */
+    ecs_add_id(world, parent, EcsOrderedChildren);
+
+    /* A child added later must appear in the ordered list. */
+    ecs_entity_t e3 = ecs_new_w_pair(world, EcsChildOf, parent);
+
+    ecs_entities_t oc = ecs_get_ordered_children(world, parent);
+    test_int(3, oc.count);
+    test_uint(e1, oc.ids[0]);
+    test_uint(e2, oc.ids[1]);
+    test_uint(e3, oc.ids[2]);
+
+    {
+        ecs_iter_t it = ecs_children(world, parent);
+        test_bool(true, ecs_children_next(&it));
+        test_int(3, it.count);
+        test_uint(e1, it.entities[0]);
+        test_uint(e2, it.entities[1]);
+        test_uint(e3, it.entities[2]);
+        test_bool(false, ecs_children_next(&it));
+    }
+
+    /* Also works after a set_child_order reorder. */
+    ecs_entity_t ord[] = {e3, e1, e2};
+    ecs_set_child_order(world, parent, ord, 3);
+    ecs_entity_t e4 = ecs_new_w_pair(world, EcsChildOf, parent);
+    oc = ecs_get_ordered_children(world, parent);
+    test_int(4, oc.count);
+    test_uint(e3, oc.ids[0]);
+    test_uint(e1, oc.ids[1]);
+    test_uint(e2, oc.ids[2]);
+    test_uint(e4, oc.ids[3]);
+
+    ecs_fini(world);
+}
+
 void OrderedChildren_change_order_no_children(void) {
     ecs_world_t *world = ecs_mini();
 

--- a/test/core/src/main.c
+++ b/test/core/src/main.c
@@ -1134,6 +1134,7 @@ void OrderedChildren_delete_with_tag_all_children(void);
 void OrderedChildren_delete_with_tag_some_children(void);
 void OrderedChildren_add_remove_ordered_children_after_in_use(void);
 void OrderedChildren_add_remove_ordered_children_no_children(void);
+void OrderedChildren_add_child_after_late_ordered_children(void);
 void OrderedChildren_change_order_no_children(void);
 void OrderedChildren_change_order_mismatching_child_count(void);
 void OrderedChildren_change_order_mismatching_child_id(void);
@@ -7802,6 +7803,10 @@ bake_test_case OrderedChildren_testcases[] = {
     {
         "add_remove_ordered_children_no_children",
         OrderedChildren_add_remove_ordered_children_no_children
+    },
+    {
+        "add_child_after_late_ordered_children",
+        OrderedChildren_add_child_after_late_ordered_children
     },
     {
         "change_order_no_children",
@@ -16694,7 +16699,7 @@ static bake_test_suite suites[] = {
         "OrderedChildren",
         NULL,
         NULL,
-        48,
+        49,
         OrderedChildren_testcases
     },
     {


### PR DESCRIPTION
(bug discovery and all content of this PR other than in these parentheses from AI)

Adding EcsOrderedChildren to a parent that already has children left the existing child tables unflagged (EcsTableHasOrderedChildren), so any child added afterwards held its (ChildOf, parent) pair but was never appended to ordered_children — silently omitted from ecs_get_ordered_children / ecs_children. Adding the trait before any children exist worked, so the bug only affected the "enable ordering on an already-populated parent" path.

The EcsOnAdd hook flecs_register_ordered_children inited + populated the ordered vec and set the cr flag, but (unlike flecs_component_ordered_children_init) never iterated cr->cache to flag existing child tables. Route the hook through flecs_component_ordered_children_init so those tables are flagged and later child moves into them are appended.

Regression test: OrderedChildren.add_child_after_late_ordered_children.