### PR TITLE
fix: validate sparse id generations

### DIFF
--- a/distr/flecs.c
+++ b/distr/flecs.c
@@ -32930,6 +32930,11 @@ bool flecs_sparse_remove(
     int32_t dense = page->sparse[offset];
 
     if (dense) {
+        uint64_t *dense_array = ecs_vec_first_t(&sparse->dense, uint64_t);
+        if ((dense >= sparse->count) || (dense_array[dense] != id)) {
+            return false;
+        }
+
         int32_t count = sparse->count;
         if (dense == (count - 1)) {
             /* If dense is the last used element, simply decrease count */
@@ -32981,9 +32986,12 @@ bool flecs_sparse_remove_w_gen(
     int32_t dense = page->sparse[offset];
 
     if (dense) {
-        /* Increase generation */
         uint64_t *dense_array = ecs_vec_first_t(&sparse->dense, uint64_t);
-        ecs_assert(dense_array[dense] == id, ECS_INVALID_PARAMETER, NULL);
+        if ((dense >= sparse->count) || (dense_array[dense] != id)) {
+            return false;
+        }
+
+        /* Increase generation */
         dense_array[dense] = flecs_sparse_inc_gen(id);
 
         int32_t count = sparse->count;
@@ -33044,8 +33052,8 @@ bool flecs_sparse_is_alive(
         return false;
     }
 
-    ecs_assert(dense == page->sparse[offset], ECS_INTERNAL_ERROR, NULL);
-    return true;
+    uint64_t *dense_array = ecs_vec_first_t(&sparse->dense, uint64_t);
+    return dense_array[dense] == id;
 }
 
 void* flecs_sparse_get_w_check(
@@ -33072,6 +33080,11 @@ void* flecs_sparse_get_w_check(
 
         int32_t dense = page->sparse[offset];
         if (!dense || (dense >= sparse->count)) {
+            return NULL;
+        }
+
+        uint64_t *dense_array = ecs_vec_first_t(&sparse->dense, uint64_t);
+        if (dense_array[dense] != id) {
             return NULL;
         }
     }
@@ -33102,7 +33115,12 @@ bool flecs_sparse_has(
 
     int32_t offset = FLECS_SPARSE_OFFSET(id);
     int32_t dense = page->sparse[offset];
-    return dense && (dense < sparse->count);
+    if (!dense || (dense >= sparse->count)) {
+        return false;
+    }
+
+    uint64_t *dense_array = ecs_vec_first_t(&sparse->dense, uint64_t);
+    return dense_array[dense] == id;
 }
 
 int32_t flecs_sparse_count(

--- a/distr/flecs_no_addons.c
+++ b/distr/flecs_no_addons.c
@@ -21788,6 +21788,11 @@ bool flecs_sparse_remove(
     int32_t dense = page->sparse[offset];
 
     if (dense) {
+        uint64_t *dense_array = ecs_vec_first_t(&sparse->dense, uint64_t);
+        if ((dense >= sparse->count) || (dense_array[dense] != id)) {
+            return false;
+        }
+
         int32_t count = sparse->count;
         if (dense == (count - 1)) {
             /* If dense is the last used element, simply decrease count */
@@ -21839,9 +21844,12 @@ bool flecs_sparse_remove_w_gen(
     int32_t dense = page->sparse[offset];
 
     if (dense) {
-        /* Increase generation */
         uint64_t *dense_array = ecs_vec_first_t(&sparse->dense, uint64_t);
-        ecs_assert(dense_array[dense] == id, ECS_INVALID_PARAMETER, NULL);
+        if ((dense >= sparse->count) || (dense_array[dense] != id)) {
+            return false;
+        }
+
+        /* Increase generation */
         dense_array[dense] = flecs_sparse_inc_gen(id);
 
         int32_t count = sparse->count;
@@ -21902,8 +21910,8 @@ bool flecs_sparse_is_alive(
         return false;
     }
 
-    ecs_assert(dense == page->sparse[offset], ECS_INTERNAL_ERROR, NULL);
-    return true;
+    uint64_t *dense_array = ecs_vec_first_t(&sparse->dense, uint64_t);
+    return dense_array[dense] == id;
 }
 
 void* flecs_sparse_get_w_check(
@@ -21930,6 +21938,11 @@ void* flecs_sparse_get_w_check(
 
         int32_t dense = page->sparse[offset];
         if (!dense || (dense >= sparse->count)) {
+            return NULL;
+        }
+
+        uint64_t *dense_array = ecs_vec_first_t(&sparse->dense, uint64_t);
+        if (dense_array[dense] != id) {
             return NULL;
         }
     }
@@ -21960,7 +21973,12 @@ bool flecs_sparse_has(
 
     int32_t offset = FLECS_SPARSE_OFFSET(id);
     int32_t dense = page->sparse[offset];
-    return dense && (dense < sparse->count);
+    if (!dense || (dense >= sparse->count)) {
+        return false;
+    }
+
+    uint64_t *dense_array = ecs_vec_first_t(&sparse->dense, uint64_t);
+    return dense_array[dense] == id;
 }
 
 int32_t flecs_sparse_count(

--- a/src/datastructures/sparse.c
+++ b/src/datastructures/sparse.c
@@ -423,6 +423,11 @@ bool flecs_sparse_remove(
     int32_t dense = page->sparse[offset];
 
     if (dense) {
+        uint64_t *dense_array = ecs_vec_first_t(&sparse->dense, uint64_t);
+        if ((dense >= sparse->count) || (dense_array[dense] != id)) {
+            return false;
+        }
+
         int32_t count = sparse->count;
         if (dense == (count - 1)) {
             /* If dense is the last used element, simply decrease count */
@@ -474,9 +479,12 @@ bool flecs_sparse_remove_w_gen(
     int32_t dense = page->sparse[offset];
 
     if (dense) {
-        /* Increase generation */
         uint64_t *dense_array = ecs_vec_first_t(&sparse->dense, uint64_t);
-        ecs_assert(dense_array[dense] == id, ECS_INVALID_PARAMETER, NULL);
+        if ((dense >= sparse->count) || (dense_array[dense] != id)) {
+            return false;
+        }
+
+        /* Increase generation */
         dense_array[dense] = flecs_sparse_inc_gen(id);
 
         int32_t count = sparse->count;
@@ -537,8 +545,8 @@ bool flecs_sparse_is_alive(
         return false;
     }
 
-    ecs_assert(dense == page->sparse[offset], ECS_INTERNAL_ERROR, NULL);
-    return true;
+    uint64_t *dense_array = ecs_vec_first_t(&sparse->dense, uint64_t);
+    return dense_array[dense] == id;
 }
 
 void* flecs_sparse_get_w_check(
@@ -565,6 +573,11 @@ void* flecs_sparse_get_w_check(
 
         int32_t dense = page->sparse[offset];
         if (!dense || (dense >= sparse->count)) {
+            return NULL;
+        }
+
+        uint64_t *dense_array = ecs_vec_first_t(&sparse->dense, uint64_t);
+        if (dense_array[dense] != id) {
             return NULL;
         }
     }
@@ -595,7 +608,12 @@ bool flecs_sparse_has(
 
     int32_t offset = FLECS_SPARSE_OFFSET(id);
     int32_t dense = page->sparse[offset];
-    return dense && (dense < sparse->count);
+    if (!dense || (dense >= sparse->count)) {
+        return false;
+    }
+
+    uint64_t *dense_array = ecs_vec_first_t(&sparse->dense, uint64_t);
+    return dense_array[dense] == id;
 }
 
 int32_t flecs_sparse_count(

--- a/test/collections/project.json
+++ b/test/collections/project.json
@@ -67,6 +67,7 @@
                 "add_after_clear",
                 "create_delete",
                 "create_delete_2",
+                "generation_validation",
                 "count_of_null",
                 "try_low_after_ensure_high",
                 "is_alive_low_after_ensure_high",

--- a/test/collections/src/Sparse.c
+++ b/test/collections/src/Sparse.c
@@ -355,6 +355,28 @@ void Sparse_create_delete_2(void) {
     flecs_sparse_free(sp);
 }
 
+void Sparse_generation_validation(void) {
+    ecs_sparse_t *sp = flecs_sparse_new(NULL, NULL, int);
+    uint64_t id = 42;
+    uint64_t recycled_id = ECS_GENERATION_INC(id);
+
+    int *ptr = flecs_sparse_ensure_t(sp, int, id, NULL);
+    *ptr = 10;
+    test_assert(flecs_sparse_remove_t(sp, int, id));
+
+    ptr = flecs_sparse_ensure_t(sp, int, recycled_id, NULL);
+    *ptr = 20;
+
+    test_assert(!flecs_sparse_is_alive(sp, id));
+    test_assert(!flecs_sparse_has(sp, id));
+    test_assert(flecs_sparse_get_t(sp, int, id) == NULL);
+    test_assert(!flecs_sparse_remove_t(sp, int, id));
+    test_assert(flecs_sparse_is_alive(sp, recycled_id));
+    test_int(*flecs_sparse_get_t(sp, int, recycled_id), 20);
+
+    flecs_sparse_free(sp);
+}
+
 void Sparse_count_of_null(void) {
     test_int(flecs_sparse_count(NULL), 0);
 }

--- a/test/collections/src/main.c
+++ b/test/collections/src/main.c
@@ -60,6 +60,7 @@ void Sparse_clear_n_chunks(void);
 void Sparse_add_after_clear(void);
 void Sparse_create_delete(void);
 void Sparse_create_delete_2(void);
+void Sparse_generation_validation(void);
 void Sparse_count_of_null(void);
 void Sparse_try_low_after_ensure_high(void);
 void Sparse_is_alive_low_after_ensure_high(void);
@@ -306,6 +307,10 @@ bake_test_case Sparse_testcases[] = {
         Sparse_create_delete_2
     },
     {
+        "generation_validation",
+        Sparse_generation_validation
+    },
+    {
         "count_of_null",
         Sparse_count_of_null
     },
@@ -497,6 +502,7 @@ bake_test_case Allocator_testcases[] = {
     }
 };
 
+
 static bake_test_suite suites[] = {
     {
         "Map",
@@ -509,7 +515,7 @@ static bake_test_suite suites[] = {
         "Sparse",
         Sparse_setup,
         NULL,
-        24,
+        25,
         Sparse_testcases
     },
     {


### PR DESCRIPTION
## Summary

- Verify sparse IDs against their dense entry before reporting, reading, or removing them.
- Return false for stale generations instead of removing the recycled entry.
- Add regression coverage for a recycled sparse ID and regenerate both distribution sources.

## Root cause

Sparse entries are indexed by the lower 32 bits of an ID. After an entry is recycled with a newer generation, the old ID could still pass liveness checks and read or remove the new entry because the dense ID was not compared with the requested full ID.

## Testing

- `bake run test/collections -- Sparse.generation_validation`
- `bake run test/collections -- Sparse`
- `cmake --build /tmp/flecs-cmake-strict -j 4`
- `clang -std=gnu99 -fsyntax-only -Werror -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers distr/flecs.c`
- `clang -std=gnu99 -fsyntax-only -Werror -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers distr/flecs_no_addons.c`
