### PR TITLE
fix: bound HTTP query parameters

### DIFF
--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -46536,6 +46536,12 @@ static bool http_header_writable(
     return frag->header_count < ECS_HTTP_HEADER_COUNT_MAX;
 }
 
+static bool http_param_writable(
+    ecs_http_fragment_t *frag)
+{
+    return frag->param_count < ECS_HTTP_QUERY_PARAM_COUNT_MAX;
+}
+
 static void http_header_buf_reset(
     ecs_http_fragment_t *frag)
 {
@@ -46752,13 +46758,17 @@ static bool http_parse_request(
                 ecs_strbuf_appendch(&frag->buf, '\0');
             } else {
                 if (c == '?' || c == '=' || c == '&') {
-                    ecs_strbuf_appendch(&frag->buf, '\0');
-                    int32_t offset = ecs_strbuf_written(&frag->buf);
-                    if (c == '?' || c == '&') {
-                        frag->param_offsets[frag->param_count] = offset;
-                    } else {
-                        frag->param_value_offsets[frag->param_count] = offset;
-                        frag->param_count ++;
+                    if (http_param_writable(frag)) {
+                        ecs_strbuf_appendch(&frag->buf, '\0');
+                        int32_t offset = ecs_strbuf_written(&frag->buf);
+                        if (c == '?' || c == '&') {
+                            frag->param_offsets[frag->param_count] = offset;
+                        } else {
+                            frag->param_value_offsets[frag->param_count] = offset;
+                            frag->param_count ++;
+                        }
+                    } else if (c == '&') {
+                        ecs_strbuf_appendch(&frag->buf, '\0');
                     }
                 } else {
                     ecs_strbuf_appendch(&frag->buf, c);

--- a/src/addons/http/http.c
+++ b/src/addons/http/http.c
@@ -304,6 +304,12 @@ static bool http_header_writable(
     return frag->header_count < ECS_HTTP_HEADER_COUNT_MAX;
 }
 
+static bool http_param_writable(
+    ecs_http_fragment_t *frag)
+{
+    return frag->param_count < ECS_HTTP_QUERY_PARAM_COUNT_MAX;
+}
+
 static void http_header_buf_reset(
     ecs_http_fragment_t *frag)
 {
@@ -520,13 +526,17 @@ static bool http_parse_request(
                 ecs_strbuf_appendch(&frag->buf, '\0');
             } else {
                 if (c == '?' || c == '=' || c == '&') {
-                    ecs_strbuf_appendch(&frag->buf, '\0');
-                    int32_t offset = ecs_strbuf_written(&frag->buf);
-                    if (c == '?' || c == '&') {
-                        frag->param_offsets[frag->param_count] = offset;
-                    } else {
-                        frag->param_value_offsets[frag->param_count] = offset;
-                        frag->param_count ++;
+                    if (http_param_writable(frag)) {
+                        ecs_strbuf_appendch(&frag->buf, '\0');
+                        int32_t offset = ecs_strbuf_written(&frag->buf);
+                        if (c == '?' || c == '&') {
+                            frag->param_offsets[frag->param_count] = offset;
+                        } else {
+                            frag->param_value_offsets[frag->param_count] = offset;
+                            frag->param_count ++;
+                        }
+                    } else if (c == '&') {
+                        ecs_strbuf_appendch(&frag->buf, '\0');
                     }
                 } else {
                     ecs_strbuf_appendch(&frag->buf, c);

--- a/test/addons/project.json
+++ b/test/addons/project.json
@@ -516,7 +516,8 @@
                 "teardown_started",
                 "teardown_stopped",
                 "stop_start",
-                "decode_plus"
+                "decode_plus",
+                "query_params_max"
             ]
         }, {
             "id": "Rest",

--- a/test/addons/src/Http.c
+++ b/test/addons/src/Http.c
@@ -22,6 +22,18 @@ static bool OnRequestEcho(
     return true;
 }
 
+static int32_t http_param_count;
+
+static bool OnRequestParamCount(
+    const ecs_http_request_t* request,
+    ecs_http_reply_t *reply,
+    void *ctx)
+{
+    http_param_count = request->param_count;
+    test_str(ecs_http_get_param(request, "p31"), "x");
+    return true;
+}
+
 void Http_decode_plus(void) {
     ecs_set_os_api_impl();
 
@@ -41,6 +53,28 @@ void Http_decode_plus(void) {
     test_assert(reply_str != NULL);
     test_str(reply_str, "foo bar|hello world");
     ecs_os_free(reply_str);
+
+    ecs_http_server_fini(srv);
+}
+
+void Http_query_params_max(void) {
+    ecs_set_os_api_impl();
+
+    ecs_http_server_t *srv = ecs_http_server_init(&(ecs_http_server_desc_t){
+        .port = 27754,
+        .callback = OnRequestParamCount
+    });
+
+    test_assert(srv != NULL);
+
+    http_param_count = 0;
+    ecs_http_reply_t reply = ECS_HTTP_REPLY_INIT;
+    test_int(0, ecs_http_server_request(srv, "GET",
+        "/?p0=x&p1=x&p2=x&p3=x&p4=x&p5=x&p6=x&p7=x&p8=x&p9=x&"
+        "p10=x&p11=x&p12=x&p13=x&p14=x&p15=x&p16=x&p17=x&p18=x&p19=x&"
+        "p20=x&p21=x&p22=x&p23=x&p24=x&p25=x&p26=x&p27=x&p28=x&p29=x&"
+        "p30=x&p31=x&p32=x", NULL, &reply));
+    test_int(http_param_count, ECS_HTTP_QUERY_PARAM_COUNT_MAX);
 
     ecs_http_server_fini(srv);
 }

--- a/test/addons/src/main.c
+++ b/test/addons/src/main.c
@@ -469,6 +469,7 @@ void Http_teardown_started(void);
 void Http_teardown_stopped(void);
 void Http_stop_start(void);
 void Http_decode_plus(void);
+void Http_query_params_max(void);
 
 // Testsuite 'Rest'
 void Rest_teardown(void);
@@ -2314,6 +2315,10 @@ bake_test_case Http_testcases[] = {
     {
         "decode_plus",
         Http_decode_plus
+    },
+    {
+        "query_params_max",
+        Http_query_params_max
     }
 };
 
@@ -2946,7 +2951,7 @@ static bake_test_suite suites[] = {
         "Http",
         NULL,
         NULL,
-        5,
+        6,
         Http_testcases
     },
     {


### PR DESCRIPTION
## Summary

- Limit parsed query parameters to `ECS_HTTP_QUERY_PARAM_COUNT_MAX`.
- Preserve the final accepted parameter when additional query fields are present.
- Add HTTP regression coverage and regenerate the distribution source.

## Root cause

The request parser recorded every query parameter although `ecs_http_request_t::params` is a fixed 32-entry array. Decoding a request with a 33rd field wrote past that array.

## Testing

- `bake run test/addons -- Http.query_params_max`
- `bake run test/addons --cfg sanitize -- Http.query_params_max`
- `bake run test/addons -- Http`
- `cmake --build /tmp/flecs-cmake-strict -j 4`
- `clang -std=gnu99 -fsyntax-only -Werror -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers distr/flecs.c`
