### PR TITLE
[cpp] Avoid temporary flecs::term objects in query builder with() methods

### DIFF
--- a/distr/flecs.h
+++ b/distr/flecs.h
@@ -35238,7 +35238,7 @@ struct query_builder_i : term_builder_i<Base> {
     template<typename T>
     Base& with() {
         this->term();
-        *this->term_ = flecs::term(_::type<T>::id(this->world_v()));
+        this->set_term_id(_::type<T>::id(this->world_v()));
         this->term_->inout = static_cast<ecs_inout_kind_t>(
             _::type_to_inout<T>());
         return *this;
@@ -35247,42 +35247,53 @@ struct query_builder_i : term_builder_i<Base> {
     /** Add a term for the specified component ID. */
     Base& with(id_t component_id) {
         this->term();
-        *this->term_ = flecs::term(component_id);
+        this->set_term_id(component_id);
         return *this;
     }
 
     /** Add a term for the specified component name. */
     Base& with(const char *component_name) {
         this->term();
-        *this->term_ = flecs::term().first(component_name);
+        this->set_term_id(0);
+        this->first(component_name);
+        this->src();
         return *this;
     }
 
     /** Add a term for a pair specified by name. */
     Base& with(const char *first, const char *second) {
         this->term();
-        *this->term_ = flecs::term().first(first).second(second);
+        this->set_term_id(0);
+        this->first(first).second(second);
+        this->src();
         return *this;
     }
 
     /** Add a term for a pair specified by entity IDs. */
     Base& with(entity_t first, entity_t second) {
         this->term();
-        *this->term_ = flecs::term(first, second);
+        this->set_term_id(0);
+        this->term_->first.id = first;
+        this->term_->second.id = second;
         return *this;
     }
 
     /** Add a term for a pair with an entity ID first and a name second. */
     Base& with(entity_t first, const char *second) {
         this->term();
-        *this->term_ = flecs::term(first).second(second);
+        this->set_term_id(first);
+        this->second(second);
+        this->src();
         return *this;
     }
 
     /** Add a term for a pair with a name first and an entity ID second. */
     Base& with(const char *first, entity_t second) {
         this->term();
-        *this->term_ = flecs::term().first(first).second(second);
+        this->set_term_id(0);
+        this->first(first);
+        this->second(second);
+        this->src();
         return *this;
     }
 
@@ -35607,6 +35618,19 @@ protected:
 private:
     operator Base&() {
         return *static_cast<Base*>(this);
+    }
+
+    /* Reset the current term and set its component/pair id. Writing the term
+     * directly avoids a temporary flecs::term, which stores pointers to its
+     * own stack memory and gets flagged by static analyzers when assigned to
+     * the descriptor (clang-analyzer core.StackAddressEscape). */
+    void set_term_id(id_t component_id) {
+        *this->term_ = {};
+        if (component_id & ECS_ID_FLAGS_MASK) {
+            this->term_->id = component_id;
+        } else if (component_id) {
+            this->term_->first.id = component_id;
+        }
     }
 
     ecs_query_desc_t *desc_;

--- a/include/flecs/addons/cpp/mixins/query/builder_i.hpp
+++ b/include/flecs/addons/cpp/mixins/query/builder_i.hpp
@@ -64,7 +64,7 @@ struct query_builder_i : term_builder_i<Base> {
     template<typename T>
     Base& with() {
         this->term();
-        *this->term_ = flecs::term(_::type<T>::id(this->world_v()));
+        this->set_term_id(_::type<T>::id(this->world_v()));
         this->term_->inout = static_cast<ecs_inout_kind_t>(
             _::type_to_inout<T>());
         return *this;
@@ -73,42 +73,53 @@ struct query_builder_i : term_builder_i<Base> {
     /** Add a term for the specified component ID. */
     Base& with(id_t component_id) {
         this->term();
-        *this->term_ = flecs::term(component_id);
+        this->set_term_id(component_id);
         return *this;
     }
 
     /** Add a term for the specified component name. */
     Base& with(const char *component_name) {
         this->term();
-        *this->term_ = flecs::term().first(component_name);
+        this->set_term_id(0);
+        this->first(component_name);
+        this->src();
         return *this;
     }
 
     /** Add a term for a pair specified by name. */
     Base& with(const char *first, const char *second) {
         this->term();
-        *this->term_ = flecs::term().first(first).second(second);
+        this->set_term_id(0);
+        this->first(first).second(second);
+        this->src();
         return *this;
     }
 
     /** Add a term for a pair specified by entity IDs. */
     Base& with(entity_t first, entity_t second) {
         this->term();
-        *this->term_ = flecs::term(first, second);
+        this->set_term_id(0);
+        this->term_->first.id = first;
+        this->term_->second.id = second;
         return *this;
     }
 
     /** Add a term for a pair with an entity ID first and a name second. */
     Base& with(entity_t first, const char *second) {
         this->term();
-        *this->term_ = flecs::term(first).second(second);
+        this->set_term_id(first);
+        this->second(second);
+        this->src();
         return *this;
     }
 
     /** Add a term for a pair with a name first and an entity ID second. */
     Base& with(const char *first, entity_t second) {
         this->term();
-        *this->term_ = flecs::term().first(first).second(second);
+        this->set_term_id(0);
+        this->first(first);
+        this->second(second);
+        this->src();
         return *this;
     }
 
@@ -433,6 +444,19 @@ protected:
 private:
     operator Base&() {
         return *static_cast<Base*>(this);
+    }
+
+    /* Reset the current term and set its component/pair id. Writing the term
+     * directly avoids a temporary flecs::term, which stores pointers to its
+     * own stack memory and gets flagged by static analyzers when assigned to
+     * the descriptor (clang-analyzer core.StackAddressEscape). */
+    void set_term_id(id_t component_id) {
+        *this->term_ = {};
+        if (component_id & ECS_ID_FLAGS_MASK) {
+            this->term_->id = component_id;
+        } else if (component_id) {
+            this->term_->first.id = component_id;
+        }
     }
 
     ecs_query_desc_t *desc_;


### PR DESCRIPTION
The `with()` overloads in `query_builder_i` construct a temporary `flecs::term` just to copy its value into the query descriptor. Term objects store pointers to their own stack memory (`term_`/`term_ref_` point at the object's own `value` member), so the assignment gets reported by clang's static analyzer as an escaping stack address (`clang-analyzer-core.StackAddressEscape`, anchored at `builder_i.hpp:77`). It is a false positive — only the pointer-free `ecs_term_t` value is copied — but it fires in any downstream project that runs clang-tidy over code that instantiates a query builder (`world.each`, query/system/observer builders), and it cannot be suppressed downstream without disabling the checker.

This writes the term value directly instead of going through the temporary:

- Term values are identical for all seven overloads; the `$` name-to-variable handling is reused through the inherited `first()` / `second()`.
- `with(flecs::term&)` / `with(flecs::term&&)` are unchanged (caller-owned objects, no temporary involved).
- Side effect: skips the temporary's construction, conversion copy and virtual destructor on every `with()` call.
- `distr/` contains the same change.

Tested with `bake run test/query` and `bake run test/cpp` (all green), and `distr/flecs.c` compiles with the CI flag set (`clang -Werror -Wshadow -Wconversion ...`). Also verified in a downstream C++26 project running clang-tidy 22 with `clang-analyzer-*` promoted to errors: the report disappears at the source and the full build stays green.
