### PR TITLE
fix: restore observer state after traversal mismatch

### DIFF
--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -15646,6 +15646,15 @@ static void flecs_uni_observer_invoke(
         return;
     }
 
+    ecs_query_t *query = o->query;
+    if (query) {
+        ecs_term_t *term = &query->terms[0];
+        ecs_assert(trav == 0 || it->sources[0] != 0, ECS_INTERNAL_ERROR, NULL);
+        if (trav && term->trav != trav) {
+            return;
+        }
+    }
+
     if (ecs_should_log_3()) {
         char *path = ecs_get_path(world, it->system);
         ecs_dbg_3("observer: invoke %s", path);
@@ -15668,7 +15677,6 @@ static void flecs_uni_observer_invoke(
     ecs_flags32_t set_fields_cur = it->set_fields;
     it->set_fields = 1;
 
-    ecs_query_t *query = o->query;
     it->query = query;
 
     if (!query) {
@@ -15677,10 +15685,6 @@ static void flecs_uni_observer_invoke(
         flecs_observer_invoke(o, it);
     } else {
         ecs_term_t *term = &query->terms[0];
-        ecs_assert(trav == 0 || it->sources[0] != 0, ECS_INTERNAL_ERROR, NULL);
-        if (trav && term->trav != trav) {
-            return;
-        }
 
         bool is_filter = term->inout == EcsInOutNone;
         ECS_BIT_COND(it->flags, EcsIterNoData, is_filter);

--- a/distr/flecs_no_addons.c
+++ b/distr/flecs_no_addons.c
@@ -13573,6 +13573,15 @@ static void flecs_uni_observer_invoke(
         return;
     }
 
+    ecs_query_t *query = o->query;
+    if (query) {
+        ecs_term_t *term = &query->terms[0];
+        ecs_assert(trav == 0 || it->sources[0] != 0, ECS_INTERNAL_ERROR, NULL);
+        if (trav && term->trav != trav) {
+            return;
+        }
+    }
+
     if (ecs_should_log_3()) {
         char *path = ecs_get_path(world, it->system);
         ecs_dbg_3("observer: invoke %s", path);
@@ -13595,7 +13604,6 @@ static void flecs_uni_observer_invoke(
     ecs_flags32_t set_fields_cur = it->set_fields;
     it->set_fields = 1;
 
-    ecs_query_t *query = o->query;
     it->query = query;
 
     if (!query) {
@@ -13604,10 +13612,6 @@ static void flecs_uni_observer_invoke(
         flecs_observer_invoke(o, it);
     } else {
         ecs_term_t *term = &query->terms[0];
-        ecs_assert(trav == 0 || it->sources[0] != 0, ECS_INTERNAL_ERROR, NULL);
-        if (trav && term->trav != trav) {
-            return;
-        }
 
         bool is_filter = term->inout == EcsInOutNone;
         ECS_BIT_COND(it->flags, EcsIterNoData, is_filter);

--- a/src/observer.c
+++ b/src/observer.c
@@ -419,6 +419,15 @@ static void flecs_uni_observer_invoke(
         return;
     }
 
+    ecs_query_t *query = o->query;
+    if (query) {
+        ecs_term_t *term = &query->terms[0];
+        ecs_assert(trav == 0 || it->sources[0] != 0, ECS_INTERNAL_ERROR, NULL);
+        if (trav && term->trav != trav) {
+            return;
+        }
+    }
+
     if (ecs_should_log_3()) {
         char *path = ecs_get_path(world, it->system);
         ecs_dbg_3("observer: invoke %s", path);
@@ -441,7 +450,6 @@ static void flecs_uni_observer_invoke(
     ecs_flags32_t set_fields_cur = it->set_fields;
     it->set_fields = 1;
 
-    ecs_query_t *query = o->query;
     it->query = query;
 
     if (!query) {
@@ -450,10 +458,6 @@ static void flecs_uni_observer_invoke(
         flecs_observer_invoke(o, it);
     } else {
         ecs_term_t *term = &query->terms[0];
-        ecs_assert(trav == 0 || it->sources[0] != 0, ECS_INTERNAL_ERROR, NULL);
-        if (trav && term->trav != trav) {
-            return;
-        }
 
         bool is_filter = term->inout == EcsInOutNone;
         ECS_BIT_COND(it->flags, EcsIterNoData, is_filter);

--- a/test/core/src/Observer.c
+++ b/test/core/src/Observer.c
@@ -1,4 +1,5 @@
 #include <core.h>
+#include "../../../src/private_api.h"
 
 static ECS_COMPONENT_DECLARE(Position);
 static ECS_COMPONENT_DECLARE(Velocity);
@@ -10332,6 +10333,8 @@ void Observer_2_up_terms_w_batched_add(void) {
     test_int(ctx.invoked, 0);
 
     ecs_defer_end(world);
+
+    test_int(world->stages[0]->system, 0);
 
     /* Observer fires twice: once for the Bar propagation through RelA, once
      * for the Bar propagation through RelB. Both are separate events (separate


### PR DESCRIPTION
## Summary

- Filter traversal-mismatched observers before changing stage or iterator state.
- Add a regression assertion for batched events propagated through multiple traversable relationships.
- Regenerate the distribution sources.

## Root cause

An expected traversal mismatch returned after setting the root stage's current observer and increasing log nesting. That early return skipped the existing cleanup path, leaving the root stage attributed to the skipped observer.

## Testing

- `bake run test/core -- Observer.2_up_terms_w_batched_add`
- `bake run test/core -- Observer`
- `cmake --build /tmp/flecs-cmake-strict -j 4`
- `clang -std=gnu99 -fsyntax-only -Werror -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers distr/flecs.c`
- `clang -std=gnu99 -fsyntax-only -Werror -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers distr/flecs_no_addons.c`
